### PR TITLE
[Memory64] Fix parsing data segment init exprs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/address64.wast.js-expected.txt
@@ -1,8 +1,8 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (address64.wast:3) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (address64.wast:209) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (address64.wast:492) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (address64.wast:3)
+PASS #3 Test that WebAssembly compilation succeeds (address64.wast:209)
+PASS #4 Test that WebAssembly compilation succeeds (address64.wast:492)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Test that WebAssembly compilation succeeds (wrapper)
@@ -18,7 +18,7 @@ PASS #16 Test that WebAssembly compilation succeeds (wrapper)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly compilation succeeds (address64.wast:539) assert_equals: expected false but got true
+PASS #20 Test that WebAssembly compilation succeeds (address64.wast:539)
 PASS #21 Test that WebAssembly compilation succeeds (wrapper)
 PASS #22 Test that WebAssembly compilation succeeds (wrapper)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
@@ -35,914 +35,310 @@ PASS #33 Test that WebAssembly compilation succeeds (wrapper)
 PASS #34 Test that WebAssembly compilation succeeds (wrapper)
 PASS #35 Test that WebAssembly compilation succeeds (wrapper)
 PASS #36 Reinitialize the default imports
-FAIL #37 Test that WebAssembly compilation succeeds (address64.wast:3) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 812: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (address64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #40 Test that a WebAssembly code returns a specific result (address64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (address64.wast:106) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (address64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (address64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (address64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (address64.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (address64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (address64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #48 Test that a WebAssembly code returns a specific result (address64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (address64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (address64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (address64.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (address64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (address64.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (address64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (address64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (address64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #57 Test that a WebAssembly code returns a specific result (address64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #58 Test that a WebAssembly code returns a specific result (address64.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #59 Test that a WebAssembly code returns a specific result (address64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #60 Test that a WebAssembly code returns a specific result (address64.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (address64.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #62 Test that a WebAssembly code returns a specific result (address64.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #63 Test that a WebAssembly code returns a specific result (address64.wast:132) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (address64.wast:134) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #65 Test that a WebAssembly code returns a specific result (address64.wast:135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #66 Test that a WebAssembly code returns a specific result (address64.wast:136) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (address64.wast:137) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (address64.wast:138) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (address64.wast:140) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (address64.wast:141) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (address64.wast:142) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (address64.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (address64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (address64.wast:146) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (address64.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (address64.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (address64.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (address64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (address64.wast:152) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (address64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (address64.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (address64.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (address64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (address64.wast:158) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (address64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (address64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (address64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (address64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (address64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (address64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (address64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (address64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (address64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (address64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (address64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (address64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (address64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (address64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (address64.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (address64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (address64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (address64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (address64.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (address64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (address64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (address64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (address64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (address64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (address64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (address64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (address64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (address64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #113 Test that a WebAssembly code traps (address64.wast:192) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:232:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #114 Test that a WebAssembly code traps (address64.wast:194) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:235:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #115 Test that a WebAssembly code traps (address64.wast:195) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:238:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #116 Test that a WebAssembly code traps (address64.wast:196) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:241:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #117 Test that a WebAssembly code traps (address64.wast:197) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:244:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #118 Test that a WebAssembly code traps (address64.wast:198) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:247:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #119 Test that a WebAssembly code traps (address64.wast:200) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:250:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #120 Test that a WebAssembly code traps (address64.wast:201) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:253:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #121 Test that a WebAssembly code traps (address64.wast:202) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:256:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #122 Test that a WebAssembly code traps (address64.wast:203) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:259:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #123 Test that a WebAssembly code traps (address64.wast:204) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:262:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #124 Test that WebAssembly compilation succeeds (address64.wast:209) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 1118: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #125 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:268:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #126 Test that a WebAssembly code returns a specific result (address64.wast:348) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #127 Test that a WebAssembly code returns a specific result (address64.wast:349) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #128 Test that a WebAssembly code returns a specific result (address64.wast:350) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (address64.wast:351) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #130 Test that a WebAssembly code returns a specific result (address64.wast:352) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #131 Test that a WebAssembly code returns a specific result (address64.wast:354) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #132 Test that a WebAssembly code returns a specific result (address64.wast:355) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #133 Test that a WebAssembly code returns a specific result (address64.wast:356) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #134 Test that a WebAssembly code returns a specific result (address64.wast:357) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #135 Test that a WebAssembly code returns a specific result (address64.wast:358) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #136 Test that a WebAssembly code returns a specific result (address64.wast:360) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:301:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #137 Test that a WebAssembly code returns a specific result (address64.wast:361) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:304:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #138 Test that a WebAssembly code returns a specific result (address64.wast:362) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:307:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (address64.wast:363) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #140 Test that a WebAssembly code returns a specific result (address64.wast:364) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #141 Test that a WebAssembly code returns a specific result (address64.wast:366) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #142 Test that a WebAssembly code returns a specific result (address64.wast:367) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #143 Test that a WebAssembly code returns a specific result (address64.wast:368) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #144 Test that a WebAssembly code returns a specific result (address64.wast:369) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:325:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (address64.wast:370) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:328:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #146 Test that a WebAssembly code returns a specific result (address64.wast:372) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:331:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #147 Test that a WebAssembly code returns a specific result (address64.wast:373) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #148 Test that a WebAssembly code returns a specific result (address64.wast:374) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:337:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #149 Test that a WebAssembly code returns a specific result (address64.wast:375) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:340:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (address64.wast:376) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:343:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #151 Test that a WebAssembly code returns a specific result (address64.wast:378) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:346:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #152 Test that a WebAssembly code returns a specific result (address64.wast:379) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:349:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #153 Test that a WebAssembly code returns a specific result (address64.wast:380) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:352:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #154 Test that a WebAssembly code returns a specific result (address64.wast:381) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:355:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (address64.wast:382) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:358:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #156 Test that a WebAssembly code returns a specific result (address64.wast:384) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:361:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #157 Test that a WebAssembly code returns a specific result (address64.wast:385) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:364:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #158 Test that a WebAssembly code returns a specific result (address64.wast:386) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:367:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #159 Test that a WebAssembly code returns a specific result (address64.wast:387) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:370:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (address64.wast:388) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:373:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #161 Test that a WebAssembly code returns a specific result (address64.wast:390) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:376:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #162 Test that a WebAssembly code returns a specific result (address64.wast:391) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:379:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #163 Test that a WebAssembly code returns a specific result (address64.wast:392) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:382:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #164 Test that a WebAssembly code returns a specific result (address64.wast:393) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:385:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (address64.wast:394) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:388:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #166 Test that a WebAssembly code returns a specific result (address64.wast:396) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:391:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #167 Test that a WebAssembly code returns a specific result (address64.wast:397) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:394:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #168 Test that a WebAssembly code returns a specific result (address64.wast:398) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:397:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #169 Test that a WebAssembly code returns a specific result (address64.wast:399) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:400:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #170 Test that a WebAssembly code returns a specific result (address64.wast:400) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:403:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (address64.wast:402) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:406:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #172 Test that a WebAssembly code returns a specific result (address64.wast:403) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:409:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #173 Test that a WebAssembly code returns a specific result (address64.wast:404) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:412:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #174 Test that a WebAssembly code returns a specific result (address64.wast:405) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:415:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #175 Test that a WebAssembly code returns a specific result (address64.wast:406) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:418:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (address64.wast:408) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:421:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #177 Test that a WebAssembly code returns a specific result (address64.wast:409) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:424:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #178 Test that a WebAssembly code returns a specific result (address64.wast:410) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:427:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #179 Test that a WebAssembly code returns a specific result (address64.wast:411) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:430:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (address64.wast:412) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:433:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (address64.wast:414) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:436:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #182 Test that a WebAssembly code returns a specific result (address64.wast:415) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:439:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #183 Test that a WebAssembly code returns a specific result (address64.wast:416) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:442:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (address64.wast:417) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:445:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #185 Test that a WebAssembly code returns a specific result (address64.wast:418) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:448:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (address64.wast:420) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:451:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #187 Test that a WebAssembly code returns a specific result (address64.wast:421) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:454:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (address64.wast:422) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:457:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #189 Test that a WebAssembly code returns a specific result (address64.wast:423) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:460:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #190 Test that a WebAssembly code returns a specific result (address64.wast:424) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:463:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (address64.wast:426) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:466:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #192 Test that a WebAssembly code returns a specific result (address64.wast:427) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:469:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #193 Test that a WebAssembly code returns a specific result (address64.wast:428) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:472:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #194 Test that a WebAssembly code returns a specific result (address64.wast:429) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:475:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #195 Test that a WebAssembly code returns a specific result (address64.wast:430) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:478:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #196 Test that a WebAssembly code returns a specific result (address64.wast:432) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:481:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #197 Test that a WebAssembly code returns a specific result (address64.wast:433) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:484:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #198 Test that a WebAssembly code returns a specific result (address64.wast:434) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:487:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #199 Test that a WebAssembly code returns a specific result (address64.wast:435) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:490:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #200 Test that a WebAssembly code returns a specific result (address64.wast:436) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:493:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #201 Test that a WebAssembly code returns a specific result (address64.wast:438) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:496:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #202 Test that a WebAssembly code returns a specific result (address64.wast:439) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:499:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #203 Test that a WebAssembly code returns a specific result (address64.wast:440) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:502:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #204 Test that a WebAssembly code returns a specific result (address64.wast:441) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:505:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #205 Test that a WebAssembly code returns a specific result (address64.wast:442) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:508:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #206 Test that a WebAssembly code returns a specific result (address64.wast:444) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:511:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #207 Test that a WebAssembly code returns a specific result (address64.wast:445) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:514:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #208 Test that a WebAssembly code returns a specific result (address64.wast:446) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:517:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #209 Test that a WebAssembly code returns a specific result (address64.wast:447) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #210 Test that a WebAssembly code returns a specific result (address64.wast:448) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #211 Test that a WebAssembly code returns a specific result (address64.wast:450) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:526:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #212 Test that a WebAssembly code returns a specific result (address64.wast:451) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:529:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #213 Test that a WebAssembly code returns a specific result (address64.wast:452) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:532:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #214 Test that a WebAssembly code returns a specific result (address64.wast:453) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:535:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #215 Test that a WebAssembly code returns a specific result (address64.wast:454) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:538:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #216 Test that a WebAssembly code returns a specific result (address64.wast:456) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:541:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #217 Test that a WebAssembly code returns a specific result (address64.wast:457) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:544:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #218 Test that a WebAssembly code returns a specific result (address64.wast:458) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:547:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #219 Test that a WebAssembly code returns a specific result (address64.wast:459) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:550:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #220 Test that a WebAssembly code returns a specific result (address64.wast:460) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:553:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #221 Test that a WebAssembly code returns a specific result (address64.wast:462) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:556:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #222 Test that a WebAssembly code returns a specific result (address64.wast:463) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:559:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #223 Test that a WebAssembly code returns a specific result (address64.wast:464) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:562:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #224 Test that a WebAssembly code returns a specific result (address64.wast:465) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:565:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #225 Test that a WebAssembly code returns a specific result (address64.wast:466) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:568:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #226 Test that a WebAssembly code returns a specific result (address64.wast:468) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:571:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #227 Test that a WebAssembly code returns a specific result (address64.wast:469) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:574:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #228 Test that a WebAssembly code returns a specific result (address64.wast:470) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:577:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #229 Test that a WebAssembly code returns a specific result (address64.wast:471) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:580:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #230 Test that a WebAssembly code traps (address64.wast:472) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:583:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #231 Test that a WebAssembly code traps (address64.wast:474) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:586:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #232 Test that a WebAssembly code traps (address64.wast:475) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:589:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #233 Test that a WebAssembly code traps (address64.wast:476) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:592:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #234 Test that a WebAssembly code traps (address64.wast:477) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:595:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #235 Test that a WebAssembly code traps (address64.wast:478) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:598:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #236 Test that a WebAssembly code traps (address64.wast:479) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:601:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #237 Test that a WebAssembly code traps (address64.wast:480) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:604:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #238 Test that a WebAssembly code traps (address64.wast:482) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:607:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #239 Test that a WebAssembly code traps (address64.wast:483) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:610:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #240 Test that a WebAssembly code traps (address64.wast:484) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:613:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #241 Test that a WebAssembly code traps (address64.wast:485) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:616:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #242 Test that a WebAssembly code traps (address64.wast:486) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:619:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #243 Test that a WebAssembly code traps (address64.wast:487) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:622:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #244 Test that a WebAssembly code traps (address64.wast:488) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:625:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #245 Test that WebAssembly compilation succeeds (address64.wast:492) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 212: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #246 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:631:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #37 Test that WebAssembly compilation succeeds (address64.wast:3)
+PASS #38 Test that WebAssembly instantiation succeeds (address64.wast:3)
+PASS #39 Test that a WebAssembly code returns a specific result (address64.wast:104)
+PASS #40 Test that a WebAssembly code returns a specific result (address64.wast:105)
+PASS #41 Test that a WebAssembly code returns a specific result (address64.wast:106)
+PASS #42 Test that a WebAssembly code returns a specific result (address64.wast:107)
+PASS #43 Test that a WebAssembly code returns a specific result (address64.wast:108)
+PASS #44 Test that a WebAssembly code returns a specific result (address64.wast:110)
+PASS #45 Test that a WebAssembly code returns a specific result (address64.wast:111)
+PASS #46 Test that a WebAssembly code returns a specific result (address64.wast:112)
+PASS #47 Test that a WebAssembly code returns a specific result (address64.wast:113)
+PASS #48 Test that a WebAssembly code returns a specific result (address64.wast:114)
+PASS #49 Test that a WebAssembly code returns a specific result (address64.wast:116)
+PASS #50 Test that a WebAssembly code returns a specific result (address64.wast:117)
+PASS #51 Test that a WebAssembly code returns a specific result (address64.wast:118)
+PASS #52 Test that a WebAssembly code returns a specific result (address64.wast:119)
+PASS #53 Test that a WebAssembly code returns a specific result (address64.wast:120)
+PASS #54 Test that a WebAssembly code returns a specific result (address64.wast:122)
+PASS #55 Test that a WebAssembly code returns a specific result (address64.wast:123)
+PASS #56 Test that a WebAssembly code returns a specific result (address64.wast:124)
+PASS #57 Test that a WebAssembly code returns a specific result (address64.wast:125)
+PASS #58 Test that a WebAssembly code returns a specific result (address64.wast:126)
+PASS #59 Test that a WebAssembly code returns a specific result (address64.wast:128)
+PASS #60 Test that a WebAssembly code returns a specific result (address64.wast:129)
+PASS #61 Test that a WebAssembly code returns a specific result (address64.wast:130)
+PASS #62 Test that a WebAssembly code returns a specific result (address64.wast:131)
+PASS #63 Test that a WebAssembly code returns a specific result (address64.wast:132)
+PASS #64 Test that a WebAssembly code returns a specific result (address64.wast:134)
+PASS #65 Test that a WebAssembly code returns a specific result (address64.wast:135)
+PASS #66 Test that a WebAssembly code returns a specific result (address64.wast:136)
+PASS #67 Test that a WebAssembly code returns a specific result (address64.wast:137)
+PASS #68 Test that a WebAssembly code returns a specific result (address64.wast:138)
+PASS #69 Test that a WebAssembly code returns a specific result (address64.wast:140)
+PASS #70 Test that a WebAssembly code returns a specific result (address64.wast:141)
+PASS #71 Test that a WebAssembly code returns a specific result (address64.wast:142)
+PASS #72 Test that a WebAssembly code returns a specific result (address64.wast:143)
+PASS #73 Test that a WebAssembly code returns a specific result (address64.wast:144)
+PASS #74 Test that a WebAssembly code returns a specific result (address64.wast:146)
+PASS #75 Test that a WebAssembly code returns a specific result (address64.wast:147)
+PASS #76 Test that a WebAssembly code returns a specific result (address64.wast:148)
+PASS #77 Test that a WebAssembly code returns a specific result (address64.wast:149)
+PASS #78 Test that a WebAssembly code returns a specific result (address64.wast:150)
+PASS #79 Test that a WebAssembly code returns a specific result (address64.wast:152)
+PASS #80 Test that a WebAssembly code returns a specific result (address64.wast:153)
+PASS #81 Test that a WebAssembly code returns a specific result (address64.wast:154)
+PASS #82 Test that a WebAssembly code returns a specific result (address64.wast:155)
+PASS #83 Test that a WebAssembly code returns a specific result (address64.wast:156)
+PASS #84 Test that a WebAssembly code returns a specific result (address64.wast:158)
+PASS #85 Test that a WebAssembly code returns a specific result (address64.wast:159)
+PASS #86 Test that a WebAssembly code returns a specific result (address64.wast:160)
+PASS #87 Test that a WebAssembly code returns a specific result (address64.wast:161)
+PASS #88 Test that a WebAssembly code returns a specific result (address64.wast:162)
+PASS #89 Test that a WebAssembly code returns a specific result (address64.wast:164)
+PASS #90 Test that a WebAssembly code returns a specific result (address64.wast:165)
+PASS #91 Test that a WebAssembly code returns a specific result (address64.wast:166)
+PASS #92 Test that a WebAssembly code returns a specific result (address64.wast:167)
+PASS #93 Test that a WebAssembly code returns a specific result (address64.wast:168)
+PASS #94 Test that a WebAssembly code returns a specific result (address64.wast:170)
+PASS #95 Test that a WebAssembly code returns a specific result (address64.wast:171)
+PASS #96 Test that a WebAssembly code returns a specific result (address64.wast:172)
+PASS #97 Test that a WebAssembly code returns a specific result (address64.wast:173)
+PASS #98 Test that a WebAssembly code returns a specific result (address64.wast:174)
+PASS #99 Test that a WebAssembly code returns a specific result (address64.wast:176)
+PASS #100 Test that a WebAssembly code returns a specific result (address64.wast:177)
+PASS #101 Test that a WebAssembly code returns a specific result (address64.wast:178)
+PASS #102 Test that a WebAssembly code returns a specific result (address64.wast:179)
+PASS #103 Test that a WebAssembly code returns a specific result (address64.wast:180)
+PASS #104 Test that a WebAssembly code returns a specific result (address64.wast:182)
+PASS #105 Test that a WebAssembly code returns a specific result (address64.wast:183)
+PASS #106 Test that a WebAssembly code returns a specific result (address64.wast:184)
+PASS #107 Test that a WebAssembly code returns a specific result (address64.wast:185)
+PASS #108 Test that a WebAssembly code returns a specific result (address64.wast:186)
+PASS #109 Test that a WebAssembly code returns a specific result (address64.wast:188)
+PASS #110 Test that a WebAssembly code returns a specific result (address64.wast:189)
+PASS #111 Test that a WebAssembly code returns a specific result (address64.wast:190)
+PASS #112 Test that a WebAssembly code returns a specific result (address64.wast:191)
+PASS #113 Test that a WebAssembly code traps (address64.wast:192)
+PASS #114 Test that a WebAssembly code traps (address64.wast:194)
+PASS #115 Test that a WebAssembly code traps (address64.wast:195)
+PASS #116 Test that a WebAssembly code traps (address64.wast:196)
+PASS #117 Test that a WebAssembly code traps (address64.wast:197)
+PASS #118 Test that a WebAssembly code traps (address64.wast:198)
+PASS #119 Test that a WebAssembly code traps (address64.wast:200)
+PASS #120 Test that a WebAssembly code traps (address64.wast:201)
+PASS #121 Test that a WebAssembly code traps (address64.wast:202)
+PASS #122 Test that a WebAssembly code traps (address64.wast:203)
+PASS #123 Test that a WebAssembly code traps (address64.wast:204)
+PASS #124 Test that WebAssembly compilation succeeds (address64.wast:209)
+PASS #125 Test that WebAssembly instantiation succeeds (address64.wast:209)
+PASS #126 Test that a WebAssembly code returns a specific result (address64.wast:348)
+PASS #127 Test that a WebAssembly code returns a specific result (address64.wast:349)
+PASS #128 Test that a WebAssembly code returns a specific result (address64.wast:350)
+PASS #129 Test that a WebAssembly code returns a specific result (address64.wast:351)
+PASS #130 Test that a WebAssembly code returns a specific result (address64.wast:352)
+PASS #131 Test that a WebAssembly code returns a specific result (address64.wast:354)
+PASS #132 Test that a WebAssembly code returns a specific result (address64.wast:355)
+PASS #133 Test that a WebAssembly code returns a specific result (address64.wast:356)
+PASS #134 Test that a WebAssembly code returns a specific result (address64.wast:357)
+PASS #135 Test that a WebAssembly code returns a specific result (address64.wast:358)
+PASS #136 Test that a WebAssembly code returns a specific result (address64.wast:360)
+PASS #137 Test that a WebAssembly code returns a specific result (address64.wast:361)
+PASS #138 Test that a WebAssembly code returns a specific result (address64.wast:362)
+PASS #139 Test that a WebAssembly code returns a specific result (address64.wast:363)
+PASS #140 Test that a WebAssembly code returns a specific result (address64.wast:364)
+PASS #141 Test that a WebAssembly code returns a specific result (address64.wast:366)
+PASS #142 Test that a WebAssembly code returns a specific result (address64.wast:367)
+PASS #143 Test that a WebAssembly code returns a specific result (address64.wast:368)
+PASS #144 Test that a WebAssembly code returns a specific result (address64.wast:369)
+PASS #145 Test that a WebAssembly code returns a specific result (address64.wast:370)
+PASS #146 Test that a WebAssembly code returns a specific result (address64.wast:372)
+PASS #147 Test that a WebAssembly code returns a specific result (address64.wast:373)
+PASS #148 Test that a WebAssembly code returns a specific result (address64.wast:374)
+PASS #149 Test that a WebAssembly code returns a specific result (address64.wast:375)
+PASS #150 Test that a WebAssembly code returns a specific result (address64.wast:376)
+PASS #151 Test that a WebAssembly code returns a specific result (address64.wast:378)
+PASS #152 Test that a WebAssembly code returns a specific result (address64.wast:379)
+PASS #153 Test that a WebAssembly code returns a specific result (address64.wast:380)
+PASS #154 Test that a WebAssembly code returns a specific result (address64.wast:381)
+PASS #155 Test that a WebAssembly code returns a specific result (address64.wast:382)
+PASS #156 Test that a WebAssembly code returns a specific result (address64.wast:384)
+PASS #157 Test that a WebAssembly code returns a specific result (address64.wast:385)
+PASS #158 Test that a WebAssembly code returns a specific result (address64.wast:386)
+PASS #159 Test that a WebAssembly code returns a specific result (address64.wast:387)
+PASS #160 Test that a WebAssembly code returns a specific result (address64.wast:388)
+PASS #161 Test that a WebAssembly code returns a specific result (address64.wast:390)
+PASS #162 Test that a WebAssembly code returns a specific result (address64.wast:391)
+PASS #163 Test that a WebAssembly code returns a specific result (address64.wast:392)
+PASS #164 Test that a WebAssembly code returns a specific result (address64.wast:393)
+PASS #165 Test that a WebAssembly code returns a specific result (address64.wast:394)
+PASS #166 Test that a WebAssembly code returns a specific result (address64.wast:396)
+PASS #167 Test that a WebAssembly code returns a specific result (address64.wast:397)
+PASS #168 Test that a WebAssembly code returns a specific result (address64.wast:398)
+PASS #169 Test that a WebAssembly code returns a specific result (address64.wast:399)
+PASS #170 Test that a WebAssembly code returns a specific result (address64.wast:400)
+PASS #171 Test that a WebAssembly code returns a specific result (address64.wast:402)
+PASS #172 Test that a WebAssembly code returns a specific result (address64.wast:403)
+PASS #173 Test that a WebAssembly code returns a specific result (address64.wast:404)
+PASS #174 Test that a WebAssembly code returns a specific result (address64.wast:405)
+PASS #175 Test that a WebAssembly code returns a specific result (address64.wast:406)
+PASS #176 Test that a WebAssembly code returns a specific result (address64.wast:408)
+PASS #177 Test that a WebAssembly code returns a specific result (address64.wast:409)
+PASS #178 Test that a WebAssembly code returns a specific result (address64.wast:410)
+PASS #179 Test that a WebAssembly code returns a specific result (address64.wast:411)
+PASS #180 Test that a WebAssembly code returns a specific result (address64.wast:412)
+PASS #181 Test that a WebAssembly code returns a specific result (address64.wast:414)
+PASS #182 Test that a WebAssembly code returns a specific result (address64.wast:415)
+PASS #183 Test that a WebAssembly code returns a specific result (address64.wast:416)
+PASS #184 Test that a WebAssembly code returns a specific result (address64.wast:417)
+PASS #185 Test that a WebAssembly code returns a specific result (address64.wast:418)
+PASS #186 Test that a WebAssembly code returns a specific result (address64.wast:420)
+PASS #187 Test that a WebAssembly code returns a specific result (address64.wast:421)
+PASS #188 Test that a WebAssembly code returns a specific result (address64.wast:422)
+PASS #189 Test that a WebAssembly code returns a specific result (address64.wast:423)
+PASS #190 Test that a WebAssembly code returns a specific result (address64.wast:424)
+PASS #191 Test that a WebAssembly code returns a specific result (address64.wast:426)
+PASS #192 Test that a WebAssembly code returns a specific result (address64.wast:427)
+PASS #193 Test that a WebAssembly code returns a specific result (address64.wast:428)
+PASS #194 Test that a WebAssembly code returns a specific result (address64.wast:429)
+PASS #195 Test that a WebAssembly code returns a specific result (address64.wast:430)
+PASS #196 Test that a WebAssembly code returns a specific result (address64.wast:432)
+PASS #197 Test that a WebAssembly code returns a specific result (address64.wast:433)
+PASS #198 Test that a WebAssembly code returns a specific result (address64.wast:434)
+PASS #199 Test that a WebAssembly code returns a specific result (address64.wast:435)
+PASS #200 Test that a WebAssembly code returns a specific result (address64.wast:436)
+PASS #201 Test that a WebAssembly code returns a specific result (address64.wast:438)
+PASS #202 Test that a WebAssembly code returns a specific result (address64.wast:439)
+PASS #203 Test that a WebAssembly code returns a specific result (address64.wast:440)
+PASS #204 Test that a WebAssembly code returns a specific result (address64.wast:441)
+PASS #205 Test that a WebAssembly code returns a specific result (address64.wast:442)
+PASS #206 Test that a WebAssembly code returns a specific result (address64.wast:444)
+PASS #207 Test that a WebAssembly code returns a specific result (address64.wast:445)
+PASS #208 Test that a WebAssembly code returns a specific result (address64.wast:446)
+PASS #209 Test that a WebAssembly code returns a specific result (address64.wast:447)
+PASS #210 Test that a WebAssembly code returns a specific result (address64.wast:448)
+PASS #211 Test that a WebAssembly code returns a specific result (address64.wast:450)
+PASS #212 Test that a WebAssembly code returns a specific result (address64.wast:451)
+PASS #213 Test that a WebAssembly code returns a specific result (address64.wast:452)
+PASS #214 Test that a WebAssembly code returns a specific result (address64.wast:453)
+PASS #215 Test that a WebAssembly code returns a specific result (address64.wast:454)
+PASS #216 Test that a WebAssembly code returns a specific result (address64.wast:456)
+PASS #217 Test that a WebAssembly code returns a specific result (address64.wast:457)
+PASS #218 Test that a WebAssembly code returns a specific result (address64.wast:458)
+PASS #219 Test that a WebAssembly code returns a specific result (address64.wast:459)
+PASS #220 Test that a WebAssembly code returns a specific result (address64.wast:460)
+PASS #221 Test that a WebAssembly code returns a specific result (address64.wast:462)
+PASS #222 Test that a WebAssembly code returns a specific result (address64.wast:463)
+PASS #223 Test that a WebAssembly code returns a specific result (address64.wast:464)
+PASS #224 Test that a WebAssembly code returns a specific result (address64.wast:465)
+PASS #225 Test that a WebAssembly code returns a specific result (address64.wast:466)
+PASS #226 Test that a WebAssembly code returns a specific result (address64.wast:468)
+PASS #227 Test that a WebAssembly code returns a specific result (address64.wast:469)
+PASS #228 Test that a WebAssembly code returns a specific result (address64.wast:470)
+PASS #229 Test that a WebAssembly code returns a specific result (address64.wast:471)
+PASS #230 Test that a WebAssembly code traps (address64.wast:472)
+PASS #231 Test that a WebAssembly code traps (address64.wast:474)
+PASS #232 Test that a WebAssembly code traps (address64.wast:475)
+PASS #233 Test that a WebAssembly code traps (address64.wast:476)
+PASS #234 Test that a WebAssembly code traps (address64.wast:477)
+PASS #235 Test that a WebAssembly code traps (address64.wast:478)
+PASS #236 Test that a WebAssembly code traps (address64.wast:479)
+PASS #237 Test that a WebAssembly code traps (address64.wast:480)
+PASS #238 Test that a WebAssembly code traps (address64.wast:482)
+PASS #239 Test that a WebAssembly code traps (address64.wast:483)
+PASS #240 Test that a WebAssembly code traps (address64.wast:484)
+PASS #241 Test that a WebAssembly code traps (address64.wast:485)
+PASS #242 Test that a WebAssembly code traps (address64.wast:486)
+PASS #243 Test that a WebAssembly code traps (address64.wast:487)
+PASS #244 Test that a WebAssembly code traps (address64.wast:488)
+PASS #245 Test that WebAssembly compilation succeeds (address64.wast:492)
+PASS #246 Test that WebAssembly instantiation succeeds (address64.wast:492)
 PASS #247 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #248 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:634:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:634:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #249 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:634:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #248 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #249 Run a WebAssembly test without special assertions (address64.wast:516)
 PASS #250 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #251 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:637:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:637:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #252 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:637:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #251 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #252 Run a WebAssembly test without special assertions (address64.wast:517)
 PASS #253 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #254 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:640:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:640:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #255 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:640:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #254 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #255 Run a WebAssembly test without special assertions (address64.wast:518)
 PASS #256 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #257 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:643:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:643:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #258 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:643:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #257 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #258 Run a WebAssembly test without special assertions (address64.wast:519)
 PASS #259 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #260 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:646:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:646:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #261 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:646:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #260 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #261 Run a WebAssembly test without special assertions (address64.wast:520)
 PASS #262 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #263 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:649:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:649:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #264 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:649:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #263 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #264 Run a WebAssembly test without special assertions (address64.wast:522)
 PASS #265 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #266 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:652:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:652:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #267 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:652:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #266 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #267 Run a WebAssembly test without special assertions (address64.wast:523)
 PASS #268 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #269 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:655:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:655:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #270 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:655:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #269 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #270 Run a WebAssembly test without special assertions (address64.wast:524)
 PASS #271 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #272 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:658:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:658:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #273 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:658:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #272 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #273 Run a WebAssembly test without special assertions (address64.wast:525)
 PASS #274 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #275 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:661:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:661:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #276 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:661:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #275 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #276 Run a WebAssembly test without special assertions (address64.wast:526)
 PASS #277 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #278 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:664:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:664:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #279 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:664:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #278 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #279 Run a WebAssembly test without special assertions (address64.wast:528)
 PASS #280 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #281 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:667:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:667:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #282 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:667:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #281 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #282 Run a WebAssembly test without special assertions (address64.wast:529)
 PASS #283 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #284 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:670:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:670:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #285 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:670:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #284 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #285 Run a WebAssembly test without special assertions (address64.wast:530)
 PASS #286 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #287 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:673:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:673:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #288 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:673:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #287 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #288 Run a WebAssembly test without special assertions (address64.wast:531)
 PASS #289 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #290 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:32_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:676:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:676:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #291 Test that a WebAssembly code traps (address64.wast:532) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:676:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #292 Test that a WebAssembly code traps (address64.wast:534) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:679:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #293 Test that a WebAssembly code traps (address64.wast:535) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:682:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #294 Test that WebAssembly compilation succeeds (address64.wast:539) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 212: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #295 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:688:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #290 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #291 Test that a WebAssembly code traps (address64.wast:532)
+PASS #292 Test that a WebAssembly code traps (address64.wast:534)
+PASS #293 Test that a WebAssembly code traps (address64.wast:535)
+PASS #294 Test that WebAssembly compilation succeeds (address64.wast:539)
+PASS #295 Test that WebAssembly instantiation succeeds (address64.wast:539)
 PASS #296 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #297 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:691:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:691:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #298 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:691:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #297 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #298 Run a WebAssembly test without special assertions (address64.wast:563)
 PASS #299 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #300 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:694:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:694:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #301 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:694:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #300 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #301 Run a WebAssembly test without special assertions (address64.wast:564)
 PASS #302 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #303 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:697:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:697:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #304 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:697:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #303 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #304 Run a WebAssembly test without special assertions (address64.wast:565)
 PASS #305 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #306 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:700:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:700:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #307 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:700:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #306 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #307 Run a WebAssembly test without special assertions (address64.wast:566)
 PASS #308 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #309 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:703:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #310 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #309 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #310 Run a WebAssembly test without special assertions (address64.wast:567)
 PASS #311 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #312 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:706:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:706:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #313 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:706:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #312 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #313 Run a WebAssembly test without special assertions (address64.wast:569)
 PASS #314 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #315 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:709:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:709:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #316 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:709:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #315 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #316 Run a WebAssembly test without special assertions (address64.wast:570)
 PASS #317 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #318 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:712:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:712:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #319 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:712:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #318 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #319 Run a WebAssembly test without special assertions (address64.wast:571)
 PASS #320 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #321 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:715:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:715:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #322 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:715:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #321 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #322 Run a WebAssembly test without special assertions (address64.wast:572)
 PASS #323 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #324 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:718:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:718:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #325 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:718:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #324 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #325 Run a WebAssembly test without special assertions (address64.wast:573)
 PASS #326 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #327 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good1 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:721:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:721:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #328 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:721:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #327 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #328 Run a WebAssembly test without special assertions (address64.wast:575)
 PASS #329 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #330 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good2 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:724:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:724:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #331 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:724:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #330 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #331 Run a WebAssembly test without special assertions (address64.wast:576)
 PASS #332 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #333 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good3 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:727:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:727:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #334 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:727:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #333 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #334 Run a WebAssembly test without special assertions (address64.wast:577)
 PASS #335 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #336 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good4 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:730:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:730:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #337 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:730:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #336 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #337 Run a WebAssembly test without special assertions (address64.wast:578)
 PASS #338 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #339 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:64_good5 must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:733:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:733:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #340 Test that a WebAssembly code traps (address64.wast:579) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:733:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #341 Test that a WebAssembly code traps (address64.wast:581) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:736:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
-FAIL #342 Test that a WebAssembly code traps (address64.wast:582) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-address64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:739:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/address64.wast.js:741:3 expected true got false
+PASS #339 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #340 Test that a WebAssembly code traps (address64.wast:579)
+PASS #341 Test that a WebAssembly code traps (address64.wast:581)
+PASS #342 Test that a WebAssembly code traps (address64.wast:582)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/bulk64.wast.js-expected.txt
@@ -2,9 +2,9 @@
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (bulk64.wast:2)
 PASS #3 Test that WebAssembly compilation succeeds (bulk64.wast:7)
-FAIL #4 Test that WebAssembly compilation succeeds (bulk64.wast:45) assert_equals: expected false but got true
+PASS #4 Test that WebAssembly compilation succeeds (bulk64.wast:45)
 PASS #5 Test that WebAssembly compilation succeeds (bulk64.wast:117)
-FAIL #6 Test that WebAssembly compilation succeeds (bulk64.wast:161) assert_equals: expected false but got true
+PASS #6 Test that WebAssembly compilation succeeds (bulk64.wast:161)
 PASS #7 Reinitialize the default imports
 PASS #8 Test that WebAssembly compilation succeeds (bulk64.wast:2)
 PASS #9 Test that WebAssembly instantiation succeeds (bulk64.wast:2)
@@ -22,118 +22,44 @@ PASS #20 Test that a WebAssembly code returns a specific result (bulk64.wast:31)
 PASS #21 Run a WebAssembly test without special assertions (bulk64.wast:34)
 PASS #22 Run a WebAssembly test without special assertions (bulk64.wast:37)
 PASS #23 Test that a WebAssembly code traps (bulk64.wast:40)
-FAIL #24 Test that WebAssembly compilation succeeds (bulk64.wast:45) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 116: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #25 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #26 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:58:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #27 Test that a WebAssembly code returns a specific result (bulk64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #28 Test that a WebAssembly code returns a specific result (bulk64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #29 Test that a WebAssembly code returns a specific result (bulk64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #30 Test that a WebAssembly code returns a specific result (bulk64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #31 Test that a WebAssembly code returns a specific result (bulk64.wast:66) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #32 Test that a WebAssembly code returns a specific result (bulk64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #33 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #34 Test that a WebAssembly code returns a specific result (bulk64.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #35 Test that a WebAssembly code returns a specific result (bulk64.wast:72) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #36 Test that a WebAssembly code returns a specific result (bulk64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #37 Test that a WebAssembly code returns a specific result (bulk64.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #38 Test that a WebAssembly code returns a specific result (bulk64.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #39 Test that a WebAssembly code returns a specific result (bulk64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #40 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:100:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (bulk64.wast:80) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:103:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #42 Test that a WebAssembly code returns a specific result (bulk64.wast:81) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #43 Test that a WebAssembly code returns a specific result (bulk64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:109:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (bulk64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #45 Test that a WebAssembly code returns a specific result (bulk64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (bulk64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (bulk64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #48 Test that a WebAssembly code traps (bulk64.wast:89) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #49 Test that a WebAssembly code returns a specific result (bulk64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #50 Test that a WebAssembly code returns a specific result (bulk64.wast:93) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (bulk64.wast:94) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #52 Test that a WebAssembly code returns a specific result (bulk64.wast:95) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #53 Test that a WebAssembly code returns a specific result (bulk64.wast:96) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #54 Test that a WebAssembly code returns a specific result (bulk64.wast:97) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #55 Test that a WebAssembly code returns a specific result (bulk64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #56 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:148:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #57 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:151:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #58 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:154:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:157:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #60 Test that a WebAssembly code traps (bulk64.wast:109) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #61 Test that a WebAssembly code traps (bulk64.wast:112) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
+PASS #24 Test that WebAssembly compilation succeeds (bulk64.wast:45)
+PASS #25 Test that WebAssembly instantiation succeeds (bulk64.wast:45)
+PASS #26 Run a WebAssembly test without special assertions (bulk64.wast:60)
+PASS #27 Test that a WebAssembly code returns a specific result (bulk64.wast:62)
+PASS #28 Test that a WebAssembly code returns a specific result (bulk64.wast:63)
+PASS #29 Test that a WebAssembly code returns a specific result (bulk64.wast:64)
+PASS #30 Test that a WebAssembly code returns a specific result (bulk64.wast:65)
+PASS #31 Test that a WebAssembly code returns a specific result (bulk64.wast:66)
+PASS #32 Test that a WebAssembly code returns a specific result (bulk64.wast:67)
+PASS #33 Run a WebAssembly test without special assertions (bulk64.wast:70)
+PASS #34 Test that a WebAssembly code returns a specific result (bulk64.wast:71)
+PASS #35 Test that a WebAssembly code returns a specific result (bulk64.wast:72)
+PASS #36 Test that a WebAssembly code returns a specific result (bulk64.wast:73)
+PASS #37 Test that a WebAssembly code returns a specific result (bulk64.wast:74)
+PASS #38 Test that a WebAssembly code returns a specific result (bulk64.wast:75)
+PASS #39 Test that a WebAssembly code returns a specific result (bulk64.wast:76)
+PASS #40 Run a WebAssembly test without special assertions (bulk64.wast:79)
+PASS #41 Test that a WebAssembly code returns a specific result (bulk64.wast:80)
+PASS #42 Test that a WebAssembly code returns a specific result (bulk64.wast:81)
+PASS #43 Test that a WebAssembly code returns a specific result (bulk64.wast:82)
+PASS #44 Test that a WebAssembly code returns a specific result (bulk64.wast:83)
+PASS #45 Test that a WebAssembly code returns a specific result (bulk64.wast:84)
+PASS #46 Test that a WebAssembly code returns a specific result (bulk64.wast:85)
+PASS #47 Test that a WebAssembly code returns a specific result (bulk64.wast:86)
+PASS #48 Test that a WebAssembly code traps (bulk64.wast:89)
+PASS #49 Test that a WebAssembly code returns a specific result (bulk64.wast:92)
+PASS #50 Test that a WebAssembly code returns a specific result (bulk64.wast:93)
+PASS #51 Test that a WebAssembly code returns a specific result (bulk64.wast:94)
+PASS #52 Test that a WebAssembly code returns a specific result (bulk64.wast:95)
+PASS #53 Test that a WebAssembly code returns a specific result (bulk64.wast:96)
+PASS #54 Test that a WebAssembly code returns a specific result (bulk64.wast:97)
+PASS #55 Test that a WebAssembly code returns a specific result (bulk64.wast:98)
+PASS #56 Run a WebAssembly test without special assertions (bulk64.wast:101)
+PASS #57 Run a WebAssembly test without special assertions (bulk64.wast:102)
+PASS #58 Run a WebAssembly test without special assertions (bulk64.wast:105)
+PASS #59 Run a WebAssembly test without special assertions (bulk64.wast:106)
+PASS #60 Test that a WebAssembly code traps (bulk64.wast:109)
+PASS #61 Test that a WebAssembly code traps (bulk64.wast:112)
 PASS #62 Test that WebAssembly compilation succeeds (bulk64.wast:117)
 PASS #63 Test that WebAssembly instantiation succeeds (bulk64.wast:117)
 PASS #64 Run a WebAssembly test without special assertions (bulk64.wast:131)
@@ -149,20 +75,10 @@ PASS #73 Run a WebAssembly test without special assertions (bulk64.wast:147)
 PASS #74 Test that a WebAssembly code traps (bulk64.wast:150)
 PASS #75 Test that a WebAssembly code traps (bulk64.wast:153)
 PASS #76 Run a WebAssembly test without special assertions (bulk64.wast:158)
-FAIL #77 Test that WebAssembly compilation succeeds (bulk64.wast:161) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 184: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #78 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:214:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #79 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:217:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #80 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:220:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #81 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:223:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
-FAIL #82 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-bulk64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:226:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/bulk64.wast.js:228:3 expected true got false
+PASS #77 Test that WebAssembly compilation succeeds (bulk64.wast:161)
+PASS #78 Test that WebAssembly instantiation succeeds (bulk64.wast:161)
+PASS #79 Run a WebAssembly test without special assertions (bulk64.wast:176)
+PASS #80 Run a WebAssembly test without special assertions (bulk64.wast:177)
+PASS #81 Run a WebAssembly test without special assertions (bulk64.wast:178)
+PASS #82 Run a WebAssembly test without special assertions (bulk64.wast:179)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/float_memory64.wast.js-expected.txt
@@ -1,496 +1,196 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (float_memory64.wast:5) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (float_memory64.wast:5)
 PASS #3 Test that WebAssembly compilation succeeds (wrapper)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
 PASS #7 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #8 Test that WebAssembly compilation succeeds (float_memory64.wast:30) assert_equals: expected false but got true
+PASS #8 Test that WebAssembly compilation succeeds (float_memory64.wast:30)
 PASS #9 Test that WebAssembly compilation succeeds (wrapper)
 PASS #10 Test that WebAssembly compilation succeeds (wrapper)
 PASS #11 Test that WebAssembly compilation succeeds (wrapper)
 PASS #12 Test that WebAssembly compilation succeeds (wrapper)
 PASS #13 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #14 Test that WebAssembly compilation succeeds (float_memory64.wast:57) assert_equals: expected false but got true
+PASS #14 Test that WebAssembly compilation succeeds (float_memory64.wast:57)
 PASS #15 Test that WebAssembly compilation succeeds (wrapper)
 PASS #16 Test that WebAssembly compilation succeeds (wrapper)
 PASS #17 Test that WebAssembly compilation succeeds (wrapper)
 PASS #18 Test that WebAssembly compilation succeeds (wrapper)
 PASS #19 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #20 Test that WebAssembly compilation succeeds (float_memory64.wast:82) assert_equals: expected false but got true
+PASS #20 Test that WebAssembly compilation succeeds (float_memory64.wast:82)
 PASS #21 Test that WebAssembly compilation succeeds (wrapper)
 PASS #22 Test that WebAssembly compilation succeeds (wrapper)
 PASS #23 Test that WebAssembly compilation succeeds (wrapper)
 PASS #24 Test that WebAssembly compilation succeeds (wrapper)
 PASS #25 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #26 Test that WebAssembly compilation succeeds (float_memory64.wast:109) assert_equals: expected false but got true
+PASS #26 Test that WebAssembly compilation succeeds (float_memory64.wast:109)
 PASS #27 Test that WebAssembly compilation succeeds (wrapper)
 PASS #28 Test that WebAssembly compilation succeeds (wrapper)
 PASS #29 Test that WebAssembly compilation succeeds (wrapper)
 PASS #30 Test that WebAssembly compilation succeeds (wrapper)
 PASS #31 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #32 Test that WebAssembly compilation succeeds (float_memory64.wast:134) assert_equals: expected false but got true
+PASS #32 Test that WebAssembly compilation succeeds (float_memory64.wast:134)
 PASS #33 Test that WebAssembly compilation succeeds (wrapper)
 PASS #34 Test that WebAssembly compilation succeeds (wrapper)
 PASS #35 Test that WebAssembly compilation succeeds (wrapper)
 PASS #36 Test that WebAssembly compilation succeeds (wrapper)
 PASS #37 Test that WebAssembly compilation succeeds (wrapper)
 PASS #38 Reinitialize the default imports
-FAIL #39 Test that WebAssembly compilation succeeds (float_memory64.wast:5) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 200: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #40 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (float_memory64.wast:15) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:10:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #39 Test that WebAssembly compilation succeeds (float_memory64.wast:5)
+PASS #40 Test that WebAssembly instantiation succeeds (float_memory64.wast:5)
+PASS #41 Test that a WebAssembly code returns a specific result (float_memory64.wast:15)
 PASS #42 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #43 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:13:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #44 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:13:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #45 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:16:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #46 Test that a WebAssembly code returns a specific result (float_memory64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #43 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #44 Run a WebAssembly test without special assertions (float_memory64.wast:16)
+PASS #45 Run a WebAssembly test without special assertions (float_memory64.wast:17)
+PASS #46 Test that a WebAssembly code returns a specific result (float_memory64.wast:18)
 PASS #47 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #48 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:22:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #49 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:22:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #50 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:25:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #51 Test that a WebAssembly code returns a specific result (float_memory64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #48 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #49 Run a WebAssembly test without special assertions (float_memory64.wast:19)
+PASS #50 Run a WebAssembly test without special assertions (float_memory64.wast:20)
+PASS #51 Test that a WebAssembly code returns a specific result (float_memory64.wast:21)
 PASS #52 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #53 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:31:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #54 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:31:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #55 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:34:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #56 Test that a WebAssembly code returns a specific result (float_memory64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #53 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #54 Run a WebAssembly test without special assertions (float_memory64.wast:22)
+PASS #55 Run a WebAssembly test without special assertions (float_memory64.wast:23)
+PASS #56 Test that a WebAssembly code returns a specific result (float_memory64.wast:24)
 PASS #57 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #58 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:40:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #59 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:40:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #60 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:43:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #61 Test that a WebAssembly code returns a specific result (float_memory64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #58 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #59 Run a WebAssembly test without special assertions (float_memory64.wast:25)
+PASS #60 Run a WebAssembly test without special assertions (float_memory64.wast:26)
+PASS #61 Test that a WebAssembly code returns a specific result (float_memory64.wast:27)
 PASS #62 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #63 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:49:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #64 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:49:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #65 Test that WebAssembly compilation succeeds (float_memory64.wast:30) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 209: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #66 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:55:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #67 Test that a WebAssembly code returns a specific result (float_memory64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #63 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #64 Run a WebAssembly test without special assertions (float_memory64.wast:28)
+PASS #65 Test that WebAssembly compilation succeeds (float_memory64.wast:30)
+PASS #66 Test that WebAssembly instantiation succeeds (float_memory64.wast:30)
+PASS #67 Test that a WebAssembly code returns a specific result (float_memory64.wast:40)
 PASS #68 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #69 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:61:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #70 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:61:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #71 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:64:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (float_memory64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #69 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #70 Run a WebAssembly test without special assertions (float_memory64.wast:41)
+PASS #71 Run a WebAssembly test without special assertions (float_memory64.wast:42)
+PASS #72 Test that a WebAssembly code returns a specific result (float_memory64.wast:43)
 PASS #73 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #74 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:70:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #75 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:70:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #76 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:73:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (float_memory64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #74 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #75 Run a WebAssembly test without special assertions (float_memory64.wast:44)
+PASS #76 Run a WebAssembly test without special assertions (float_memory64.wast:45)
+PASS #77 Test that a WebAssembly code returns a specific result (float_memory64.wast:46)
 PASS #78 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #79 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:79:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #80 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:79:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #81 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:82:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (float_memory64.wast:49) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #79 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #80 Run a WebAssembly test without special assertions (float_memory64.wast:47)
+PASS #81 Run a WebAssembly test without special assertions (float_memory64.wast:48)
+PASS #82 Test that a WebAssembly code returns a specific result (float_memory64.wast:49)
 PASS #83 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #84 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:88:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:88:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #85 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:88:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #86 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:91:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (float_memory64.wast:52) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #84 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #85 Run a WebAssembly test without special assertions (float_memory64.wast:50)
+PASS #86 Run a WebAssembly test without special assertions (float_memory64.wast:51)
+PASS #87 Test that a WebAssembly code returns a specific result (float_memory64.wast:52)
 PASS #88 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #89 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:97:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:97:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #90 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:97:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #91 Test that WebAssembly compilation succeeds (float_memory64.wast:57) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 200: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #92 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:103:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (float_memory64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:106:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #89 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #90 Run a WebAssembly test without special assertions (float_memory64.wast:53)
+PASS #91 Test that WebAssembly compilation succeeds (float_memory64.wast:57)
+PASS #92 Test that WebAssembly instantiation succeeds (float_memory64.wast:57)
+PASS #93 Test that a WebAssembly code returns a specific result (float_memory64.wast:67)
 PASS #94 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #95 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:109:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #96 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #97 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:112:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (float_memory64.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #95 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #96 Run a WebAssembly test without special assertions (float_memory64.wast:68)
+PASS #97 Run a WebAssembly test without special assertions (float_memory64.wast:69)
+PASS #98 Test that a WebAssembly code returns a specific result (float_memory64.wast:70)
 PASS #99 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #100 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:118:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:118:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #101 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:118:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #102 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:121:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (float_memory64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #100 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #101 Run a WebAssembly test without special assertions (float_memory64.wast:71)
+PASS #102 Run a WebAssembly test without special assertions (float_memory64.wast:72)
+PASS #103 Test that a WebAssembly code returns a specific result (float_memory64.wast:73)
 PASS #104 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #105 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:127:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:127:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #106 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:127:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #107 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:130:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (float_memory64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #105 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #106 Run a WebAssembly test without special assertions (float_memory64.wast:74)
+PASS #107 Run a WebAssembly test without special assertions (float_memory64.wast:75)
+PASS #108 Test that a WebAssembly code returns a specific result (float_memory64.wast:76)
 PASS #109 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #110 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:136:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:136:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #111 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:136:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #112 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:139:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #113 Test that a WebAssembly code returns a specific result (float_memory64.wast:79) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #110 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #111 Run a WebAssembly test without special assertions (float_memory64.wast:77)
+PASS #112 Run a WebAssembly test without special assertions (float_memory64.wast:78)
+PASS #113 Test that a WebAssembly code returns a specific result (float_memory64.wast:79)
 PASS #114 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #115 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:145:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:145:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #116 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:145:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #117 Test that WebAssembly compilation succeeds (float_memory64.wast:82) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 209: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #118 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:151:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #119 Test that a WebAssembly code returns a specific result (float_memory64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #115 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #116 Run a WebAssembly test without special assertions (float_memory64.wast:80)
+PASS #117 Test that WebAssembly compilation succeeds (float_memory64.wast:82)
+PASS #118 Test that WebAssembly instantiation succeeds (float_memory64.wast:82)
+PASS #119 Test that a WebAssembly code returns a specific result (float_memory64.wast:92)
 PASS #120 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #121 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:157:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:157:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #122 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:157:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #123 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:160:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #124 Test that a WebAssembly code returns a specific result (float_memory64.wast:95) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #121 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #122 Run a WebAssembly test without special assertions (float_memory64.wast:93)
+PASS #123 Run a WebAssembly test without special assertions (float_memory64.wast:94)
+PASS #124 Test that a WebAssembly code returns a specific result (float_memory64.wast:95)
 PASS #125 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #126 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:166:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:166:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #127 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:166:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #128 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:169:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (float_memory64.wast:98) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #126 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #127 Run a WebAssembly test without special assertions (float_memory64.wast:96)
+PASS #128 Run a WebAssembly test without special assertions (float_memory64.wast:97)
+PASS #129 Test that a WebAssembly code returns a specific result (float_memory64.wast:98)
 PASS #130 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #131 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:175:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:175:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #132 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:175:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #133 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:178:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #134 Test that a WebAssembly code returns a specific result (float_memory64.wast:101) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #131 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #132 Run a WebAssembly test without special assertions (float_memory64.wast:99)
+PASS #133 Run a WebAssembly test without special assertions (float_memory64.wast:100)
+PASS #134 Test that a WebAssembly code returns a specific result (float_memory64.wast:101)
 PASS #135 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #136 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:184:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:184:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #137 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:184:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #138 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:187:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (float_memory64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #136 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #137 Run a WebAssembly test without special assertions (float_memory64.wast:102)
+PASS #138 Run a WebAssembly test without special assertions (float_memory64.wast:103)
+PASS #139 Test that a WebAssembly code returns a specific result (float_memory64.wast:104)
 PASS #140 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #141 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:193:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:193:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #142 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:193:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #143 Test that WebAssembly compilation succeeds (float_memory64.wast:109) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 200: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #144 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:199:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (float_memory64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #141 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #142 Run a WebAssembly test without special assertions (float_memory64.wast:105)
+PASS #143 Test that WebAssembly compilation succeeds (float_memory64.wast:109)
+PASS #144 Test that WebAssembly instantiation succeeds (float_memory64.wast:109)
+PASS #145 Test that a WebAssembly code returns a specific result (float_memory64.wast:119)
 PASS #146 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #147 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:205:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:205:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #148 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:205:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #149 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (float_memory64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #147 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #148 Run a WebAssembly test without special assertions (float_memory64.wast:120)
+PASS #149 Run a WebAssembly test without special assertions (float_memory64.wast:121)
+PASS #150 Test that a WebAssembly code returns a specific result (float_memory64.wast:122)
 PASS #151 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #152 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:214:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:214:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #153 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:214:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #154 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:217:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (float_memory64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #152 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #153 Run a WebAssembly test without special assertions (float_memory64.wast:123)
+PASS #154 Run a WebAssembly test without special assertions (float_memory64.wast:124)
+PASS #155 Test that a WebAssembly code returns a specific result (float_memory64.wast:125)
 PASS #156 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #157 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:223:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:223:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #158 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:223:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #159 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:226:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (float_memory64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #157 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #158 Run a WebAssembly test without special assertions (float_memory64.wast:126)
+PASS #159 Run a WebAssembly test without special assertions (float_memory64.wast:127)
+PASS #160 Test that a WebAssembly code returns a specific result (float_memory64.wast:128)
 PASS #161 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #162 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:232:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:232:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #163 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:232:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #164 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:235:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (float_memory64.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #162 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #163 Run a WebAssembly test without special assertions (float_memory64.wast:129)
+PASS #164 Run a WebAssembly test without special assertions (float_memory64.wast:130)
+PASS #165 Test that a WebAssembly code returns a specific result (float_memory64.wast:131)
 PASS #166 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #167 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:241:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:241:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #168 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:241:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #169 Test that WebAssembly compilation succeeds (float_memory64.wast:134) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 209: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #170 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:247:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (float_memory64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #167 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #168 Run a WebAssembly test without special assertions (float_memory64.wast:132)
+PASS #169 Test that WebAssembly compilation succeeds (float_memory64.wast:134)
+PASS #170 Test that WebAssembly instantiation succeeds (float_memory64.wast:134)
+PASS #171 Test that a WebAssembly code returns a specific result (float_memory64.wast:144)
 PASS #172 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #173 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:253:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:253:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #174 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:253:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #175 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:256:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (float_memory64.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #173 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #174 Run a WebAssembly test without special assertions (float_memory64.wast:145)
+PASS #175 Run a WebAssembly test without special assertions (float_memory64.wast:146)
+PASS #176 Test that a WebAssembly code returns a specific result (float_memory64.wast:147)
 PASS #177 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #178 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:262:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:262:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #179 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:262:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #180 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:265:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (float_memory64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #178 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #179 Run a WebAssembly test without special assertions (float_memory64.wast:148)
+PASS #180 Run a WebAssembly test without special assertions (float_memory64.wast:149)
+PASS #181 Test that a WebAssembly code returns a specific result (float_memory64.wast:150)
 PASS #182 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #183 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:271:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:271:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #184 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:271:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #185 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:274:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (float_memory64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #183 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #184 Run a WebAssembly test without special assertions (float_memory64.wast:151)
+PASS #185 Run a WebAssembly test without special assertions (float_memory64.wast:152)
+PASS #186 Test that a WebAssembly code returns a specific result (float_memory64.wast:153)
 PASS #187 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #188 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:280:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:280:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #189 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:280:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #190 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:283:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (float_memory64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #188 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #189 Run a WebAssembly test without special assertions (float_memory64.wast:154)
+PASS #190 Run a WebAssembly test without special assertions (float_memory64.wast:155)
+PASS #191 Test that a WebAssembly code returns a specific result (float_memory64.wast:156)
 PASS #192 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #193 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:289:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:289:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
-FAIL #194 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-float_memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:289:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/float_memory64.wast.js:291:3 expected true got false
+PASS #193 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #194 Run a WebAssembly test without special assertions (float_memory64.wast:157)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory64.wast.js-expected.txt
@@ -6,9 +6,9 @@ PASS #4 Test that WebAssembly compilation succeeds (memory64.wast:6)
 PASS #5 Test that WebAssembly compilation succeeds (memory64.wast:7)
 FAIL #6 Test that WebAssembly compilation succeeds (memory64.wast:8) assert_equals: expected false but got true
 FAIL #7 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (memory64.wast:11) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory64.wast:13) assert_equals: expected false but got true
-FAIL #10 Test that WebAssembly compilation succeeds (memory64.wast:15) assert_equals: expected false but got true
+PASS #8 Test that WebAssembly compilation succeeds (memory64.wast:11)
+PASS #9 Test that WebAssembly compilation succeeds (memory64.wast:13)
+PASS #10 Test that WebAssembly compilation succeeds (memory64.wast:15)
 PASS #11 Test that WebAssembly compilation fails (memory64.wast:18)
 PASS #12 Test that WebAssembly compilation fails (memory64.wast:19)
 PASS #13 Test that WebAssembly compilation fails (memory64.wast:20)
@@ -23,7 +23,7 @@ PASS #21 Test that WebAssembly compilation fails (memory64.wast:53)
 PASS #22 Test that WebAssembly compilation fails (memory64.wast:57)
 PASS #23 Test that WebAssembly compilation fails (memory64.wast:62)
 PASS #24 Test that WebAssembly compilation fails (memory64.wast:66)
-FAIL #25 Test that WebAssembly compilation succeeds (memory64.wast:71) assert_equals: expected false but got true
+PASS #25 Test that WebAssembly compilation succeeds (memory64.wast:71)
 PASS #26 Test that WebAssembly compilation succeeds (wrapper)
 PASS #27 Reinitialize the default imports
 PASS #28 Test that WebAssembly compilation succeeds (memory64.wast:4)
@@ -39,27 +39,15 @@ FAIL #37 Test that WebAssembly compilation succeeds (memory64.wast:9) assert_tru
 FAIL #38 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
 memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:34:18
 global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #39 Test that WebAssembly compilation succeeds (memory64.wast:11) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 81: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #40 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:40:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #41 Test that a WebAssembly code returns a specific result (memory64.wast:12) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #42 Test that WebAssembly compilation succeeds (memory64.wast:13) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 81: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #43 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:49:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #44 Test that a WebAssembly code returns a specific result (memory64.wast:14) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #45 Test that WebAssembly compilation succeeds (memory64.wast:15) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 81: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #46 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:58:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #47 Test that a WebAssembly code returns a specific result (memory64.wast:16) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+PASS #39 Test that WebAssembly compilation succeeds (memory64.wast:11)
+PASS #40 Test that WebAssembly instantiation succeeds (memory64.wast:11)
+PASS #41 Test that a WebAssembly code returns a specific result (memory64.wast:12)
+PASS #42 Test that WebAssembly compilation succeeds (memory64.wast:13)
+PASS #43 Test that WebAssembly instantiation succeeds (memory64.wast:13)
+PASS #44 Test that a WebAssembly code returns a specific result (memory64.wast:14)
+PASS #45 Test that WebAssembly compilation succeeds (memory64.wast:15)
+PASS #46 Test that WebAssembly instantiation succeeds (memory64.wast:15)
+PASS #47 Test that a WebAssembly code returns a specific result (memory64.wast:16)
 PASS #48 Test that WebAssembly compilation fails (memory64.wast:18)
 PASS #49 Test that WebAssembly compilation fails (memory64.wast:19)
 PASS #50 Test that WebAssembly compilation fails (memory64.wast:20)
@@ -74,140 +62,50 @@ PASS #58 Test that WebAssembly compilation fails (memory64.wast:53)
 PASS #59 Test that WebAssembly compilation fails (memory64.wast:57)
 PASS #60 Test that WebAssembly compilation fails (memory64.wast:62)
 PASS #61 Test that WebAssembly compilation fails (memory64.wast:66)
-FAIL #62 Test that WebAssembly compilation succeeds (memory64.wast:71) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 580: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #63 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:109:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #64 Test that a WebAssembly code returns a specific result (memory64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+PASS #62 Test that WebAssembly compilation succeeds (memory64.wast:71)
+PASS #63 Test that WebAssembly instantiation succeeds (memory64.wast:71)
+PASS #64 Test that a WebAssembly code returns a specific result (memory64.wast:159)
 PASS #65 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #66 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:cast must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:115:24
-run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:243:37
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:115:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #67 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:115:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #68 Test that a WebAssembly code returns a specific result (memory64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #69 Test that a WebAssembly code returns a specific result (memory64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #70 Test that a WebAssembly code returns a specific result (memory64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #71 Test that a WebAssembly code returns a specific result (memory64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #72 Test that a WebAssembly code returns a specific result (memory64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #73 Test that a WebAssembly code returns a specific result (memory64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #74 Test that a WebAssembly code returns a specific result (memory64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #75 Test that a WebAssembly code returns a specific result (memory64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #76 Test that a WebAssembly code returns a specific result (memory64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #77 Test that a WebAssembly code returns a specific result (memory64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #78 Test that a WebAssembly code returns a specific result (memory64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #79 Test that a WebAssembly code returns a specific result (memory64.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #80 Test that a WebAssembly code returns a specific result (memory64.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #81 Test that a WebAssembly code returns a specific result (memory64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #82 Test that a WebAssembly code returns a specific result (memory64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #83 Test that a WebAssembly code returns a specific result (memory64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #84 Test that a WebAssembly code returns a specific result (memory64.wast:181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #85 Test that a WebAssembly code returns a specific result (memory64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #86 Test that a WebAssembly code returns a specific result (memory64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #87 Test that a WebAssembly code returns a specific result (memory64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #88 Test that a WebAssembly code returns a specific result (memory64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #89 Test that a WebAssembly code returns a specific result (memory64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #90 Test that a WebAssembly code returns a specific result (memory64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #91 Test that a WebAssembly code returns a specific result (memory64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #92 Test that a WebAssembly code returns a specific result (memory64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #93 Test that a WebAssembly code returns a specific result (memory64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #94 Test that a WebAssembly code returns a specific result (memory64.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #95 Test that a WebAssembly code returns a specific result (memory64.wast:193) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #96 Test that a WebAssembly code returns a specific result (memory64.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:202:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (memory64.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:205:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (memory64.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:208:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (memory64.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (memory64.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (memory64.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (memory64.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory64.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory64.wast:203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (memory64.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (memory64.wast:205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (memory64.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory64.wast.js:237:3 expected true got false
+PASS #66 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #67 Run a WebAssembly test without special assertions (memory64.wast:160)
+PASS #68 Test that a WebAssembly code returns a specific result (memory64.wast:162)
+PASS #69 Test that a WebAssembly code returns a specific result (memory64.wast:163)
+PASS #70 Test that a WebAssembly code returns a specific result (memory64.wast:164)
+PASS #71 Test that a WebAssembly code returns a specific result (memory64.wast:165)
+PASS #72 Test that a WebAssembly code returns a specific result (memory64.wast:167)
+PASS #73 Test that a WebAssembly code returns a specific result (memory64.wast:168)
+PASS #74 Test that a WebAssembly code returns a specific result (memory64.wast:169)
+PASS #75 Test that a WebAssembly code returns a specific result (memory64.wast:170)
+PASS #76 Test that a WebAssembly code returns a specific result (memory64.wast:172)
+PASS #77 Test that a WebAssembly code returns a specific result (memory64.wast:173)
+PASS #78 Test that a WebAssembly code returns a specific result (memory64.wast:174)
+PASS #79 Test that a WebAssembly code returns a specific result (memory64.wast:175)
+PASS #80 Test that a WebAssembly code returns a specific result (memory64.wast:176)
+PASS #81 Test that a WebAssembly code returns a specific result (memory64.wast:177)
+PASS #82 Test that a WebAssembly code returns a specific result (memory64.wast:178)
+PASS #83 Test that a WebAssembly code returns a specific result (memory64.wast:179)
+PASS #84 Test that a WebAssembly code returns a specific result (memory64.wast:181)
+PASS #85 Test that a WebAssembly code returns a specific result (memory64.wast:182)
+PASS #86 Test that a WebAssembly code returns a specific result (memory64.wast:183)
+PASS #87 Test that a WebAssembly code returns a specific result (memory64.wast:184)
+PASS #88 Test that a WebAssembly code returns a specific result (memory64.wast:185)
+PASS #89 Test that a WebAssembly code returns a specific result (memory64.wast:186)
+PASS #90 Test that a WebAssembly code returns a specific result (memory64.wast:188)
+PASS #91 Test that a WebAssembly code returns a specific result (memory64.wast:189)
+PASS #92 Test that a WebAssembly code returns a specific result (memory64.wast:190)
+PASS #93 Test that a WebAssembly code returns a specific result (memory64.wast:191)
+PASS #94 Test that a WebAssembly code returns a specific result (memory64.wast:192)
+PASS #95 Test that a WebAssembly code returns a specific result (memory64.wast:193)
+PASS #96 Test that a WebAssembly code returns a specific result (memory64.wast:195)
+PASS #97 Test that a WebAssembly code returns a specific result (memory64.wast:196)
+PASS #98 Test that a WebAssembly code returns a specific result (memory64.wast:197)
+PASS #99 Test that a WebAssembly code returns a specific result (memory64.wast:198)
+PASS #100 Test that a WebAssembly code returns a specific result (memory64.wast:199)
+PASS #101 Test that a WebAssembly code returns a specific result (memory64.wast:200)
+PASS #102 Test that a WebAssembly code returns a specific result (memory64.wast:201)
+PASS #103 Test that a WebAssembly code returns a specific result (memory64.wast:202)
+PASS #104 Test that a WebAssembly code returns a specific result (memory64.wast:203)
+PASS #105 Test that a WebAssembly code returns a specific result (memory64.wast:204)
+PASS #106 Test that a WebAssembly code returns a specific result (memory64.wast:205)
+PASS #107 Test that a WebAssembly code returns a specific result (memory64.wast:206)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_copy64.wast.js-expected.txt
@@ -1,13 +1,13 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_copy64.wast:6) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_copy64.wast:48) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_copy64.wast:90) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory_copy64.wast:132) assert_equals: expected false but got true
-FAIL #6 Test that WebAssembly compilation succeeds (memory_copy64.wast:174) assert_equals: expected false but got true
-FAIL #7 Test that WebAssembly compilation succeeds (memory_copy64.wast:216) assert_equals: expected false but got true
-FAIL #8 Test that WebAssembly compilation succeeds (memory_copy64.wast:258) assert_equals: expected false but got true
-FAIL #9 Test that WebAssembly compilation succeeds (memory_copy64.wast:300) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_copy64.wast:6)
+PASS #3 Test that WebAssembly compilation succeeds (memory_copy64.wast:48)
+PASS #4 Test that WebAssembly compilation succeeds (memory_copy64.wast:90)
+PASS #5 Test that WebAssembly compilation succeeds (memory_copy64.wast:132)
+PASS #6 Test that WebAssembly compilation succeeds (memory_copy64.wast:174)
+PASS #7 Test that WebAssembly compilation succeeds (memory_copy64.wast:216)
+PASS #8 Test that WebAssembly compilation succeeds (memory_copy64.wast:258)
+PASS #9 Test that WebAssembly compilation succeeds (memory_copy64.wast:300)
 PASS #10 Test that WebAssembly compilation succeeds (memory_copy64.wast:342)
 PASS #11 Test that WebAssembly compilation succeeds (memory_copy64.wast:703)
 PASS #12 Test that WebAssembly compilation succeeds (memory_copy64.wast:1065)
@@ -98,782 +98,270 @@ PASS #96 Test that WebAssembly compilation succeeds (memory_copy64.wast:4887)
 PASS #97 Test that WebAssembly compilation succeeds (memory_copy64.wast:4893)
 PASS #98 Test that WebAssembly compilation succeeds (memory_copy64.wast:4899)
 PASS #99 Reinitialize the default imports
-FAIL #100 Test that WebAssembly compilation succeeds (memory_copy64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 114: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #101 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #102 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory_copy64.wast:17) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory_copy64.wast:18) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (memory_copy64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (memory_copy64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (memory_copy64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (memory_copy64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (memory_copy64.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (memory_copy64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (memory_copy64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (memory_copy64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #113 Test that a WebAssembly code returns a specific result (memory_copy64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #114 Test that a WebAssembly code returns a specific result (memory_copy64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #115 Test that a WebAssembly code returns a specific result (memory_copy64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #116 Test that a WebAssembly code returns a specific result (memory_copy64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #117 Test that a WebAssembly code returns a specific result (memory_copy64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #118 Test that a WebAssembly code returns a specific result (memory_copy64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #119 Test that a WebAssembly code returns a specific result (memory_copy64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #120 Test that a WebAssembly code returns a specific result (memory_copy64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #121 Test that a WebAssembly code returns a specific result (memory_copy64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #122 Test that a WebAssembly code returns a specific result (memory_copy64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #123 Test that a WebAssembly code returns a specific result (memory_copy64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #124 Test that a WebAssembly code returns a specific result (memory_copy64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #125 Test that a WebAssembly code returns a specific result (memory_copy64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #126 Test that a WebAssembly code returns a specific result (memory_copy64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #127 Test that a WebAssembly code returns a specific result (memory_copy64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #128 Test that a WebAssembly code returns a specific result (memory_copy64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #129 Test that a WebAssembly code returns a specific result (memory_copy64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #130 Test that a WebAssembly code returns a specific result (memory_copy64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #131 Test that a WebAssembly code returns a specific result (memory_copy64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #132 Test that a WebAssembly code returns a specific result (memory_copy64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #133 Test that WebAssembly compilation succeeds (memory_copy64.wast:48) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #134 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:106:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #135 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #136 Test that a WebAssembly code returns a specific result (memory_copy64.wast:59) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #137 Test that a WebAssembly code returns a specific result (memory_copy64.wast:60) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #138 Test that a WebAssembly code returns a specific result (memory_copy64.wast:61) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (memory_copy64.wast:62) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #140 Test that a WebAssembly code returns a specific result (memory_copy64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #141 Test that a WebAssembly code returns a specific result (memory_copy64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #142 Test that a WebAssembly code returns a specific result (memory_copy64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #143 Test that a WebAssembly code returns a specific result (memory_copy64.wast:66) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #144 Test that a WebAssembly code returns a specific result (memory_copy64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (memory_copy64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #146 Test that a WebAssembly code returns a specific result (memory_copy64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #147 Test that a WebAssembly code returns a specific result (memory_copy64.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #148 Test that a WebAssembly code returns a specific result (memory_copy64.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #149 Test that a WebAssembly code returns a specific result (memory_copy64.wast:72) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (memory_copy64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #151 Test that a WebAssembly code returns a specific result (memory_copy64.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #152 Test that a WebAssembly code returns a specific result (memory_copy64.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #153 Test that a WebAssembly code returns a specific result (memory_copy64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #154 Test that a WebAssembly code returns a specific result (memory_copy64.wast:77) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (memory_copy64.wast:78) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #156 Test that a WebAssembly code returns a specific result (memory_copy64.wast:79) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #157 Test that a WebAssembly code returns a specific result (memory_copy64.wast:80) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #158 Test that a WebAssembly code returns a specific result (memory_copy64.wast:81) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #159 Test that a WebAssembly code returns a specific result (memory_copy64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #160 Test that a WebAssembly code returns a specific result (memory_copy64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #161 Test that a WebAssembly code returns a specific result (memory_copy64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #162 Test that a WebAssembly code returns a specific result (memory_copy64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #163 Test that a WebAssembly code returns a specific result (memory_copy64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #164 Test that a WebAssembly code returns a specific result (memory_copy64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (memory_copy64.wast:88) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #166 Test that WebAssembly compilation succeeds (memory_copy64.wast:90) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #167 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:205:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #168 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #169 Test that a WebAssembly code returns a specific result (memory_copy64.wast:101) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #170 Test that a WebAssembly code returns a specific result (memory_copy64.wast:102) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (memory_copy64.wast:103) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #172 Test that a WebAssembly code returns a specific result (memory_copy64.wast:104) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #173 Test that a WebAssembly code returns a specific result (memory_copy64.wast:105) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #174 Test that a WebAssembly code returns a specific result (memory_copy64.wast:106) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #175 Test that a WebAssembly code returns a specific result (memory_copy64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (memory_copy64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #177 Test that a WebAssembly code returns a specific result (memory_copy64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #178 Test that a WebAssembly code returns a specific result (memory_copy64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #179 Test that a WebAssembly code returns a specific result (memory_copy64.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:241:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (memory_copy64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:244:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (memory_copy64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:247:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #182 Test that a WebAssembly code returns a specific result (memory_copy64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #183 Test that a WebAssembly code returns a specific result (memory_copy64.wast:115) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:253:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (memory_copy64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:256:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #185 Test that a WebAssembly code returns a specific result (memory_copy64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (memory_copy64.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:262:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #187 Test that a WebAssembly code returns a specific result (memory_copy64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:265:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (memory_copy64.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #189 Test that a WebAssembly code returns a specific result (memory_copy64.wast:121) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #190 Test that a WebAssembly code returns a specific result (memory_copy64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (memory_copy64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #192 Test that a WebAssembly code returns a specific result (memory_copy64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #193 Test that a WebAssembly code returns a specific result (memory_copy64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #194 Test that a WebAssembly code returns a specific result (memory_copy64.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #195 Test that a WebAssembly code returns a specific result (memory_copy64.wast:127) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #196 Test that a WebAssembly code returns a specific result (memory_copy64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #197 Test that a WebAssembly code returns a specific result (memory_copy64.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #198 Test that a WebAssembly code returns a specific result (memory_copy64.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #199 Test that WebAssembly compilation succeeds (memory_copy64.wast:132) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #200 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:304:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #201 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:307:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #202 Test that a WebAssembly code returns a specific result (memory_copy64.wast:143) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #203 Test that a WebAssembly code returns a specific result (memory_copy64.wast:144) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #204 Test that a WebAssembly code returns a specific result (memory_copy64.wast:145) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #205 Test that a WebAssembly code returns a specific result (memory_copy64.wast:146) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #206 Test that a WebAssembly code returns a specific result (memory_copy64.wast:147) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #207 Test that a WebAssembly code returns a specific result (memory_copy64.wast:148) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:325:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #208 Test that a WebAssembly code returns a specific result (memory_copy64.wast:149) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:328:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #209 Test that a WebAssembly code returns a specific result (memory_copy64.wast:150) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:331:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #210 Test that a WebAssembly code returns a specific result (memory_copy64.wast:151) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #211 Test that a WebAssembly code returns a specific result (memory_copy64.wast:152) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:337:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #212 Test that a WebAssembly code returns a specific result (memory_copy64.wast:153) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:340:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #213 Test that a WebAssembly code returns a specific result (memory_copy64.wast:154) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:343:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #214 Test that a WebAssembly code returns a specific result (memory_copy64.wast:155) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:346:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #215 Test that a WebAssembly code returns a specific result (memory_copy64.wast:156) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:349:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #216 Test that a WebAssembly code returns a specific result (memory_copy64.wast:157) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:352:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #217 Test that a WebAssembly code returns a specific result (memory_copy64.wast:158) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:355:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #218 Test that a WebAssembly code returns a specific result (memory_copy64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:358:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #219 Test that a WebAssembly code returns a specific result (memory_copy64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:361:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #220 Test that a WebAssembly code returns a specific result (memory_copy64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:364:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #221 Test that a WebAssembly code returns a specific result (memory_copy64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:367:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #222 Test that a WebAssembly code returns a specific result (memory_copy64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:370:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #223 Test that a WebAssembly code returns a specific result (memory_copy64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:373:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #224 Test that a WebAssembly code returns a specific result (memory_copy64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:376:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #225 Test that a WebAssembly code returns a specific result (memory_copy64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:379:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #226 Test that a WebAssembly code returns a specific result (memory_copy64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:382:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #227 Test that a WebAssembly code returns a specific result (memory_copy64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:385:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #228 Test that a WebAssembly code returns a specific result (memory_copy64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:388:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #229 Test that a WebAssembly code returns a specific result (memory_copy64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:391:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #230 Test that a WebAssembly code returns a specific result (memory_copy64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:394:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #231 Test that a WebAssembly code returns a specific result (memory_copy64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:397:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #232 Test that WebAssembly compilation succeeds (memory_copy64.wast:174) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #233 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:403:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #234 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:406:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #235 Test that a WebAssembly code returns a specific result (memory_copy64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:409:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #236 Test that a WebAssembly code returns a specific result (memory_copy64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:412:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #237 Test that a WebAssembly code returns a specific result (memory_copy64.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:415:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #238 Test that a WebAssembly code returns a specific result (memory_copy64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:418:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #239 Test that a WebAssembly code returns a specific result (memory_copy64.wast:189) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:421:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #240 Test that a WebAssembly code returns a specific result (memory_copy64.wast:190) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:424:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #241 Test that a WebAssembly code returns a specific result (memory_copy64.wast:191) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:427:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #242 Test that a WebAssembly code returns a specific result (memory_copy64.wast:192) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:430:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #243 Test that a WebAssembly code returns a specific result (memory_copy64.wast:193) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:433:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #244 Test that a WebAssembly code returns a specific result (memory_copy64.wast:194) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:436:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #245 Test that a WebAssembly code returns a specific result (memory_copy64.wast:195) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:439:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #246 Test that a WebAssembly code returns a specific result (memory_copy64.wast:196) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:442:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #247 Test that a WebAssembly code returns a specific result (memory_copy64.wast:197) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:445:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #248 Test that a WebAssembly code returns a specific result (memory_copy64.wast:198) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:448:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #249 Test that a WebAssembly code returns a specific result (memory_copy64.wast:199) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:451:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #250 Test that a WebAssembly code returns a specific result (memory_copy64.wast:200) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:454:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #251 Test that a WebAssembly code returns a specific result (memory_copy64.wast:201) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:457:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #252 Test that a WebAssembly code returns a specific result (memory_copy64.wast:202) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:460:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #253 Test that a WebAssembly code returns a specific result (memory_copy64.wast:203) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:463:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #254 Test that a WebAssembly code returns a specific result (memory_copy64.wast:204) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:466:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #255 Test that a WebAssembly code returns a specific result (memory_copy64.wast:205) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:469:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #256 Test that a WebAssembly code returns a specific result (memory_copy64.wast:206) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:472:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #257 Test that a WebAssembly code returns a specific result (memory_copy64.wast:207) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:475:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #258 Test that a WebAssembly code returns a specific result (memory_copy64.wast:208) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:478:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #259 Test that a WebAssembly code returns a specific result (memory_copy64.wast:209) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:481:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #260 Test that a WebAssembly code returns a specific result (memory_copy64.wast:210) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:484:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #261 Test that a WebAssembly code returns a specific result (memory_copy64.wast:211) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:487:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #262 Test that a WebAssembly code returns a specific result (memory_copy64.wast:212) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:490:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #263 Test that a WebAssembly code returns a specific result (memory_copy64.wast:213) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:493:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #264 Test that a WebAssembly code returns a specific result (memory_copy64.wast:214) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:496:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #265 Test that WebAssembly compilation succeeds (memory_copy64.wast:216) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #266 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:502:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #267 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:505:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #268 Test that a WebAssembly code returns a specific result (memory_copy64.wast:227) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:508:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #269 Test that a WebAssembly code returns a specific result (memory_copy64.wast:228) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:511:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #270 Test that a WebAssembly code returns a specific result (memory_copy64.wast:229) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:514:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #271 Test that a WebAssembly code returns a specific result (memory_copy64.wast:230) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:517:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #272 Test that a WebAssembly code returns a specific result (memory_copy64.wast:231) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #273 Test that a WebAssembly code returns a specific result (memory_copy64.wast:232) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #274 Test that a WebAssembly code returns a specific result (memory_copy64.wast:233) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:526:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #275 Test that a WebAssembly code returns a specific result (memory_copy64.wast:234) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:529:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #276 Test that a WebAssembly code returns a specific result (memory_copy64.wast:235) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:532:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #277 Test that a WebAssembly code returns a specific result (memory_copy64.wast:236) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:535:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #278 Test that a WebAssembly code returns a specific result (memory_copy64.wast:237) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:538:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #279 Test that a WebAssembly code returns a specific result (memory_copy64.wast:238) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:541:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #280 Test that a WebAssembly code returns a specific result (memory_copy64.wast:239) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:544:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #281 Test that a WebAssembly code returns a specific result (memory_copy64.wast:240) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:547:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #282 Test that a WebAssembly code returns a specific result (memory_copy64.wast:241) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:550:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #283 Test that a WebAssembly code returns a specific result (memory_copy64.wast:242) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:553:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #284 Test that a WebAssembly code returns a specific result (memory_copy64.wast:243) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:556:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #285 Test that a WebAssembly code returns a specific result (memory_copy64.wast:244) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:559:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #286 Test that a WebAssembly code returns a specific result (memory_copy64.wast:245) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:562:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #287 Test that a WebAssembly code returns a specific result (memory_copy64.wast:246) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:565:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #288 Test that a WebAssembly code returns a specific result (memory_copy64.wast:247) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:568:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #289 Test that a WebAssembly code returns a specific result (memory_copy64.wast:248) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:571:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #290 Test that a WebAssembly code returns a specific result (memory_copy64.wast:249) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:574:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #291 Test that a WebAssembly code returns a specific result (memory_copy64.wast:250) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:577:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #292 Test that a WebAssembly code returns a specific result (memory_copy64.wast:251) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:580:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #293 Test that a WebAssembly code returns a specific result (memory_copy64.wast:252) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:583:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #294 Test that a WebAssembly code returns a specific result (memory_copy64.wast:253) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:586:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #295 Test that a WebAssembly code returns a specific result (memory_copy64.wast:254) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:589:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #296 Test that a WebAssembly code returns a specific result (memory_copy64.wast:255) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:592:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #297 Test that a WebAssembly code returns a specific result (memory_copy64.wast:256) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:595:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #298 Test that WebAssembly compilation succeeds (memory_copy64.wast:258) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #299 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:601:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #300 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:604:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #301 Test that a WebAssembly code returns a specific result (memory_copy64.wast:269) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:607:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #302 Test that a WebAssembly code returns a specific result (memory_copy64.wast:270) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:610:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #303 Test that a WebAssembly code returns a specific result (memory_copy64.wast:271) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:613:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #304 Test that a WebAssembly code returns a specific result (memory_copy64.wast:272) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:616:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #305 Test that a WebAssembly code returns a specific result (memory_copy64.wast:273) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:619:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #306 Test that a WebAssembly code returns a specific result (memory_copy64.wast:274) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:622:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #307 Test that a WebAssembly code returns a specific result (memory_copy64.wast:275) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:625:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #308 Test that a WebAssembly code returns a specific result (memory_copy64.wast:276) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:628:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #309 Test that a WebAssembly code returns a specific result (memory_copy64.wast:277) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:631:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #310 Test that a WebAssembly code returns a specific result (memory_copy64.wast:278) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:634:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #311 Test that a WebAssembly code returns a specific result (memory_copy64.wast:279) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:637:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #312 Test that a WebAssembly code returns a specific result (memory_copy64.wast:280) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:640:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #313 Test that a WebAssembly code returns a specific result (memory_copy64.wast:281) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:643:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #314 Test that a WebAssembly code returns a specific result (memory_copy64.wast:282) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:646:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #315 Test that a WebAssembly code returns a specific result (memory_copy64.wast:283) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:649:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #316 Test that a WebAssembly code returns a specific result (memory_copy64.wast:284) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:652:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #317 Test that a WebAssembly code returns a specific result (memory_copy64.wast:285) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:655:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #318 Test that a WebAssembly code returns a specific result (memory_copy64.wast:286) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:658:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #319 Test that a WebAssembly code returns a specific result (memory_copy64.wast:287) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:661:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #320 Test that a WebAssembly code returns a specific result (memory_copy64.wast:288) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:664:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #321 Test that a WebAssembly code returns a specific result (memory_copy64.wast:289) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:667:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #322 Test that a WebAssembly code returns a specific result (memory_copy64.wast:290) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:670:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #323 Test that a WebAssembly code returns a specific result (memory_copy64.wast:291) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:673:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #324 Test that a WebAssembly code returns a specific result (memory_copy64.wast:292) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:676:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #325 Test that a WebAssembly code returns a specific result (memory_copy64.wast:293) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:679:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #326 Test that a WebAssembly code returns a specific result (memory_copy64.wast:294) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:682:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #327 Test that a WebAssembly code returns a specific result (memory_copy64.wast:295) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:685:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #328 Test that a WebAssembly code returns a specific result (memory_copy64.wast:296) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:688:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #329 Test that a WebAssembly code returns a specific result (memory_copy64.wast:297) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:691:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #330 Test that a WebAssembly code returns a specific result (memory_copy64.wast:298) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:694:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #331 Test that WebAssembly compilation succeeds (memory_copy64.wast:300) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 123: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #332 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:700:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #333 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:703:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #334 Test that a WebAssembly code returns a specific result (memory_copy64.wast:311) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:706:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #335 Test that a WebAssembly code returns a specific result (memory_copy64.wast:312) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:709:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #336 Test that a WebAssembly code returns a specific result (memory_copy64.wast:313) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:712:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #337 Test that a WebAssembly code returns a specific result (memory_copy64.wast:314) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:715:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #338 Test that a WebAssembly code returns a specific result (memory_copy64.wast:315) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:718:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #339 Test that a WebAssembly code returns a specific result (memory_copy64.wast:316) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:721:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #340 Test that a WebAssembly code returns a specific result (memory_copy64.wast:317) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:724:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #341 Test that a WebAssembly code returns a specific result (memory_copy64.wast:318) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:727:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #342 Test that a WebAssembly code returns a specific result (memory_copy64.wast:319) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:730:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #343 Test that a WebAssembly code returns a specific result (memory_copy64.wast:320) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:733:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #344 Test that a WebAssembly code returns a specific result (memory_copy64.wast:321) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:736:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #345 Test that a WebAssembly code returns a specific result (memory_copy64.wast:322) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:739:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #346 Test that a WebAssembly code returns a specific result (memory_copy64.wast:323) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:742:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #347 Test that a WebAssembly code returns a specific result (memory_copy64.wast:324) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:745:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #348 Test that a WebAssembly code returns a specific result (memory_copy64.wast:325) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:748:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #349 Test that a WebAssembly code returns a specific result (memory_copy64.wast:326) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:751:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #350 Test that a WebAssembly code returns a specific result (memory_copy64.wast:327) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:754:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #351 Test that a WebAssembly code returns a specific result (memory_copy64.wast:328) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:757:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #352 Test that a WebAssembly code returns a specific result (memory_copy64.wast:329) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:760:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #353 Test that a WebAssembly code returns a specific result (memory_copy64.wast:330) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:763:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #354 Test that a WebAssembly code returns a specific result (memory_copy64.wast:331) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:766:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #355 Test that a WebAssembly code returns a specific result (memory_copy64.wast:332) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:769:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #356 Test that a WebAssembly code returns a specific result (memory_copy64.wast:333) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:772:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #357 Test that a WebAssembly code returns a specific result (memory_copy64.wast:334) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:775:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #358 Test that a WebAssembly code returns a specific result (memory_copy64.wast:335) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:778:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #359 Test that a WebAssembly code returns a specific result (memory_copy64.wast:336) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:781:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #360 Test that a WebAssembly code returns a specific result (memory_copy64.wast:337) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:784:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #361 Test that a WebAssembly code returns a specific result (memory_copy64.wast:338) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:787:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #362 Test that a WebAssembly code returns a specific result (memory_copy64.wast:339) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:790:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
-FAIL #363 Test that a WebAssembly code returns a specific result (memory_copy64.wast:340) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_copy64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:793:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_copy64.wast.js:13452:3 expected true got false
+PASS #100 Test that WebAssembly compilation succeeds (memory_copy64.wast:6)
+PASS #101 Test that WebAssembly instantiation succeeds (memory_copy64.wast:6)
+PASS #102 Run a WebAssembly test without special assertions (memory_copy64.wast:15)
+PASS #103 Test that a WebAssembly code returns a specific result (memory_copy64.wast:17)
+PASS #104 Test that a WebAssembly code returns a specific result (memory_copy64.wast:18)
+PASS #105 Test that a WebAssembly code returns a specific result (memory_copy64.wast:19)
+PASS #106 Test that a WebAssembly code returns a specific result (memory_copy64.wast:20)
+PASS #107 Test that a WebAssembly code returns a specific result (memory_copy64.wast:21)
+PASS #108 Test that a WebAssembly code returns a specific result (memory_copy64.wast:22)
+PASS #109 Test that a WebAssembly code returns a specific result (memory_copy64.wast:23)
+PASS #110 Test that a WebAssembly code returns a specific result (memory_copy64.wast:24)
+PASS #111 Test that a WebAssembly code returns a specific result (memory_copy64.wast:25)
+PASS #112 Test that a WebAssembly code returns a specific result (memory_copy64.wast:26)
+PASS #113 Test that a WebAssembly code returns a specific result (memory_copy64.wast:27)
+PASS #114 Test that a WebAssembly code returns a specific result (memory_copy64.wast:28)
+PASS #115 Test that a WebAssembly code returns a specific result (memory_copy64.wast:29)
+PASS #116 Test that a WebAssembly code returns a specific result (memory_copy64.wast:30)
+PASS #117 Test that a WebAssembly code returns a specific result (memory_copy64.wast:31)
+PASS #118 Test that a WebAssembly code returns a specific result (memory_copy64.wast:32)
+PASS #119 Test that a WebAssembly code returns a specific result (memory_copy64.wast:33)
+PASS #120 Test that a WebAssembly code returns a specific result (memory_copy64.wast:34)
+PASS #121 Test that a WebAssembly code returns a specific result (memory_copy64.wast:35)
+PASS #122 Test that a WebAssembly code returns a specific result (memory_copy64.wast:36)
+PASS #123 Test that a WebAssembly code returns a specific result (memory_copy64.wast:37)
+PASS #124 Test that a WebAssembly code returns a specific result (memory_copy64.wast:38)
+PASS #125 Test that a WebAssembly code returns a specific result (memory_copy64.wast:39)
+PASS #126 Test that a WebAssembly code returns a specific result (memory_copy64.wast:40)
+PASS #127 Test that a WebAssembly code returns a specific result (memory_copy64.wast:41)
+PASS #128 Test that a WebAssembly code returns a specific result (memory_copy64.wast:42)
+PASS #129 Test that a WebAssembly code returns a specific result (memory_copy64.wast:43)
+PASS #130 Test that a WebAssembly code returns a specific result (memory_copy64.wast:44)
+PASS #131 Test that a WebAssembly code returns a specific result (memory_copy64.wast:45)
+PASS #132 Test that a WebAssembly code returns a specific result (memory_copy64.wast:46)
+PASS #133 Test that WebAssembly compilation succeeds (memory_copy64.wast:48)
+PASS #134 Test that WebAssembly instantiation succeeds (memory_copy64.wast:48)
+PASS #135 Run a WebAssembly test without special assertions (memory_copy64.wast:57)
+PASS #136 Test that a WebAssembly code returns a specific result (memory_copy64.wast:59)
+PASS #137 Test that a WebAssembly code returns a specific result (memory_copy64.wast:60)
+PASS #138 Test that a WebAssembly code returns a specific result (memory_copy64.wast:61)
+PASS #139 Test that a WebAssembly code returns a specific result (memory_copy64.wast:62)
+PASS #140 Test that a WebAssembly code returns a specific result (memory_copy64.wast:63)
+PASS #141 Test that a WebAssembly code returns a specific result (memory_copy64.wast:64)
+PASS #142 Test that a WebAssembly code returns a specific result (memory_copy64.wast:65)
+PASS #143 Test that a WebAssembly code returns a specific result (memory_copy64.wast:66)
+PASS #144 Test that a WebAssembly code returns a specific result (memory_copy64.wast:67)
+PASS #145 Test that a WebAssembly code returns a specific result (memory_copy64.wast:68)
+PASS #146 Test that a WebAssembly code returns a specific result (memory_copy64.wast:69)
+PASS #147 Test that a WebAssembly code returns a specific result (memory_copy64.wast:70)
+PASS #148 Test that a WebAssembly code returns a specific result (memory_copy64.wast:71)
+PASS #149 Test that a WebAssembly code returns a specific result (memory_copy64.wast:72)
+PASS #150 Test that a WebAssembly code returns a specific result (memory_copy64.wast:73)
+PASS #151 Test that a WebAssembly code returns a specific result (memory_copy64.wast:74)
+PASS #152 Test that a WebAssembly code returns a specific result (memory_copy64.wast:75)
+PASS #153 Test that a WebAssembly code returns a specific result (memory_copy64.wast:76)
+PASS #154 Test that a WebAssembly code returns a specific result (memory_copy64.wast:77)
+PASS #155 Test that a WebAssembly code returns a specific result (memory_copy64.wast:78)
+PASS #156 Test that a WebAssembly code returns a specific result (memory_copy64.wast:79)
+PASS #157 Test that a WebAssembly code returns a specific result (memory_copy64.wast:80)
+PASS #158 Test that a WebAssembly code returns a specific result (memory_copy64.wast:81)
+PASS #159 Test that a WebAssembly code returns a specific result (memory_copy64.wast:82)
+PASS #160 Test that a WebAssembly code returns a specific result (memory_copy64.wast:83)
+PASS #161 Test that a WebAssembly code returns a specific result (memory_copy64.wast:84)
+PASS #162 Test that a WebAssembly code returns a specific result (memory_copy64.wast:85)
+PASS #163 Test that a WebAssembly code returns a specific result (memory_copy64.wast:86)
+PASS #164 Test that a WebAssembly code returns a specific result (memory_copy64.wast:87)
+PASS #165 Test that a WebAssembly code returns a specific result (memory_copy64.wast:88)
+PASS #166 Test that WebAssembly compilation succeeds (memory_copy64.wast:90)
+PASS #167 Test that WebAssembly instantiation succeeds (memory_copy64.wast:90)
+PASS #168 Run a WebAssembly test without special assertions (memory_copy64.wast:99)
+PASS #169 Test that a WebAssembly code returns a specific result (memory_copy64.wast:101)
+PASS #170 Test that a WebAssembly code returns a specific result (memory_copy64.wast:102)
+PASS #171 Test that a WebAssembly code returns a specific result (memory_copy64.wast:103)
+PASS #172 Test that a WebAssembly code returns a specific result (memory_copy64.wast:104)
+PASS #173 Test that a WebAssembly code returns a specific result (memory_copy64.wast:105)
+PASS #174 Test that a WebAssembly code returns a specific result (memory_copy64.wast:106)
+PASS #175 Test that a WebAssembly code returns a specific result (memory_copy64.wast:107)
+PASS #176 Test that a WebAssembly code returns a specific result (memory_copy64.wast:108)
+PASS #177 Test that a WebAssembly code returns a specific result (memory_copy64.wast:109)
+PASS #178 Test that a WebAssembly code returns a specific result (memory_copy64.wast:110)
+PASS #179 Test that a WebAssembly code returns a specific result (memory_copy64.wast:111)
+PASS #180 Test that a WebAssembly code returns a specific result (memory_copy64.wast:112)
+PASS #181 Test that a WebAssembly code returns a specific result (memory_copy64.wast:113)
+PASS #182 Test that a WebAssembly code returns a specific result (memory_copy64.wast:114)
+PASS #183 Test that a WebAssembly code returns a specific result (memory_copy64.wast:115)
+PASS #184 Test that a WebAssembly code returns a specific result (memory_copy64.wast:116)
+PASS #185 Test that a WebAssembly code returns a specific result (memory_copy64.wast:117)
+PASS #186 Test that a WebAssembly code returns a specific result (memory_copy64.wast:118)
+PASS #187 Test that a WebAssembly code returns a specific result (memory_copy64.wast:119)
+PASS #188 Test that a WebAssembly code returns a specific result (memory_copy64.wast:120)
+PASS #189 Test that a WebAssembly code returns a specific result (memory_copy64.wast:121)
+PASS #190 Test that a WebAssembly code returns a specific result (memory_copy64.wast:122)
+PASS #191 Test that a WebAssembly code returns a specific result (memory_copy64.wast:123)
+PASS #192 Test that a WebAssembly code returns a specific result (memory_copy64.wast:124)
+PASS #193 Test that a WebAssembly code returns a specific result (memory_copy64.wast:125)
+PASS #194 Test that a WebAssembly code returns a specific result (memory_copy64.wast:126)
+PASS #195 Test that a WebAssembly code returns a specific result (memory_copy64.wast:127)
+PASS #196 Test that a WebAssembly code returns a specific result (memory_copy64.wast:128)
+PASS #197 Test that a WebAssembly code returns a specific result (memory_copy64.wast:129)
+PASS #198 Test that a WebAssembly code returns a specific result (memory_copy64.wast:130)
+PASS #199 Test that WebAssembly compilation succeeds (memory_copy64.wast:132)
+PASS #200 Test that WebAssembly instantiation succeeds (memory_copy64.wast:132)
+PASS #201 Run a WebAssembly test without special assertions (memory_copy64.wast:141)
+PASS #202 Test that a WebAssembly code returns a specific result (memory_copy64.wast:143)
+PASS #203 Test that a WebAssembly code returns a specific result (memory_copy64.wast:144)
+PASS #204 Test that a WebAssembly code returns a specific result (memory_copy64.wast:145)
+PASS #205 Test that a WebAssembly code returns a specific result (memory_copy64.wast:146)
+PASS #206 Test that a WebAssembly code returns a specific result (memory_copy64.wast:147)
+PASS #207 Test that a WebAssembly code returns a specific result (memory_copy64.wast:148)
+PASS #208 Test that a WebAssembly code returns a specific result (memory_copy64.wast:149)
+PASS #209 Test that a WebAssembly code returns a specific result (memory_copy64.wast:150)
+PASS #210 Test that a WebAssembly code returns a specific result (memory_copy64.wast:151)
+PASS #211 Test that a WebAssembly code returns a specific result (memory_copy64.wast:152)
+PASS #212 Test that a WebAssembly code returns a specific result (memory_copy64.wast:153)
+PASS #213 Test that a WebAssembly code returns a specific result (memory_copy64.wast:154)
+PASS #214 Test that a WebAssembly code returns a specific result (memory_copy64.wast:155)
+PASS #215 Test that a WebAssembly code returns a specific result (memory_copy64.wast:156)
+PASS #216 Test that a WebAssembly code returns a specific result (memory_copy64.wast:157)
+PASS #217 Test that a WebAssembly code returns a specific result (memory_copy64.wast:158)
+PASS #218 Test that a WebAssembly code returns a specific result (memory_copy64.wast:159)
+PASS #219 Test that a WebAssembly code returns a specific result (memory_copy64.wast:160)
+PASS #220 Test that a WebAssembly code returns a specific result (memory_copy64.wast:161)
+PASS #221 Test that a WebAssembly code returns a specific result (memory_copy64.wast:162)
+PASS #222 Test that a WebAssembly code returns a specific result (memory_copy64.wast:163)
+PASS #223 Test that a WebAssembly code returns a specific result (memory_copy64.wast:164)
+PASS #224 Test that a WebAssembly code returns a specific result (memory_copy64.wast:165)
+PASS #225 Test that a WebAssembly code returns a specific result (memory_copy64.wast:166)
+PASS #226 Test that a WebAssembly code returns a specific result (memory_copy64.wast:167)
+PASS #227 Test that a WebAssembly code returns a specific result (memory_copy64.wast:168)
+PASS #228 Test that a WebAssembly code returns a specific result (memory_copy64.wast:169)
+PASS #229 Test that a WebAssembly code returns a specific result (memory_copy64.wast:170)
+PASS #230 Test that a WebAssembly code returns a specific result (memory_copy64.wast:171)
+PASS #231 Test that a WebAssembly code returns a specific result (memory_copy64.wast:172)
+PASS #232 Test that WebAssembly compilation succeeds (memory_copy64.wast:174)
+PASS #233 Test that WebAssembly instantiation succeeds (memory_copy64.wast:174)
+PASS #234 Run a WebAssembly test without special assertions (memory_copy64.wast:183)
+PASS #235 Test that a WebAssembly code returns a specific result (memory_copy64.wast:185)
+PASS #236 Test that a WebAssembly code returns a specific result (memory_copy64.wast:186)
+PASS #237 Test that a WebAssembly code returns a specific result (memory_copy64.wast:187)
+PASS #238 Test that a WebAssembly code returns a specific result (memory_copy64.wast:188)
+PASS #239 Test that a WebAssembly code returns a specific result (memory_copy64.wast:189)
+PASS #240 Test that a WebAssembly code returns a specific result (memory_copy64.wast:190)
+PASS #241 Test that a WebAssembly code returns a specific result (memory_copy64.wast:191)
+PASS #242 Test that a WebAssembly code returns a specific result (memory_copy64.wast:192)
+PASS #243 Test that a WebAssembly code returns a specific result (memory_copy64.wast:193)
+PASS #244 Test that a WebAssembly code returns a specific result (memory_copy64.wast:194)
+PASS #245 Test that a WebAssembly code returns a specific result (memory_copy64.wast:195)
+PASS #246 Test that a WebAssembly code returns a specific result (memory_copy64.wast:196)
+PASS #247 Test that a WebAssembly code returns a specific result (memory_copy64.wast:197)
+PASS #248 Test that a WebAssembly code returns a specific result (memory_copy64.wast:198)
+PASS #249 Test that a WebAssembly code returns a specific result (memory_copy64.wast:199)
+PASS #250 Test that a WebAssembly code returns a specific result (memory_copy64.wast:200)
+PASS #251 Test that a WebAssembly code returns a specific result (memory_copy64.wast:201)
+PASS #252 Test that a WebAssembly code returns a specific result (memory_copy64.wast:202)
+PASS #253 Test that a WebAssembly code returns a specific result (memory_copy64.wast:203)
+PASS #254 Test that a WebAssembly code returns a specific result (memory_copy64.wast:204)
+PASS #255 Test that a WebAssembly code returns a specific result (memory_copy64.wast:205)
+PASS #256 Test that a WebAssembly code returns a specific result (memory_copy64.wast:206)
+PASS #257 Test that a WebAssembly code returns a specific result (memory_copy64.wast:207)
+PASS #258 Test that a WebAssembly code returns a specific result (memory_copy64.wast:208)
+PASS #259 Test that a WebAssembly code returns a specific result (memory_copy64.wast:209)
+PASS #260 Test that a WebAssembly code returns a specific result (memory_copy64.wast:210)
+PASS #261 Test that a WebAssembly code returns a specific result (memory_copy64.wast:211)
+PASS #262 Test that a WebAssembly code returns a specific result (memory_copy64.wast:212)
+PASS #263 Test that a WebAssembly code returns a specific result (memory_copy64.wast:213)
+PASS #264 Test that a WebAssembly code returns a specific result (memory_copy64.wast:214)
+PASS #265 Test that WebAssembly compilation succeeds (memory_copy64.wast:216)
+PASS #266 Test that WebAssembly instantiation succeeds (memory_copy64.wast:216)
+PASS #267 Run a WebAssembly test without special assertions (memory_copy64.wast:225)
+PASS #268 Test that a WebAssembly code returns a specific result (memory_copy64.wast:227)
+PASS #269 Test that a WebAssembly code returns a specific result (memory_copy64.wast:228)
+PASS #270 Test that a WebAssembly code returns a specific result (memory_copy64.wast:229)
+PASS #271 Test that a WebAssembly code returns a specific result (memory_copy64.wast:230)
+PASS #272 Test that a WebAssembly code returns a specific result (memory_copy64.wast:231)
+PASS #273 Test that a WebAssembly code returns a specific result (memory_copy64.wast:232)
+PASS #274 Test that a WebAssembly code returns a specific result (memory_copy64.wast:233)
+PASS #275 Test that a WebAssembly code returns a specific result (memory_copy64.wast:234)
+PASS #276 Test that a WebAssembly code returns a specific result (memory_copy64.wast:235)
+PASS #277 Test that a WebAssembly code returns a specific result (memory_copy64.wast:236)
+PASS #278 Test that a WebAssembly code returns a specific result (memory_copy64.wast:237)
+PASS #279 Test that a WebAssembly code returns a specific result (memory_copy64.wast:238)
+PASS #280 Test that a WebAssembly code returns a specific result (memory_copy64.wast:239)
+PASS #281 Test that a WebAssembly code returns a specific result (memory_copy64.wast:240)
+PASS #282 Test that a WebAssembly code returns a specific result (memory_copy64.wast:241)
+PASS #283 Test that a WebAssembly code returns a specific result (memory_copy64.wast:242)
+PASS #284 Test that a WebAssembly code returns a specific result (memory_copy64.wast:243)
+PASS #285 Test that a WebAssembly code returns a specific result (memory_copy64.wast:244)
+PASS #286 Test that a WebAssembly code returns a specific result (memory_copy64.wast:245)
+PASS #287 Test that a WebAssembly code returns a specific result (memory_copy64.wast:246)
+PASS #288 Test that a WebAssembly code returns a specific result (memory_copy64.wast:247)
+PASS #289 Test that a WebAssembly code returns a specific result (memory_copy64.wast:248)
+PASS #290 Test that a WebAssembly code returns a specific result (memory_copy64.wast:249)
+PASS #291 Test that a WebAssembly code returns a specific result (memory_copy64.wast:250)
+PASS #292 Test that a WebAssembly code returns a specific result (memory_copy64.wast:251)
+PASS #293 Test that a WebAssembly code returns a specific result (memory_copy64.wast:252)
+PASS #294 Test that a WebAssembly code returns a specific result (memory_copy64.wast:253)
+PASS #295 Test that a WebAssembly code returns a specific result (memory_copy64.wast:254)
+PASS #296 Test that a WebAssembly code returns a specific result (memory_copy64.wast:255)
+PASS #297 Test that a WebAssembly code returns a specific result (memory_copy64.wast:256)
+PASS #298 Test that WebAssembly compilation succeeds (memory_copy64.wast:258)
+PASS #299 Test that WebAssembly instantiation succeeds (memory_copy64.wast:258)
+PASS #300 Run a WebAssembly test without special assertions (memory_copy64.wast:267)
+PASS #301 Test that a WebAssembly code returns a specific result (memory_copy64.wast:269)
+PASS #302 Test that a WebAssembly code returns a specific result (memory_copy64.wast:270)
+PASS #303 Test that a WebAssembly code returns a specific result (memory_copy64.wast:271)
+PASS #304 Test that a WebAssembly code returns a specific result (memory_copy64.wast:272)
+PASS #305 Test that a WebAssembly code returns a specific result (memory_copy64.wast:273)
+PASS #306 Test that a WebAssembly code returns a specific result (memory_copy64.wast:274)
+PASS #307 Test that a WebAssembly code returns a specific result (memory_copy64.wast:275)
+PASS #308 Test that a WebAssembly code returns a specific result (memory_copy64.wast:276)
+PASS #309 Test that a WebAssembly code returns a specific result (memory_copy64.wast:277)
+PASS #310 Test that a WebAssembly code returns a specific result (memory_copy64.wast:278)
+PASS #311 Test that a WebAssembly code returns a specific result (memory_copy64.wast:279)
+PASS #312 Test that a WebAssembly code returns a specific result (memory_copy64.wast:280)
+PASS #313 Test that a WebAssembly code returns a specific result (memory_copy64.wast:281)
+PASS #314 Test that a WebAssembly code returns a specific result (memory_copy64.wast:282)
+PASS #315 Test that a WebAssembly code returns a specific result (memory_copy64.wast:283)
+PASS #316 Test that a WebAssembly code returns a specific result (memory_copy64.wast:284)
+PASS #317 Test that a WebAssembly code returns a specific result (memory_copy64.wast:285)
+PASS #318 Test that a WebAssembly code returns a specific result (memory_copy64.wast:286)
+PASS #319 Test that a WebAssembly code returns a specific result (memory_copy64.wast:287)
+PASS #320 Test that a WebAssembly code returns a specific result (memory_copy64.wast:288)
+PASS #321 Test that a WebAssembly code returns a specific result (memory_copy64.wast:289)
+PASS #322 Test that a WebAssembly code returns a specific result (memory_copy64.wast:290)
+PASS #323 Test that a WebAssembly code returns a specific result (memory_copy64.wast:291)
+PASS #324 Test that a WebAssembly code returns a specific result (memory_copy64.wast:292)
+PASS #325 Test that a WebAssembly code returns a specific result (memory_copy64.wast:293)
+PASS #326 Test that a WebAssembly code returns a specific result (memory_copy64.wast:294)
+PASS #327 Test that a WebAssembly code returns a specific result (memory_copy64.wast:295)
+PASS #328 Test that a WebAssembly code returns a specific result (memory_copy64.wast:296)
+PASS #329 Test that a WebAssembly code returns a specific result (memory_copy64.wast:297)
+PASS #330 Test that a WebAssembly code returns a specific result (memory_copy64.wast:298)
+PASS #331 Test that WebAssembly compilation succeeds (memory_copy64.wast:300)
+PASS #332 Test that WebAssembly instantiation succeeds (memory_copy64.wast:300)
+PASS #333 Run a WebAssembly test without special assertions (memory_copy64.wast:309)
+PASS #334 Test that a WebAssembly code returns a specific result (memory_copy64.wast:311)
+PASS #335 Test that a WebAssembly code returns a specific result (memory_copy64.wast:312)
+PASS #336 Test that a WebAssembly code returns a specific result (memory_copy64.wast:313)
+PASS #337 Test that a WebAssembly code returns a specific result (memory_copy64.wast:314)
+PASS #338 Test that a WebAssembly code returns a specific result (memory_copy64.wast:315)
+PASS #339 Test that a WebAssembly code returns a specific result (memory_copy64.wast:316)
+PASS #340 Test that a WebAssembly code returns a specific result (memory_copy64.wast:317)
+PASS #341 Test that a WebAssembly code returns a specific result (memory_copy64.wast:318)
+PASS #342 Test that a WebAssembly code returns a specific result (memory_copy64.wast:319)
+PASS #343 Test that a WebAssembly code returns a specific result (memory_copy64.wast:320)
+PASS #344 Test that a WebAssembly code returns a specific result (memory_copy64.wast:321)
+PASS #345 Test that a WebAssembly code returns a specific result (memory_copy64.wast:322)
+PASS #346 Test that a WebAssembly code returns a specific result (memory_copy64.wast:323)
+PASS #347 Test that a WebAssembly code returns a specific result (memory_copy64.wast:324)
+PASS #348 Test that a WebAssembly code returns a specific result (memory_copy64.wast:325)
+PASS #349 Test that a WebAssembly code returns a specific result (memory_copy64.wast:326)
+PASS #350 Test that a WebAssembly code returns a specific result (memory_copy64.wast:327)
+PASS #351 Test that a WebAssembly code returns a specific result (memory_copy64.wast:328)
+PASS #352 Test that a WebAssembly code returns a specific result (memory_copy64.wast:329)
+PASS #353 Test that a WebAssembly code returns a specific result (memory_copy64.wast:330)
+PASS #354 Test that a WebAssembly code returns a specific result (memory_copy64.wast:331)
+PASS #355 Test that a WebAssembly code returns a specific result (memory_copy64.wast:332)
+PASS #356 Test that a WebAssembly code returns a specific result (memory_copy64.wast:333)
+PASS #357 Test that a WebAssembly code returns a specific result (memory_copy64.wast:334)
+PASS #358 Test that a WebAssembly code returns a specific result (memory_copy64.wast:335)
+PASS #359 Test that a WebAssembly code returns a specific result (memory_copy64.wast:336)
+PASS #360 Test that a WebAssembly code returns a specific result (memory_copy64.wast:337)
+PASS #361 Test that a WebAssembly code returns a specific result (memory_copy64.wast:338)
+PASS #362 Test that a WebAssembly code returns a specific result (memory_copy64.wast:339)
+PASS #363 Test that a WebAssembly code returns a specific result (memory_copy64.wast:340)
 PASS #364 Test that WebAssembly compilation succeeds (memory_copy64.wast:342)
 PASS #365 Test that WebAssembly instantiation succeeds (memory_copy64.wast:342)
 PASS #366 Test that a WebAssembly code traps (memory_copy64.wast:350)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_init64.wast.js-expected.txt
@@ -1,14 +1,14 @@
 
 PASS #1 Reinitialize the default imports
-FAIL #2 Test that WebAssembly compilation succeeds (memory_init64.wast:6) assert_equals: expected false but got true
-FAIL #3 Test that WebAssembly compilation succeeds (memory_init64.wast:50) assert_equals: expected false but got true
-FAIL #4 Test that WebAssembly compilation succeeds (memory_init64.wast:94) assert_equals: expected false but got true
-FAIL #5 Test that WebAssembly compilation succeeds (memory_init64.wast:138) assert_equals: expected false but got true
+PASS #2 Test that WebAssembly compilation succeeds (memory_init64.wast:6)
+PASS #3 Test that WebAssembly compilation succeeds (memory_init64.wast:50)
+PASS #4 Test that WebAssembly compilation succeeds (memory_init64.wast:94)
+PASS #5 Test that WebAssembly compilation succeeds (memory_init64.wast:138)
 PASS #6 Test that WebAssembly compilation fails (memory_init64.wast:189)
 PASS #7 Test that WebAssembly compilation fails (memory_init64.wast:195)
 PASS #8 Test that WebAssembly compilation succeeds (memory_init64.wast:203)
 PASS #9 Test that WebAssembly compilation succeeds (memory_init64.wast:211)
-FAIL #10 Test that WebAssembly compilation succeeds (memory_init64.wast:219) assert_equals: expected false but got true
+PASS #10 Test that WebAssembly compilation succeeds (memory_init64.wast:219)
 PASS #11 Test that WebAssembly compilation fails (memory_init64.wast:226)
 PASS #12 Test that WebAssembly compilation fails (memory_init64.wast:232)
 PASS #13 Test that WebAssembly compilation succeeds (memory_init64.wast:240)
@@ -92,394 +92,138 @@ PASS #90 Test that WebAssembly compilation succeeds (memory_init64.wast:907)
 PASS #91 Test that WebAssembly compilation succeeds (memory_init64.wast:930)
 PASS #92 Test that WebAssembly compilation succeeds (memory_init64.wast:954)
 PASS #93 Reinitialize the default imports
-FAIL #94 Test that WebAssembly compilation succeeds (memory_init64.wast:6) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 114: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #95 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:7:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #96 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:10:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #97 Test that a WebAssembly code returns a specific result (memory_init64.wast:19) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:13:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #98 Test that a WebAssembly code returns a specific result (memory_init64.wast:20) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:16:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #99 Test that a WebAssembly code returns a specific result (memory_init64.wast:21) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:19:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #100 Test that a WebAssembly code returns a specific result (memory_init64.wast:22) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:22:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #101 Test that a WebAssembly code returns a specific result (memory_init64.wast:23) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:25:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #102 Test that a WebAssembly code returns a specific result (memory_init64.wast:24) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:28:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #103 Test that a WebAssembly code returns a specific result (memory_init64.wast:25) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:31:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #104 Test that a WebAssembly code returns a specific result (memory_init64.wast:26) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:34:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #105 Test that a WebAssembly code returns a specific result (memory_init64.wast:27) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:37:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #106 Test that a WebAssembly code returns a specific result (memory_init64.wast:28) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:40:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #107 Test that a WebAssembly code returns a specific result (memory_init64.wast:29) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:43:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #108 Test that a WebAssembly code returns a specific result (memory_init64.wast:30) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:46:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #109 Test that a WebAssembly code returns a specific result (memory_init64.wast:31) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:49:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #110 Test that a WebAssembly code returns a specific result (memory_init64.wast:32) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:52:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #111 Test that a WebAssembly code returns a specific result (memory_init64.wast:33) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:55:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #112 Test that a WebAssembly code returns a specific result (memory_init64.wast:34) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:58:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #113 Test that a WebAssembly code returns a specific result (memory_init64.wast:35) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:61:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #114 Test that a WebAssembly code returns a specific result (memory_init64.wast:36) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:64:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #115 Test that a WebAssembly code returns a specific result (memory_init64.wast:37) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:67:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #116 Test that a WebAssembly code returns a specific result (memory_init64.wast:38) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:70:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #117 Test that a WebAssembly code returns a specific result (memory_init64.wast:39) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:73:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #118 Test that a WebAssembly code returns a specific result (memory_init64.wast:40) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:76:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #119 Test that a WebAssembly code returns a specific result (memory_init64.wast:41) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:79:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #120 Test that a WebAssembly code returns a specific result (memory_init64.wast:42) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:82:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #121 Test that a WebAssembly code returns a specific result (memory_init64.wast:43) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:85:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #122 Test that a WebAssembly code returns a specific result (memory_init64.wast:44) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:88:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #123 Test that a WebAssembly code returns a specific result (memory_init64.wast:45) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:91:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #124 Test that a WebAssembly code returns a specific result (memory_init64.wast:46) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:94:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #125 Test that a WebAssembly code returns a specific result (memory_init64.wast:47) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:97:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #126 Test that a WebAssembly code returns a specific result (memory_init64.wast:48) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:100:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #127 Test that WebAssembly compilation succeeds (memory_init64.wast:50) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 130: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #128 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:106:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #129 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:109:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #130 Test that a WebAssembly code returns a specific result (memory_init64.wast:63) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:112:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #131 Test that a WebAssembly code returns a specific result (memory_init64.wast:64) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:115:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #132 Test that a WebAssembly code returns a specific result (memory_init64.wast:65) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:118:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #133 Test that a WebAssembly code returns a specific result (memory_init64.wast:66) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:121:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #134 Test that a WebAssembly code returns a specific result (memory_init64.wast:67) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:124:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #135 Test that a WebAssembly code returns a specific result (memory_init64.wast:68) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:127:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #136 Test that a WebAssembly code returns a specific result (memory_init64.wast:69) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:130:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #137 Test that a WebAssembly code returns a specific result (memory_init64.wast:70) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:133:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #138 Test that a WebAssembly code returns a specific result (memory_init64.wast:71) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:136:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #139 Test that a WebAssembly code returns a specific result (memory_init64.wast:72) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:139:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #140 Test that a WebAssembly code returns a specific result (memory_init64.wast:73) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:142:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #141 Test that a WebAssembly code returns a specific result (memory_init64.wast:74) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:145:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #142 Test that a WebAssembly code returns a specific result (memory_init64.wast:75) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:148:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #143 Test that a WebAssembly code returns a specific result (memory_init64.wast:76) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:151:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #144 Test that a WebAssembly code returns a specific result (memory_init64.wast:77) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:154:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #145 Test that a WebAssembly code returns a specific result (memory_init64.wast:78) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:157:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #146 Test that a WebAssembly code returns a specific result (memory_init64.wast:79) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:160:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #147 Test that a WebAssembly code returns a specific result (memory_init64.wast:80) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:163:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #148 Test that a WebAssembly code returns a specific result (memory_init64.wast:81) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:166:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #149 Test that a WebAssembly code returns a specific result (memory_init64.wast:82) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:169:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #150 Test that a WebAssembly code returns a specific result (memory_init64.wast:83) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:172:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #151 Test that a WebAssembly code returns a specific result (memory_init64.wast:84) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:175:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #152 Test that a WebAssembly code returns a specific result (memory_init64.wast:85) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:178:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #153 Test that a WebAssembly code returns a specific result (memory_init64.wast:86) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:181:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #154 Test that a WebAssembly code returns a specific result (memory_init64.wast:87) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:184:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #155 Test that a WebAssembly code returns a specific result (memory_init64.wast:88) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:187:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #156 Test that a WebAssembly code returns a specific result (memory_init64.wast:89) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:190:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #157 Test that a WebAssembly code returns a specific result (memory_init64.wast:90) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:193:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #158 Test that a WebAssembly code returns a specific result (memory_init64.wast:91) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:196:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #159 Test that a WebAssembly code returns a specific result (memory_init64.wast:92) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:199:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #160 Test that WebAssembly compilation succeeds (memory_init64.wast:94) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 130: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #161 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:205:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #162 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:208:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #163 Test that a WebAssembly code returns a specific result (memory_init64.wast:107) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:211:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #164 Test that a WebAssembly code returns a specific result (memory_init64.wast:108) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:214:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #165 Test that a WebAssembly code returns a specific result (memory_init64.wast:109) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:217:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #166 Test that a WebAssembly code returns a specific result (memory_init64.wast:110) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:220:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #167 Test that a WebAssembly code returns a specific result (memory_init64.wast:111) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:223:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #168 Test that a WebAssembly code returns a specific result (memory_init64.wast:112) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:226:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #169 Test that a WebAssembly code returns a specific result (memory_init64.wast:113) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:229:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #170 Test that a WebAssembly code returns a specific result (memory_init64.wast:114) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:232:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #171 Test that a WebAssembly code returns a specific result (memory_init64.wast:115) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:235:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #172 Test that a WebAssembly code returns a specific result (memory_init64.wast:116) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:238:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #173 Test that a WebAssembly code returns a specific result (memory_init64.wast:117) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:241:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #174 Test that a WebAssembly code returns a specific result (memory_init64.wast:118) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:244:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #175 Test that a WebAssembly code returns a specific result (memory_init64.wast:119) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:247:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #176 Test that a WebAssembly code returns a specific result (memory_init64.wast:120) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:250:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #177 Test that a WebAssembly code returns a specific result (memory_init64.wast:121) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:253:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #178 Test that a WebAssembly code returns a specific result (memory_init64.wast:122) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:256:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #179 Test that a WebAssembly code returns a specific result (memory_init64.wast:123) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:259:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #180 Test that a WebAssembly code returns a specific result (memory_init64.wast:124) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:262:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #181 Test that a WebAssembly code returns a specific result (memory_init64.wast:125) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:265:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #182 Test that a WebAssembly code returns a specific result (memory_init64.wast:126) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:268:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #183 Test that a WebAssembly code returns a specific result (memory_init64.wast:127) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:271:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #184 Test that a WebAssembly code returns a specific result (memory_init64.wast:128) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:274:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #185 Test that a WebAssembly code returns a specific result (memory_init64.wast:129) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:277:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #186 Test that a WebAssembly code returns a specific result (memory_init64.wast:130) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:280:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #187 Test that a WebAssembly code returns a specific result (memory_init64.wast:131) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:283:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #188 Test that a WebAssembly code returns a specific result (memory_init64.wast:132) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:286:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #189 Test that a WebAssembly code returns a specific result (memory_init64.wast:133) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:289:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #190 Test that a WebAssembly code returns a specific result (memory_init64.wast:134) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:292:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #191 Test that a WebAssembly code returns a specific result (memory_init64.wast:135) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:295:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #192 Test that a WebAssembly code returns a specific result (memory_init64.wast:136) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:298:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #193 Test that WebAssembly compilation succeeds (memory_init64.wast:138) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 196: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #194 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:304:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #195 run assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') run@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:242:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:307:4
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #196 Test that a WebAssembly code returns a specific result (memory_init64.wast:159) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:310:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #197 Test that a WebAssembly code returns a specific result (memory_init64.wast:160) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:313:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #198 Test that a WebAssembly code returns a specific result (memory_init64.wast:161) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:316:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #199 Test that a WebAssembly code returns a specific result (memory_init64.wast:162) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:319:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #200 Test that a WebAssembly code returns a specific result (memory_init64.wast:163) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:322:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #201 Test that a WebAssembly code returns a specific result (memory_init64.wast:164) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:325:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #202 Test that a WebAssembly code returns a specific result (memory_init64.wast:165) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:328:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #203 Test that a WebAssembly code returns a specific result (memory_init64.wast:166) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:331:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #204 Test that a WebAssembly code returns a specific result (memory_init64.wast:167) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:334:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #205 Test that a WebAssembly code returns a specific result (memory_init64.wast:168) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:337:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #206 Test that a WebAssembly code returns a specific result (memory_init64.wast:169) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:340:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #207 Test that a WebAssembly code returns a specific result (memory_init64.wast:170) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:343:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #208 Test that a WebAssembly code returns a specific result (memory_init64.wast:171) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:346:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #209 Test that a WebAssembly code returns a specific result (memory_init64.wast:172) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:349:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #210 Test that a WebAssembly code returns a specific result (memory_init64.wast:173) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:352:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #211 Test that a WebAssembly code returns a specific result (memory_init64.wast:174) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:355:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #212 Test that a WebAssembly code returns a specific result (memory_init64.wast:175) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:358:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #213 Test that a WebAssembly code returns a specific result (memory_init64.wast:176) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:361:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #214 Test that a WebAssembly code returns a specific result (memory_init64.wast:177) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:364:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #215 Test that a WebAssembly code returns a specific result (memory_init64.wast:178) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:367:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #216 Test that a WebAssembly code returns a specific result (memory_init64.wast:179) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:370:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #217 Test that a WebAssembly code returns a specific result (memory_init64.wast:180) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:373:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #218 Test that a WebAssembly code returns a specific result (memory_init64.wast:181) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:376:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #219 Test that a WebAssembly code returns a specific result (memory_init64.wast:182) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:379:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #220 Test that a WebAssembly code returns a specific result (memory_init64.wast:183) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:382:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #221 Test that a WebAssembly code returns a specific result (memory_init64.wast:184) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:385:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #222 Test that a WebAssembly code returns a specific result (memory_init64.wast:185) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:388:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #223 Test that a WebAssembly code returns a specific result (memory_init64.wast:186) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:391:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #224 Test that a WebAssembly code returns a specific result (memory_init64.wast:187) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:394:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #225 Test that a WebAssembly code returns a specific result (memory_init64.wast:188) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:397:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
+PASS #94 Test that WebAssembly compilation succeeds (memory_init64.wast:6)
+PASS #95 Test that WebAssembly instantiation succeeds (memory_init64.wast:6)
+PASS #96 Run a WebAssembly test without special assertions (memory_init64.wast:17)
+PASS #97 Test that a WebAssembly code returns a specific result (memory_init64.wast:19)
+PASS #98 Test that a WebAssembly code returns a specific result (memory_init64.wast:20)
+PASS #99 Test that a WebAssembly code returns a specific result (memory_init64.wast:21)
+PASS #100 Test that a WebAssembly code returns a specific result (memory_init64.wast:22)
+PASS #101 Test that a WebAssembly code returns a specific result (memory_init64.wast:23)
+PASS #102 Test that a WebAssembly code returns a specific result (memory_init64.wast:24)
+PASS #103 Test that a WebAssembly code returns a specific result (memory_init64.wast:25)
+PASS #104 Test that a WebAssembly code returns a specific result (memory_init64.wast:26)
+PASS #105 Test that a WebAssembly code returns a specific result (memory_init64.wast:27)
+PASS #106 Test that a WebAssembly code returns a specific result (memory_init64.wast:28)
+PASS #107 Test that a WebAssembly code returns a specific result (memory_init64.wast:29)
+PASS #108 Test that a WebAssembly code returns a specific result (memory_init64.wast:30)
+PASS #109 Test that a WebAssembly code returns a specific result (memory_init64.wast:31)
+PASS #110 Test that a WebAssembly code returns a specific result (memory_init64.wast:32)
+PASS #111 Test that a WebAssembly code returns a specific result (memory_init64.wast:33)
+PASS #112 Test that a WebAssembly code returns a specific result (memory_init64.wast:34)
+PASS #113 Test that a WebAssembly code returns a specific result (memory_init64.wast:35)
+PASS #114 Test that a WebAssembly code returns a specific result (memory_init64.wast:36)
+PASS #115 Test that a WebAssembly code returns a specific result (memory_init64.wast:37)
+PASS #116 Test that a WebAssembly code returns a specific result (memory_init64.wast:38)
+PASS #117 Test that a WebAssembly code returns a specific result (memory_init64.wast:39)
+PASS #118 Test that a WebAssembly code returns a specific result (memory_init64.wast:40)
+PASS #119 Test that a WebAssembly code returns a specific result (memory_init64.wast:41)
+PASS #120 Test that a WebAssembly code returns a specific result (memory_init64.wast:42)
+PASS #121 Test that a WebAssembly code returns a specific result (memory_init64.wast:43)
+PASS #122 Test that a WebAssembly code returns a specific result (memory_init64.wast:44)
+PASS #123 Test that a WebAssembly code returns a specific result (memory_init64.wast:45)
+PASS #124 Test that a WebAssembly code returns a specific result (memory_init64.wast:46)
+PASS #125 Test that a WebAssembly code returns a specific result (memory_init64.wast:47)
+PASS #126 Test that a WebAssembly code returns a specific result (memory_init64.wast:48)
+PASS #127 Test that WebAssembly compilation succeeds (memory_init64.wast:50)
+PASS #128 Test that WebAssembly instantiation succeeds (memory_init64.wast:50)
+PASS #129 Run a WebAssembly test without special assertions (memory_init64.wast:61)
+PASS #130 Test that a WebAssembly code returns a specific result (memory_init64.wast:63)
+PASS #131 Test that a WebAssembly code returns a specific result (memory_init64.wast:64)
+PASS #132 Test that a WebAssembly code returns a specific result (memory_init64.wast:65)
+PASS #133 Test that a WebAssembly code returns a specific result (memory_init64.wast:66)
+PASS #134 Test that a WebAssembly code returns a specific result (memory_init64.wast:67)
+PASS #135 Test that a WebAssembly code returns a specific result (memory_init64.wast:68)
+PASS #136 Test that a WebAssembly code returns a specific result (memory_init64.wast:69)
+PASS #137 Test that a WebAssembly code returns a specific result (memory_init64.wast:70)
+PASS #138 Test that a WebAssembly code returns a specific result (memory_init64.wast:71)
+PASS #139 Test that a WebAssembly code returns a specific result (memory_init64.wast:72)
+PASS #140 Test that a WebAssembly code returns a specific result (memory_init64.wast:73)
+PASS #141 Test that a WebAssembly code returns a specific result (memory_init64.wast:74)
+PASS #142 Test that a WebAssembly code returns a specific result (memory_init64.wast:75)
+PASS #143 Test that a WebAssembly code returns a specific result (memory_init64.wast:76)
+PASS #144 Test that a WebAssembly code returns a specific result (memory_init64.wast:77)
+PASS #145 Test that a WebAssembly code returns a specific result (memory_init64.wast:78)
+PASS #146 Test that a WebAssembly code returns a specific result (memory_init64.wast:79)
+PASS #147 Test that a WebAssembly code returns a specific result (memory_init64.wast:80)
+PASS #148 Test that a WebAssembly code returns a specific result (memory_init64.wast:81)
+PASS #149 Test that a WebAssembly code returns a specific result (memory_init64.wast:82)
+PASS #150 Test that a WebAssembly code returns a specific result (memory_init64.wast:83)
+PASS #151 Test that a WebAssembly code returns a specific result (memory_init64.wast:84)
+PASS #152 Test that a WebAssembly code returns a specific result (memory_init64.wast:85)
+PASS #153 Test that a WebAssembly code returns a specific result (memory_init64.wast:86)
+PASS #154 Test that a WebAssembly code returns a specific result (memory_init64.wast:87)
+PASS #155 Test that a WebAssembly code returns a specific result (memory_init64.wast:88)
+PASS #156 Test that a WebAssembly code returns a specific result (memory_init64.wast:89)
+PASS #157 Test that a WebAssembly code returns a specific result (memory_init64.wast:90)
+PASS #158 Test that a WebAssembly code returns a specific result (memory_init64.wast:91)
+PASS #159 Test that a WebAssembly code returns a specific result (memory_init64.wast:92)
+PASS #160 Test that WebAssembly compilation succeeds (memory_init64.wast:94)
+PASS #161 Test that WebAssembly instantiation succeeds (memory_init64.wast:94)
+PASS #162 Run a WebAssembly test without special assertions (memory_init64.wast:105)
+PASS #163 Test that a WebAssembly code returns a specific result (memory_init64.wast:107)
+PASS #164 Test that a WebAssembly code returns a specific result (memory_init64.wast:108)
+PASS #165 Test that a WebAssembly code returns a specific result (memory_init64.wast:109)
+PASS #166 Test that a WebAssembly code returns a specific result (memory_init64.wast:110)
+PASS #167 Test that a WebAssembly code returns a specific result (memory_init64.wast:111)
+PASS #168 Test that a WebAssembly code returns a specific result (memory_init64.wast:112)
+PASS #169 Test that a WebAssembly code returns a specific result (memory_init64.wast:113)
+PASS #170 Test that a WebAssembly code returns a specific result (memory_init64.wast:114)
+PASS #171 Test that a WebAssembly code returns a specific result (memory_init64.wast:115)
+PASS #172 Test that a WebAssembly code returns a specific result (memory_init64.wast:116)
+PASS #173 Test that a WebAssembly code returns a specific result (memory_init64.wast:117)
+PASS #174 Test that a WebAssembly code returns a specific result (memory_init64.wast:118)
+PASS #175 Test that a WebAssembly code returns a specific result (memory_init64.wast:119)
+PASS #176 Test that a WebAssembly code returns a specific result (memory_init64.wast:120)
+PASS #177 Test that a WebAssembly code returns a specific result (memory_init64.wast:121)
+PASS #178 Test that a WebAssembly code returns a specific result (memory_init64.wast:122)
+PASS #179 Test that a WebAssembly code returns a specific result (memory_init64.wast:123)
+PASS #180 Test that a WebAssembly code returns a specific result (memory_init64.wast:124)
+PASS #181 Test that a WebAssembly code returns a specific result (memory_init64.wast:125)
+PASS #182 Test that a WebAssembly code returns a specific result (memory_init64.wast:126)
+PASS #183 Test that a WebAssembly code returns a specific result (memory_init64.wast:127)
+PASS #184 Test that a WebAssembly code returns a specific result (memory_init64.wast:128)
+PASS #185 Test that a WebAssembly code returns a specific result (memory_init64.wast:129)
+PASS #186 Test that a WebAssembly code returns a specific result (memory_init64.wast:130)
+PASS #187 Test that a WebAssembly code returns a specific result (memory_init64.wast:131)
+PASS #188 Test that a WebAssembly code returns a specific result (memory_init64.wast:132)
+PASS #189 Test that a WebAssembly code returns a specific result (memory_init64.wast:133)
+PASS #190 Test that a WebAssembly code returns a specific result (memory_init64.wast:134)
+PASS #191 Test that a WebAssembly code returns a specific result (memory_init64.wast:135)
+PASS #192 Test that a WebAssembly code returns a specific result (memory_init64.wast:136)
+PASS #193 Test that WebAssembly compilation succeeds (memory_init64.wast:138)
+PASS #194 Test that WebAssembly instantiation succeeds (memory_init64.wast:138)
+PASS #195 Run a WebAssembly test without special assertions (memory_init64.wast:157)
+PASS #196 Test that a WebAssembly code returns a specific result (memory_init64.wast:159)
+PASS #197 Test that a WebAssembly code returns a specific result (memory_init64.wast:160)
+PASS #198 Test that a WebAssembly code returns a specific result (memory_init64.wast:161)
+PASS #199 Test that a WebAssembly code returns a specific result (memory_init64.wast:162)
+PASS #200 Test that a WebAssembly code returns a specific result (memory_init64.wast:163)
+PASS #201 Test that a WebAssembly code returns a specific result (memory_init64.wast:164)
+PASS #202 Test that a WebAssembly code returns a specific result (memory_init64.wast:165)
+PASS #203 Test that a WebAssembly code returns a specific result (memory_init64.wast:166)
+PASS #204 Test that a WebAssembly code returns a specific result (memory_init64.wast:167)
+PASS #205 Test that a WebAssembly code returns a specific result (memory_init64.wast:168)
+PASS #206 Test that a WebAssembly code returns a specific result (memory_init64.wast:169)
+PASS #207 Test that a WebAssembly code returns a specific result (memory_init64.wast:170)
+PASS #208 Test that a WebAssembly code returns a specific result (memory_init64.wast:171)
+PASS #209 Test that a WebAssembly code returns a specific result (memory_init64.wast:172)
+PASS #210 Test that a WebAssembly code returns a specific result (memory_init64.wast:173)
+PASS #211 Test that a WebAssembly code returns a specific result (memory_init64.wast:174)
+PASS #212 Test that a WebAssembly code returns a specific result (memory_init64.wast:175)
+PASS #213 Test that a WebAssembly code returns a specific result (memory_init64.wast:176)
+PASS #214 Test that a WebAssembly code returns a specific result (memory_init64.wast:177)
+PASS #215 Test that a WebAssembly code returns a specific result (memory_init64.wast:178)
+PASS #216 Test that a WebAssembly code returns a specific result (memory_init64.wast:179)
+PASS #217 Test that a WebAssembly code returns a specific result (memory_init64.wast:180)
+PASS #218 Test that a WebAssembly code returns a specific result (memory_init64.wast:181)
+PASS #219 Test that a WebAssembly code returns a specific result (memory_init64.wast:182)
+PASS #220 Test that a WebAssembly code returns a specific result (memory_init64.wast:183)
+PASS #221 Test that a WebAssembly code returns a specific result (memory_init64.wast:184)
+PASS #222 Test that a WebAssembly code returns a specific result (memory_init64.wast:185)
+PASS #223 Test that a WebAssembly code returns a specific result (memory_init64.wast:186)
+PASS #224 Test that a WebAssembly code returns a specific result (memory_init64.wast:187)
+PASS #225 Test that a WebAssembly code returns a specific result (memory_init64.wast:188)
 PASS #226 Test that WebAssembly compilation fails (memory_init64.wast:189)
 PASS #227 Test that WebAssembly compilation fails (memory_init64.wast:195)
 PASS #228 Test that WebAssembly compilation succeeds (memory_init64.wast:203)
@@ -488,13 +232,9 @@ PASS #230 Run a WebAssembly test without special assertions (memory_init64.wast:
 PASS #231 Test that WebAssembly compilation succeeds (memory_init64.wast:211)
 PASS #232 Test that WebAssembly instantiation succeeds (memory_init64.wast:211)
 PASS #233 Test that a WebAssembly code traps (memory_init64.wast:217)
-FAIL #234 Test that WebAssembly compilation succeeds (memory_init64.wast:219) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 92: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #235 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:427:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
-FAIL #236 Test that a WebAssembly code traps (memory_init64.wast:224) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_init64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:430:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_init64.wast.js:795:3 expected true got false
+PASS #234 Test that WebAssembly compilation succeeds (memory_init64.wast:219)
+PASS #235 Test that WebAssembly instantiation succeeds (memory_init64.wast:219)
+PASS #236 Test that a WebAssembly code traps (memory_init64.wast:224)
 PASS #237 Test that WebAssembly compilation fails (memory_init64.wast:226)
 PASS #238 Test that WebAssembly compilation fails (memory_init64.wast:232)
 PASS #239 Test that WebAssembly compilation succeeds (memory_init64.wast:240)

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/core/memory64/memory_trap64.wast.js-expected.txt
@@ -1,7 +1,7 @@
 
 PASS #1 Reinitialize the default imports
 PASS #2 Test that WebAssembly compilation succeeds (memory_trap64.wast:1)
-FAIL #3 Test that WebAssembly compilation succeeds (memory_trap64.wast:34) assert_equals: expected false but got true
+PASS #3 Test that WebAssembly compilation succeeds (memory_trap64.wast:34)
 PASS #4 Test that WebAssembly compilation succeeds (wrapper)
 PASS #5 Test that WebAssembly compilation succeeds (wrapper)
 PASS #6 Test that WebAssembly compilation succeeds (wrapper)
@@ -65,770 +65,260 @@ PASS #63 Test that a WebAssembly code traps (memory_trap64.wast:29)
 PASS #64 Test that a WebAssembly code traps (memory_trap64.wast:30)
 PASS #65 Test that a WebAssembly code traps (memory_trap64.wast:31)
 PASS #66 Test that a WebAssembly code traps (memory_trap64.wast:32)
-FAIL #67 Test that WebAssembly compilation succeeds (memory_trap64.wast:34) assert_true: WebAssembly.compile failed unexpectedly with CompileError: WebAssembly.Module doesn't parse at byte 719: Data init_expr must produce an i32 at {loc} expected true got false
-FAIL #68 Test that WebAssembly instantiation succeeds assert_true: unexpected instantiation error, observed TypeError: undefined is not an object (evaluating 'values[0].source') instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:49:18
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #69 Test that a WebAssembly code traps (memory_trap64.wast:110) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:52:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #70 Test that a WebAssembly code traps (memory_trap64.wast:111) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:55:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #71 Test that a WebAssembly code traps (memory_trap64.wast:112) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:58:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #72 Test that a WebAssembly code traps (memory_trap64.wast:113) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:61:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #73 Test that a WebAssembly code traps (memory_trap64.wast:114) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:64:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #74 Test that a WebAssembly code traps (memory_trap64.wast:115) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:67:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #75 Test that a WebAssembly code traps (memory_trap64.wast:116) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:70:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #76 Test that a WebAssembly code traps (memory_trap64.wast:117) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:73:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #77 Test that a WebAssembly code traps (memory_trap64.wast:118) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:76:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #78 Test that a WebAssembly code traps (memory_trap64.wast:119) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:79:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #79 Test that a WebAssembly code traps (memory_trap64.wast:120) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:82:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #80 Test that a WebAssembly code traps (memory_trap64.wast:121) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:85:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #81 Test that a WebAssembly code traps (memory_trap64.wast:122) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:88:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #82 Test that a WebAssembly code traps (memory_trap64.wast:123) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:91:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #83 Test that a WebAssembly code traps (memory_trap64.wast:124) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:94:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #84 Test that a WebAssembly code traps (memory_trap64.wast:125) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:97:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #85 Test that a WebAssembly code traps (memory_trap64.wast:126) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:100:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #86 Test that a WebAssembly code traps (memory_trap64.wast:127) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:103:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #87 Test that a WebAssembly code traps (memory_trap64.wast:128) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:106:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #88 Test that a WebAssembly code traps (memory_trap64.wast:129) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:109:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #89 Test that a WebAssembly code traps (memory_trap64.wast:130) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:112:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #90 Test that a WebAssembly code traps (memory_trap64.wast:131) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:115:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #91 Test that a WebAssembly code traps (memory_trap64.wast:132) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:118:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #92 Test that a WebAssembly code traps (memory_trap64.wast:133) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:121:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #67 Test that WebAssembly compilation succeeds (memory_trap64.wast:34)
+PASS #68 Test that WebAssembly instantiation succeeds (memory_trap64.wast:34)
+PASS #69 Test that a WebAssembly code traps (memory_trap64.wast:110)
+PASS #70 Test that a WebAssembly code traps (memory_trap64.wast:111)
+PASS #71 Test that a WebAssembly code traps (memory_trap64.wast:112)
+PASS #72 Test that a WebAssembly code traps (memory_trap64.wast:113)
+PASS #73 Test that a WebAssembly code traps (memory_trap64.wast:114)
+PASS #74 Test that a WebAssembly code traps (memory_trap64.wast:115)
+PASS #75 Test that a WebAssembly code traps (memory_trap64.wast:116)
+PASS #76 Test that a WebAssembly code traps (memory_trap64.wast:117)
+PASS #77 Test that a WebAssembly code traps (memory_trap64.wast:118)
+PASS #78 Test that a WebAssembly code traps (memory_trap64.wast:119)
+PASS #79 Test that a WebAssembly code traps (memory_trap64.wast:120)
+PASS #80 Test that a WebAssembly code traps (memory_trap64.wast:121)
+PASS #81 Test that a WebAssembly code traps (memory_trap64.wast:122)
+PASS #82 Test that a WebAssembly code traps (memory_trap64.wast:123)
+PASS #83 Test that a WebAssembly code traps (memory_trap64.wast:124)
+PASS #84 Test that a WebAssembly code traps (memory_trap64.wast:125)
+PASS #85 Test that a WebAssembly code traps (memory_trap64.wast:126)
+PASS #86 Test that a WebAssembly code traps (memory_trap64.wast:127)
+PASS #87 Test that a WebAssembly code traps (memory_trap64.wast:128)
+PASS #88 Test that a WebAssembly code traps (memory_trap64.wast:129)
+PASS #89 Test that a WebAssembly code traps (memory_trap64.wast:130)
+PASS #90 Test that a WebAssembly code traps (memory_trap64.wast:131)
+PASS #91 Test that a WebAssembly code traps (memory_trap64.wast:132)
+PASS #92 Test that a WebAssembly code traps (memory_trap64.wast:133)
 PASS #93 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #94 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:124:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #95 Test that a WebAssembly code traps (memory_trap64.wast:134) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:124:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #94 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #95 Test that a WebAssembly code traps (memory_trap64.wast:134)
 PASS #96 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #97 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:127:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:127:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #98 Test that a WebAssembly code traps (memory_trap64.wast:135) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:127:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #97 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #98 Test that a WebAssembly code traps (memory_trap64.wast:135)
 PASS #99 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #100 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:130:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:130:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #101 Test that a WebAssembly code traps (memory_trap64.wast:136) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:130:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #100 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #101 Test that a WebAssembly code traps (memory_trap64.wast:136)
 PASS #102 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #103 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:133:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:133:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #104 Test that a WebAssembly code traps (memory_trap64.wast:137) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:133:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #103 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #104 Test that a WebAssembly code traps (memory_trap64.wast:137)
 PASS #105 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #106 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:136:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:136:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #107 Test that a WebAssembly code traps (memory_trap64.wast:138) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:136:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #106 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #107 Test that a WebAssembly code traps (memory_trap64.wast:138)
 PASS #108 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #109 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:139:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:139:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #110 Test that a WebAssembly code traps (memory_trap64.wast:139) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:139:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #109 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #110 Test that a WebAssembly code traps (memory_trap64.wast:139)
 PASS #111 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #112 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:142:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:142:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #113 Test that a WebAssembly code traps (memory_trap64.wast:140) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:142:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #112 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #113 Test that a WebAssembly code traps (memory_trap64.wast:140)
 PASS #114 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #115 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:145:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:145:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #116 Test that a WebAssembly code traps (memory_trap64.wast:141) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:145:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #115 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #116 Test that a WebAssembly code traps (memory_trap64.wast:141)
 PASS #117 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #118 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:148:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:148:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #119 Test that a WebAssembly code traps (memory_trap64.wast:142) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:148:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #118 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #119 Test that a WebAssembly code traps (memory_trap64.wast:142)
 PASS #120 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #121 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:151:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:151:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #122 Test that a WebAssembly code traps (memory_trap64.wast:143) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:151:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #121 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #122 Test that a WebAssembly code traps (memory_trap64.wast:143)
 PASS #123 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #124 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:154:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:154:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #125 Test that a WebAssembly code traps (memory_trap64.wast:144) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:154:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #124 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #125 Test that a WebAssembly code traps (memory_trap64.wast:144)
 PASS #126 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #127 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:157:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:157:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #128 Test that a WebAssembly code traps (memory_trap64.wast:145) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:157:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #127 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #128 Test that a WebAssembly code traps (memory_trap64.wast:145)
 PASS #129 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #130 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:160:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #131 Test that a WebAssembly code traps (memory_trap64.wast:146) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:160:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #130 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #131 Test that a WebAssembly code traps (memory_trap64.wast:146)
 PASS #132 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #133 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:163:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #134 Test that a WebAssembly code traps (memory_trap64.wast:147) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:163:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #133 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #134 Test that a WebAssembly code traps (memory_trap64.wast:147)
 PASS #135 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #136 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:166:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:166:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #137 Test that a WebAssembly code traps (memory_trap64.wast:148) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:166:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #136 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #137 Test that a WebAssembly code traps (memory_trap64.wast:148)
 PASS #138 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #139 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:169:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:169:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #140 Test that a WebAssembly code traps (memory_trap64.wast:149) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:169:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #139 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #140 Test that a WebAssembly code traps (memory_trap64.wast:149)
 PASS #141 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #142 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:172:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:172:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #143 Test that a WebAssembly code traps (memory_trap64.wast:150) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:172:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #142 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #143 Test that a WebAssembly code traps (memory_trap64.wast:150)
 PASS #144 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #145 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:175:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:175:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #146 Test that a WebAssembly code traps (memory_trap64.wast:151) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:175:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #145 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #146 Test that a WebAssembly code traps (memory_trap64.wast:151)
 PASS #147 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #148 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:178:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:178:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #149 Test that a WebAssembly code traps (memory_trap64.wast:152) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:178:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #148 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #149 Test that a WebAssembly code traps (memory_trap64.wast:152)
 PASS #150 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #151 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:181:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:181:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #152 Test that a WebAssembly code traps (memory_trap64.wast:153) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:181:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #151 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #152 Test that a WebAssembly code traps (memory_trap64.wast:153)
 PASS #153 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #154 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:184:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:184:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #155 Test that a WebAssembly code traps (memory_trap64.wast:154) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:184:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #154 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #155 Test that a WebAssembly code traps (memory_trap64.wast:154)
 PASS #156 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #157 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:187:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:187:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #158 Test that a WebAssembly code traps (memory_trap64.wast:155) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:187:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #157 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #158 Test that a WebAssembly code traps (memory_trap64.wast:155)
 PASS #159 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #160 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:190:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:190:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #161 Test that a WebAssembly code traps (memory_trap64.wast:156) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:190:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #160 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #161 Test that a WebAssembly code traps (memory_trap64.wast:156)
 PASS #162 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #163 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.store must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:193:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:193:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #164 Test that a WebAssembly code traps (memory_trap64.wast:157) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:193:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #165 Test that a WebAssembly code traps (memory_trap64.wast:158) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:196:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #166 Test that a WebAssembly code traps (memory_trap64.wast:159) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:199:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #167 Test that a WebAssembly code traps (memory_trap64.wast:160) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:202:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #168 Test that a WebAssembly code traps (memory_trap64.wast:161) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:205:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #169 Test that a WebAssembly code traps (memory_trap64.wast:162) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:208:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #170 Test that a WebAssembly code traps (memory_trap64.wast:163) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:211:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #171 Test that a WebAssembly code traps (memory_trap64.wast:164) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:214:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #172 Test that a WebAssembly code traps (memory_trap64.wast:165) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:217:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #173 Test that a WebAssembly code traps (memory_trap64.wast:166) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:220:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #174 Test that a WebAssembly code traps (memory_trap64.wast:167) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:223:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #175 Test that a WebAssembly code traps (memory_trap64.wast:168) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:226:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #176 Test that a WebAssembly code traps (memory_trap64.wast:169) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:229:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #177 Test that a WebAssembly code traps (memory_trap64.wast:170) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:232:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #178 Test that a WebAssembly code traps (memory_trap64.wast:171) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:235:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #179 Test that a WebAssembly code traps (memory_trap64.wast:172) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:238:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #180 Test that a WebAssembly code traps (memory_trap64.wast:173) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:241:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #181 Test that a WebAssembly code traps (memory_trap64.wast:174) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:244:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #182 Test that a WebAssembly code traps (memory_trap64.wast:175) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:247:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #183 Test that a WebAssembly code traps (memory_trap64.wast:176) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:250:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #184 Test that a WebAssembly code traps (memory_trap64.wast:177) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:253:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #185 Test that a WebAssembly code traps (memory_trap64.wast:178) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:256:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #186 Test that a WebAssembly code traps (memory_trap64.wast:179) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:259:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #187 Test that a WebAssembly code traps (memory_trap64.wast:180) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:262:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #188 Test that a WebAssembly code traps (memory_trap64.wast:181) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:265:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #189 Test that a WebAssembly code traps (memory_trap64.wast:182) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:268:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #190 Test that a WebAssembly code traps (memory_trap64.wast:183) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:271:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #191 Test that a WebAssembly code traps (memory_trap64.wast:184) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:274:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #192 Test that a WebAssembly code traps (memory_trap64.wast:185) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:277:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #193 Test that a WebAssembly code traps (memory_trap64.wast:186) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:280:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #194 Test that a WebAssembly code traps (memory_trap64.wast:187) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:283:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #195 Test that a WebAssembly code traps (memory_trap64.wast:188) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:286:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #196 Test that a WebAssembly code traps (memory_trap64.wast:189) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:289:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #197 Test that a WebAssembly code traps (memory_trap64.wast:190) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:292:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #198 Test that a WebAssembly code traps (memory_trap64.wast:191) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:295:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #199 Test that a WebAssembly code traps (memory_trap64.wast:192) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:298:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #200 Test that a WebAssembly code traps (memory_trap64.wast:193) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:301:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #201 Test that a WebAssembly code traps (memory_trap64.wast:194) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:304:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #202 Test that a WebAssembly code traps (memory_trap64.wast:195) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:307:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #203 Test that a WebAssembly code traps (memory_trap64.wast:196) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:310:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #204 Test that a WebAssembly code traps (memory_trap64.wast:197) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:313:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #205 Test that a WebAssembly code traps (memory_trap64.wast:198) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:316:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #206 Test that a WebAssembly code traps (memory_trap64.wast:199) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:319:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #207 Test that a WebAssembly code traps (memory_trap64.wast:200) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:322:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #208 Test that a WebAssembly code traps (memory_trap64.wast:201) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:325:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #163 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #164 Test that a WebAssembly code traps (memory_trap64.wast:157)
+PASS #165 Test that a WebAssembly code traps (memory_trap64.wast:158)
+PASS #166 Test that a WebAssembly code traps (memory_trap64.wast:159)
+PASS #167 Test that a WebAssembly code traps (memory_trap64.wast:160)
+PASS #168 Test that a WebAssembly code traps (memory_trap64.wast:161)
+PASS #169 Test that a WebAssembly code traps (memory_trap64.wast:162)
+PASS #170 Test that a WebAssembly code traps (memory_trap64.wast:163)
+PASS #171 Test that a WebAssembly code traps (memory_trap64.wast:164)
+PASS #172 Test that a WebAssembly code traps (memory_trap64.wast:165)
+PASS #173 Test that a WebAssembly code traps (memory_trap64.wast:166)
+PASS #174 Test that a WebAssembly code traps (memory_trap64.wast:167)
+PASS #175 Test that a WebAssembly code traps (memory_trap64.wast:168)
+PASS #176 Test that a WebAssembly code traps (memory_trap64.wast:169)
+PASS #177 Test that a WebAssembly code traps (memory_trap64.wast:170)
+PASS #178 Test that a WebAssembly code traps (memory_trap64.wast:171)
+PASS #179 Test that a WebAssembly code traps (memory_trap64.wast:172)
+PASS #180 Test that a WebAssembly code traps (memory_trap64.wast:173)
+PASS #181 Test that a WebAssembly code traps (memory_trap64.wast:174)
+PASS #182 Test that a WebAssembly code traps (memory_trap64.wast:175)
+PASS #183 Test that a WebAssembly code traps (memory_trap64.wast:176)
+PASS #184 Test that a WebAssembly code traps (memory_trap64.wast:177)
+PASS #185 Test that a WebAssembly code traps (memory_trap64.wast:178)
+PASS #186 Test that a WebAssembly code traps (memory_trap64.wast:179)
+PASS #187 Test that a WebAssembly code traps (memory_trap64.wast:180)
+PASS #188 Test that a WebAssembly code traps (memory_trap64.wast:181)
+PASS #189 Test that a WebAssembly code traps (memory_trap64.wast:182)
+PASS #190 Test that a WebAssembly code traps (memory_trap64.wast:183)
+PASS #191 Test that a WebAssembly code traps (memory_trap64.wast:184)
+PASS #192 Test that a WebAssembly code traps (memory_trap64.wast:185)
+PASS #193 Test that a WebAssembly code traps (memory_trap64.wast:186)
+PASS #194 Test that a WebAssembly code traps (memory_trap64.wast:187)
+PASS #195 Test that a WebAssembly code traps (memory_trap64.wast:188)
+PASS #196 Test that a WebAssembly code traps (memory_trap64.wast:189)
+PASS #197 Test that a WebAssembly code traps (memory_trap64.wast:190)
+PASS #198 Test that a WebAssembly code traps (memory_trap64.wast:191)
+PASS #199 Test that a WebAssembly code traps (memory_trap64.wast:192)
+PASS #200 Test that a WebAssembly code traps (memory_trap64.wast:193)
+PASS #201 Test that a WebAssembly code traps (memory_trap64.wast:194)
+PASS #202 Test that a WebAssembly code traps (memory_trap64.wast:195)
+PASS #203 Test that a WebAssembly code traps (memory_trap64.wast:196)
+PASS #204 Test that a WebAssembly code traps (memory_trap64.wast:197)
+PASS #205 Test that a WebAssembly code traps (memory_trap64.wast:198)
+PASS #206 Test that a WebAssembly code traps (memory_trap64.wast:199)
+PASS #207 Test that a WebAssembly code traps (memory_trap64.wast:200)
+PASS #208 Test that a WebAssembly code traps (memory_trap64.wast:201)
 PASS #209 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #210 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:328:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #211 Test that a WebAssembly code traps (memory_trap64.wast:202) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:328:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #210 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #211 Test that a WebAssembly code traps (memory_trap64.wast:202)
 PASS #212 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #213 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:331:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #214 Test that a WebAssembly code traps (memory_trap64.wast:203) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:331:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #213 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #214 Test that a WebAssembly code traps (memory_trap64.wast:203)
 PASS #215 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #216 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:334:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #217 Test that a WebAssembly code traps (memory_trap64.wast:204) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:334:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #216 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #217 Test that a WebAssembly code traps (memory_trap64.wast:204)
 PASS #218 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #219 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:337:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #220 Test that a WebAssembly code traps (memory_trap64.wast:205) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:337:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #219 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #220 Test that a WebAssembly code traps (memory_trap64.wast:205)
 PASS #221 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #222 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:340:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #223 Test that a WebAssembly code traps (memory_trap64.wast:206) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:340:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #222 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #223 Test that a WebAssembly code traps (memory_trap64.wast:206)
 PASS #224 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #225 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:343:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #226 Test that a WebAssembly code traps (memory_trap64.wast:207) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:343:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #225 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #226 Test that a WebAssembly code traps (memory_trap64.wast:207)
 PASS #227 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #228 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:346:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #229 Test that a WebAssembly code traps (memory_trap64.wast:208) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:346:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #228 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #229 Test that a WebAssembly code traps (memory_trap64.wast:208)
 PASS #230 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #231 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f32.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:349:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #232 Test that a WebAssembly code traps (memory_trap64.wast:209) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:349:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #231 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #232 Test that a WebAssembly code traps (memory_trap64.wast:209)
 PASS #233 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #234 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:352:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #235 Test that a WebAssembly code traps (memory_trap64.wast:210) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:352:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #234 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #235 Test that a WebAssembly code traps (memory_trap64.wast:210)
 PASS #236 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #237 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:355:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #238 Test that a WebAssembly code traps (memory_trap64.wast:211) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:355:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #237 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #238 Test that a WebAssembly code traps (memory_trap64.wast:211)
 PASS #239 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #240 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:358:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:358:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #241 Test that a WebAssembly code traps (memory_trap64.wast:212) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:358:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #240 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #241 Test that a WebAssembly code traps (memory_trap64.wast:212)
 PASS #242 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #243 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:361:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:361:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #244 Test that a WebAssembly code traps (memory_trap64.wast:213) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:361:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #243 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #244 Test that a WebAssembly code traps (memory_trap64.wast:213)
 PASS #245 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #246 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:364:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:364:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #247 Test that a WebAssembly code traps (memory_trap64.wast:214) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:364:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #246 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #247 Test that a WebAssembly code traps (memory_trap64.wast:214)
 PASS #248 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #249 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:367:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:367:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #250 Test that a WebAssembly code traps (memory_trap64.wast:215) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:367:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #249 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #250 Test that a WebAssembly code traps (memory_trap64.wast:215)
 PASS #251 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #252 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:370:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:370:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #253 Test that a WebAssembly code traps (memory_trap64.wast:216) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:370:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #252 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #253 Test that a WebAssembly code traps (memory_trap64.wast:216)
 PASS #254 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #255 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:373:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:373:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #256 Test that a WebAssembly code traps (memory_trap64.wast:217) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:373:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #255 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #256 Test that a WebAssembly code traps (memory_trap64.wast:217)
 PASS #257 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #258 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:376:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:376:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #259 Test that a WebAssembly code traps (memory_trap64.wast:218) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:376:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #258 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #259 Test that a WebAssembly code traps (memory_trap64.wast:218)
 PASS #260 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #261 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:379:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:379:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #262 Test that a WebAssembly code traps (memory_trap64.wast:219) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:379:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #261 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #262 Test that a WebAssembly code traps (memory_trap64.wast:219)
 PASS #263 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #264 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:382:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:382:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #265 Test that a WebAssembly code traps (memory_trap64.wast:220) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:382:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #264 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #265 Test that a WebAssembly code traps (memory_trap64.wast:220)
 PASS #266 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #267 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:385:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:385:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #268 Test that a WebAssembly code traps (memory_trap64.wast:221) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:385:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #267 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #268 Test that a WebAssembly code traps (memory_trap64.wast:221)
 PASS #269 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #270 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:388:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:388:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #271 Test that a WebAssembly code traps (memory_trap64.wast:222) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:388:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #270 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #271 Test that a WebAssembly code traps (memory_trap64.wast:222)
 PASS #272 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #273 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:391:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:391:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #274 Test that a WebAssembly code traps (memory_trap64.wast:223) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:391:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #273 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #274 Test that a WebAssembly code traps (memory_trap64.wast:223)
 PASS #275 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #276 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:394:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:394:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #277 Test that a WebAssembly code traps (memory_trap64.wast:224) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:394:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #276 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #277 Test that a WebAssembly code traps (memory_trap64.wast:224)
 PASS #278 Test that WebAssembly compilation succeeds (wrapper)
-FAIL #279 Test that WebAssembly instantiation succeeds (wrapper) assert_true: unexpected instantiation error, observed TypeError: import module:f64.load must be an object instance@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:201:24
-@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:397:32
-assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:264:37
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:397:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #280 Test that a WebAssembly code traps (memory_trap64.wast:225) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:397:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #281 Test that a WebAssembly code traps (memory_trap64.wast:226) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:400:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #282 Test that a WebAssembly code traps (memory_trap64.wast:227) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:403:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #283 Test that a WebAssembly code traps (memory_trap64.wast:228) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:406:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #284 Test that a WebAssembly code traps (memory_trap64.wast:229) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:409:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #285 Test that a WebAssembly code traps (memory_trap64.wast:230) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:412:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #286 Test that a WebAssembly code traps (memory_trap64.wast:231) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:415:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #287 Test that a WebAssembly code traps (memory_trap64.wast:232) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:418:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #288 Test that a WebAssembly code traps (memory_trap64.wast:233) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:421:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #289 Test that a WebAssembly code traps (memory_trap64.wast:234) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:424:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #290 Test that a WebAssembly code traps (memory_trap64.wast:235) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:427:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #291 Test that a WebAssembly code traps (memory_trap64.wast:236) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:430:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #292 Test that a WebAssembly code traps (memory_trap64.wast:237) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:433:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #293 Test that a WebAssembly code traps (memory_trap64.wast:238) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:436:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #294 Test that a WebAssembly code traps (memory_trap64.wast:239) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:439:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #295 Test that a WebAssembly code traps (memory_trap64.wast:240) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:442:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #296 Test that a WebAssembly code traps (memory_trap64.wast:241) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:445:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #297 Test that a WebAssembly code traps (memory_trap64.wast:242) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:448:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #298 Test that a WebAssembly code traps (memory_trap64.wast:243) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:451:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #299 Test that a WebAssembly code traps (memory_trap64.wast:244) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:454:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #300 Test that a WebAssembly code traps (memory_trap64.wast:245) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:457:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #301 Test that a WebAssembly code traps (memory_trap64.wast:246) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:460:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #302 Test that a WebAssembly code traps (memory_trap64.wast:247) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:463:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #303 Test that a WebAssembly code traps (memory_trap64.wast:248) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:466:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #304 Test that a WebAssembly code traps (memory_trap64.wast:249) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:469:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #305 Test that a WebAssembly code traps (memory_trap64.wast:250) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:472:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #306 Test that a WebAssembly code traps (memory_trap64.wast:251) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:475:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #307 Test that a WebAssembly code traps (memory_trap64.wast:252) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:478:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #308 Test that a WebAssembly code traps (memory_trap64.wast:253) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:481:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #309 Test that a WebAssembly code traps (memory_trap64.wast:254) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:484:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #310 Test that a WebAssembly code traps (memory_trap64.wast:255) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:487:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #311 Test that a WebAssembly code traps (memory_trap64.wast:256) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:490:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #312 Test that a WebAssembly code traps (memory_trap64.wast:257) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:493:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #313 Test that a WebAssembly code traps (memory_trap64.wast:258) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:496:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #314 Test that a WebAssembly code traps (memory_trap64.wast:259) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:499:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #315 Test that a WebAssembly code traps (memory_trap64.wast:260) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:502:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #316 Test that a WebAssembly code traps (memory_trap64.wast:261) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:505:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #317 Test that a WebAssembly code traps (memory_trap64.wast:262) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:508:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #318 Test that a WebAssembly code traps (memory_trap64.wast:263) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:511:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #319 Test that a WebAssembly code traps (memory_trap64.wast:264) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:514:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #320 Test that a WebAssembly code traps (memory_trap64.wast:265) assert_true: expected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_trap@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:263:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:517:12
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #321 Test that a WebAssembly code returns a specific result (memory_trap64.wast:268) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:520:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
-FAIL #322 Test that a WebAssembly code returns a specific result (memory_trap64.wast:269) assert_true: unexpected runtime error, observed TypeError: undefined is not an object (evaluating 'values[0].exports[name]') assert_return@http://web-platform.test:8800/wasm/core/js/harness/async_index.js:306:24
-memory_trap64_wast_js@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:523:14
-global code@http://web-platform.test:8800/wasm/core/js/memory64/memory_trap64.wast.js:525:3 expected true got false
+PASS #279 Test that WebAssembly instantiation succeeds (wrapper)
+PASS #280 Test that a WebAssembly code traps (memory_trap64.wast:225)
+PASS #281 Test that a WebAssembly code traps (memory_trap64.wast:226)
+PASS #282 Test that a WebAssembly code traps (memory_trap64.wast:227)
+PASS #283 Test that a WebAssembly code traps (memory_trap64.wast:228)
+PASS #284 Test that a WebAssembly code traps (memory_trap64.wast:229)
+PASS #285 Test that a WebAssembly code traps (memory_trap64.wast:230)
+PASS #286 Test that a WebAssembly code traps (memory_trap64.wast:231)
+PASS #287 Test that a WebAssembly code traps (memory_trap64.wast:232)
+PASS #288 Test that a WebAssembly code traps (memory_trap64.wast:233)
+PASS #289 Test that a WebAssembly code traps (memory_trap64.wast:234)
+PASS #290 Test that a WebAssembly code traps (memory_trap64.wast:235)
+PASS #291 Test that a WebAssembly code traps (memory_trap64.wast:236)
+PASS #292 Test that a WebAssembly code traps (memory_trap64.wast:237)
+PASS #293 Test that a WebAssembly code traps (memory_trap64.wast:238)
+PASS #294 Test that a WebAssembly code traps (memory_trap64.wast:239)
+PASS #295 Test that a WebAssembly code traps (memory_trap64.wast:240)
+PASS #296 Test that a WebAssembly code traps (memory_trap64.wast:241)
+PASS #297 Test that a WebAssembly code traps (memory_trap64.wast:242)
+PASS #298 Test that a WebAssembly code traps (memory_trap64.wast:243)
+PASS #299 Test that a WebAssembly code traps (memory_trap64.wast:244)
+PASS #300 Test that a WebAssembly code traps (memory_trap64.wast:245)
+PASS #301 Test that a WebAssembly code traps (memory_trap64.wast:246)
+PASS #302 Test that a WebAssembly code traps (memory_trap64.wast:247)
+PASS #303 Test that a WebAssembly code traps (memory_trap64.wast:248)
+PASS #304 Test that a WebAssembly code traps (memory_trap64.wast:249)
+PASS #305 Test that a WebAssembly code traps (memory_trap64.wast:250)
+PASS #306 Test that a WebAssembly code traps (memory_trap64.wast:251)
+PASS #307 Test that a WebAssembly code traps (memory_trap64.wast:252)
+PASS #308 Test that a WebAssembly code traps (memory_trap64.wast:253)
+PASS #309 Test that a WebAssembly code traps (memory_trap64.wast:254)
+PASS #310 Test that a WebAssembly code traps (memory_trap64.wast:255)
+PASS #311 Test that a WebAssembly code traps (memory_trap64.wast:256)
+PASS #312 Test that a WebAssembly code traps (memory_trap64.wast:257)
+PASS #313 Test that a WebAssembly code traps (memory_trap64.wast:258)
+PASS #314 Test that a WebAssembly code traps (memory_trap64.wast:259)
+PASS #315 Test that a WebAssembly code traps (memory_trap64.wast:260)
+PASS #316 Test that a WebAssembly code traps (memory_trap64.wast:261)
+PASS #317 Test that a WebAssembly code traps (memory_trap64.wast:262)
+PASS #318 Test that a WebAssembly code traps (memory_trap64.wast:263)
+PASS #319 Test that a WebAssembly code traps (memory_trap64.wast:264)
+PASS #320 Test that a WebAssembly code traps (memory_trap64.wast:265)
+PASS #321 Test that a WebAssembly code returns a specific result (memory_trap64.wast:268)
+PASS #322 Test that a WebAssembly code returns a specific result (memory_trap64.wast:269)
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -658,7 +658,7 @@ class I32InitExpr {
         ExtendedExpression
     };
 
-    I32InitExpr(Type type, uint32_t bits)
+    I32InitExpr(Type type, uint64_t bits)
         : m_bits(bits)
         , m_type(type)
     { }
@@ -666,33 +666,35 @@ class I32InitExpr {
 public:
     I32InitExpr() = delete;
 
-    static I32InitExpr globalImport(uint32_t globalImportNumber) { return I32InitExpr(Global, globalImportNumber); }
-    static I32InitExpr constValue(uint32_t constValue) { return I32InitExpr(Const, constValue); }
-    static I32InitExpr extendedExpression(uint32_t constantExpressionNumber) { return I32InitExpr(ExtendedExpression, constantExpressionNumber); }
+    static I32InitExpr globalImport(uint64_t globalImportNumber) { return I32InitExpr(Global, globalImportNumber); }
+    static I32InitExpr constValue(uint64_t constValue) { return I32InitExpr(Const, constValue); }
+    static I32InitExpr extendedExpression(uint64_t constantExpressionNumber) { return I32InitExpr(ExtendedExpression, constantExpressionNumber); }
 
     bool isConst() const { return m_type == Const; }
     bool isGlobalImport() const { return m_type == Global; }
     bool isExtendedExpression() const { return m_type == ExtendedExpression; }
-    uint32_t constValue() const
+    uint64_t constValue() const
     {
         RELEASE_ASSERT(isConst());
         return m_bits;
     }
-    uint32_t globalImportIndex() const
+    uint64_t globalImportIndex() const
     {
         RELEASE_ASSERT(isGlobalImport());
         return m_bits;
     }
-    uint32_t constantExpressionIndex() const
+    uint64_t constantExpressionIndex() const
     {
         RELEASE_ASSERT(isExtendedExpression());
         return m_bits;
     }
 
 private:
-    uint32_t m_bits;
+    uint64_t m_bits;
     Type m_type;
 };
+
+using I64InitExpr = I32InitExpr;
 
 class Segment final : public TrailingArray<Segment, uint8_t> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Segment);

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -373,7 +373,7 @@ ALWAYS_INLINE bool ParserBase::parseExternalKind(ExternalKind& result)
     return true;
 }
 
-ALWAYS_INLINE I32InitExpr makeI32InitExpr(uint8_t opcode, bool isExtendedConstantExpression, uint32_t bits)
+ALWAYS_INLINE I32InitExpr makeI32InitExpr(uint8_t opcode, bool isExtendedConstantExpression, uint64_t bits)
 {
     RELEASE_ASSERT(opcode == I32Const || opcode == GetGlobal);
     if (isExtendedConstantExpression)
@@ -381,6 +381,16 @@ ALWAYS_INLINE I32InitExpr makeI32InitExpr(uint8_t opcode, bool isExtendedConstan
     if (opcode == I32Const)
         return I32InitExpr::constValue(bits);
     return I32InitExpr::globalImport(bits);
+}
+
+ALWAYS_INLINE I64InitExpr makeI64InitExpr(uint8_t opcode, bool isExtendedConstantExpression, uint64_t bits)
+{
+    RELEASE_ASSERT(opcode == I64Const || opcode == GetGlobal);
+    if (isExtendedConstantExpression)
+        return I64InitExpr::extendedExpression(bits);
+    if (opcode == I64Const)
+        return I64InitExpr::constValue(bits);
+    return I64InitExpr::globalImport(bits);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -888,6 +888,20 @@ auto SectionParser::parseI32InitExpr(std::optional<I32InitExpr>& initExpr, ASCII
     return { };
 }
 
+auto SectionParser::parseI64InitExpr(std::optional<I64InitExpr>& initExpr, ASCIILiteral failMessage) -> PartialResult
+{
+    uint8_t initOpcode;
+    bool isExtendedConstantExpression;
+    uint64_t initExprBits;
+    Type initExprType;
+    v128_t unused;
+    WASM_FAIL_IF_HELPER_FAILS(parseInitExpr(initOpcode, isExtendedConstantExpression, initExprBits, unused, Types::I64, initExprType));
+    WASM_PARSER_FAIL_IF(!initExprType.isI64(), failMessage);
+    initExpr = makeI64InitExpr(initOpcode, isExtendedConstantExpression, initExprBits);
+
+    return { };
+}
+
 auto SectionParser::parseFunctionType(uint32_t position, ParsedDef& functionSignature) -> PartialResult
 {
     uint32_t argumentCount;
@@ -1299,6 +1313,11 @@ auto SectionParser::parseI32InitExprForDataSection(std::optional<I32InitExpr>& i
     return parseI32InitExpr(initExpr, "Data init_expr must produce an i32"_s);
 }
 
+auto SectionParser::parseI64InitExprForDataSection(std::optional<I64InitExpr>& initExpr) -> PartialResult
+{
+    return parseI64InitExpr(initExpr, "Data init_expr must produce an i64"_s);
+}
+
 auto SectionParser::parseGlobalType(GlobalInformation& global) -> PartialResult
 {
     uint8_t mutability;
@@ -1328,7 +1347,10 @@ auto SectionParser::parseData() -> PartialResult
             WASM_PARSER_FAIL_IF(memoryIndex >= m_info->memoryCount(), segmentNumber, "th Data segment has index "_s, memoryIndex, " which exceeds the number of Memories "_s, m_info->memoryCount());
 
             std::optional<I32InitExpr> initExpr;
-            WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForDataSection(initExpr));
+            if (m_info->memory(memoryIndex).isMemory64())
+                WASM_FAIL_IF_HELPER_FAILS(parseI64InitExprForDataSection(initExpr));
+            else
+                WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForDataSection(initExpr));
 
             uint32_t dataByteLength;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get "_s, segmentNumber, "th Data segment's data byte length"_s);
@@ -1369,7 +1391,10 @@ auto SectionParser::parseData() -> PartialResult
             WASM_PARSER_FAIL_IF(memoryIndex >= m_info->memoryCount(), segmentNumber, "th Data segment has index "_s, memoryIndex, " which exceeds the number of Memories "_s, m_info->memoryCount());
 
             std::optional<I32InitExpr> initExpr;
-            WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForDataSection(initExpr));
+            if (m_info->memory(memoryIndex).isMemory64())
+                WASM_FAIL_IF_HELPER_FAILS(parseI64InitExprForDataSection(initExpr));
+            else
+                WASM_FAIL_IF_HELPER_FAILS(parseI32InitExprForDataSection(initExpr));
 
             uint32_t dataByteLength;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(dataByteLength), "can't get "_s, segmentNumber, "th Data segment's data byte length"_s);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -71,6 +71,7 @@ private:
     [[nodiscard]] PartialResult parseResizableLimits(uint64_t& initial, std::optional<uint64_t>& maximum, bool& isShared, bool& is64bit);
     [[nodiscard]] PartialResult parseInitExpr(uint8_t&, bool&, uint64_t&, v128_t&, Type, Type& initExprType);
     [[nodiscard]] PartialResult parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);
+    [[nodiscard]] PartialResult parseI64InitExpr(std::optional<I64InitExpr>&, ASCIILiteral failMessage);
 
     [[nodiscard]] PartialResult parseFunctionType(uint32_t position, ParsedDef&);
     [[nodiscard]] PartialResult parsePackedType(PackedType&);
@@ -88,6 +89,7 @@ private:
     [[nodiscard]] PartialResult parseElementSegmentVectorOfIndexes(Vector<Element::InitializationType>&, Vector<uint64_t>&, const unsigned, const unsigned);
 
     [[nodiscard]] PartialResult parseI32InitExprForDataSection(std::optional<I32InitExpr>&);
+    [[nodiscard]] PartialResult parseI64InitExprForDataSection(std::optional<I64InitExpr>&);
 
     static bool checkStructuralSubtype(const RTT& subRTT, const RTT& expandedRTT);
     [[nodiscard]] PartialResult checkSubtypeValidity(const Subtype&, const RTT& canonicalRTT);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -868,16 +868,16 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
             uint8_t* memory = static_cast<uint8_t*>(wasmMemory.basePointer());
             uint64_t sizeInBytes = wasmMemory.size();
 
-            uint32_t offset = 0;
+            uint64_t offset = 0;
             if (segment->offsetIfActive()->isGlobalImport())
-                offset = static_cast<uint32_t>(m_instance->loadI32Global(segment->offsetIfActive()->globalImportIndex()));
+                offset = static_cast<uint64_t>(m_instance->loadI32Global(segment->offsetIfActive()->globalImportIndex()));
             else if (segment->offsetIfActive()->isConst())
                 offset = segment->offsetIfActive()->constValue();
             else {
                 uint64_t result;
                 evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[segment->offsetIfActive()->constantExpressionIndex()], moduleInformation, Wasm::Types::I32, result);
                 RETURN_IF_EXCEPTION(scope, void());
-                offset = static_cast<uint32_t>(result);
+                offset = result;
             }
 
             if (fn(memory, sizeInBytes, segment, offset) == IterationStatus::Done)
@@ -904,13 +904,13 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
         return exception.value();
 
     // Validation of all segment ranges comes before all Table and Memory initialization.
-    forEachActiveDataSegment([&](uint8_t* memory, uint64_t sizeInBytes, const std::unique_ptr<Wasm::Segment>& segment, uint32_t offset) {
+    forEachActiveDataSegment([&](uint8_t* memory, uint64_t sizeInBytes, const std::unique_ptr<Wasm::Segment>& segment, uint64_t offset) {
         if (sizeInBytes < segment->sizeInBytes()) [[unlikely]] {
-            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes(), offset, ", segment is too big"_s);
+            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, static_cast<uint64_t>(segment->sizeInBytes()), offset, ", segment is too big"_s);
             return IterationStatus::Done;
         }
         if (offset > sizeInBytes - segment->sizeInBytes()) [[unlikely]] {
-            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, segment->sizeInBytes(), offset, ", segment writes outside of memory"_s);
+            exception = dataSegmentFail(globalObject, vm, scope, sizeInBytes, static_cast<uint64_t>(segment->sizeInBytes()), offset, ", segment writes outside of memory"_s);
             return IterationStatus::Done;
         }
 


### PR DESCRIPTION
#### 6cc8cf35745f32def288fac14687aefc8ac86e6a
<pre>
[Memory64] Fix parsing data segment init exprs
<a href="https://bugs.webkit.org/show_bug.cgi?id=317794">https://bugs.webkit.org/show_bug.cgi?id=317794</a>
<a href="https://rdar.apple.com/180563067">rdar://180563067</a>

Reviewed by Keith Miller.

Pasring for data segment init expressions did not
support Memory64.

I fixed this by widening the bits in the I32InitExpr from a
uint32_t to a uint64_t. I aliased I32IntExpr to I64InitExpr
because they use the same structure, but sometimes it&apos;s useful
to refer to them differently.

I added a path for parsing an I64 instead of an I32 in
SectionParser::parseData when the memory is 64 bits.

This fixes a large number of WPT tests that were failing
due to the type mismatch during the parsing phase.

* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::I32InitExpr::I32InitExpr):
(JSC::Wasm::I32InitExpr::globalImport):
(JSC::Wasm::I32InitExpr::constValue):
(JSC::Wasm::I32InitExpr::extendedExpression):
(JSC::Wasm::I32InitExpr::constValue const):
(JSC::Wasm::I32InitExpr::globalImportIndex const):
(JSC::Wasm::I32InitExpr::constantExpressionIndex const):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::makeI32InitExpr):
(JSC::Wasm::makeI64InitExpr):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseI64InitExpr):
(JSC::Wasm::SectionParser::parseI64InitExprForDataSection):
(JSC::Wasm::SectionParser::parseData):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::evaluate):

Canonical link: <a href="https://commits.webkit.org/315915@main">https://commits.webkit.org/315915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a19277aba97defd2245a49f17b9644500ce5dea4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179819 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128155 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6497fcd-f4b2-43b5-8843-167e8931fe4c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44001 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/389f4634-6890-4e51-bc4d-a29d5776ecc3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113407 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f5ecfde-2109-41f5-9982-457769a6ba86) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28500 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1759 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182402 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31697 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44023 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38020 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44712 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109195 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36444 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116601 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203121 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7831 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54405 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42627 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->