### PR TITLE
Setting user dir suffix should not be fatal

### DIFF
--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -30,6 +30,7 @@
 
 #import "ApplicationServicesSPI.h"
 #import "CodeSigning.h"
+#import "Logging.h"
 #import "SandboxInitializationParameters.h"
 #import "SandboxUtilities.h"
 #import "WKFoundation.h"
@@ -665,7 +666,8 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
 
     // Use private temporary and cache directories.
     CString userDirectorySuffixString = FileSystem::fileSystemRepresentation(sandboxParameters.userDirectorySuffix());
-    RELEASE_ASSERT(_set_user_dir_suffix(userDirectorySuffixString.data()));
+    if (!_set_user_dir_suffix(userDirectorySuffixString.data()))
+        RELEASE_LOG_ERROR(Process, "Unable to set user dir suffix");
 
     char temporaryDirectory[PATH_MAX];
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryDirectory, sizeof(temporaryDirectory))) {


### PR DESCRIPTION
#### c06326d5937a47d0a25ae7bf542a60956e0f5c12
<pre>
Setting user dir suffix should not be fatal
<a href="https://bugs.webkit.org/show_bug.cgi?id=317795">https://bugs.webkit.org/show_bug.cgi?id=317795</a>
<a href="https://rdar.apple.com/180342936">rdar://180342936</a>

Reviewed by Sihui Liu.

Failing to set user dir suffix is not a fatal condition.

* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::populateSandboxInitializationParameters):

Canonical link: <a href="https://commits.webkit.org/315819@main">https://commits.webkit.org/315819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8f4af9c7b6378d34248682fe8d3fb47e2b638c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44009 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37424 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179448 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/feaafd1d-7577-40cf-b550-2562a6de30f6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132575 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/661e2bb0-2cec-443a-98d0-b2bd82d2c273) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173045 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4869084d-8481-486a-9ca0-329c3892bceb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28144 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182045 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31341 "Build is in progress. Recent messages:") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34834 "") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36882 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 344 new passes 21 flakes 4 failures; Uploaded test results; Running re-run-layout-tests; Running compile-webkit-without-change; layout-tests; Running analyze-layout-tests-results") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141025 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43665 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140854 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44354 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29385 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108705 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25945 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36123 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116235 "Found 97 new failures in plugins/DOMPluginArray.cpp, bytecode/ExpressionInfo.cpp, rendering/NinePieceImagePainter.cpp, layout/formattingContexts/inline/InlineFormattingContext.cpp, dfg/DFGSpeculativeJIT.cpp, dom/ImageOverlay.cpp, dfg/DFGFixupPhase.cpp, html/canvas/WebGLTransformFeedback.cpp, rendering/cocoa/RenderThemeCocoa.mm, plugins/DOMPlugin.cpp ...") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42865 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7484 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42257 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->