### PR TITLE
Require two or more arguments for checked arithmetic operations.

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -373,7 +373,7 @@ GUniquePtr<char*> jscContextJSArrayToGStrv(JSCContext* context, JSValueRef jsArr
     if (*exception)
         return nullptr;
 
-    auto sizeInBytes = checkedSum<size_t>(length + 1);
+    auto sizeInBytes = checkedSum<size_t>(length, 1);
     sizeInBytes *= sizeof(char*);
     if (sizeInBytes.hasOverflowed())
         return nullptr;

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -890,15 +890,11 @@ typedef Checked<int64_t, RecordOverflow> CheckedInt64;
 typedef Checked<uint64_t, RecordOverflow> CheckedUint64;
 typedef Checked<size_t, RecordOverflow> CheckedSize;
 
-template<typename T, typename U>
-Checked<T, RecordOverflow> checkedSum(U value)
+template<typename T, typename... Args>
+requires (sizeof...(Args) >= 2)
+Checked<T, RecordOverflow> checkedSum(Args... args)
 {
-    return Checked<T, RecordOverflow>(value);
-}
-template<typename T, typename U, typename... Args>
-Checked<T, RecordOverflow> checkedSum(U value, Args... args)
-{
-    return Checked<T, RecordOverflow>(value) + checkedSum<T>(args...);
+    return (... + Checked<T, RecordOverflow>(args));
 }
 
 template<typename T, typename U, typename V>
@@ -926,15 +922,11 @@ template<typename T> T sumIfNoOverflowOrFirstValue(T firstValue, T secondValue)
     return result.hasOverflowed() ? firstValue : result.value();
 }
 
-template<typename T, typename U>
-Checked<T, RecordOverflow> checkedProduct(U value)
+template<typename T, typename... Args>
+requires (sizeof...(Args) >= 2)
+Checked<T, RecordOverflow> checkedProduct(Args... args)
 {
-    return Checked<T, RecordOverflow>(value);
-}
-template<typename T, typename U, typename... Args>
-Checked<T, RecordOverflow> checkedProduct(U value, Args... args)
-{
-    return Checked<T, RecordOverflow>(value) * checkedProduct<T>(args...);
+    return (... * Checked<T, RecordOverflow>(args));
 }
 
 // Sometimes, you just want to check if some math would overflow - the code to do the math is

--- a/Source/WTF/wtf/text/MakeString.h
+++ b/Source/WTF/wtf/text/MakeString.h
@@ -77,7 +77,12 @@ String tryMakeStringFromAdapters(StringTypeAdapters&&... adapters)
         builder.appendFromAdapters(std::forward<StringTypeAdapters>(adapters)...);
         return builder.toString();
     } else {
-        auto sum = checkedSum<int32_t>(adapters.length()...);
+        CheckedInt32 sum;
+        if constexpr (sizeof...(adapters) >= 2)
+            sum = checkedSum<int32_t>(adapters.length()...);
+        else
+            sum = std::get<0>(std::tie(adapters...)).length();
+
         if (sum.hasOverflowed())
             return String();
 
@@ -111,7 +116,12 @@ AtomString tryMakeAtomStringFromAdapters(StringTypeAdapters ...adapters)
         builder.appendFromAdapters(adapters...);
         return builder.toAtomString();
     } else {
-        auto sum = checkedSum<int32_t>(adapters.length()...);
+        CheckedInt32 sum;
+        if constexpr (sizeof...(adapters) >= 2)
+            sum = checkedSum<int32_t>(adapters.length()...);
+        else
+            sum = std::get<0>(std::tie(adapters...)).length();
+
         if (sum.hasOverflowed())
             return AtomString();
 


### PR DESCRIPTION
#### 429ffbc56515710b3d8d7c638a10179985def466
<pre>
Require two or more arguments for checked arithmetic operations.
<a href="https://rdar.apple.com/129831277">rdar://129831277</a>

Reviewed by Chris Dumez.

The one-argument versions of checkedSum and checkedProduct are prone to misuse by performing the operation before passing the unchecked result to the function, e.g. checkedSum(a + b). Using a fold expression removes the need to include a base case, so we can require multiple arguments.

* Source/JavaScriptCore/API/glib/JSCContext.cpp: Fix unchecked addition.
* Source/WTF/wtf/CheckedArithmetic.h:
(WTF::checkedSum): Replace recursive variadic function with fold and add requires expression.
(WTF::checkedProduct): Replace recursive variadic function with fold and add requires expression.
* Source/WTF/wtf/text/MakeString.h:
(WTF::tryMakeStringFromAdapters): Add check to only call checkedSum if there&apos;s two or more arguments.
(WTF::tryMakeAtomStringFromAdapters): Add check to only call checkedSum if there&apos;s two or more arguments.

Canonical link: <a href="https://commits.webkit.org/316082@main">https://commits.webkit.org/316082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa2f34be1a46d5740a380bc12954872d11e627c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128235 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132993 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93773 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34780 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33122 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28580 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1829 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182482 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31777 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141432 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44103 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38153 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44792 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29799 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109300 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36520 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116681 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203201 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7901 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54417 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->