### PR TITLE
Cross-origin parent DOM exposed via NavigateEvent.sourceElement

### DIFF
--- a/LayoutTests/http/wpt/navigation-api/resources/sourceElement-cross-origin-leak-frame.html
+++ b/LayoutTests/http/wpt/navigation-api/resources/sourceElement-cross-origin-leak-frame.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>web2 frame (cross-origin)</title>
+<script>
+navigation.addEventListener("navigate", event => {
+  if (!event.destination.url.includes("#updated"))
+    return;
+  event.preventDefault();
+  const source = event.sourceElement;
+  let leakedEmail = null;
+  let leakedAccountId = null;
+  let tagName = null;
+  if (source) {
+    tagName = source.tagName;
+    try { leakedEmail = source.ownerDocument.querySelector("#profile-email").textContent; } catch (e) {}
+    try { leakedAccountId = source.ownerDocument.querySelector("#account-panel").dataset.accountId; } catch (e) {}
+  }
+  window.parent.postMessage({
+    type: "result",
+    sourceElementIsNull: source === null,
+    tagName: tagName,
+    leakedEmail: leakedEmail,
+    leakedAccountId: leakedAccountId,
+  }, "*");
+});
+window.parent.postMessage({ type: "ready" }, "*");
+</script>

--- a/LayoutTests/http/wpt/navigation-api/sourceElement-cross-origin-leak.sub-expected.txt
+++ b/LayoutTests/http/wpt/navigation-api/sourceElement-cross-origin-leak.sub-expected.txt
@@ -1,0 +1,8 @@
+Private account area
+
+alice@example.test
+
+Refresh embedded frame
+
+PASS NavigateEvent.sourceElement must be null for cross-origin same-document initiators (parent DOM read)
+

--- a/LayoutTests/http/wpt/navigation-api/sourceElement-cross-origin-leak.sub.html
+++ b/LayoutTests/http/wpt/navigation-api/sourceElement-cross-origin-leak.sub.html
@@ -1,0 +1,28 @@
+<!doctype html><!-- webkit-test-runner [ SiteIsolationEnabled=false ] -->
+<meta charset="utf-8">
+<title>NavigateEvent.sourceElement must not leak parent DOM cross-origin (rdar://180371329)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<section id="account-panel" data-account-id="ACCOUNT_314159">
+  <h2>Private account area</h2>
+  <p id="profile-email">alice@example.test</p>
+</section>
+<a id="victim-link"
+   href="http://{{hosts[alt][]}}:{{ports[http][0]}}/WebKit/navigation-api/resources/sourceElement-cross-origin-leak-frame.html#updated"
+   target="targetFrame">Refresh embedded frame</a>
+<iframe name="targetFrame"
+        src="http://{{hosts[alt][]}}:{{ports[http][0]}}/WebKit/navigation-api/resources/sourceElement-cross-origin-leak-frame.html"></iframe>
+<script>
+async_test(t => {
+  window.addEventListener("message", t.step_func(e => {
+    if (e.data.type === "ready") {
+      document.getElementById("victim-link").click();
+    } else if (e.data.type === "result") {
+      assert_true(e.data.sourceElementIsNull,
+        "sourceElement must be null for cross-origin initiators (was tagName=" + e.data.tagName +
+        ", leakedEmail=" + e.data.leakedEmail + ", leakedAccountId=" + e.data.leakedAccountId + ")");
+      t.done();
+    }
+  }));
+}, "NavigateEvent.sourceElement must be null for cross-origin same-document initiators (parent DOM read)");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/sourceElement-cross-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/sourceElement-cross-origin.sub-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL NavigateEvent.sourceElement should be null for cross-origin same-document initiators assert_true: sourceElement must be null for cross-origin initiators (it was A) expected true got false
+PASS NavigateEvent.sourceElement should be null for cross-origin same-document initiators
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -64,6 +64,7 @@
 #include "NavigationHistoryEntry.h"
 #include "NavigationNavigationType.h"
 #include "NavigationScheduler.h"
+#include "NodeDocument.h"
 #include "Page.h"
 #include "ScriptExecutionContextInlines.h"
 #include "SecurityOrigin.h"
@@ -1355,6 +1356,12 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         updatedSourceElement = submitter.get();
         if (!updatedSourceElement)
             updatedSourceElement = form.ptr();
+    }
+
+    if (updatedSourceElement) {
+        Ref sourceOrigin = protect(updatedSourceElement->document())->securityOrigin();
+        if (!protect(document->securityOrigin())->isSameOriginDomain(sourceOrigin))
+            updatedSourceElement = nullptr;
     }
 
     RefPtr abortController = AbortController::create(*scriptExecutionContext);


### PR DESCRIPTION
#### 0beaf193cc762422145d23259b6d039796135c0f
<pre>
Cross-origin parent DOM exposed via NavigateEvent.sourceElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=317796">https://bugs.webkit.org/show_bug.cgi?id=317796</a>
<a href="https://rdar.apple.com/180371329">rdar://180371329</a>

Reviewed by Rupin Mittal.

When a navigation in a cross-origin iframe is initiated by an element in the
embedding document (for example, an &lt;a&gt; with target= pointing into the iframe),
NavigateEvent.sourceElement received inside the iframe was the parent&apos;s element
itself, with full DOM access via event.sourceElement.ownerDocument. This let
the iframe read arbitrary content from the embedder&apos;s document, bypassing the
same-origin policy.

Null out sourceElement in Navigation::innerDispatchNavigateEvent when its
owning document is not same-origin-domain with the navigation&apos;s relevant
document. The check sits at the central dispatch funnel after the form
submitter/form rewrite, so anchor, form, submitter, and download paths are
covered uniformly.

The upstream WPT navigation-api/navigate-event/sourceElement-cross-origin.sub.html
already covered this case as a baseline failure; flipped to PASS. Added a
WebKit HTTP/WPT regression test that exercises the leak with private
parent-document data so the bypass scenario is explicit.

* LayoutTests/http/wpt/navigation-api/resources/sourceElement-cross-origin-leak-frame.html: Added.
* LayoutTests/http/wpt/navigation-api/sourceElement-cross-origin-leak.sub-expected.txt: Added.
* LayoutTests/http/wpt/navigation-api/sourceElement-cross-origin-leak.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/sourceElement-cross-origin.sub-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/316245@main">https://commits.webkit.org/316245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b20a4c1a3c152f210cebf9e34922a642c1ce9ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129088 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fc355f9-2dcd-4bbf-be96-a4aca641a1af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133577 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73f5360f-a3f1-4104-be2c-411728b53e0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114052 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3dd3cfe-ccf3-404a-bf66-a76e64b75410) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35468 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29575 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183479 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142126 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38359 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45788 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110432 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37250 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44293 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8467 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43699 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43944 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43775 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->