### PR TITLE
Fastmail requires login on every launch

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -547,6 +547,7 @@ void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDa
     RetainPtr<CFHTTPCookieStorageRef> uiProcessCookieStorage;
     if (!sessionID.isEphemeral() && !parameters.uiProcessCookieStorageIdentifier.isEmpty()) {
         SandboxExtension::consumePermanently(parameters.cookieStoragePathExtensionHandle);
+        setSharedHTTPCookieStorage(parameters.uiProcessCookieStorageIdentifier);
         if (sessionID != PAL::SessionID::defaultSessionID())
             uiProcessCookieStorage = cookieStorageFromIdentifyingData(parameters.uiProcessCookieStorageIdentifier);
     }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -593,9 +593,7 @@ private:
     void setNetworkProxySettings(PAL::SessionID, WebCore::CurlProxySettings&&);
 #endif
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     static void setSharedHTTPCookieStorage(const Vector<uint8_t>& identifier);
-#endif
 
     void terminateRemoteWorkerContextConnectionWhenPossible(RemoteWorkerType, PAL::SessionID, const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);
     void runningOrTerminatingServiceWorkerCountForTesting(PAL::SessionID, CompletionHandler<void(unsigned)>&&) const;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -224,13 +224,11 @@ void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<vo
     }).get());
 }
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 void NetworkProcess::setSharedHTTPCookieStorage(const Vector<uint8_t>& identifier)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
     [NSHTTPCookieStorage _setSharedHTTPCookieStorage:adoptNS([[NSHTTPCookieStorage alloc] _initWithCFHTTPCookieStorage:cookieStorageFromIdentifyingData(identifier).get()]).get()];
 }
-#endif
 
 void NetworkProcess::flushCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -221,6 +221,12 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.manualPrevalentResource = WTF::move(resourceLoadStatisticsManualPrevalentResource);
 
     auto cookieFile = directories.cookieStorageFile;
+#if PLATFORM(IOS_FAMILY)
+    if (cookieFile.isEmpty())
+        cookieFile = FileSystem::pathByAppendingComponent(WebsiteDataStore::resolvedCookieStorageDirectory(), "Cookies.binarycookies"_s);
+
+#endif // PLATFORM(IOS_FAMILY)
+
     createHandleFromResolvedPathIfPossible(FileSystem::parentPath(cookieFile), parameters.cookieStoragePathExtensionHandle);
 
     if (m_uiProcessCookieStorageIdentifier.isEmpty()) {


### PR DESCRIPTION
#### ac8b6f25f426634f569c6a5a7a55619ac161790b
<pre>
Fastmail requires login on every launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=317801">https://bugs.webkit.org/show_bug.cgi?id=317801</a>
<a href="https://rdar.apple.com/180440606">rdar://180440606</a>

Reviewed by NOBODY (OOPS!).

Draft. After <a href="https://commits.webkit.org/314751@main">314751@main</a>, the Library directory of the Networking process is located in it&apos;s container.
This caused the cookie file location to be moved there, and the previous cookies were lost. This patch
makes sure we are still using the cookie file location in the UI process container.

I have verified the fix locally with Fastmail.

No new tests, since no processes are sandboxed in the Simulator.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::addStorageSession):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::setSharedHTTPCookieStorage):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac8b6f25f426634f569c6a5a7a55619ac161790b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170263 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44186 "Hash ac8b6f25 for PR 67822 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179637 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d13d447-61a8-4b45-ab04-2f25235779fe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132743 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/282ab19c-306d-410d-adb0-43c1a4f1a7d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35927 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113244 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2922e64e-f4c6-4451-8a5a-4635db9303a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34516 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28321 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144999 "Found 16 new API test failures: TestWebKitAPI.WKWebsiteDataStore.RemoveSessionWithIdentifierFromNetworkProcess, TestWebKitAPI.ServiceWorkers.V2DatabaseUpgrade, TestWebKitAPI.ResourceLoadStatistics.EnableResourceLoadStatisticsAfterNetworkProcessCreation, TestWebKitAPI.WebKit.WebsiteDataStoreCustomPathsWithPrewarming, TestWebKitAPI.TimeBasedEviction.ThrottledToConfiguredInterval, TestWebKitAPI.ResourceLoadStatistics.StoreSuspension, TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent, TestWebKitAPI.TimeBasedEviction.DiskCacheAccessUpdatesTimestamp, TestWebKitAPI.PrivateClickMeasurement.DatabaseLocation, TestWebKitAPI.WebKit.WebsiteDataStoreCustomPathsWithoutPrewarming ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32570 "Found 60 new test failures: fast/css/pseudo-in-range-out-of-range-on-disabled-input-trivial.html fast/repaint/intermediate-layout-position.html fullscreen/full-screen-keyboard-lock-option-enabled.html http/tests/inspector/dom/cross-domain-inspected-node-access.html http/tests/inspector/dom/didFireEvent.html http/tests/inspector/gatherWebInspectorRTCLogs.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182222 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35012 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37043 "Found 60 new test failures: accessibility/mac/input-replacevalue-userinfo.html http/tests/cache/cancel-multiple-post-xhrs.html http/tests/inspector/dom/cross-domain-inspected-node-access.html http/tests/inspector/gatherWebInspectorRTCLogs.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html http/tests/inspector/network/fetch-network-data.html http/tests/inspector/network/fetch-response-body.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141198 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43843 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141012 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44532 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29554 "Found 60 new test failures: compositing/animation/animation-backing.html css3/calc/transforms-scale.html css3/filters/backdrop/backdrop-filter-with-reflection.html css3/masking/clip-path-content-box.html css3/viewport-percentage-lengths/css3-viewport-percentage-lengths-vmin.html fast/forms/input-step-as-double.html fast/inline/blocks-in-inline-layout-single-block-with-margin.html http/tests/inspector/dom/cross-domain-inspected-node-access.html http/tests/inspector/dom/didFireEvent.html http/tests/inspector/gatherWebInspectorRTCLogs.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108947 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36283 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116414 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43042 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7655 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42447 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42577 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->