### PR TITLE
[Site Isolation] Per-frame back/forward walk dispatches to dead BF frame items, navigating main frame to iframe URL

### DIFF
--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal-expected.txt
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal-expected.txt
@@ -1,3 +1,6 @@
 
+PASS cross-document traversals in opposite directions: the result is going nowhere
+PASS cross-document traversals in opposite directions, second traversal invalid at queuing time but valid at the time it is run: the result is going nowhere
 PASS cross-document traversals in the same (back) direction: the result is going -2 with only one load event
+PASS cross-document traversals in the same (forward) direction: the result is going +2 with only one load event
 

--- a/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
+++ b/LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
@@ -1,21 +1,64 @@
 <!-- webkit-test-runner [ SiteIsolationEnabled=true UseUIProcessForBackForwardItemLoading=true ] -->
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Cross-document traversals during cross-document traversals (back direction)</title>
+<title>Cross-document traversals during cross-document traversals</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-
-<!--
-  Focused subset of the upstream WPT cluster test for bug 317044 (iframe
-  client-redirect URL preservation). Only the back-direction subtest is
-  included here; the other three subtests need the dead-frame skip
-  follow-up to bug 317090 to avoid timing out, and are added by that
-  commit.
--->
 
 <body>
 <script type="module">
 import { createIframe, waitForLoad, delay, waitForPotentialNetworkLoads } from "./resources/helpers.mjs";
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?2";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?3";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.history.back();
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  assert_equals(iframe.contentWindow.location.search, "?2", "we made our way to ?2 for setup");
+
+  iframe.contentWindow.history.back();
+  assert_equals(iframe.contentWindow.location.search, "?2", "must not go back synchronously");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?2", "must not go forward synchronously");
+
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?2", "must stay on ?2");
+}, "cross-document traversals in opposite directions: the result is going nowhere");
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?2";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+
+  iframe.contentWindow.history.back();
+  assert_equals(iframe.contentWindow.location.search, "?2", "must not go back synchronously");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?2", "must not go forward synchronously");
+
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?2", "must stay on ?2");
+}, "cross-document traversals in opposite directions, second traversal invalid at queuing time but valid at the time it is run: the result is going nowhere");
 
 promise_test(async t => {
   const iframe = await createIframe(t);
@@ -44,4 +87,40 @@ promise_test(async t => {
   await waitForPotentialNetworkLoads(t);
   assert_equals(iframe.contentWindow.location.search, "?1", "must stay on ?1");
 }, "cross-document traversals in the same (back) direction: the result is going -2 with only one load event");
+
+promise_test(async t => {
+  const iframe = await createIframe(t);
+
+  iframe.contentWindow.location.search = "?1";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?2";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.location.search = "?3";
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  iframe.contentWindow.history.back();
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  assert_equals(iframe.contentWindow.location.search, "?2", "we made our way to ?2 for setup");
+  iframe.contentWindow.history.back();
+  await waitForLoad(iframe);
+  await delay(t, 0);
+  assert_equals(iframe.contentWindow.location.search, "?1", "we made our way to ?1 for setup");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?1", "must not go forward synchronously (1)");
+
+  iframe.contentWindow.history.forward();
+  assert_equals(iframe.contentWindow.location.search, "?1", "must not go forward synchronously (2)");
+
+  await waitForLoad(iframe);
+  assert_equals(iframe.contentWindow.location.search, "?3", "first load event must be going forward");
+
+  iframe.onload = t.unreached_func("second load event");
+
+  await waitForPotentialNetworkLoads(t);
+  assert_equals(iframe.contentWindow.location.search, "?3", "must stay on ?3");
+}, "cross-document traversals in the same (forward) direction: the result is going +2 with only one load event");
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2398,3 +2398,5 @@ webkit.org/b/317173 [ arm64 ] fast/webgpu/nocrash/fuzz-298315.html [ Pass Crash 
 webkit.org/b/317857 [ Debug ] http/tests/site-isolation/frame-index.html [ Skip ]
 
 webkit.org/b/317884 imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Failure ]
+
+webkit.org/b/317799 [ Debug ] http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html [ Skip ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2860,12 +2860,10 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
         bool anySent = false;
         if (RefPtr currentItem = backForwardList().currentItem())
             anySent = dispatchPerFrameTraversals(protect(currentItem->mainFrameItem()), protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
-        if (!anySent) {
-            if (!backForwardList().currentItem() || isSessionRestore == IsSessionRestoreNavigation::Yes)
-                sendGoToBackForwardItemForFrame(protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
-            else
-                WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
-        }
+        if (!anySent && (!backForwardList().currentItem() || isSessionRestore == IsSessionRestoreNavigation::Yes))
+            anySent = sendGoToBackForwardItemForFrame(protect(item->mainFrameItem()), navigation->navigationID(), frameLoadType, shouldRestoreFromBackForwardCache, publicSuffix);
+        if (!anySent)
+            WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "goToBackForwardItem: walk dispatched no GoToBackForwardItem messages — back/forward action will be silently dropped");
     } else {
         process->markProcessAsRecentlyUsed();
         process->send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), copyFrameStateForBackForwardNavigation(frameItem), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, shouldRestoreFromBackForwardCache, std::nullopt, WTF::move(publicSuffix), { }, WebCore::ProcessSwapDisposition::None }), webPageIDInProcess(process));
@@ -2878,10 +2876,8 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
 bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
 {
     bool anySent = false;
-    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber) {
-        sendGoToBackForwardItemForFrame(toFrame, navigationID, frameLoadType, shouldRestore, publicSuffix);
-        anySent = true;
-    }
+    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber)
+        anySent = sendGoToBackForwardItemForFrame(toFrame, navigationID, frameLoadType, shouldRestore, publicSuffix);
 
     bool sameDocument = fromFrame.frameState().documentSequenceNumber == toFrame.frameState().documentSequenceNumber;
     if (!sameDocument)
@@ -2905,8 +2901,17 @@ bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromF
     return anySent;
 }
 
-void WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
+bool WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
 {
+    if (targetFrame.parent()) {
+        auto frameID = targetFrame.frameID();
+        if (!frameID)
+            return false;
+        RefPtr liveFrame = WebFrameProxy::webFrame(*frameID);
+        if (!liveFrame || liveFrame->page() != this)
+            return false;
+    }
+
     Ref process = processForTheFrameItem(targetFrame);
     auto suffixCopy = publicSuffix;
     process->markProcessAsRecentlyUsed();
@@ -2924,6 +2929,7 @@ void WebPageProxy::sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& 
         WebCore::ProcessSwapDisposition::None
     }), webPageIDInProcess(process));
     process->startResponsivenessTimer();
+    return true;
 }
 
 Ref<WebBackForwardListFrameItem> WebPageProxy::frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3025,7 +3025,7 @@ private:
     RefPtr<API::Navigation> goToBackForwardItem(WebBackForwardListFrameItem&, WebCore::FrameLoadType, IsSessionRestoreNavigation = IsSessionRestoreNavigation::No);
 
     bool dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
-    void sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
+    bool sendGoToBackForwardItemForFrame(WebBackForwardListFrameItem& targetFrame, WebCore::NavigationIdentifier, WebCore::FrameLoadType, WebCore::ShouldRestoreFromBackForwardCache, const WebCore::PublicSuffix&);
     Ref<WebBackForwardListFrameItem> frameItemForLegacyTraversalRouting(WebBackForwardListItem& targetItem, ASCIILiteral logTag);
 
     void updateActivityState(OptionSet<WebCore::ActivityState> flagsToUpdate);


### PR DESCRIPTION
#### e651f7053f95c26c76e6bc4a112d1385a7a56f37
<pre>
[Site Isolation] Per-frame back/forward walk dispatches to dead BF frame items, navigating main frame to iframe URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a>
<a href="https://rdar.apple.com/180568019">rdar://180568019</a>

Reviewed by Sihui Liu.

Follow-up to 315516@main (<a href="https://bugs.webkit.org/show_bug.cgi?id=317090">https://bugs.webkit.org/show_bug.cgi?id=317090</a>,
walk-as-replacement).

WebPageProxy::dispatchPerFrameTraversals walks every frame in the target
back/forward item&apos;s tree and, through sendGoToBackForwardItemForFrame,
dispatches GoToBackForwardItem to each frame whose itemSequenceNumber
differs. The BF tree retains FrameState entries for iframes that have since
been removed from the DOM (e.g. an iframe a previous test created and tore
down via t.add_cleanup). For those dead slots
WebProcess::singleton().webFrame(frameID) returns null at the WebPage
receiver, and WebPage::goToBackForwardItem falls back to m_mainFrame — so
the main frame ends up navigating to the dead iframe&apos;s URL. In the WPT
cluster test cross-document-traversal-cross-document-traversal.html this
manifests as the test page itself being navigated to ?1 partway through
subtest 4, killing the test harness and timing out all subtests.

For child-frame BF items, have sendGoToBackForwardItemForFrame resolve the
target frameID to a live WebFrameProxy belonging to this page before
sending, and skip dispatch — returning false — when it does not. Propagate
that result as a bool through dispatchPerFrameTraversals and
goToBackForwardItem&apos;s anySent bookkeeping, so a walk whose only differing
frames are dead now sends nothing and falls through to the existing
&quot;silently dropped&quot; release-log warning instead of mis-navigating the main
frame. The check is gated on targetFrame.parent() so it applies only to
iframe BF items: a main-frame BF item&apos;s stale frameID is expected after
session restore to a new WebView (the BF list is hydrated with the
originating page&apos;s frameIDs before this page&apos;s main frame loads), and the
WebProcess receiver&apos;s m_mainFrame fallback is the correct destination for
the main frame — skipping would silently drop the restore, regressing
SiteIsolation.RestoreSessionFromAnotherWebView and the two
NavigateIframe*BackForwardAfterSessionRestoreToNewWebView tests reactivated
in 315817@main.

Bug 317044 (315779@main) introduced the http/wpt/site-isolation/ copy of
this cluster test with only the back-direction subtest, because the other
three subtests timed out across the shared BF list without this fix. Extend
that copy to all four subtests now that the dead-frame skip is in place;
the platform-specific mac-site-isolation expected.txt override is no longer
needed because the http/wpt/site-isolation copy pins both flags via its
webkit-test-runner header.

The extended 4-subtest test exposes a separate pre-existing Debug-only
assertion in HistoryItem::addChildItem when the BF tree happens to contain
duplicate-frameID children after multiple subtests&apos; iframes have been torn
down. That root cause (BF tree retaining frameIDs of destroyed iframes) is
fixed at the source by bug 317814 (eng/basuke/si-implies-uiproc-bfwd —
clears frameID in ~WebFrameProxy via a recursive BF tree walk); until that
lands, skip the test on Debug. Release continues to exercise all four
subtests.

* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal-expected.txt:
* LayoutTests/http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::dispatchPerFrameTraversals):
(WebKit::WebPageProxy::sendGoToBackForwardItemForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/315925@main">https://commits.webkit.org/315925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7552c56d53c6cf3bb26d73dec184fd29658a6fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128183 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58837c2a-d8a1-47c8-b0f0-335d5755273d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d058621-71f5-48e8-86a1-5302e2340c9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd5293f1-23a8-4d0f-84ca-1a4ba5751b8c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28528 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182430 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141204 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38028 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44740 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109223 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36470 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116629 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43250 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7851 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42655 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->