### PR TITLE
WPT clone should use same protocol as WebKit

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_downloader.py
+++ b/Tools/Scripts/webkitpy/w3c/test_downloader.py
@@ -31,6 +31,7 @@ import json
 import logging
 
 from webkitcorepy import run
+from webkitscmpy import local
 from webkitscmpy.local.git import Git
 
 from webkitpy.common.webkit_finder import WebKitFinder
@@ -83,6 +84,10 @@ class TestDownloader(object):
         self.repository_directory = repository_directory
         self.upstream_revision = None
 
+        url = self._get_webkit_remote_url()
+        protocol = self._protocol_from_url(url) if url else None
+        self._webkit_protocol = 'ssh' if protocol == 'ssh' else 'https'
+
         self.test_repositories = self.load_test_repositories(self._filesystem)
 
         self.paths_to_skip_new_directories = []
@@ -100,7 +105,44 @@ class TestDownloader(object):
         if not self._options.import_all:
             self._init_paths_from_expectations()
 
+    def _get_webkit_remote_url(self):
+        try:
+            webkit_finder = WebKitFinder(self._filesystem)
+            webkit_root = webkit_finder.webkit_base()
+            scm = local.Scm.from_path(webkit_root)
+            remote_repo = scm.remote()
+            if remote_repo:
+                return remote_repo.url
+        except Exception as e:
+            _log.debug('Could not get WebKit remote URL: %s' % e)
+        return None
+
+    @staticmethod
+    def _protocol_from_url(url):
+        if '://' in url:
+            return url.split(':', 1)[0]
+        elif ':' in url:
+            return 'ssh'
+        return None
+
+    @staticmethod
+    def _normalize_url_protocol(url, target_protocol):
+        if target_protocol == 'ssh':
+            if '://' in url:
+                repo_path = '/'.join(url.split('/')[3:])
+                return 'git@github.com:%s' % repo_path
+        else:
+            if '://' in url:
+                repo_path = '/'.join(url.split('/')[3:])
+                return '%s://github.com/%s' % (target_protocol, repo_path)
+            elif ':' in url:
+                repo_path = url.split(':')[1]
+                return '%s://github.com/%s' % (target_protocol, repo_path)
+        return url
+
     def checkout_test_repository(self, revision, url, directory):
+        url = self._normalize_url_protocol(url, self._webkit_protocol)
+
         needs_clone = not self._filesystem.exists(directory)
         if needs_clone:
             _log.info('Cloning %s into %s...' % (url, directory))

--- a/Tools/Scripts/webkitpy/w3c/test_downloader_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_downloader_unittest.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitpy.w3c.test_downloader import TestDownloader
+
+
+class TestDownloaderProtocolTest(unittest.TestCase):
+    def test_protocol_from_url_https(self):
+        self.assertEqual(TestDownloader._protocol_from_url('https://github.com/web-platform-tests/wpt.git'), 'https')
+
+    def test_protocol_from_url_http(self):
+        self.assertEqual(TestDownloader._protocol_from_url('http://github.com/web-platform-tests/wpt.git'), 'http')
+
+    def test_protocol_from_url_git(self):
+        self.assertEqual(TestDownloader._protocol_from_url('git://github.com/web-platform-tests/wpt.git'), 'git')
+
+    def test_protocol_from_url_ssh_scheme(self):
+        self.assertEqual(TestDownloader._protocol_from_url('ssh://git@github.com/web-platform-tests/wpt.git'), 'ssh')
+
+    def test_protocol_from_url_scp_like(self):
+        self.assertEqual(TestDownloader._protocol_from_url('git@github.com:web-platform-tests/wpt.git'), 'ssh')
+
+    def test_protocol_from_url_scp_like_with_user(self):
+        self.assertEqual(TestDownloader._protocol_from_url('user@host.com:path/to/repo.git'), 'ssh')
+
+    def test_protocol_from_url_ftp(self):
+        self.assertEqual(TestDownloader._protocol_from_url('ftp://example.com/repo.git'), 'ftp')
+
+    def test_protocol_from_url_ftps(self):
+        self.assertEqual(TestDownloader._protocol_from_url('ftps://example.com/repo.git'), 'ftps')
+
+    def test_protocol_from_url_file(self):
+        self.assertEqual(TestDownloader._protocol_from_url('file:///path/to/repo.git'), 'file')
+
+    def test_protocol_from_url_local_path(self):
+        self.assertIsNone(TestDownloader._protocol_from_url('/path/to/repo'))
+
+    def test_normalize_url_protocol_https_to_https(self):
+        url = 'https://github.com/web-platform-tests/wpt.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'https'), url)
+
+    def test_normalize_url_protocol_ssh_to_ssh(self):
+        url = 'git@github.com:web-platform-tests/wpt.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'ssh'), url)
+
+    def test_normalize_url_protocol_https_to_ssh(self):
+        url = 'https://github.com/web-platform-tests/wpt.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'ssh'), 'git@github.com:web-platform-tests/wpt.git')
+
+    def test_normalize_url_protocol_ssh_to_https(self):
+        url = 'git@github.com:web-platform-tests/wpt.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'https'), 'https://github.com/web-platform-tests/wpt.git')
+
+    def test_normalize_url_protocol_git_to_https(self):
+        url = 'git://github.com/web-platform-tests/wpt.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'https'), 'https://github.com/web-platform-tests/wpt.git')
+
+    def test_normalize_url_protocol_ssh_scheme_to_https(self):
+        url = 'ssh://git@github.com/web-platform-tests/wpt.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'https'), 'https://github.com/web-platform-tests/wpt.git')
+
+    def test_normalize_url_protocol_preserves_path(self):
+        url = 'https://github.com/org/project/repo.git'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'ssh'), 'git@github.com:org/project/repo.git')
+
+    def test_normalize_url_protocol_no_change_needed(self):
+        url = '/local/path'
+        self.assertEqual(TestDownloader._normalize_url_protocol(url, 'https'), url)


### PR DESCRIPTION
#### 32e492d4320ee92b65bd4e056b4eb5d8fe6d1839
<pre>
WPT clone should use same protocol as WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=277452">https://bugs.webkit.org/show_bug.cgi?id=277452</a>
<a href="https://rdar.apple.com/133417147">rdar://133417147</a>

Reviewed by Elliott Williams.

Use the same protocol (SSH or HTTPS) as the WebKit repository instead of
always HTTPS. This avoids authentication friction when exporting W3C tests
and matches how webkitscmpy handles fork remotes.

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.__init__):
(TestDownloader._get_webkit_remote_url):
(TestDownloader):
(TestDownloader._protocol_from_url):
(TestDownloader._normalize_url_protocol):
(TestDownloader.checkout_test_repository):
* Tools/Scripts/webkitpy/w3c/test_downloader_unittest.py: Added.
(TestDownloaderProtocolTest):
(TestDownloaderProtocolTest.test_protocol_from_url_https):
(TestDownloaderProtocolTest.test_protocol_from_url_http):
(TestDownloaderProtocolTest.test_protocol_from_url_git):
(TestDownloaderProtocolTest.test_protocol_from_url_ssh_scheme):
(TestDownloaderProtocolTest.test_protocol_from_url_scp_like):
(TestDownloaderProtocolTest.test_protocol_from_url_scp_like_with_user):
(TestDownloaderProtocolTest.test_protocol_from_url_ftp):
(TestDownloaderProtocolTest.test_protocol_from_url_ftps):
(TestDownloaderProtocolTest.test_protocol_from_url_file):
(TestDownloaderProtocolTest.test_protocol_from_url_local_path):
(TestDownloaderProtocolTest.test_normalize_url_protocol_https_to_https):
(TestDownloaderProtocolTest.test_normalize_url_protocol_ssh_to_ssh):
(TestDownloaderProtocolTest.test_normalize_url_protocol_https_to_ssh):
(TestDownloaderProtocolTest.test_normalize_url_protocol_ssh_to_https):
(TestDownloaderProtocolTest.test_normalize_url_protocol_git_to_https):
(TestDownloaderProtocolTest.test_normalize_url_protocol_ssh_scheme_to_https):
(TestDownloaderProtocolTest.test_normalize_url_protocol_preserves_path):
(TestDownloaderProtocolTest.test_normalize_url_protocol_no_change_needed):

Canonical link: <a href="https://commits.webkit.org/316550@main">https://commits.webkit.org/316550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8483e690e4e9f46f7bbaf482eb96adb640fb43f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127821 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b84ecdb-48f9-4bef-aff5-ab8f4bffcb6d) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171975 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43664 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132595 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests; Uploaded test results; Running layout-tests-repeat-failures; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93435 "15 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0429e267-c979-4273-9639-5d4aa8bcdeb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113097 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87ff69b1-e41b-4f51-85b9-e70822cc2db1) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169430 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32734 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28167 "Built successfully") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/JSC-Tests-x86-64-EWS "Waiting to run tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144856 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinProtocol2 (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182068 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31364 "Build is in progress. Recent messages:") | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36901 "Found 1 new test failure: http/tests/site-isolation/https-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141047 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43688 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140874 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; run-api-tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44377 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108729 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36144 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42888 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7509 "") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42280 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42534 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->