### PR TITLE
Stored XSS on bugs.webkit.org in Commits extension; fix guidance (escape captured groups; optionally tighten \S+)

### DIFF
--- a/Websites/bugs.webkit.org/extensions/Commits/Extension.pm
+++ b/Websites/bugs.webkit.org/extensions/Commits/Extension.pm
@@ -26,6 +26,7 @@ use strict;
 use warnings;
 
 use parent qw(Bugzilla::Extension);
+use Bugzilla::Util qw(html_quote);
 
 our $VERSION = "1.0.0";
 
@@ -36,14 +37,14 @@ sub bug_format_comment {
     # Should match "r12345" and "trac.webkit.org/r12345" but not "https://trac.webkit.org/r12345"
     push(@$regexes, { match => qr/(?<!\/|\#)\b((r[[:digit:]]{5,}))\b/, replace => \&_replace_reference });
     push(@$regexes, { match => qr/(?<!\/)(trac.webkit.org\/(r[[:digit:]]{5,}))\b/, replace => \&_replace_reference });
-    push(@$regexes, { match => qr/\b((?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+@\S+))\b/, replace => \&_replace_reference });
-    push(@$regexes, { match => qr/\b((?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+\.?\d+@\S+))\b/, replace => \&_replace_reference });
+    push(@$regexes, { match => qr/\b((?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+@[A-Za-z0-9._\/-]+))\b/, replace => \&_replace_reference });
+    push(@$regexes, { match => qr/\b((?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+\.?\d+@[A-Za-z0-9._\/-]+))\b/, replace => \&_replace_reference });
 }
 
 sub _replace_reference {
     my $args = shift;
-    my $text = $args->{matches}->[0];
-    my $reference = $args->{matches}->[1];
+    my $text = html_quote($args->{matches}->[0]);
+    my $reference = html_quote($args->{matches}->[1]);
     return qq{<a href="https://commits.webkit.org/$reference">$text</a>};
 };
 


### PR DESCRIPTION
#### f9eddcaf98287f34656c442729d52b77fe28b714
<pre>
Stored XSS on bugs.webkit.org in Commits extension; fix guidance (escape captured groups; optionally tighten \S+)
<a href="https://bugs.webkit.org/show_bug.cgi?id=317709">https://bugs.webkit.org/show_bug.cgi?id=317709</a>
<a href="https://rdar.apple.com/180318956">rdar://180318956</a>

Reviewed by Stephanie Lewis.

Escape matched text in Commits extension link generation

_replace_reference interpolated matched comment text into an &lt;a&gt; tag
without HTML-encoding it. Because bug_format_comment regexes run before
html_quote in Bugzilla::Template::quoteUrls and their return values are
reinserted after escaping, that text reached the page unescaped (core
avoids this by calling html_quote itself).

Fix: run both captured groups through Bugzilla::Util::html_quote before
interpolation (primary fix), and narrow the two \S+ matchers to the
legal commit-identifier charset [A-Za-z0-9._/-]+ as defense in depth.

* Websites/bugs.webkit.org/extensions/Commits/Extension.pm:
(bug_format_comment):
(_replace_reference):

Canonical link: <a href="https://commits.webkit.org/316170@main">https://commits.webkit.org/316170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2a1ed2996109d50ed475ba304f3672b3f61ba9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171539 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01eaaff7-18a6-4251-8c15-b4c32cedb329) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45096 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1782eb9b-ea7d-4d38-9dc1-65853dc2e2f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174497 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba3b8f89-d00e-43bf-a6c0-8aa877e81af3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183510 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44321 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->