### PR TITLE
PrettyPatch should HTML-escape image URLs when rendering binary image diffs

### DIFF
--- a/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb
+++ b/Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb
@@ -740,7 +740,8 @@ EOF
                 image_checksum = IMAGE_CHECKSUM_ERROR
             end
 
-            return "<p>" + image_checksum + "</p><img class='image' src='" + @image_url + "' />"
+            return "<p>" + image_checksum + "</p><img class='image' src='" + CGI.escapeHTML(@image_url) + "' />"
+
         end
 
         def to_html


### PR DESCRIPTION
#### 9bb8fdfc34571f35695a3510d84fac8bebde1ecf
<pre>
PrettyPatch should HTML-escape image URLs when rendering binary image diffs
<a href="https://bugs.webkit.org/show_bug.cgi?id=317806">https://bugs.webkit.org/show_bug.cgi?id=317806</a>
<a href="https://rdar.apple.com/180321002">rdar://180321002</a>

Reviewed by Stephanie Lewis.

When rendering binary image diffs in the legacy SVN format, PrettyPatch
interpolated the image URL into the generated markup without escaping it,
unlike the equivalent handling elsewhere. Escape the value before it is
emitted so untrusted content cannot affect the surrounding HTML.

* Websites/bugs.webkit.org/PrettyPatch/PrettyPatch.rb:

Canonical link: <a href="https://commits.webkit.org/316177@main">https://commits.webkit.org/316177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb56a9a112def427e04fad4f37051cc6be8c9aa5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127827 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bf28abe-dbf0-41c3-9a1d-3cf08a116379) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/171981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132600 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93440 "13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99b976c0-395a-464e-9c2f-b04d6491e523) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113102 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2f1be09-93a7-4a0e-8841-80be7ac9b785) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169436 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34379 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32740 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28173 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1453 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182074 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31370 "Built successfully and passed tests") | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36907 "Found 1 new test failure: http/tests/site-isolation/frame-index.html (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141054 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 42 flakes 6 failures; Uploaded test results; 4 flakes; Passed layout tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169515 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43694 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152507 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38303 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44383 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29419 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108739 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36150 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42894 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7517 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54347 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42286 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->