### PR TITLE
[JSC] Avoid setting unnecessary watchpoints

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -6273,7 +6273,7 @@ void AbstractInterpreter<AbstractStateType>::observeTransition(
     AbstractValue::TransitionObserver transitionObserver(from, to);
     forAllValues(clobberLimit, transitionObserver);
     
-    ASSERT(!from->dfgShouldWatch()); // We don't need to claim to be in a clobbered state because 'from' was never watchable (during the time we were compiling), hence no constants ever introduced into the DFG IR that ever had a watchable structure would ever have the same structure as from.
+    ASSERT(!from->dfgMayWatch()); // We don't need to claim to be in a clobbered state because 'from' was never watchable (during the time we were compiling), hence no constants ever introduced into the DFG IR that ever had a watchable structure would ever have the same structure as from.
     
     m_state.mergeClobberState(AbstractInterpreterClobberState::ObservedTransitions);
 }
@@ -6299,7 +6299,7 @@ void AbstractInterpreter<AbstractStateType>::observeTransitions(
     if (ASSERT_ENABLED) {
         // We don't need to claim to be in a clobbered state because none of the Transition::previous structures are watchable.
         for (unsigned i = vector.size(); i--;)
-            ASSERT(!vector[i].previous->dfgShouldWatch());
+            ASSERT(!vector[i].previous->dfgMayWatch());
     }
 
     m_state.mergeClobberState(AbstractInterpreterClobberState::ObservedTransitions);

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -54,13 +54,11 @@ void AbstractValue::set(Graph& graph, const FrozenValue& value, StructureClobber
 {
     if (!!value && value.value().isCell()) {
         Structure* structure = value.structure();
-        StructureRegistrationResult result;
-        RegisteredStructure registeredStructure = graph.registerStructure(structure, result);
-        if (result == StructureRegisteredAndWatched) {
-            m_structure = registeredStructure;
+        if (graph.tryWatch(structure)) {
+            m_structure = graph.registerStructure(structure);
             if (clobberState == StructuresAreClobbered) {
                 m_arrayModes = ALL_ARRAY_MODES;
-                m_structure.clobber();
+                m_structure.clobber(graph);
             } else
                 m_arrayModes = arrayModesFromStructure(structure);
         } else {
@@ -317,11 +315,11 @@ FiltrationResult AbstractValue::filterSlow(SpeculatedType type)
     return normalizeClarity();
 }
 
-FiltrationResult AbstractValue::fastForwardToAndFilterSlow(AbstractValueClobberEpoch newEpoch, SpeculatedType type)
+FiltrationResult AbstractValue::fastForwardToAndFilterSlow(Graph& graph, AbstractValueClobberEpoch newEpoch, SpeculatedType type)
 {
     if (newEpoch != m_effectEpoch)
-        fastForwardToSlow(newEpoch);
-    
+        fastForwardToSlow(graph, newEpoch);
+
     return filterSlow(type);
 }
 
@@ -537,12 +535,12 @@ void AbstractValue::ensureCanInitializeWithZeros()
 }
 #endif
 
-void AbstractValue::fastForwardToSlow(AbstractValueClobberEpoch newEpoch)
+void AbstractValue::fastForwardToSlow(Graph& graph, AbstractValueClobberEpoch newEpoch)
 {
     ASSERT(newEpoch != m_effectEpoch);
     
     if (newEpoch.clobberEpoch() != m_effectEpoch.clobberEpoch())
-        clobberStructures();
+        clobberStructures(graph);
     if (newEpoch.structureClobberState() == StructuresAreWatched)
         m_structure.observeInvalidationPoint();
     

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.h
@@ -93,10 +93,10 @@ struct AbstractValue {
         makeTop(SpecFullTop);
     }
     
-    void clobberStructures()
+    void clobberStructures(Graph& graph)
     {
         if (m_type & SpecCell) {
-            m_structure.clobber();
+            m_structure.clobber(graph);
             clobberArrayModes();
         } else {
             ASSERT(m_structure.isClear());
@@ -105,7 +105,7 @@ struct AbstractValue {
         checkConsistency();
     }
     
-    ALWAYS_INLINE void fastForwardFromTo(AbstractValueClobberEpoch oldEpoch, AbstractValueClobberEpoch newEpoch)
+    ALWAYS_INLINE void fastForwardFromTo(Graph& graph, AbstractValueClobberEpoch oldEpoch, AbstractValueClobberEpoch newEpoch)
     {
         if (newEpoch == oldEpoch)
             return;
@@ -114,14 +114,14 @@ struct AbstractValue {
             return;
 
         if (newEpoch.clobberEpoch() != oldEpoch.clobberEpoch())
-            clobberStructures();
+            clobberStructures(graph);
         if (newEpoch.structureClobberState() == StructuresAreWatched)
             m_structure.observeInvalidationPoint();
 
         checkConsistency();
     }
     
-    ALWAYS_INLINE void fastForwardTo(AbstractValueClobberEpoch newEpoch)
+    ALWAYS_INLINE void fastForwardTo(Graph& graph, AbstractValueClobberEpoch newEpoch)
     {
         if (newEpoch == m_effectEpoch)
             return;
@@ -131,7 +131,7 @@ struct AbstractValue {
             return;
         }
 
-        fastForwardToSlow(newEpoch);
+        fastForwardToSlow(graph, newEpoch);
     }
     
     void observeTransition(RegisteredStructure from, RegisteredStructure to)
@@ -359,10 +359,10 @@ struct AbstractValue {
     FiltrationResult filter(const AbstractValue&);
     FiltrationResult filterClassInfo(Graph&, const ClassInfo*);
 
-    ALWAYS_INLINE FiltrationResult fastForwardToAndFilterUnproven(AbstractValueClobberEpoch newEpoch, SpeculatedType type)
+    ALWAYS_INLINE FiltrationResult fastForwardToAndFilterUnproven(Graph& graph, AbstractValueClobberEpoch newEpoch, SpeculatedType type)
     {
         if (m_type & SpecCell)
-            return fastForwardToAndFilterSlow(newEpoch, type);
+            return fastForwardToAndFilterSlow(graph, newEpoch, type);
         
         m_effectEpoch = newEpoch;
         m_type &= type;
@@ -488,9 +488,9 @@ private:
         checkConsistency();
     }
     
-    void fastForwardToSlow(AbstractValueClobberEpoch);
+    void fastForwardToSlow(Graph&, AbstractValueClobberEpoch);
     FiltrationResult filterSlow(SpeculatedType);
-    FiltrationResult fastForwardToAndFilterSlow(AbstractValueClobberEpoch, SpeculatedType);
+    FiltrationResult fastForwardToAndFilterSlow(Graph&, AbstractValueClobberEpoch, SpeculatedType);
     
     void filterValueByType();
     void NODELETE filterArrayModesByType();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -6686,13 +6686,13 @@ GetByOffsetMethod ByteCodeParser::planLoad(const ObjectPropertyCondition& condit
     //    Hence this results in zero code and we won't jettison this compilation if the object
     //    transitions, even if the structure is watchable right now.
     //
-    // 2) Need to emit a load, and the current structure of the base is going to be watched by the
-    //    DFG anyway (i.e. dfgShouldWatch). Watch the structure and emit the load. Don't watch the
+    // 2) Need to emit a load, and the current structure of the base may be watched by the
+    //    DFG anyway (i.e. dfgMayWatch). Watch the structure and emit the load. Don't watch the
     //    condition, since the act of turning the base into a constant in IR will cause the DFG to
     //    watch the structure anyway and doing so would subsume watching the condition.
     //
     // 3) Need to emit a load, and the current structure of the base is watchable but not by the
-    //    DFG (i.e. transitionWatchpointSetIsStillValid() and !dfgShouldWatchIfPossible()). Watch
+    //    DFG (i.e. transitionWatchpointSetIsStillValid() and !dfgMayWatchIfPossible()). Watch
     //    the condition, and emit a load.
     //
     // 4) Need to emit a load, and the current structure of the base is not watchable. Emit a
@@ -6719,9 +6719,9 @@ GetByOffsetMethod ByteCodeParser::planLoad(const ObjectPropertyCondition& condit
     if (!condition.structureEnsuresValidity(Concurrency::ConcurrentThread, structure))
         return GetByOffsetMethod();
     
-    // If the structure is watched by the DFG already, then just use this fact to emit the load.
+    // If the structure may be watched by the DFG, then watch it and use this fact to emit the load.
     // This is case (2) above.
-    if (structure->dfgShouldWatch())
+    if (m_graph.tryWatch(structure))
         return m_graph.promoteToConstant(GetByOffsetMethod::loadFromPrototype(base, condition.offset()));
     
     // If we can watch the condition right now, then we can emit the load after watching it. This
@@ -6867,7 +6867,7 @@ Node* ByteCodeParser::load(
         // Try to optimize away the structure check. Note that it's not worth doing anything about this
         // if the base's structure is watched.
         Structure* structure = unwrapped->constant()->structure();
-        if (!structure->dfgShouldWatch()) {
+        if (!m_graph.tryWatch(structure)) {
             if (!variant.conditionSet().isEmpty()) {
                 // This means that we're loading from a prototype or we have a property miss. We expect
                 // the base not to have the property. We can only use ObjectPropertyCondition if all of

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -152,8 +152,6 @@ enum PredictionPass {
 
 enum StructureRegistrationState { HaveNotStartedRegistering, AllStructuresAreRegistered };
 
-enum StructureRegistrationResult { StructureRegisteredNormally, StructureRegisteredAndWatched };
-
 enum OptimizationFixpointState { BeforeFixpoint, FixpointNotConverged, FixpointConverged };
 
 // Describes the form you can expect the entire graph to be in.

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -2446,9 +2446,7 @@ private:
     void addStructureTransitionCheck(NodeOrigin origin, unsigned indexInBlock, JSCell* cell, Structure* structure)
     {
         {
-            StructureRegistrationResult result;
-            m_graph.registerStructure(cell->structure(), result);
-            if (result == StructureRegisteredAndWatched)
+            if (m_graph.tryWatch(cell->structure()))
                 return;
         }
         

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
@@ -150,14 +150,6 @@ void DesiredWatchpoints::addLazily(DesiredGlobalProperty&& property)
     m_globalProperties.addLazily(WTF::move(property));
 }
 
-bool DesiredWatchpoints::consider(Structure* structure)
-{
-    if (!structure->dfgShouldWatch())
-        return false;
-    addLazily(structure->transitionWatchpointSet());
-    return true;
-}
-
 void DesiredWatchpoints::countWatchpoints(CodeBlock* codeBlock, DesiredIdentifiers& identifiers, CommonData* commonData)
 {
     WatchpointCollector collector(*commonData);

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h
@@ -257,8 +257,6 @@ public:
 
     void addLazily(DesiredGlobalProperty&&);
     
-    bool consider(Structure*);
-
     void countWatchpoints(CodeBlock*, DesiredIdentifiers&, CommonData*);
     
     bool reallyAdd(CodeBlock*, DesiredIdentifiers&, CommonData*);
@@ -289,6 +287,20 @@ public:
     {
         return m_adaptiveStructureSets.isWatched(key);
     }
+
+    void addRegisteredNotWatched(Structure* structure)
+    {
+        m_registeredNotWatchedStructures.add(structure);
+    }
+    bool isRegisteredNotWatched(Structure* structure) const
+    {
+        return m_registeredNotWatchedStructures.contains(structure);
+    }
+    bool takeRegisteredNotWatched(Structure* structure)
+    {
+        return m_registeredNotWatchedStructures.remove(structure);
+    }
+
     void dumpInContext(PrintStream&, DumpContext*) const;
     
 private:
@@ -299,6 +311,7 @@ private:
     GenericDesiredWatchpoints<JSArrayBufferView*, ArrayBufferViewWatchpointAdaptor> m_bufferViews;
     GenericDesiredWatchpoints<ObjectPropertyCondition, AdaptiveStructureWatchpointAdaptor> m_adaptiveStructureSets;
     DesiredGlobalProperties m_globalProperties;
+    UncheckedKeyHashSet<Structure*> m_registeredNotWatchedStructures;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1134,7 +1134,7 @@ bool Graph::isSafeToLoad(JSObject* base, PropertyOffset offset)
 GetByOffsetMethod Graph::promoteToConstant(GetByOffsetMethod method)
 {
     if (method.kind() == GetByOffsetMethod::LoadFromPrototype
-        && method.prototype()->structure()->dfgShouldWatch()) {
+        && tryWatch(method.prototype()->structure())) {
         if (JSValue constant = tryGetConstantProperty(method.prototype()->value(), method.prototype()->structure(), method.offset()))
             return GetByOffsetMethod::constant(freeze(constant));
     }
@@ -1366,16 +1366,19 @@ JSValue Graph::tryGetConstantProperty(
 
     // If all structures are watched, we don't need to consider whether object transitions and changes the value.
     // If the object gets transition while compiling, then it invalidates the code.
-    bool allAreWatched = true;
+    bool allAreWatchable = true;
     for (unsigned i = structureSet.size(); i--;) {
         RegisteredStructure structure = structureSet[i];
-        if (!structure->dfgShouldWatch()) {
-            allAreWatched = false;
+        if (!structure->dfgMayWatch()) {
+            allAreWatchable = false;
             break;
         }
     }
-    if (allAreWatched)
+    if (allAreWatchable) {
+        for (unsigned i = structureSet.size(); i--;)
+            watch(structureSet[i].get());
         return result;
+    }
 
     // However, if structures transitions are not watched, then object can get to the one of the structures transitively while it is changing the value.
     // But we can still optimize it if StructureSet is only one: in that case, there is no way to fulfill Structure requirement while changing the property
@@ -1689,20 +1692,38 @@ FrozenValue* Graph::bottomValueMatchingSpeculation(SpeculatedType prediction)
     return freeze(JSValue());
 }
 
-RegisteredStructure Graph::registerStructure(Structure* structure, StructureRegistrationResult& result)
+RegisteredStructure Graph::registerStructure(Structure* structure)
 {
-    m_plan.weakReferences().addLazily(structure);
-    if (m_plan.watchpoints().consider(structure))
-        result = StructureRegisteredAndWatched;
-    else
-        result = StructureRegisteredNormally;
+    if (!isWatched(structure)) {
+        m_plan.weakReferences().addLazily(structure);
+        m_plan.watchpoints().addRegisteredNotWatched(structure);
+    }
     return RegisteredStructure::createPrivate(structure);
 }
 
-void Graph::registerAndWatchStructureTransition(Structure* structure)
+bool Graph::tryWatch(Structure* structure)
 {
+    if (!structure->dfgMayWatch())
+        return false;
+    watch(structure);
+    return true;
+}
+
+void Graph::watch(Structure* structure)
+{
+    if (Options::verboseDFGFailure() && !structure->dfgMayWatch()) [[unlikely]] {
+        dataLogLn("DFG: Graph::watch on a non-watchable structure ", RawPointer(structure),
+            "; could be caused by race in which mutator fired watchpoint after deciding to watch"
+            " or might indicate that we're incorrectly deciding to watch.");
+    }
     m_plan.weakReferences().addLazily(structure);
+    m_plan.watchpoints().takeRegisteredNotWatched(structure);
     m_plan.watchpoints().addLazily(structure->transitionWatchpointSet());
+}
+
+bool Graph::isWatched(Structure* structure)
+{
+    return m_plan.watchpoints().isWatched(structure->transitionWatchpointSet());
 }
 
 void Graph::assertIsRegistered(Structure* structure)
@@ -1713,11 +1734,13 @@ void Graph::assertIsRegistered(Structure* structure)
 
     DFG_ASSERT(*this, nullptr, m_plan.weakReferences().contains(structure));
 
-    if (!structure->dfgShouldWatch())
+    if (!structure->dfgMayWatch())
         return;
-    if (watchpoints().isWatched(structure->transitionWatchpointSet()))
+    if (isWatched(structure))
         return;
-    
+    if (m_plan.watchpoints().isRegisteredNotWatched(structure))
+        return;
+
     DFG_CRASH(*this, nullptr, toCString("Structure ", pointerDump(structure), " is watchable but isn't being watched.").data());
 }
 

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -290,13 +290,11 @@ public:
     // https://bugs.webkit.org/show_bug.cgi?id=210627
     FrozenValue* bottomValueMatchingSpeculation(SpeculatedType);
     
-    RegisteredStructure registerStructure(Structure* structure)
-    {
-        StructureRegistrationResult ignored;
-        return registerStructure(structure, ignored);
-    }
-    RegisteredStructure registerStructure(Structure*, StructureRegistrationResult&);
-    void registerAndWatchStructureTransition(Structure*);
+    RegisteredStructure registerStructure(Structure*);
+    bool tryWatch(Structure*);
+    void watch(Structure*);
+    bool isWatched(Structure*);
+
     void assertIsRegistered(Structure* structure);
     
     // CodeBlock is optional, but may allow additional information to be dumped (e.g. Identifier names).

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
@@ -225,7 +225,7 @@ bool InPlaceAbstractState::endBasicBlock()
             
             if (!m_activeVariables[index]) {
                 destination = block->valuesAtHead[index];
-                destination.fastForwardFromTo(epochAtHead, currentEpoch);
+                destination.fastForwardFromTo(m_graph, epochAtHead, currentEpoch);
                 continue;
             }
             
@@ -297,7 +297,7 @@ bool InPlaceAbstractState::endBasicBlock()
 
             if (!m_activeVariables[i]) {
                 destination = block->valuesAtHead[i];
-                destination.fastForwardFromTo(epochAtHead, currentEpoch);
+                destination.fastForwardFromTo(m_graph, epochAtHead, currentEpoch);
                 continue;
             }
             

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -55,13 +55,13 @@ public:
 
     ALWAYS_INLINE AbstractValue& fastForward(AbstractValue& value)
     {
-        value.fastForwardTo(m_effectEpoch);
+        value.fastForwardTo(m_graph, m_effectEpoch);
         return value;
     }
     
     ALWAYS_INLINE FiltrationResult fastForwardAndFilterUnproven(AbstractValue& value, SpeculatedType type)
     {
-        return value.fastForwardToAndFilterUnproven(m_effectEpoch, type);
+        return value.fastForwardToAndFilterUnproven(m_graph, m_effectEpoch, type);
     }
     
     ALWAYS_INLINE AbstractValue& forNodeWithoutFastForward(NodeFlowProjection node)

--- a/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp
@@ -46,12 +46,11 @@ void StructureAbstractValue::assertIsRegistered(Graph& graph) const
 }
 #endif // ASSERT_ENABLED
 
-void StructureAbstractValue::clobber()
+void StructureAbstractValue::clobber(Graph& graph)
 {
     // The premise of this approach to clobbering is that anytime we introduce
-    // a watchable structure into an abstract value, we watchpoint it. You can assert
-    // that this holds by calling assertIsWatched().
-        
+    // a watchable structure into an abstract value, we watchpoint it.
+
     if (isTop())
         return;
 
@@ -60,22 +59,25 @@ void StructureAbstractValue::clobber()
     if (m_set.isThin()) {
         if (!m_set.singleEntry())
             return;
-        if (!m_set.singleEntry()->dfgShouldWatch())
+        if (!graph.tryWatch(m_set.singleEntry().get()))
             makeTopWhenThin();
         return;
     }
 
     for (auto& item : m_set.list()->lengthSpan() | std::views::reverse) {
-        if (!item->dfgShouldWatch()) {
+        if (!item->dfgMayWatch()) {
             makeTop();
             return;
         }
     }
+
+    for (auto& item : m_set.list()->lengthSpan())
+        graph.watch(item.get());
 }
 
 void StructureAbstractValue::observeTransition(RegisteredStructure from, RegisteredStructure to)
 {
-    ASSERT(!from->dfgShouldWatch());
+    ASSERT(!from->dfgMayWatch());
 
     if (isTop())
         return;
@@ -97,7 +99,7 @@ void StructureAbstractValue::observeTransitions(const TransitionVector& vector)
     
     RegisteredStructureSet newStructures;
     for (unsigned i = vector.size(); i--;) {
-        ASSERT(!vector[i].previous->dfgShouldWatch());
+        ASSERT(!vector[i].previous->dfgMayWatch());
 
         if (!m_set.contains(vector[i].previous))
             continue;

--- a/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGStructureAbstractValue.h
@@ -96,7 +96,7 @@ public:
     void assertIsRegistered(Graph&) const { }
 #endif
     
-    void clobber();
+    void clobber(Graph&);
     void observeInvalidationPoint() { setClobbered(false); }
     
     void observeTransition(RegisteredStructure from, RegisteredStructure to);

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -337,20 +337,20 @@ public:
                     VALIDATE((node), !!node->child1());
                     break;
                 case PutStructure:
-                    VALIDATE((node), !node->transition()->previous->dfgShouldWatch());
+                    VALIDATE((node), !node->transition()->previous->dfgMayWatch());
                     break;
                 case MultiPutByOffset:
                     for (unsigned i = node->multiPutByOffsetData().variants.size(); i--;) {
                         const PutByVariant& variant = node->multiPutByOffsetData().variants[i];
                         if (variant.kind() != PutByVariant::Transition)
                             continue;
-                        VALIDATE((node), !variant.oldStructureForTransition()->dfgShouldWatch());
+                        VALIDATE((node), !variant.oldStructureForTransition()->dfgMayWatch());
                     }
                     break;
                 case MultiDeleteByOffset:
                     for (unsigned i = node->multiDeleteByOffsetData().variants.size(); i--;) {
                         const DeleteByVariant& variant = node->multiDeleteByOffsetData().variants[i];
-                        VALIDATE((node), !variant.newStructure() || !variant.oldStructure()->dfgShouldWatch());
+                        VALIDATE((node), !variant.newStructure() || !variant.oldStructure()->dfgMayWatch());
                     }
                     break;
                 case MaterializeNewObject:

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -700,7 +700,7 @@ public:
         return m_transitionWatchpointSet.isStillValid();
     }
     
-    bool dfgShouldWatchIfPossible() const
+    bool dfgMayWatchIfPossible() const
     {
         // FIXME: We would like to not watch things that are unprofitable to watch, like
         // dictionaries. Unfortunately, we can't do such things: a dictionary could get flattened,
@@ -721,14 +721,14 @@ public:
         return true;
     }
     
-    bool dfgShouldWatch() const
+    bool dfgMayWatch() const
     {
-        return dfgShouldWatchIfPossible() && transitionWatchpointSetIsStillValid();
+        return dfgMayWatchIfPossible() && transitionWatchpointSetIsStillValid();
     }
 
-    bool propertyNameEnumeratorShouldWatch() const
+    bool propertyNameEnumeratorMayWatch() const
     {
-        return dfgShouldWatch() && !hasPolyProto();
+        return dfgMayWatch() && !hasPolyProto();
     }
         
     inline void addTransitionWatchpoint(Watchpoint* watchpoint) const; // Defined in StructureInlinesLight.h

--- a/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -205,7 +205,7 @@ inline bool StructureRareData::tryCachePropertyNameEnumeratorViaWatchpoint(VM&, 
         ++size;
         StructureID structureID = *current;
         Structure* structure = structureID.decode();
-        if (!structure->propertyNameEnumeratorShouldWatch())
+        if (!structure->propertyNameEnumeratorMayWatch())
             return false;
     }
     m_cachedPropertyNameEnumeratorWatchpoints = FixedVector<StructureChainInvalidationWatchpoint>(size);


### PR DESCRIPTION
#### 17d76fab1e3b088fde6a048e60dc130972266ee0
<pre>
[JSC] Avoid setting unnecessary watchpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=317809">https://bugs.webkit.org/show_bug.cgi?id=317809</a>
<a href="https://rdar.apple.com/180580140">rdar://180580140</a>

Reviewed by Yusuke Suzuki.

AbstractInterpreter registers many structures (Graph::registerStructure)
and this sets many CodeBlockJettisoningWatchpoints eagerly. This
jettisons CodeBlocks in cases when the emitted code doesn&apos;t speculate on
the watchpoint being set, which is wasteful.

Change the DFG to explicitly watch structures with tryWatch or watch and
don&apos;t eagerly set the watchpoint in registerStructure. Also rename
dfgShouldWatch to dfgMayWatch and a few other things to reflect this.

Before this change, we called dfgShouldWatch after registerStructure to
know that we already set the watchpoint. After this change, we need to
check the result of tryWatch or isWatched or call watch to know that the
watchpoint has been set.

Note that after this change, we can still set watchpoints that are not
needed for the emitted code; to avoid this, we&apos;d need to keep track of
which abstract values would need to set watchpoints to be trusted and
only set those watchpoints when trusting the abstract value enables
emitting better code.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::noteDFGWatchedStructure):
(JSC::CodeBlock::~CodeBlock):
(JSC::CodeBlock::jettison):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/Watchpoint.h:
(JSC::FireDetail::watchpointStructure const):
* Source/JavaScriptCore/dfg/DFGAbstractValue.cpp:
(JSC::DFG::AbstractValue::set):
(JSC::DFG::AbstractValue::fastForwardToAndFilterSlow):
(JSC::DFG::AbstractValue::fastForwardToSlow):
* Source/JavaScriptCore/dfg/DFGAbstractValue.h:
(JSC::DFG::AbstractValue::clobberStructures):
(JSC::DFG::AbstractValue::fastForwardFromTo):
(JSC::DFG::AbstractValue::fastForwardTo):
(JSC::DFG::AbstractValue::fastForwardToAndFilterUnproven):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::planLoad):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::addStructureTransitionCheck):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp:
(JSC::DFG::DesiredWatchpoints::processNonLoadBearingStructureTransitions):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
(JSC::DFG::DesiredWatchpoints::addPotentiallyWatchedTransition):
(JSC::DFG::DesiredWatchpoints::isPotentiallyWatchedTransition const):
(JSC::DFG::DesiredWatchpoints::takePotentiallyWatchedTransition):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::promoteToConstant):
(JSC::DFG::Graph::tryGetConstantProperty):
(JSC::DFG::Graph::registerStructure):
(JSC::DFG::Graph::registerStructureAndTryWatch):
(JSC::DFG::Graph::tryWatch):
(JSC::DFG::Graph::watch):
(JSC::DFG::Graph::isWatched):
(JSC::DFG::Graph::assertIsRegistered):
(JSC::DFG::Graph::registerAndWatchStructureTransition): Deleted.
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
(JSC::DFG::InPlaceAbstractState::endBasicBlock):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
(JSC::DFG::InPlaceAbstractState::fastForward):
(JSC::DFG::InPlaceAbstractState::fastForwardAndFilterUnproven):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::finalizeInThread):
* Source/JavaScriptCore/dfg/DFGStructureAbstractValue.cpp:
(JSC::DFG::StructureAbstractValue::clobber):
* Source/JavaScriptCore/dfg/DFGStructureAbstractValue.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/Structure.h:

Canonical link: <a href="https://commits.webkit.org/316084@main">https://commits.webkit.org/316084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18aec8083ffcede1d894e6c9b7cc160c3b636c74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128152 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e43d8411-b490-46ef-9b52-90971567c3db) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132910 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93704 "1 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2feecd26-6f54-4523-86ab-f30ebd5e359d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113408 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a50ce077-a81a-4dc4-9f6b-26f79e5c2906) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33047 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28497 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1754 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31694 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141358 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44020 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38155 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44709 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109189 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36443 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116598 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203118 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43219 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7826 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54404 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42755 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->