### PR TITLE
AX: VoiceOver cannot reach the content of a presentational local iframe

### DIFF
--- a/LayoutTests/accessibility/mac/local-frame-presentational-iframe-content-expected.txt
+++ b/LayoutTests/accessibility/mac/local-frame-presentational-iframe-content-expected.txt
@@ -1,0 +1,18 @@
+This test ensures the content of a presentational (accessibility-ignored) iframe is hoisted in the accessibility tree, with childrenCount and indexOfChild consistent with the hoisted children, and can reach the root via ancestry walk.
+
+PASS: host.childrenCount === 4
+PASS: host.childAtIndex(0).domIdentifier === 'before'
+PASS: host.childAtIndex(1).domIdentifier === 'frame-button-1'
+PASS: host.childAtIndex(1).role === 'AXRole: AXButton'
+PASS: host.childAtIndex(2).domIdentifier === 'frame-button-2'
+PASS: host.childAtIndex(3).domIdentifier === 'after'
+PASS: host.indexOfChild(host.childAtIndex(1)) === 1
+PASS: host.indexOfChild(host.childAtIndex(2)) === 2
+PASS: host.indexOfChild(host.childAtIndex(3)) === 3
+PASS: (button && host ? ancestryReaches(button, host) : false) === true
+PASS: (button && root ? ancestryReaches(button, root) : false) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Before  After

--- a/LayoutTests/accessibility/mac/local-frame-presentational-iframe-content.html
+++ b/LayoutTests/accessibility/mac/local-frame-presentational-iframe-content.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="host" role="group">
+<button id="before">Before</button>
+<iframe id="iframe" role="presentation" src="../resources/presentational-iframe-content.html"></iframe>
+<button id="after">After</button>
+</div>
+
+<script>
+var output = "This test ensures the content of a presentational (accessibility-ignored) iframe is hoisted in the accessibility tree, with childrenCount and indexOfChild consistent with the hoisted children, and can reach the root via ancestry walk.\n\n";
+
+var host, root, button;
+function ancestryReaches(element, target) {
+    for (var ancestor = element; ancestor; ancestor = ancestor.parentElement()) {
+        if (ancestor.isEqual(target))
+            return true;
+    }
+    return false;
+}
+
+window.jsTestIsAsync = true;
+
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    // The iframe has more than one top-level child, so its content must be hoisted as multiple children of
+    // the host -- this is what distinguishes the cross-frame-aware count and index paths from the raw stitched
+    // children (where the iframe counts as a single placeholder).
+    button = await waitForElementById("frame-button-1");
+    await waitFor(() => {
+        if (!button)
+            return false;
+        host = accessibilityController.accessibleElementById("host");
+        return host && host.childrenCount === 4 && host.childAtIndex(1).isEqual(button);
+    });
+
+    root = accessibilityController.rootElement;
+
+    output += expect("host.childrenCount", "4");
+    output += expect("host.childAtIndex(0).domIdentifier", "'before'");
+    output += expect("host.childAtIndex(1).domIdentifier", "'frame-button-1'");
+    output += expect("host.childAtIndex(1).role", "'AXRole: AXButton'");
+    output += expect("host.childAtIndex(2).domIdentifier", "'frame-button-2'");
+    output += expect("host.childAtIndex(3).domIdentifier", "'after'");
+
+    // The count, children list, and index lookups must all agree on the hoisted list, otherwise
+    // NSAccessibility drops trailing children or misindexes them.
+    output += expect("host.indexOfChild(host.childAtIndex(1))", "1");
+    output += expect("host.indexOfChild(host.childAtIndex(2))", "2");
+    output += expect("host.indexOfChild(host.childAtIndex(3))", "3");
+
+    output += expect("(button && host ? ancestryReaches(button, host) : false)", "true");
+    output += expect("(button && root ? ancestryReaches(button, root) : false)", "true");
+
+    debug(output);
+    finishJSTest();
+}
+
+window.addEventListener("load", runTest);
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/resources/presentational-iframe-content.html
+++ b/LayoutTests/accessibility/resources/presentational-iframe-content.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<button id="frame-button-1">Click me</button>
+<button id="frame-button-2">Click me too</button>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -479,27 +479,80 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::crossFrameUnignoredChild
     AXCoreObject::AccessibilityChildrenVector result = stitchedUnignoredChildren();
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+    // When a cross-frame child (i.e. a local frame's root) is ignored, e.g. via
+    // role="presentation", hoist its content rather than returning the ignored root,
+    // which would cause parent-child mismatches in the AT-exposed accessibility tree.
+    // crossFrameParentObjectUnignored() is the matching parent-side hoist that keeps the
+    // hoisted content reciprocal.
+    auto appendCrossFrameContent = [](AccessibilityChildrenVector& out, AXCoreObject& crossFrameChild) {
+        if (crossFrameChild.isIgnored()) {
+            for (auto& grandchild : crossFrameChild.stitchedUnignoredChildren())
+                out.append(grandchild);
+        } else
+            out.append(crossFrameChild);
+    };
+
     if (result.isEmpty()) {
         if (RefPtr crossFrameChild = crossFrameChildObject())
-            result.append(*crossFrameChild);
+            appendCrossFrameContent(result, *crossFrameChild);
     } else {
+        AccessibilityChildrenVector splicedResult;
+        splicedResult.reserveInitialCapacity(result.size());
         for (size_t i = 0; i < result.size(); i++) {
             if (RefPtr crossFrameChild = protect(result[i])->crossFrameChildObject())
-                result[i] = crossFrameChild.releaseNonNull();
+                appendCrossFrameContent(splicedResult, *crossFrameChild);
+            else
+                splicedResult.append(WTF::move(result[i]));
         }
+        result = WTF::move(splicedResult);
     }
 #endif
 
     return result;
 }
 
+size_t AXCoreObject::crossFrameUnignoredChildrenCount()
+{
+    std::optional hasCrossFrameChild = cachedHasCrossFrameChild();
+    if (hasCrossFrameChild && !*hasCrossFrameChild)
+        return stitchedUnignoredChildrenCount();
+    return crossFrameUnignoredChildren().size();
+}
+
+std::optional<bool> AXCoreObject::cachedHasCrossFrameChild()
+{
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+    // The base (live) tree has no cached has-cross-frame-child flag, so it can't answer cheaply.
+    return std::nullopt;
+#else
+    // Cross-frame children only exist with ACCESSIBILITY_LOCAL_FRAME.
+    return false;
+#endif
+}
+
 AXCoreObject* AXCoreObject::crossFrameParentObjectUnignored() const
 {
-    if (SUPPRESS_UNCOUNTED_LOCAL auto* result = parentObjectUnignored())
-        return result;
+    if (auto* parent = roleSpecificUnignoredParent())
+        return parent;
+
+    // Walk to the nearest unignored ancestor, crossing a local-frame boundary when the walk
+    // reaches a frame root (e.g. the frame's scroll view + web area are ignored, as for a
+    // presentational iframe). crossFrameParentObject() already returns an unignored object in the
+    // parent frame, so it needs no further ignored check. Returning no parent causes lots of issues
+    // for assistive technologies.
+    for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
+        if (!ancestor->isIgnored())
+            return ancestor.unsafeGet();
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+        if (auto* crossParent = ancestor->crossFrameParentObject())
+            return crossParent;
+#endif
+    }
+
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
     return crossFrameParentObject();
 #endif
+
     return nullptr;
 }
 
@@ -2037,12 +2090,21 @@ void AXCoreObject::appendRadioButtonGroupMembers(AccessibilityChildrenVector& li
     }
 }
 
-AXCoreObject* AXCoreObject::parentObjectUnignored() const
+AXCoreObject* AXCoreObject::roleSpecificUnignoredParent() const
 {
+    // Some roles have a parent determined by structure rather than the nearest unignored ancestor:
+    // a table row's parent is its exposed table. Returns nullptr when no such special case applies.
     if (role() == AccessibilityRole::Row) {
         if (auto* table = exposedTableAncestor())
             return table;
     }
+    return nullptr;
+}
+
+AXCoreObject* AXCoreObject::parentObjectUnignored() const
+{
+    if (auto* parent = roleSpecificUnignoredParent())
+        return parent;
 
     return Accessibility::findAncestor<AXCoreObject>(*this, false, [&] (const AXCoreObject& object) {
         return !object.isIgnored();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -868,6 +868,9 @@ public:
 #endif
     virtual AXCoreObject* parentObject() const = 0;
     virtual AXCoreObject* parentObjectUnignored() const;
+    // The unignored parent for roles whose parent is structural rather than the nearest unignored
+    // ancestor (currently a table row -> its exposed table); nullptr if no such special case applies.
+    AXCoreObject* roleSpecificUnignoredParent() const;
     AXCoreObject* parentInCoreTree() const
     {
         // Returns the parent in the "core", platform-agnostic accessibility tree, which is not necessarily
@@ -889,6 +892,11 @@ public:
     // Helpers that run on any platform and return children and parents, calling the cross frame functions if needed
     // to walk between LocalFrames.
     AccessibilityChildrenVector crossFrameUnignoredChildren();
+    size_t crossFrameUnignoredChildrenCount();
+    // Whether this object hosts a cross-frame subtree that crossFrameUnignoredChildren() hoists.
+    // Returns std::nullopt when the implementation can not cheaply determine (i.e. from a cache)
+    // whether a cross-frame child is present.
+    virtual std::optional<bool> cachedHasCrossFrameChild();
     AXCoreObject* crossFrameParentObjectUnignored() const;
     AccessibilityChildrenVector crossFrameChildrenIncludingIgnored(bool updateChildrenIfNeeded = true);
     bool crossFrameIsAncestorOfObject(const AXCoreObject&) const;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -329,13 +329,21 @@ AXIsolatedTree::CachedUnignoredChildren& AXIsolatedObject::ensureCachedUnignored
     auto result = cache.ensure(objectID(), [&] {
         auto children = AXCoreObject::unignoredChildren();
         bool hasPotentialStitchable = false;
+        bool hasCrossFrameChild = false;
         for (const auto& child : children) {
-            if (child->hasStitchableRole()) {
+            if (!hasPotentialStitchable && child->hasStitchableRole())
                 hasPotentialStitchable = true;
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+            if (child->isLocalFrame())
+                hasCrossFrameChild = true;
+            if (hasPotentialStitchable && hasCrossFrameChild)
                 break;
-            }
+#else
+            if (hasPotentialStitchable)
+                break;
+#endif
         }
-        return AXIsolatedTree::CachedUnignoredChildren { WTF::move(children), hasPotentialStitchable };
+        return AXIsolatedTree::CachedUnignoredChildren { WTF::move(children), hasPotentialStitchable, hasCrossFrameChild };
     });
     return result.iterator->value;
 }
@@ -398,41 +406,43 @@ const AXCoreObject::AccessibilityChildrenVector* AXIsolatedObject::cachedStitche
     return nullptr;
 }
 
+std::optional<bool> AXIsolatedObject::cachedHasCrossFrameChild()
+{
+    AX_ASSERT(!isMainThread());
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+    auto& entry = ensureCachedUnignoredChildren();
+    return entry.hasCrossFrameChild || (entry.children.isEmpty() && crossFrameChildObject());
+#else
+    return false;
+#endif
+}
+
 AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount)
 {
     AX_ASSERT(!isMainThread());
     auto& entry = ensureCachedUnignoredChildren();
 
-    if (entry.children.isEmpty()) {
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-        if (!start && maxCount) {
-            if (RefPtr crossFrameChild = crossFrameChildObject())
-                return { Ref { *crossFrameChild } };
-        }
-#endif
-        return { };
+    if (entry.hasCrossFrameChild || (entry.children.isEmpty() && crossFrameChildObject())) {
+        auto children = crossFrameUnignoredChildren();
+        if (start >= children.size())
+            return { };
+        size_t count = std::min(maxCount, children.size() - start);
+        return AccessibilityChildrenVector { children.span().subspan(start, count) };
     }
+#endif
+
+    if (entry.children.isEmpty())
+        return { };
 
     if (!entry.hasPotentialStitchable) {
         if (start >= entry.children.size())
             return { };
-        size_t end = std::min(start + maxCount, entry.children.size());
-
-        AccessibilityChildrenVector result;
-        result.reserveInitialCapacity(end - start);
-        for (size_t i = start; i < end; i++) {
-            Ref child = entry.children[i];
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-            if (RefPtr crossFrameChild = child->crossFrameChildObject())
-                result.append(crossFrameChild.releaseNonNull());
-            else
-#endif
-                result.append(WTF::move(child));
-        }
-        return result;
+        size_t count = std::min(maxCount, entry.children.size() - start);
+        return AccessibilityChildrenVector { entry.children.span().subspan(start, count) };
     }
 
-    // Has potential stitchable children — need to skip stitched-away elements
+    // Has potential stitchable children -- need to skip stitched-away elements
     // while computing the range relative to the stitched result.
     AccessibilityChildrenVector result;
     size_t stitchedIndex = 0;
@@ -444,14 +454,8 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::crossFrameUnignoredC
         }
         if (stitchedIndex >= start + maxCount)
             break;
-        if (stitchedIndex >= start) {
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-            if (RefPtr crossFrameChild = child->crossFrameChildObject())
-                result.append(*crossFrameChild);
-            else
-#endif
-                result.append(child);
-        }
+        if (stitchedIndex >= start)
+            result.append(child);
         ++stitchedIndex;
     }
     return result;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -87,6 +87,7 @@ public:
     const AccessibilityChildrenVector* cachedUnignoredChildren() final;
     const AccessibilityChildrenVector* cachedStitchedUnignoredChildren() final;
     AccessibilityChildrenVector crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount) final;
+    std::optional<bool> cachedHasCrossFrameChild() final;
     AXIsolatedObject* parentObject() const final { return tree().objectForID(parent()); }
     AXIsolatedObject* parentObjectUnignored() const final { return downcast<AXIsolatedObject>(AXCoreObject::parentObjectUnignored()); }
     bool isEditableWebArea() const final { return boolAttributeValue(AXProperty::IsEditableWebArea); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2196,6 +2196,15 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             if (auto frameID = localFrame ? localFrame->frameID() : std::nullopt)
                 setProperty(AXProperty::CrossFrameChildFrameID, *frameID);
         }
+
+        if (object.isScrollArea() && !object.parentObject()) {
+            if (RefPtr crossFrameParent = object.crossFrameParentObject()) {
+                if (WeakPtr parentCache = crossFrameParent->axObjectCache()) {
+                    setProperty(AXProperty::CrossFrameParentFrameID, parentCache->frameID());
+                    setProperty(AXProperty::CrossFrameParentAXID, Markable { crossFrameParent->objectID() });
+                }
+            }
+        }
 #endif
     };
 
@@ -2275,16 +2284,6 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         bool isWebArea = axObject->isWebArea();
         bool isScrollArea = axObject->isScrollArea();
         if (isScrollArea && !axObject->parentObject()) {
-#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-            RefPtr crossFrameParent = axObject->crossFrameParentObject();
-            if (crossFrameParent) {
-                WeakPtr parentCache = crossFrameParent->axObjectCache();
-                if (parentCache) {
-                    setProperty(AXProperty::CrossFrameParentFrameID, parentCache->frameID());
-                    setProperty(AXProperty::CrossFrameParentAXID, Markable { crossFrameParent->objectID() });
-                }
-            }
-#endif
             // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
             // of non-root objects depend on the root object's screen relative position, so make sure it's there
             // from the start. We keep this up-to-date via AXIsolatedTree::updateRootScreenRelativePosition().

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -482,6 +482,8 @@ public:
     struct CachedUnignoredChildren {
         Vector<Ref<AXCoreObject>> children;
         bool hasPotentialStitchable { false };
+        // true if any child hosts a cross-frame subtree (i.e. a LocalFrame).
+        bool hasCrossFrameChild { false };
     };
     HashMap<AXID, CachedUnignoredChildren>& cachedUnignoredChildrenMap() { AX_ASSERT(!isMainThread()); return m_cachedUnignoredChildren; }
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1324,7 +1324,7 @@ static id handleParentAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& ba
         }
     }
 
-    RefPtr parent = backingObject.parentObjectUnignored();
+    RefPtr parent = backingObject.crossFrameParentObjectUnignored();
     if (!parent)
         return nil;
 
@@ -4433,10 +4433,20 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (backingObject->isTree())
         return [super accessibilityIndexOfChild:targetChild];
 
-    const auto* childrenPointer = backingObject->cachedStitchedUnignoredChildren();
     AXCoreObject::AccessibilityChildrenVector computedChildren;
-    if (!childrenPointer) {
-        computedChildren = backingObject->stitchedUnignoredChildren();
+    const AXCoreObject::AccessibilityChildrenVector* childrenPointer = nullptr;
+    std::optional hasCrossFrameChild = backingObject->cachedHasCrossFrameChild();
+    if (hasCrossFrameChild && !*hasCrossFrameChild) {
+        // Cheaply known to have no cross-frame child, so we can directly use
+        // the cached children.
+        childrenPointer = backingObject->cachedStitchedUnignoredChildren();
+        if (!childrenPointer) {
+            computedChildren = backingObject->stitchedUnignoredChildren();
+            childrenPointer = &computedChildren;
+        }
+    } else {
+        // There is a cross-frame child (or we can't tell cheaply), so take the slow path.
+        computedChildren = backingObject->crossFrameUnignoredChildren();
         childrenPointer = &computedChildren;
     }
     const auto& children = *childrenPointer;
@@ -4478,7 +4488,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             return children(*backingObject).count;
 
         // FIXME: this is duplicating the logic in children(AXCoreObject&) so it should be reworked.
-        size_t childrenSize = backingObject->stitchedUnignoredChildrenCount();
+        size_t childrenSize = backingObject->crossFrameUnignoredChildrenCount();
         if (!childrenSize) {
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
             if (backingObject->isModel())


### PR DESCRIPTION
#### 7fc011a98165013068d21d572cb7f3bb7795a939
<pre>
AX: VoiceOver cannot reach the content of a presentational local iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=317808">https://bugs.webkit.org/show_bug.cgi?id=317808</a>
<a href="https://rdar.apple.com/179822336">rdar://179822336</a>

Reviewed by Dominic Mazzoni.

With ENABLE(ACCESSIBILITY_LOCAL_FRAME), a presentational iframe&apos;s frame root -- an
accessibility-ignored AXScrollArea -- was spliced into the host frame as-is, which
causes trouble for VoiceOver and other ATs, since it resulted in a parent-child
mismatch in the accessibility tree, and leaves the iframe with no reachable parent.

Fix this by hoisting the ignored iframes content in the accessibility
tree rather than exposing the ignored iframe root in the tree directly.

In the isolated tree, cache the cross-frame parent linkage in the always-run
base-property path (an ignored root skips the needsAllProperties branch that set it),
and have crossFrameUnignoredChildrenInRange() delegate to crossFrameUnignoredChildren()
for cross-frame hosts -- detected via a cached hasCrossFrameChild flag -- keeping the
cheap ranged slice otherwise.

* LayoutTests/accessibility/mac/local-frame-presentational-iframe-content-expected.txt: Added.
* LayoutTests/accessibility/mac/local-frame-presentational-iframe-content.html: Added.
* LayoutTests/accessibility/resources/presentational-iframe-content.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::crossFrameUnignoredChildren):
(WebCore::AXCoreObject::crossFrameParentObjectUnignored const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::ensureCachedUnignoredChildren):
(WebCore::AXIsolatedObject::crossFrameUnignoredChildrenInRange):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleParentAttribute):

Canonical link: <a href="https://commits.webkit.org/315933@main">https://commits.webkit.org/315933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36abf0005073bd174bcf6979b99d63b2ae9b61f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170436 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128149 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3da53811-40a3-46f3-a20e-19c860a41d7a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132906 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9509154-d143-426d-998d-cfd191582a55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113404 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d410838-c568-451d-bc3f-7fc32251c5ea) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28494 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145166 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182396 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141355 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141173 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38033 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44706 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29722 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109184 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36439 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116595 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43216 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7824 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42621 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42862 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42752 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->