### PR TITLE
Avoid serializing and re-parsing the navigation URL twice in NavigationActionData

### DIFF
--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -88,10 +88,15 @@ struct NavigationActionData {
     std::optional<WebPageProxyIdentifier> originatingPageID;
     FrameInfoData frameInfo;
     std::optional<WebCore::NavigationIdentifier> navigationID;
-    WebCore::ResourceRequest originalRequest;
+    // Sent as nullopt when equal to `request`, to avoid serializing and re-parsing a potentially
+    // very large URL twice. Resolve via originalRequestOrFallback() / fall back to `request`.
+    std::optional<WebCore::ResourceRequest> originalRequest;
     WebCore::ResourceRequest request;
     String invalidURLString;
     std::optional<WebCore::NavigationRequester> requester;
+
+    // `originalRequest` is sent as nullopt when it equals `request`; resolve it here.
+    const WebCore::ResourceRequest& originalRequestOrFallback() const { return originalRequest ? *originalRequest : request; }
 };
 
 }

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -59,7 +59,7 @@ struct WebKit::NavigationActionData {
     std::optional<WebKit::WebPageProxyIdentifier> originatingPageID;
     WebKit::FrameInfoData frameInfo;
     std::optional<WebCore::NavigationIdentifier> navigationID;
-    WebCore::ResourceRequest originalRequest;
+    std::optional<WebCore::ResourceRequest> originalRequest;
     [EncodeRequestBody] WebCore::ResourceRequest request;
     String invalidURLString;
     std::optional<WebCore::NavigationRequester> requester;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9310,7 +9310,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     auto frameInfo = navigationActionData.frameInfo;
     auto navigationID = navigationActionData.navigationID;
     auto originatingFrameInfoData = navigationActionData.originatingFrameInfoData;
-    auto originalRequest = navigationActionData.originalRequest;
+    auto originalRequest = navigationActionData.originalRequestOrFallback();
     auto request = navigationActionData.request;
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "decidePolicyForNavigationAction: frameID=%" PRIu64 ", isMainFrame=%d, navigationID=%" PRIu64, frame.frameID().toUInt64(), frame.isMainFrame(), navigationID ? navigationID->toUInt64() : 0);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -136,6 +136,14 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         ownerPermissionsPolicy = coreFrame->ownerPermissionsPolicy();
 
     auto& mouseEventData = navigationAction.mouseEventData();
+
+    // Avoid serializing (and re-parsing in the UIProcess) the navigation URL twice: when the
+    // original request is equal to the current request, send nullopt and let the receiver fall
+    // back to `request`. See NavigationActionData::originalRequestOrFallback().
+    std::optional<WebCore::ResourceRequest> originalRequest;
+    if (navigationAction.originalRequest() != request)
+        originalRequest = navigationAction.originalRequest();
+
     return NavigationActionData {
         navigationAction.type(),
         modifiersForNavigationAction(navigationAction),
@@ -175,7 +183,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         originatingPageID,
         m_frame->info(),
         navigationID,
-        navigationAction.originalRequest(),
+        WTF::move(originalRequest),
         request,
         request.url().isValid() ? String() : request.url().string(),
         requester,


### PR DESCRIPTION
#### e778f1ba5d72ff38eeeae8021cee33fe751f8043
<pre>
Avoid serializing and re-parsing the navigation URL twice in NavigationActionData
<a href="https://bugs.webkit.org/show_bug.cgi?id=317812">https://bugs.webkit.org/show_bug.cgi?id=317812</a>
<a href="https://rdar.apple.com/180510568">rdar://180510568</a>

Reviewed by Per Arne Vollan.

NavigationActionData carries two ResourceRequests, `originalRequest` and `request`,
each of which is decoded on the UIProcess main thread when handling
DecidePolicyForNavigationAction. Decoding a ResourceRequest re-parses its URL (via
ResourceRequest::doUpdateResourceRequest), so for a top-level navigation with no
redirect — where `originalRequest` equals `request` — the same URL is serialized and
parsed twice.

Given that the URL decoding is happening on the main thread of the UIProcess
and that we see some hangs in this code path, this cuts the amount of work
by half in the common case.

* Source/WebKit/Shared/NavigationActionData.h:
(WebKit::NavigationActionData::originalRequestOrFallback const):
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):

Canonical link: <a href="https://commits.webkit.org/315860@main">https://commits.webkit.org/315860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/080861260d3ff820eea29b44e38d96ab0f1c72bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127839 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fb73d48-ce23-44a8-b12f-7a77a6955878) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45293 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43682 "Build is in progress. Recent messages:Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132678 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05a5b036-3e8f-48af-ab65-e9b7912fa534) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113179 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91008200-a0fb-464f-a717-0c418d30cdde) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32752 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28185 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1468 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182086 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34875 "Found 109 new failures in wasm/WasmIPIntGenerator.cpp, runtime/IndexingType.cpp, rendering/NinePieceImagePainter.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm, jit/GdbJIT.cpp, dom/TreeScope.cpp, Modules/speech/SpeechRecognitionResultList.cpp, layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp, bytecode/CheckPrivateBrandStatus.cpp, dfg/DFGByteCodeParser.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141068 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169527 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43706 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37970 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44395 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29434 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108757 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36163 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116276 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 28157 issues") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42906 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7533 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42552 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->