### PR TITLE
AX: Move libAccessibility soft-linking into a shared LibAccessibilitySoftLink.{h,mm}

### DIFF
--- a/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
+++ b/Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm
@@ -27,12 +27,7 @@
 #import "AccessibilityPreferences.h"
 
 #import "AccessibilitySupportSPI.h"
-#import <wtf/SoftLinking.h>
-
-#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
-SOFT_LINK_LIBRARY_OPTIONAL(libAccessibility)
-SOFT_LINK_OPTIONAL(libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabled, Boolean, (), ());
-#endif
+#import "LibAccessibilitySoftLink.h"
 
 #if ENABLE(ACCESSIBILITY_VIDEO_AUTOPLAY_CONTROL)
 #import <UIKit/UIAccessibility.h>
@@ -95,8 +90,8 @@ bool imageAnimationEnabled()
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     if (shouldUseDefault()) [[unlikely]]
         return WebKit::initialImageAnimationEnabled;
-    if (auto* functionPointer = _AXSReduceMotionAutoplayAnimatedImagesEnabledPtr())
-        return functionPointer();
+    if (WebKit::islibAccessibilityLibraryAvailable() && WebKit::canLoad_libAccessibility__AXSReduceMotionAutoplayAnimatedImagesEnabled())
+        return WebKit::softLink_libAccessibility__AXSReduceMotionAutoplayAnimatedImagesEnabled();
 #endif
     return true;
 }

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "AuxiliaryProcess.h"
 
+#import "LibAccessibilitySoftLink.h"
 #import "Logging.h"
 #import "OSStateSPI.h"
 #import "SharedBufferReference.h"
@@ -71,10 +72,6 @@
 #endif
 
 #import <pal/cf/AudioToolboxSoftLink.h>
-
-#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
-SOFT_LINK_OPTIONAL(libAccessibility, _AXSUpdateWebAccessibilitySettings, void, (), ());
-#endif
 
 namespace WebKit {
 
@@ -273,15 +270,15 @@ static const WTF::String& invertColorsPreferenceKey()
 
 void AuxiliaryProcess::handleAXPreferenceChange(const String& domain, const String& key, id value)
 {
-#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS)
-    if (!libAccessibilityLibrary())
+#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
+    if (!WebKit::islibAccessibilityLibraryAvailable())
         return;
 #endif
 
     if (domain == String(kAXSAccessibilityPreferenceDomain)) {
-#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS)
-        if (_AXSUpdateWebAccessibilitySettingsPtr())
-            _AXSUpdateWebAccessibilitySettingsPtr()();
+#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
+        if (WebKit::canLoad_libAccessibility__AXSUpdateWebAccessibilitySettings())
+            WebKit::softLink_libAccessibility__AXSUpdateWebAccessibilitySettings();
 #elif PLATFORM(IOS_FAMILY)
         // If the update method is not available, to update the cache inside AccessibilitySupport,
         // these methods need to be called directly.

--- a/Source/WebKit/Shared/Cocoa/LibAccessibilitySoftLink.h
+++ b/Source/WebKit/Shared/Cocoa/LibAccessibilitySoftLink.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "AccessibilitySupportSPI.h"
+#import <wtf/SoftLinking.h>
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL) || (HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE))
+
+SOFT_LINK_LIBRARY_FOR_HEADER(WebKit, libAccessibility)
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabled, Boolean, (), ())
+#endif
+
+#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(WebKit, libAccessibility, _AXSUpdateWebAccessibilitySettings, void, (), ())
+#endif
+
+#endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL) || (HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE))

--- a/Source/WebKit/Shared/Cocoa/LibAccessibilitySoftLink.mm
+++ b/Source/WebKit/Shared/Cocoa/LibAccessibilitySoftLink.mm
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "AccessibilitySupportSPI.h"
+#import <wtf/SoftLinking.h>
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL) || (HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE))
+
+SOFT_LINK_LIBRARY_FOR_SOURCE(WebKit, libAccessibility)
+
+#if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, libAccessibility, _AXSReduceMotionAutoplayAnimatedImagesEnabled, Boolean, (), ())
+#endif
+
+#if HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(WebKit, libAccessibility, _AXSUpdateWebAccessibilitySettings, void, (), ())
+#endif
+
+#endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL) || (HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && ENABLE(CFPREFS_DIRECT_MODE))

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -188,6 +188,7 @@ Shared/Cocoa/DefaultWebBrowserChecks.mm @nonARC
 Shared/Cocoa/EnhancedSecurityLinkUtilities.mm @nonARC
 Shared/Cocoa/InteractionInformationAtPosition.mm @nonARC
 Shared/Cocoa/InteractionInformationRequest.cpp
+Shared/Cocoa/LibAccessibilitySoftLink.mm @nonARC
 Shared/Cocoa/LoadParametersCocoa.mm @nonARC
 Shared/Cocoa/PDFKitSoftLink.mm @nonARC
 Shared/Cocoa/RevealItem.mm @nonARC

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5944,6 +5944,8 @@
 		46F96C662B02A58100253A2B /* WebContextMenuItemData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebContextMenuItemData.serialization.in; sourceTree = "<group>"; };
 		46F9B26223526ED0006FE5FA /* WebBackForwardCacheEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackForwardCacheEntry.h; sourceTree = "<group>"; };
 		46FA2E752A04240300912BFE /* RemoteWorkerType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWorkerType.serialization.in; sourceTree = "<group>"; };
+		489B47702FED6E0100884EE7 /* LibAccessibilitySoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAccessibilitySoftLink.h; sourceTree = "<group>"; };
+		489B47712FED6E0100884EE7 /* LibAccessibilitySoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LibAccessibilitySoftLink.mm; sourceTree = "<group>"; };
 		48B188FE2E789A3B009B57A9 /* AccessibilityPreferences.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = AccessibilityPreferences.mm; sourceTree = "<group>"; };
 		493102BC2683F3A5002BB885 /* AppPrivacyReport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppPrivacyReport.h; sourceTree = "<group>"; };
 		4955A6E528076D4C00BB91C4 /* ArrayReferenceTuple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayReferenceTuple.h; sourceTree = "<group>"; };
@@ -13442,6 +13444,8 @@
 				E385F3662E86D6C900461B0C /* LaunchLogHook.mm */,
 				E385F37B2E87076100461B0C /* LaunchLogMessages.h */,
 				C1663E5A24AEA74200C6A3B2 /* LaunchServicesDatabaseXPCConstants.h */,
+				489B47702FED6E0100884EE7 /* LibAccessibilitySoftLink.h */,
+				489B47712FED6E0100884EE7 /* LibAccessibilitySoftLink.mm */,
 				2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */,
 				2D440B8325EF235E00A98D87 /* PDFKitSoftLink.h */,
 				2D440B8225EF235E00A98D87 /* PDFKitSoftLink.mm */,


### PR DESCRIPTION
#### 6b5f79b75b8f8ba1a3a5db9bef8b7b31c0804c74
<pre>
AX: Move libAccessibility soft-linking into a shared LibAccessibilitySoftLink.{h,mm}
<a href="https://bugs.webkit.org/show_bug.cgi?id=317797">https://bugs.webkit.org/show_bug.cgi?id=317797</a>
<a href="https://rdar.apple.com/180565005">rdar://180565005</a>

Reviewed by Andres Gonzalez and Dominic Mazzoni.

AccessibilityPreferences.mm declared the libAccessibility library soft-link with
SOFT_LINK_LIBRARY_OPTIONAL(), and AuxiliaryProcessCocoa.mm relied on that
declaration to resolve libAccessibilityLibrary() for its own
SOFT_LINK_OPTIONAL(libAccessibility, _AXSUpdateWebAccessibilitySettings, ...).
SOFT_LINK_LIBRARY_OPTIONAL() and SOFT_LINK_OPTIONAL() generate static, file-local
symbols, so this only compiled because both files happened to land in the same
unified-sources translation unit. Adding or reordering files in Shared/Cocoa
would eventually break the build.

Move both soft-links into a dedicated LibAccessibilitySoftLink.{h,mm} that uses
the SOFT_LINK_LIBRARY_FOR_HEADER/_FOR_SOURCE and
SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER/_FOR_SOURCE macros, which emit extern,
namespaced symbols defined once and intended for sharing across source files.

* Source/WebKit/Shared/Cocoa/AccessibilityPreferences.mm:
(AXPreferenceHelpers::imageAnimationEnabled):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::handleAXPreferenceChange):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/315903@main">https://commits.webkit.org/315903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15d071470fced7732b3707eb6a5e38e0f721f0d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127908 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9bbab01-e403-46fb-a1a4-850bb9ef02bb) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45363 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132689 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89b45f8d-c9a0-4a04-bf62-039ec663aacf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113190 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2878630e-dd46-4423-ad1b-fe90c4a2311c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34452 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182155 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141131 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43776 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38016 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44465 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29493 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108859 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36225 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116345 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42975 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7592 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42621 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->