### PR TITLE
[LegacySVG] Rename inner loop variable in SVGResourcesCycleSolver

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCycleSolver.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCycleSolver.cpp
@@ -57,8 +57,8 @@ bool SVGResourcesCycleSolver::resourceContainsCycles(LegacyRenderSVGResourceCont
                 SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> resourceSet;
                 resources->buildSetOfResources(resourceSet);
 
-                for (auto& resource : resourceSet) {
-                    if (activeResources.contains(resource) || resourceContainsCycles(resource, activeResources, acyclicResources))
+                for (auto& childResource : resourceSet) {
+                    if (activeResources.contains(childResource) || resourceContainsCycles(childResource, activeResources, acyclicResources))
                         return true;
                 }
             }


### PR DESCRIPTION
#### 678a72bcb8503b8d9e493d8d3cf38376f033b5bf
<pre>
[LegacySVG] Rename inner loop variable in SVGResourcesCycleSolver
<a href="https://bugs.webkit.org/show_bug.cgi?id=317816">https://bugs.webkit.org/show_bug.cgi?id=317816</a>
<a href="https://rdar.apple.com/180585525">rdar://180585525</a>

Reviewed by Taher Ali.

In SVGResourcesCycleSolver::resourceContainsCycles(), the inner range-based
for loop declared a variable named `resource`, shadowing the function&apos;s
`resource` parameter of the same type. Rename the loop variable to
`childResource` to remove the shadowing. No behavior change.

* Source/WebCore/rendering/svg/legacy/SVGResourcesCycleSolver.cpp:
(WebCore::SVGResourcesCycleSolver::resourceContainsCycles):

Canonical link: <a href="https://commits.webkit.org/315826@main">https://commits.webkit.org/315826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a79c35aa90fd97da240a814bb37770b1ba9c144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37473 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179496 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127846 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e31210e7-66bd-4f00-8f86-f2eae92ae082) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132619 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5aa3d8b-b968-4f04-af99-36b9626f8dc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173093 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113121 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a98eda70-a00b-4f33-b8e0-04f7ede2460a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169455 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28192 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1469 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182093 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31389 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34882 "Found 21 new failures in bytecode/ExpressionInfo.cpp, rendering/NinePieceImagePainter.cpp, dfg/DFGCPSRethreadingPhase.cpp, jit/ScratchRegisterAllocator.cpp, page/Page.cpp, layout/floats/FloatingContext.cpp, runtime/ScopedArgumentsTable.cpp, dfg/DFGLoopUnrollingPhase.cpp, jit/JITDisassembler.cpp, b3/B3LowerToAir.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141071 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169534 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43713 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152523 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37953 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44402 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29435 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108766 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36166 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116283 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202813 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42913 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7534 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54351 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Running checkout-pull-request; Found 9 jsc stress test failures: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/string-replace-regexp-with-own-property.js.default, stress/temporal-plain-date-time-with-era-calendar.js.bytecode-cache, stress/temporal-plain-date-time-with-era-calendar.js.default, stress/temporal-plaindatetime.js.bytecode-cache ..., JSC test binary failure: testapi; Running compile-jsc-without-change; Found 9 jsc stress test failures: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/string-replace-regexp-with-own-property.js.default, stress/temporal-plain-date-time-with-era-calendar.js.bytecode-cache, stress/temporal-plain-date-time-with-era-calendar.js.default, stress/temporal-plaindatetime.js.bytecode-cache ..., JSC test binary failure: testapi; Passed JSC tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42305 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->