### PR TITLE
Async Clipboard API should request paste access asynchronously

### DIFF
--- a/LayoutTests/editing/async-clipboard/clipboard-read-text-resolves-after-input-event-expected.txt
+++ b/LayoutTests/editing/async-clipboard/clipboard-read-text-resolves-after-input-event-expected.txt
@@ -1,0 +1,13 @@
+Regression test for bug 223597: navigator.clipboard.readText() called inside a 'paste' handler that does not preventDefault must resolve in a separate task — after the native paste's 'input' event has fired. Order of observed events should be ['input', 'readText'].
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS doneWritingText became true
+PASS done became true
+PASS order[0] is "input"
+PASS order[1] is "readText:hello"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Copy

--- a/LayoutTests/editing/async-clipboard/clipboard-read-text-resolves-after-input-event.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-read-text-resolves-after-input-event.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncClipboardAPIEnabled=true DOMPasteAllowed=false ] -->
+<html>
+<meta charset="utf8">
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+input { display: block; font-size: 40px; width: 300px; }
+button { width: 300px; padding: 1em; }
+</style>
+</head>
+<script>
+jsTestIsAsync = true;
+doneWritingText = false;
+order = [];
+done = false;
+
+async function runTest() {
+    description("Regression test for bug 223597: navigator.clipboard.readText() called inside a 'paste' handler that does not preventDefault must resolve in a separate task — after the native paste's 'input' event has fired. Order of observed events should be ['input', 'readText'].");
+
+    const copyButton = document.querySelector("button");
+    const field = document.querySelector("input");
+
+    copyButton.addEventListener("click", async () => {
+        await navigator.clipboard.writeText("hello");
+        doneWritingText = true;
+    });
+
+    field.addEventListener("paste", () => {
+        navigator.clipboard.readText().then(text => {
+            order.push(`readText:${text}`);
+            if (order.length === 2)
+                done = true;
+        });
+    });
+
+    field.addEventListener("input", () => {
+        order.push("input");
+        if (order.length === 2)
+            done = true;
+    });
+
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.activateElement(copyButton);
+    await new Promise(resolve => shouldBecomeEqual("doneWritingText", "true", resolve));
+    await UIHelper.activateElementAndWaitForInputSession(field);
+    await UIHelper.paste();
+    await new Promise(resolve => shouldBecomeEqual("done", "true", resolve));
+
+    shouldBeEqualToString("order[0]", "input");
+    shouldBeEqualToString("order[1]", "readText:hello");
+
+    field.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+}
+
+addEventListener("load", runTest);
+</script>
+<body>
+<button>Copy</button>
+<input>
+</body>
+</html>

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -30,8 +30,10 @@
 #include "ClipboardItem.h"
 #include "CommonAtomStrings.h"
 #include "ContextDestructionObserverInlines.h"
+#include "Document.h"
 #include "DocumentPage.h"
 #include "Editor.h"
+#include "EventLoop.h"
 #include "EventTargetInterfaces.h"
 #include "FrameInlines.h"
 #include "JSBlob.h"
@@ -46,6 +48,7 @@
 #include "Pasteboard.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
+#include "TaskSource.h"
 #include "UserGestureIndicator.h"
 #include "WebContentReader.h"
 #include <wtf/CompletionHandler.h>
@@ -108,21 +111,29 @@ ScriptExecutionContext* Clipboard::scriptExecutionContext() const
 void Clipboard::readText(Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();
-    if (!frame) {
+    RefPtr document = frame ? frame->document() : nullptr;
+    if (!document) {
         promise->reject(ExceptionCode::NotAllowedError);
         return;
     }
 
+    auto reject = [&] {
+        protect(document->eventLoop())->queueTask(TaskSource::Clipboard,
+            [promise = WTF::move(promise)] mutable {
+                promise->reject(ExceptionCode::NotAllowedError);
+            });
+    };
+
     auto pasteboard = Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(frame->pageID()));
     auto changeCountAtStart = pasteboard->changeCount();
     if (!frame->requestDOMPasteAccess()) {
-        promise->reject(ExceptionCode::NotAllowedError);
+        reject();
         return;
     }
 
     auto allInfo = pasteboard->allPasteboardItemInfo();
     if (!allInfo) {
-        promise->reject(ExceptionCode::NotAllowedError);
+        reject();
         return;
     }
 
@@ -136,10 +147,15 @@ void Clipboard::readText(Ref<DeferredPromise>&& promise)
         }
     }
 
-    if (changeCountAtStart == pasteboard->changeCount())
-        promise->resolve<IDLDOMString>(WTF::move(text));
-    else
-        promise->reject(ExceptionCode::NotAllowedError);
+    if (changeCountAtStart != pasteboard->changeCount()) {
+        reject();
+        return;
+    }
+
+    protect(document->eventLoop())->queueTask(TaskSource::Clipboard,
+        [promise = WTF::move(promise), text = WTF::move(text)] mutable {
+            promise->resolve<IDLDOMString>(WTF::move(text));
+        });
 }
 
 void Clipboard::writeText(const String& data, Ref<DeferredPromise>&& promise)
@@ -160,29 +176,34 @@ void Clipboard::writeText(const String& data, Ref<DeferredPromise>&& promise)
 
 void Clipboard::read(Ref<DeferredPromise>&& promise)
 {
-    auto rejectPromiseAndClearActiveSession = [&] {
+    RefPtr frame = this->frame();
+    RefPtr document = frame ? frame->document() : nullptr;
+    if (!document) {
         m_activeSession = std::nullopt;
         promise->reject(ExceptionCode::NotAllowedError);
-    };
-
-    RefPtr frame = this->frame();
-    if (!frame) {
-        rejectPromiseAndClearActiveSession();
         return;
     }
+
+    auto reject = [&] {
+        m_activeSession = std::nullopt;
+        protect(document->eventLoop())->queueTask(TaskSource::Clipboard,
+            [promise = WTF::move(promise)] mutable {
+                promise->reject(ExceptionCode::NotAllowedError);
+            });
+    };
 
     auto pasteboard = Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(frame->pageID()));
     auto changeCountAtStart = pasteboard->changeCount();
 
     if (!frame->requestDOMPasteAccess()) {
-        rejectPromiseAndClearActiveSession();
+        reject();
         return;
     }
 
     if (!m_activeSession || m_activeSession->changeCount != changeCountAtStart) {
         auto allInfo = pasteboard->allPasteboardItemInfo();
         if (!allInfo) {
-            rejectPromiseAndClearActiveSession();
+            reject();
             return;
         }
 
@@ -192,7 +213,10 @@ void Clipboard::read(Ref<DeferredPromise>&& promise)
         m_activeSession = {{ WTF::move(pasteboard), WTF::move(clipboardItems), changeCountAtStart }};
     }
 
-    promise->resolve<IDLSequence<IDLInterface<ClipboardItem>>>(m_activeSession->items);
+    protect(document->eventLoop())->queueTask(TaskSource::Clipboard,
+        [promise = WTF::move(promise), items = m_activeSession->items] mutable {
+            promise->resolve<IDLSequence<IDLInterface<ClipboardItem>>>(items);
+        });
 }
 
 void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/TaskSource.h
+++ b/Source/WebCore/dom/TaskSource.h
@@ -28,6 +28,7 @@
 namespace WebCore {
 
 enum class TaskSource : uint8_t {
+    Clipboard,
     DOMManipulation,
     DatabaseAccess,
     FileReading,


### PR DESCRIPTION
#### 02741dfccee549e335bc3d542a0f5f851f9a153c
<pre>
Async Clipboard API should request paste access asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=223597">https://bugs.webkit.org/show_bug.cgi?id=223597</a>
<a href="https://rdar.apple.com/75969974">rdar://75969974</a>

Reviewed by Wenson Hsieh.

The Clipboard API spec requires readText() to settle on a queued task,
not on the calling task.

  Clipboard.readText() — step 3
  <a href="https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext">https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext</a>

  3. Run the following steps in parallel:
     1. Let r be the result of running [check clipboard read permission].
     2. If r is false, then queue a global task on the clipboard task
        source ... reject p with &quot;NotAllowedError&quot; DOMException ...
     3. Let data be a copy of the system clipboard data.
     4. Queue a global task on the clipboard task source ... resolve p
        with textString ...

Clipboard.read() has the same shape (#dom-clipboard-read).

WebKit walked the pasteboard read synchronously and called
promise-&gt;resolve() on the same call stack as the JS await. The promise
settled as a microtask of the calling task. Firefox and Chrome queue a
real task and settle later.

The user-visible symptom is the webcompat bug with a six-box OTP
component. It calls navigator.clipboard.readText() inside a paste handler
that does not preventDefault. Two writes race. The microtask resolve
runs first and distributes &quot;123456&quot; to all six boxes. The native paste&apos;s
input event task then runs and a single-box state write clears boxes 2-6.

Firefox and Chrome show the input event first, so distribution wins
last and all six boxes stay filled.

Test: editing/async-clipboard/clipboard-read-text-resolves-after-input-event.html

* LayoutTests/editing/async-clipboard/clipboard-read-text-resolves-after-input-event-expected.txt: Added.
* LayoutTests/editing/async-clipboard/clipboard-read-text-resolves-after-input-event.html: Added.
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::readText):
(WebCore::Clipboard::read):
* Source/WebCore/dom/TaskSource.h:

Canonical link: <a href="https://commits.webkit.org/315997@main">https://commits.webkit.org/315997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97378fe3d0d71880f0a1f04f1acea9bec2e42fb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128251 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132994 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93780 "1 flakes 16 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113491 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34793 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33136 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28596 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182499 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141446 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141263 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38077 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44808 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29811 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109323 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36530 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116697 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43318 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7913 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->