### PR TITLE
[JSC] Use `InstanceOf` DFG node for `Object#isPrototypeOf`

### DIFF
--- a/JSTests/microbenchmarks/is-prototype-of-deep-hit.js
+++ b/JSTests/microbenchmarks/is-prototype-of-deep-hit.js
@@ -1,0 +1,16 @@
+(function() {
+    var root = {};
+    var leaf = root;
+    for (var i = 0; i < 10; ++i)
+        leaf = Object.create(leaf);
+
+    function test(root, leaf) {
+        return root.isPrototypeOf(leaf);
+    }
+    noInline(test);
+
+    for (var i = 0; i < 2e6; ++i) {
+        if (!test(root, leaf))
+            throw "Error: bad result";
+    }
+})();

--- a/JSTests/microbenchmarks/is-prototype-of-deep-miss.js
+++ b/JSTests/microbenchmarks/is-prototype-of-deep-miss.js
@@ -1,0 +1,16 @@
+(function() {
+    var leaf = {};
+    for (var i = 0; i < 10; ++i)
+        leaf = Object.create(leaf);
+    var probe = { unrelated: true };
+
+    function test(probe, leaf) {
+        return probe.isPrototypeOf(leaf);
+    }
+    noInline(test);
+
+    for (var i = 0; i < 2e6; ++i) {
+        if (test(probe, leaf))
+            throw "Error: bad result";
+    }
+})();

--- a/JSTests/microbenchmarks/is-prototype-of-shallow.js
+++ b/JSTests/microbenchmarks/is-prototype-of-shallow.js
@@ -1,0 +1,15 @@
+(function() {
+    class Foo { }
+    var foo = new Foo();
+    var proto = Foo.prototype;
+
+    function test(proto, foo) {
+        return proto.isPrototypeOf(foo);
+    }
+    noInline(test);
+
+    for (var i = 0; i < 5e6; ++i) {
+        if (!test(proto, foo))
+            throw "Error: bad result";
+    }
+})();

--- a/JSTests/microbenchmarks/is-prototype-of-sometimes-hit.js
+++ b/JSTests/microbenchmarks/is-prototype-of-sometimes-hit.js
@@ -1,0 +1,23 @@
+(function() {
+    class Foo { }
+    var foo = new Foo();
+    var fooProto = Foo.prototype;
+
+    class Bar { }
+    var bar = new Bar();
+
+    function test(proto, o) {
+        return proto.isPrototypeOf(o);
+    }
+    noInline(test);
+
+    for (var i = 0; i < 5e6; ++i) {
+        var o;
+        if (i & 1)
+            o = foo;
+        else
+            o = bar;
+        if (test(fooProto, o) != !!(i & 1))
+            throw "Error: bad result at i = " + i;
+    }
+})();

--- a/JSTests/stress/object-is-prototype-of-intrinsic.js
+++ b/JSTests/stress/object-is-prototype-of-intrinsic.js
@@ -1,0 +1,120 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad: " + actual + " !== " + expected);
+}
+
+function shouldThrow(func, errorType) {
+    let thrown = false;
+    try {
+        func();
+    } catch (e) {
+        thrown = true;
+        if (!(e instanceof errorType))
+            throw new Error("bad error type: " + e);
+    }
+    if (!thrown)
+        throw new Error("not thrown");
+}
+
+var isPrototypeOf = Object.prototype.isPrototypeOf;
+
+// Basic hit / miss with class hierarchy.
+(function() {
+    class A { }
+    class B extends A { }
+    class C extends B { }
+    var c = new C();
+    var unrelated = {};
+
+    function hit(o) { return A.prototype.isPrototypeOf(o); }
+    function miss(o) { return unrelated.isPrototypeOf(o); }
+    noInline(hit);
+    noInline(miss);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(hit(c), true);
+        shouldBe(miss(c), false);
+    }
+})();
+
+// Argument is not an object → false (no exception even with null/undefined receiver).
+(function() {
+    function test(proto, value) { return isPrototypeOf.call(proto, value); }
+    noInline(test);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        shouldBe(test(Object.prototype, 42), false);
+        shouldBe(test(Object.prototype, "foo"), false);
+        shouldBe(test(Object.prototype, null), false);
+        shouldBe(test(Object.prototype, undefined), false);
+        shouldBe(test(Object.prototype, true), false);
+        shouldBe(test(Object.prototype, Symbol()), false);
+        // V is not an object so step 1 returns false before ToObject(this).
+        shouldBe(test(null, 42), false);
+        shouldBe(test(undefined, "foo"), false);
+    }
+})();
+
+// Receiver is null/undefined and argument is an object → TypeError.
+(function() {
+    function test(proto, value) { return isPrototypeOf.call(proto, value); }
+    noInline(test);
+    var obj = {};
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        // Warm up with an object receiver so the intrinsic compiles, then OSR exit.
+        shouldBe(test(Object.prototype, obj), true);
+    }
+    shouldThrow(() => test(null, obj), TypeError);
+    shouldThrow(() => test(undefined, obj), TypeError);
+})();
+
+// Receiver is a primitive (not null/undefined) → always false because the wrapper
+// object is freshly allocated and cannot appear in any prototype chain.
+(function() {
+    function test(proto, value) { return isPrototypeOf.call(proto, value); }
+    noInline(test);
+    var obj = Object.create(String.prototype);
+
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(test(String.prototype, obj), true);
+    shouldBe(test("foo", obj), false);
+    shouldBe(test(42, Object.create(Number.prototype)), false);
+})();
+
+// Polymorphic value with hit/miss alternation.
+(function() {
+    class Foo { }
+    class Bar { }
+    var foo = new Foo();
+    var bar = new Bar();
+    var proto = Foo.prototype;
+
+    function test(o) { return proto.isPrototypeOf(o); }
+    noInline(test);
+
+    for (var i = 0; i < testLoopCount; ++i) {
+        var o = (i & 1) ? foo : bar;
+        shouldBe(test(o), !!(i & 1));
+    }
+})();
+
+// Proxy in the chain: ensure [[GetPrototypeOf]] trap is called.
+(function() {
+    var trapCalls = 0;
+    var target = {};
+    var proxy = new Proxy(target, {
+        getPrototypeOf() {
+            trapCalls++;
+            return Object.prototype;
+        }
+    });
+    var leaf = Object.create(proxy);
+
+    function test(o) { return Object.prototype.isPrototypeOf(o); }
+    noInline(test);
+
+    for (var i = 0; i < testLoopCount; ++i)
+        shouldBe(test(leaf), true);
+    shouldBe(trapCalls, testLoopCount);
+})();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3996,6 +3996,24 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case ObjectPrototypeIsPrototypeOfIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            // When |this| is an object, isPrototypeOf(V) is exactly the prototype-chain walk of
+            // OrdinaryHasInstance, so reuse the InstanceOf node. Speculate ObjectUse on |this| and
+            // OSR exit to the C++ slow path for primitive receivers.
+            insertChecks();
+            Node* prototype = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* value = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            addToGraph(Check, Edge(prototype, ObjectUse));
+            setResult(addToGraph(InstanceOf, value, prototype));
+            return CallOptimizationResult::Inlined;
+        }
+
         case ReflectOwnKeysIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -122,6 +122,7 @@ namespace JSC {
     macro(ObjectHasOwnIntrinsic) \
     macro(ObjectIsIntrinsic) \
     macro(ObjectKeysIntrinsic) \
+    macro(ObjectPrototypeIsPrototypeOfIntrinsic) \
     macro(ObjectToStringIntrinsic) \
     macro(ReflectGetPrototypeOfIntrinsic) \
     macro(ReflectOwnKeysIntrinsic) \

--- a/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectPrototype.cpp
@@ -64,7 +64,7 @@ void ObjectPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->valueOf, objectProtoFuncValueOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->hasOwnProperty, objectProtoFuncHasOwnProperty, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, HasOwnPropertyIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->propertyIsEnumerable, objectProtoFuncPropertyIsEnumerable, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isPrototypeOf, objectProtoFuncIsPrototypeOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isPrototypeOf, objectProtoFuncIsPrototypeOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ObjectPrototypeIsPrototypeOfIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->__defineGetter__, objectProtoFuncDefineGetter, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->__defineSetter__, objectProtoFuncDefineSetter, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->__lookupGetter__, objectProtoFuncLookupGetter, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);


### PR DESCRIPTION
#### 0071dfd4f18a9cc5230a2814211ab15d3d43822f
<pre>
[JSC] Use `InstanceOf` DFG node for `Object#isPrototypeOf`
<a href="https://bugs.webkit.org/show_bug.cgi?id=317821">https://bugs.webkit.org/show_bug.cgi?id=317821</a>

Reviewed by Yusuke Suzuki.

Object.prototype.isPrototypeOf was registered without an intrinsic, so DFG/FTL
always emitted a native call. When |this| is an object, isPrototypeOf(V) performs
exactly the prototype-chain walk of OrdinaryHasInstance, so we can lower it to the
existing InstanceOf node and reuse its inline cache. We speculate ObjectUse on
|this| and OSR exit to the C++ slow path for primitive receivers; the BadType exit
profile prevents recompilation loops.

                                    Baseline                  Patched

is-prototype-of-deep-hit        30.6899+-5.4560     ^      6.5041+-1.1688   ^ definitely 4.7186x faster
is-prototype-of-sometimes-hit   41.9869+-8.2872     ^     13.9098+-0.7257   ^ definitely 3.0185x faster
is-prototype-of-deep-miss       35.0449+-2.4496     ^      6.5066+-1.1866   ^ definitely 5.3860x faster
is-prototype-of-shallow         41.7880+-11.8943    ^     11.9066+-1.5946   ^ definitely 3.5097x faster

Tests: JSTests/microbenchmarks/is-prototype-of-deep-hit.js
       JSTests/microbenchmarks/is-prototype-of-deep-miss.js
       JSTests/microbenchmarks/is-prototype-of-shallow.js
       JSTests/microbenchmarks/is-prototype-of-sometimes-hit.js
       JSTests/stress/object-is-prototype-of-intrinsic.js

* JSTests/microbenchmarks/is-prototype-of-deep-hit.js: Added.
(test):
* JSTests/microbenchmarks/is-prototype-of-deep-miss.js: Added.
(test):
* JSTests/microbenchmarks/is-prototype-of-shallow.js: Added.
(Foo):
(test):
* JSTests/microbenchmarks/is-prototype-of-sometimes-hit.js: Added.
(Foo):
(Bar):
(test):
* JSTests/stress/object-is-prototype-of-intrinsic.js: Added.
(shouldBe):
(shouldThrow):
(A):
(B):
(C):
(miss):
(test):
(Foo):
(Bar):
(getPrototypeOf):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/ObjectPrototype.cpp:
(JSC::ObjectPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/315966@main">https://commits.webkit.org/315966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2135b9ffe210e04cab9be9dce2c7c858b70f289a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170142 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179553 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127854 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Running checkout-pull-request; Running compile-webkit") 
| | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132682 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93467 "25 flakes 15 failures") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173101 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113183 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169463 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32765 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28200 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1482 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182101 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31397 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Running compile-jsc; Passed JSC tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141082 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169542 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43722 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140907 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38053 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44411 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108775 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36178 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116291 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202821 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Running compile-jsc") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42921 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7547 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54354 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42313 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42567 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->