### PR TITLE
[JSC] `Array#flat` fast path drops prototype-backed holes in nested arrays

### DIFF
--- a/JSTests/stress/array-prototype-flat-nested-holes-prototype.js
+++ b/JSTests/stress/array-prototype-flat-nested-holes-prototype.js
@@ -1,0 +1,56 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Nested ArrayWithInt32 with a hole and a prototype that fills it.
+{
+    let child = [, 1, 2];
+    Object.setPrototypeOf(child, { 0: 99 });
+    shouldBeArray([child].flat(), [99, 1, 2]);
+}
+
+// Nested ArrayWithDouble with a hole and a prototype that fills it.
+{
+    let child = [1.5, , 3.5];
+    Object.setPrototypeOf(child, { 1: 2.5 });
+    shouldBeArray([child].flat(), [1.5, 2.5, 3.5]);
+}
+
+// Nested ArrayWithContiguous with a hole and a prototype that fills it.
+{
+    let child = ["a", , "c"];
+    Object.setPrototypeOf(child, { 1: "b" });
+    shouldBeArray([child].flat(), ["a", "b", "c"]);
+}
+
+// Deeper nesting (depth = 2): the array two levels deep has the prototype.
+{
+    let inner = [, 1];
+    Object.setPrototypeOf(inner, { 0: 42 });
+    shouldBeArray([[inner]].flat(2), [42, 1]);
+}
+
+// The hole resolves to an array on the prototype, which itself should be flattened.
+{
+    let child = [, 3];
+    Object.setPrototypeOf(child, { 0: [1, 2] });
+    shouldBeArray([child].flat(2), [1, 2, 3]);
+}
+
+// Prototype with a getter, ensure it is invoked.
+{
+    let calls = 0;
+    let proto = {};
+    Object.defineProperty(proto, "0", { get() { calls++; return "x"; } });
+    let child = [, "y"];
+    Object.setPrototypeOf(child, proto);
+    shouldBeArray([child].flat(), ["x", "y"]);
+    shouldBe(calls, 1);
+}

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2393,6 +2393,8 @@ static uint64_t calculateFlattenedLength(JSGlobalObject* globalObject, JSArray* 
                 continue;
             if (depth > 0 && isJSArray(element)) {
                 JSArray* elementArray = uncheckedDowncast<JSArray>(element);
+                if (elementArray->holesMustForwardToPrototype()) [[unlikely]]
+                    return std::numeric_limits<uint64_t>::max();
                 uint64_t newDepth = (depth == std::numeric_limits<uint64_t>::max()) ? depth : depth - 1;
                 uint64_t flatLength = calculateFlattenedLength(globalObject, elementArray, elementArray->length(), newDepth);
                 RETURN_IF_EXCEPTION(scope, flatLength);
@@ -2479,6 +2481,8 @@ static uint64_t fastFlatIntoBuffer(JSGlobalObject* globalObject, T* resultBuffer
                 continue;
             if (depth > 0 && isJSArray(element)) {
                 JSArray* elementArray = uncheckedDowncast<JSArray>(element);
+                if (elementArray->holesMustForwardToPrototype()) [[unlikely]]
+                    return std::numeric_limits<uint64_t>::max();
                 uint64_t newDepth = (depth == std::numeric_limits<uint64_t>::max()) ? depth : depth - 1;
                 resultIndex = fastFlatIntoBuffer(globalObject, resultBuffer, resultIndex, elementArray, elementArray->length(), newDepth, vectorLength);
                 RETURN_IF_EXCEPTION(scope, resultIndex);


### PR DESCRIPTION
#### c05343136dd6915718266d138dcdb303e7bff5f0
<pre>
[JSC] `Array#flat` fast path drops prototype-backed holes in nested arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=317823">https://bugs.webkit.org/show_bug.cgi?id=317823</a>

Reviewed by Yusuke Suzuki.

JSArray::fastFlat checks holesMustForwardToPrototype() only on the
receiver. When calculateFlattenedLength / fastFlatIntoBuffer recurse
into a nested child array, the check is not repeated, so a child whose
prototype provides indexed properties (e.g. via Object.setPrototypeOf)
has its holes silently skipped instead of forwarding to the prototype
chain as FlattenIntoArray requires.

    let child = [, 1, 2];
    Object.setPrototypeOf(child, { 0: 99 });
    [child].flat();  // was [1, 2], should be [99, 1, 2]

Bail out to the slow path when a nested array&apos;s
holesMustForwardToPrototype() is true.

Test: JSTests/stress/array-prototype-flat-nested-holes-prototype.js

* JSTests/stress/array-prototype-flat-nested-holes-prototype.js: Added.
(shouldBe):
(shouldBeArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::calculateFlattenedLength):
(JSC::fastFlatIntoBuffer):

Canonical link: <a href="https://commits.webkit.org/315806@main">https://commits.webkit.org/315806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bbc55935d46fc0bf83e1d04526a550038a5671e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45311 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43699 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132630 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173103 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35816 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113132 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1479 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182103 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31399 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34892 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141083 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43724 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140908 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 2 api tests failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change; Passed API tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37941 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44413 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108777 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36177 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116293 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42923 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7544 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54356 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42569 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->