### PR TITLE
[JSC] Cache named-capture "groups" Structure on RegExp

### DIFF
--- a/JSTests/microbenchmarks/regexp-named-capture-exec.js
+++ b/JSTests/microbenchmarks/regexp-named-capture-exec.js
@@ -1,0 +1,12 @@
+function test() {
+    var re = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/;
+    var str = "Event on 2024-03-15 at noon";
+    var result = 0;
+    for (var i = 0; i < 500000; ++i) {
+        var m = re.exec(str);
+        result += m.groups.year.length;
+    }
+    return result;
+}
+noInline(test);
+test();

--- a/JSTests/microbenchmarks/regexp-named-capture-replace.js
+++ b/JSTests/microbenchmarks/regexp-named-capture-replace.js
@@ -1,0 +1,14 @@
+function test() {
+    var re = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/g;
+    var str = "Dates: 2024-03-15, 2025-12-31, 2026-01-01.";
+    var result = 0;
+    function replacer(match, y, m, d, offset, string, groups) {
+        return groups.month + "/" + groups.day + "/" + groups.year;
+    }
+    noInline(replacer);
+    for (var i = 0; i < 100000; ++i)
+        result += str.replace(re, replacer).length;
+    return result;
+}
+noInline(test);
+test();

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -28,6 +28,7 @@
 #include "RegExpInlines.h"
 #include "YarrJIT.h"
 #include <wtf/Assertions.h>
+#include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/text/MakeString.h>
 
@@ -171,10 +172,15 @@ void RegExp::finishCreation(VM& vm)
 
     m_numSubpatterns = pattern.m_numSubpatterns;
     if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndices.isEmpty()) {
-        m_rareData = makeUnique<RareData>();
-        m_rareData->m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
-        m_rareData->m_captureGroupNames.swap(pattern.m_captureGroupNames);
-        m_rareData->m_namedGroupToParenIndices.swap(pattern.m_namedGroupToParenIndices);
+        auto rareData = makeUnique<RareData>();
+        rareData->m_numDuplicateNamedCaptureGroups = pattern.m_numDuplicateNamedCaptureGroups;
+        rareData->m_captureGroupNames = WTF::map(pattern.m_captureGroupNames, [](auto& name) {
+            return AtomString { name };
+        });
+        rareData->m_namedGroupToParenIndices.swap(pattern.m_namedGroupToParenIndices);
+        // The concurrent GC thread reads m_rareData in visitChildren, so it must observe a fully initialized RareData.
+        WTF::storeStoreFence();
+        m_rareData = WTF::move(rareData);
     }
 
     unsigned offsetVectorSize = offsetVectorBaseForNamedCaptures();
@@ -202,6 +208,47 @@ size_t RegExp::estimatedSize(JSCell* cell, VM& vm)
 #endif
     regexDataSize += thisObject->m_ovector.capacity() * sizeof(int);
     return Base::estimatedSize(cell, vm) + regexDataSize;
+}
+
+template<typename Visitor>
+void RegExp::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = uncheckedDowncast<RegExp>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+    if (thisObject->m_rareData)
+        visitor.append(thisObject->m_rareData->m_cachedGroupsStructureID);
+}
+
+DEFINE_VISIT_CHILDREN(RegExp);
+
+Structure* RegExp::ensureGroupsStructure(VM& vm, JSGlobalObject* globalObject)
+{
+    ASSERT(hasNamedCaptures());
+    if (Structure* cached = m_rareData->m_cachedGroupsStructureID.get()) {
+        if (cached->realm() == globalObject)
+            return cached;
+    }
+
+    Structure* baseStructure = globalObject->nullPrototypeObjectStructure();
+    if (m_rareData->m_namedGroupToParenIndices.size() > baseStructure->inlineCapacity())
+        return nullptr;
+
+    Structure* structure = baseStructure;
+    PropertyOffset offset = invalidOffset;
+    PropertyOffset expectedOffset = 0;
+    for (auto& name : m_rareData->m_captureGroupNames) {
+        if (name.isEmpty())
+            continue;
+        structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, name), 0, offset);
+        // Callers store via putDirectOffset assuming sequential inline offsets.
+        if (offset != expectedOffset || structure->isDictionary())
+            return nullptr;
+        expectedOffset++;
+    }
+    ASSERT(!structure->outOfLineCapacity());
+    m_rareData->m_cachedGroupsStructureID.set(vm, this, structure);
+    return structure;
 }
 
 RegExp* RegExp::createWithoutCaching(VM& vm, const String& patternString, OptionSet<Yarr::Flags> flags)

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -52,6 +52,7 @@ public:
     JS_EXPORT_PRIVATE static RegExp* create(VM&, const String& pattern, OptionSet<Yarr::Flags>);
     static void destroy(JSCell*);
     static size_t estimatedSize(JSCell*, VM&);
+    DECLARE_VISIT_CHILDREN;
     JS_EXPORT_PRIVATE static void dumpToStream(const JSCell*, PrintStream&);
     void dumpSimpleName(PrintStream&) const;
 
@@ -106,13 +107,20 @@ public:
         return m_rareData && !m_rareData->m_captureGroupNames.isEmpty();
     }
 
-    String getCaptureGroupNameForSubpatternId(unsigned i) const
+    bool hasDuplicateNamedCaptureGroups() const
+    {
+        return m_rareData && m_rareData->m_numDuplicateNamedCaptureGroups;
+    }
+
+    const AtomString& getCaptureGroupNameForSubpatternId(unsigned i) const
     {
         if (!i || !m_rareData || m_rareData->m_captureGroupNames.isEmpty())
-            return String();
+            return nullAtom();
         ASSERT(m_rareData);
         return m_rareData->m_captureGroupNames[i];
     }
+
+    Structure* ensureGroupsStructure(VM&, JSGlobalObject*);
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template <typename Offsets>
@@ -208,12 +216,13 @@ private:
     struct RareData {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(RareData);
         unsigned m_numDuplicateNamedCaptureGroups;
-        Vector<String> m_captureGroupNames;
+        Vector<AtomString> m_captureGroupNames;
 
         // This first element of the RHS vector is the subpatternId in the non-duplicate case.
         // For the duplicate case, the first element is the namedCaptureGroupId.
         // The remaining elements are the subpatternIds for each of the duplicate groups.
         UncheckedKeyHashMap<String, Vector<unsigned>> m_namedGroupToParenIndices;
+        WriteBarrierStructureID m_cachedGroupsStructureID;
     };
 
     String m_patternString;

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp
@@ -83,10 +83,17 @@ JSArray* createRegExpMatchesArrayWithGroupsOrIndices(VM& vm, JSGlobalObject* glo
     // FIXME: This should handle array allocation errors gracefully.
     // https://bugs.webkit.org/show_bug.cgi?id=155144
 
-    JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
+    Structure* groupsStructure = nullptr;
+    JSObject* groups = nullptr;
+    JSObject* indicesGroups = nullptr;
+    if (hasNamedCaptures) {
+        groupsStructure = regExp->ensureGroupsStructure(vm, globalObject);
+        Structure* structureForGroups = groupsStructure ? groupsStructure : globalObject->nullPrototypeObjectStructure();
+        groups = constructEmptyObject(vm, structureForGroups);
+        if (createIndices)
+            indicesGroups = constructEmptyObject(vm, structureForGroups);
+    }
     Structure* matchStructure = createIndices ? globalObject->regExpMatchesArrayWithIndicesStructure() : globalObject->regExpMatchesArrayStructure();
-
-    JSObject* indicesGroups = createIndices && hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
 
     auto setProperties = [&] () {
         array->putDirectOffset(vm, RegExpMatchesArrayIndexPropertyOffset, jsNumber(result.start));
@@ -210,21 +217,34 @@ JSArray* createRegExpMatchesArrayWithGroupsOrIndices(VM& vm, JSGlobalObject* glo
     // We initialize the groups and indices objects late as they could allocate, which with the current API could cause
     // allocations.
     if (hasNamedCaptures) {
+        bool hasDuplicateNamedCaptureGroups = regExp->hasDuplicateNamedCaptureGroups();
+        PropertyOffset groupOffset = 0;
         for (unsigned i = 1; i <= numSubpatterns; ++i) {
-            String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
+            const AtomString& groupName = regExp->getCaptureGroupNameForSubpatternId(i);
             if (!groupName.isEmpty()) {
-                auto captureIndex = regExp->subpatternIdForGroupName(groupName, subpatternResults);
+                unsigned captureIndex = i;
+                if (hasDuplicateNamedCaptureGroups) [[unlikely]]
+                    captureIndex = regExp->subpatternIdForGroupName(groupName, subpatternResults);
 
                 JSValue value;
                 if (captureIndex > 0)
                     value = array->getIndexQuickly(captureIndex);
                 else
                     value = jsUndefined();
-                groups->putDirect(vm, Identifier::fromString(vm, groupName), value);
+                JSValue indicesValue;
+                if (createIndices)
+                    indicesValue = captureIndex > 0 ? indicesArray->getIndexQuickly(captureIndex) : jsUndefined();
 
-                if (createIndices) {
-                    JSValue indicesValue = captureIndex > 0 ? indicesArray->getIndexQuickly(captureIndex) : jsUndefined();
-                    indicesGroups->putDirect(vm, Identifier::fromString(vm, groupName), indicesValue);
+                if (groupsStructure) {
+                    groups->putDirectOffset(vm, groupOffset, value);
+                    if (createIndices)
+                        indicesGroups->putDirectOffset(vm, groupOffset, indicesValue);
+                    groupOffset++;
+                } else {
+                    Identifier ident = Identifier::fromString(vm, groupName);
+                    groups->putDirect(vm, ident, value);
+                    if (createIndices)
+                        indicesGroups->putDirect(vm, ident, indicesValue);
                 }
             }
         }

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -345,6 +345,8 @@ JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSStrin
     RegExp* regExp = regExpObject->regExp();
     bool global = regExp->global();
     bool hasNamedCaptures = regExp->hasNamedCaptures();
+    bool hasDuplicateNamedCaptureGroups = regExp->hasDuplicateNamedCaptureGroups();
+    Structure* groupsStructure = hasNamedCaptures ? regExp->ensureGroupsStructure(vm, globalObject) : nullptr;
 
     if (global) {
         // ES5.1 15.5.4.10 step 8.a.
@@ -414,7 +416,8 @@ JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSStrin
                 cachedCall = &cachedCallHolder.value();
             }
             cachedCall->clearArguments();
-            JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
+            JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, groupsStructure ? groupsStructure : globalObject->nullPrototypeObjectStructure()) : nullptr;
+            PropertyOffset groupOffset = 0;
 
             for (unsigned i = 0; i < regExp->numSubpatterns() + 1; ++i) {
                 int matchStart = ovector[i * 2];
@@ -432,25 +435,31 @@ JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSStrin
                 cachedCall->appendArgument(patternValue);
 
                 if (i && hasNamedCaptures) {
-                    String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
+                    const AtomString& groupName = regExp->getCaptureGroupNameForSubpatternId(i);
                     if (!groupName.isEmpty()) {
-                        auto captureIndex = regExp->subpatternIdForGroupName(groupName, ovector);
+                        unsigned captureIndex = i;
+                        if (hasDuplicateNamedCaptureGroups) [[unlikely]]
+                            captureIndex = regExp->subpatternIdForGroupName(groupName, ovector);
 
+                        JSValue captureValue;
                         if (captureIndex == i)
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
+                            captureValue = patternValue;
                         else if (captureIndex > 0) {
                             int captureStart = ovector[captureIndex * 2];
                             int captureEnd = ovector[captureIndex * 2 + 1];
-                            JSValue captureValue;
                             if (captureStart < 0 || captureEnd < captureStart)
                                 captureValue = jsUndefined();
                             else {
                                 captureValue = jsSubstring(globalObject, vm, string, captureStart, captureEnd - captureStart);
                                 RETURN_IF_EXCEPTION(scope, nullptr);
                             }
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
                         } else
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), jsUndefined());
+                            captureValue = jsUndefined();
+
+                        if (groupsStructure)
+                            groups->putDirectOffset(vm, groupOffset++, captureValue);
+                        else
+                            groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
                     }
                 }
             }
@@ -499,7 +508,8 @@ JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSStrin
                 OUT_OF_MEMORY(globalObject, scope);
 
             MarkedArgumentBuffer args;
-            JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure()) : nullptr;
+            JSObject* groups = hasNamedCaptures ? constructEmptyObject(vm, groupsStructure ? groupsStructure : globalObject->nullPrototypeObjectStructure()) : nullptr;
+            PropertyOffset groupOffset = 0;
 
             for (unsigned i = 0; i < regExp->numSubpatterns() + 1; ++i) {
                 int matchStart = ovector[i * 2];
@@ -517,25 +527,31 @@ JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSStrin
                 args.append(patternValue);
 
                 if (i && hasNamedCaptures) {
-                    String groupName = regExp->getCaptureGroupNameForSubpatternId(i);
+                    const AtomString& groupName = regExp->getCaptureGroupNameForSubpatternId(i);
                     if (!groupName.isEmpty()) {
-                        auto captureIndex = regExp->subpatternIdForGroupName(groupName, ovector);
+                        unsigned captureIndex = i;
+                        if (hasDuplicateNamedCaptureGroups) [[unlikely]]
+                            captureIndex = regExp->subpatternIdForGroupName(groupName, ovector);
 
+                        JSValue captureValue;
                         if (captureIndex == i)
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
+                            captureValue = patternValue;
                         else if (captureIndex > 0) {
                             int captureStart = ovector[captureIndex * 2];
                             int captureEnd = ovector[captureIndex * 2 + 1];
-                            JSValue captureValue;
                             if (captureStart < 0 || captureEnd < captureStart)
                                 captureValue = jsUndefined();
                             else {
                                 captureValue = jsSubstring(globalObject, vm, string, captureStart, captureEnd - captureStart);
                                 RETURN_IF_EXCEPTION(scope, nullptr);
                             }
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
                         } else
-                            groups->putDirect(vm, Identifier::fromString(vm, groupName), jsUndefined());
+                            captureValue = jsUndefined();
+
+                        if (groupsStructure)
+                            groups->putDirectOffset(vm, groupOffset++, captureValue);
+                        else
+                            groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
                     }
                 }
             }


### PR DESCRIPTION
#### cae81af25d037bae6d8013d1be7cf946132ebf75
<pre>
[JSC] Cache named-capture &quot;groups&quot; Structure on RegExp
<a href="https://bugs.webkit.org/show_bug.cgi?id=317822">https://bugs.webkit.org/show_bug.cgi?id=317822</a>

Reviewed by Yusuke Suzuki.

When a RegExp with named captures is exec&apos;d, JSC builds the &quot;groups&quot;
object by starting from nullPrototypeObjectStructure and calling
putDirect for each capture name. On every exec this incurs, per group:
a hash lookup in m_namedGroupToParenIndices (redundant when there are no
duplicate names), an AtomString table intern via Identifier::fromString
(m_captureGroupNames held non-atomic Strings), and a Structure
transition table lookup. The shape of the groups object is fixed by the
pattern, so all of this is repeated work.

Store m_captureGroupNames as Vector&lt;AtomString&gt;, atomized once in
RegExp::finishCreation. Skip subpatternIdForGroupName when
m_numDuplicateNamedCaptureGroups is zero, since the answer is just the
loop index. Add RegExp::ensureGroupsStructure which lazily builds the
final {name0, name1, ...} Structure off nullPrototypeObjectStructure
and caches it in RareData (re-created when the realm differs, or
bypassed when the group count exceeds inline capacity). Callers then
allocate the groups object with that Structure directly and fill values
via putDirectOffset.

                                      TipOfTree                  Patched

regexp-named-capture-exec          51.9984+-0.5105     ^     28.5615+-0.1432        ^ definitely 1.8206x faster
regexp-named-capture-replace       44.1759+-0.3794     ^     29.3697+-0.3389        ^ definitely 1.5041x faster

Tests: JSTests/microbenchmarks/regexp-named-capture-exec.js
       JSTests/microbenchmarks/regexp-named-capture-replace.js

* JSTests/microbenchmarks/regexp-named-capture-exec.js: Added.
(test):
* JSTests/microbenchmarks/regexp-named-capture-replace.js: Added.
(test.replacer):
(test):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
(JSC::RegExp::visitChildrenImpl):
(JSC::RegExp::ensureGroupsStructure):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpMatchesArray.cpp:
(JSC::createRegExpMatchesArrayWithGroupsOrIndices):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::replaceUsingRegExpSearch):

Canonical link: <a href="https://commits.webkit.org/315989@main">https://commits.webkit.org/315989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33d4c76b13c75a850038d9435953eb949dae7b8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133024 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93816 "1 flakes 16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34833 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33173 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28634 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1877 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182537 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31831 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141482 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44157 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141299 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38070 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44846 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29847 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109388 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36566 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116735 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43356 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7952 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54425 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42761 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->