### PR TITLE
[JSC] Optimize doubleToStrictInt52 and convertDoubleToInt32 on ARM64

### DIFF
--- a/JSTests/stress/double-as-int32-fjcvtzs-negative-zero.js
+++ b/JSTests/stress/double-as-int32-fjcvtzs-negative-zero.js
@@ -1,0 +1,72 @@
+// Exercises the double->int32 conversion (DoubleAsInt32 / rounding / bit-op coercion) across all
+// tiers. On ARM64 with FEAT_JSCVT this is lowered using FJCVTZS plus a flag branch; the negative-zero
+// handling is the subtle part: when the bytecode observes -0 it must be preserved (accepted as 0 for
+// "ignore -0" sites, and detected for "check -0" sites). Throws on any mismatch; silent on success.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + String(actual) + ' expected ' + String(expected));
+}
+noInline(shouldBe);
+
+function shouldBeNegativeZero(value) {
+    if (!Object.is(value, -0))
+        throw new Error('expected -0 but got: ' + String(value));
+}
+noInline(shouldBeNegativeZero);
+
+// Bit-or coercion ignores negative zero: (-0)|0 === 0.
+function bitOr(x) { return x | 0; }
+noInline(bitOr);
+
+// Typed-array store goes through ToInt32 (DoubleAsInt32-style) and ignores -0.
+function viaInt32Array(x) {
+    var a = new Int32Array(1);
+    a[0] = x;
+    return a[0];
+}
+noInline(viaInt32Array);
+
+// Math.round into an int32 context where -0 must be ignored (used numerically).
+function roundIgnoringNegZero(x) { return Math.round(x) | 0; }
+noInline(roundIgnoringNegZero);
+
+// Math.round whose -0 result is observed (Object.is): -0 must be preserved.
+function roundObservingNegZero(x) { return Math.round(x); }
+noInline(roundObservingNegZero);
+
+function test() {
+    // Ignore-negative-zero conversions.
+    shouldBe(bitOr(-0.0), 0);
+    shouldBe(bitOr(0.0), 0);
+    shouldBe(bitOr(3.0), 3);
+    shouldBe(bitOr(-1.0), -1);
+    shouldBe(bitOr(2147483647.0), 2147483647);  // INT32_MAX
+    shouldBe(bitOr(-2147483648.0), -2147483648); // INT32_MIN
+    shouldBe(bitOr(2147483648.0), -2147483648);  // 2^31 wraps
+    shouldBe(bitOr(4294967296.0), 0);            // 2^32 wraps
+    shouldBe(bitOr(3000000000.0), -1294967296);  // > INT32_MAX wraps
+    shouldBe(bitOr(NaN), 0);
+    shouldBe(bitOr(Infinity), 0);
+    shouldBe(bitOr(-Infinity), 0);
+    shouldBe(bitOr(1.5), 1);
+    shouldBe(bitOr(-1.5), -1);
+
+    shouldBe(viaInt32Array(-0.0), 0);
+    shouldBe(viaInt32Array(5.0), 5);
+    shouldBe(viaInt32Array(-7.0), -7);
+    shouldBe(viaInt32Array(2147483648.0), -2147483648);
+
+    shouldBe(roundIgnoringNegZero(0.4), 0);
+    shouldBe(roundIgnoringNegZero(-0.4), 0); // Math.round(-0.4) is -0, coerced to 0.
+    shouldBe(roundIgnoringNegZero(2.6), 3);
+
+    // Observe-negative-zero conversions: -0 must survive.
+    shouldBeNegativeZero(roundObservingNegZero(-0.4));
+    shouldBe(roundObservingNegZero(0.4), 0);
+    shouldBe(roundObservingNegZero(2.6), 3);
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i)
+    test();

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2938,8 +2938,13 @@ public:
     // If the result is not representable as a 32 bit value, branch.
     // May also branch for some values that are representable in 32 bits
     // (specifically, in this case, 0).
-    void branchConvertDoubleToInt32(FPRegisterID src, RegisterID dest, JumpList& failureCases, FPRegisterID, bool negZeroCheck = true)
+    void branchConvertDoubleToInt32(FPRegisterID src, RegisterID dest, JumpList& failureCases, FPRegisterID scratch, bool negZeroCheck = true)
     {
+        if (supportsDoubleToInt32ConversionUsingJavaScriptSemantics()) {
+            branchConvertDoubleToInt32UsingJavaScriptSemantics(src, dest, failureCases, scratch, negZeroCheck);
+            return;
+        }
+
         m_assembler.fcvtns<32, 64>(dest, src);
         if (supportsRoundFloatToIntegerFloat())
             m_assembler.frint32z<64>(fpTempRegister, src);
@@ -2957,6 +2962,30 @@ public:
             failureCases.append(makeTestBitAndBranch(scratch, 63, IsNonZero));
             valueIsNonZero.link(this);
         }
+    }
+
+    // Uses the ARMv8.3 FJCVTZS instruction (FEAT_JSCVT). FJCVTZS performs a JavaScript-semantics
+    // double->int32 conversion and sets the Z flag iff the conversion is exact AND the input is not
+    // negative zero. So:
+    //   negZeroCheck == true  -> Z==1 is exactly the success condition; a single b.ne is the check.
+    //   negZeroCheck == false -> negative zero must be accepted, so on the inexact (Z==0) path we
+    //     fall back to a convert-back-and-compare. fcmp(-0.0, +0.0) is equal, so -0.0 is accepted,
+    //     while non-integers / overflow / NaN are rejected.
+    void branchConvertDoubleToInt32UsingJavaScriptSemantics(FPRegisterID src, RegisterID dest, JumpList& failureCases, FPRegisterID scratch, bool negZeroCheck)
+    {
+        m_assembler.fjcvtzs(dest, src); // This zero extends and sets the Z flag on exact, non-negative-zero results.
+        if (negZeroCheck) {
+            failureCases.append(makeBranch(Assembler::ConditionNE));
+            return;
+        }
+
+        Jump exact = makeBranch(Assembler::ConditionEQ);
+        // Convert the integer result back to double & compare to the original value - if not equal or
+        // unordered (NaN) then jump. Note that -0.0 converts to int 0, and fcmp(-0.0, 0.0) is equal,
+        // so -0.0 is correctly accepted here.
+        m_assembler.scvtf<64, 32>(scratch, dest);
+        failureCases.append(branchDouble(DoubleNotEqualOrUnordered, src, scratch));
+        exact.link(this);
     }
 
     Jump branchDouble(DoubleCondition cond, FPRegisterID left, FPRegisterID right)
@@ -5605,6 +5634,18 @@ public:
     void compareOnFlagsFloat(FPRegisterID left, FPRegisterID right)
     {
         m_assembler.fcmp<32>(left, right);
+    }
+
+    // Emits a tst that only sets NZCV flags (no result register), for use with ccmp chains / branchOnFlags.
+    void testOnFlags64(RegisterID reg, TrustedImm64 mask)
+    {
+        LogicalImmediate logicalImm = LogicalImmediate::create64(mask.m_value);
+        if (logicalImm.isValid()) {
+            m_assembler.tst<64>(reg, logicalImm);
+            return;
+        }
+        move(mask, getCachedDataTempRegisterIDAndInvalidate());
+        m_assembler.tst<64>(reg, dataTempRegister);
     }
 
     void compareOnFlagsDouble(FPRegisterID left, FPRegisterID right)

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -6943,6 +6943,44 @@ static void testBranchConvertDoubleToInt52()
     CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(0.3))), (1LL << 52));
     CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(-0.1))), (1LL << 52));
 }
+
+static void testBranchConvertDoubleToInt52IgnoreNegativeZero()
+{
+    auto toInt52 = compile([](CCallHelpers& jit) {
+        emitFunctionPrologue(jit);
+        constexpr bool canIgnoreNegativeZero = true;
+        CCallHelpers::JumpList failureCases;
+        jit.branchConvertDoubleToInt52(FPRInfo::argumentFPR0, GPRInfo::returnValueGPR, failureCases, GPRInfo::returnValueGPR2, FPRInfo::argumentFPR1, canIgnoreNegativeZero);
+        auto done = jit.jump();
+        failureCases.link(&jit);
+        jit.move(CCallHelpers::TrustedImm64(1ULL << 52), GPRInfo::returnValueGPR);
+        done.link(&jit);
+        emitFunctionEpilogue(jit);
+        jit.ret();
+    });
+
+    // In-range integers convert successfully.
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(1LL << 50))), (1LL << 50));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>((1LL << 51) - 1))), ((1LL << 51) - 1));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(-(1LL << 51)))), (-(1LL << 51)));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(1))), 1LL);
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(-1))), -1LL);
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(0))), 0LL);
+    // Unlike the negative-zero-checking variant, -0.0 is accepted and yields 0.
+    CHECK_EQ((invoke<int64_t>(toInt52, -static_cast<double>(0))), 0LL);
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(13790395561LL))), 13790395561LL); // a real sha256 intermediate
+
+    // Out-of-range / non-integral / NaN / Inf all fail.
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(1LL << 51))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>((1LL << 51) + 1))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(-((1LL << 51) + 1)))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(1LL << 52))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(std::numeric_limits<double>::infinity()))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(-std::numeric_limits<double>::infinity()))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(std::numeric_limits<double>::quiet_NaN()))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(42.195))), (1LL << 52));
+    CHECK_EQ((invoke<int64_t>(toInt52, static_cast<double>(-0.1))), (1LL << 52));
+}
 #endif
 
 #if CPU(ARM64)
@@ -8689,6 +8727,7 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     RUN(testBranchIfNotType());
 #if CPU(X86_64) || CPU(ARM64)
     RUN(testBranchConvertDoubleToInt52());
+    RUN(testBranchConvertDoubleToInt52IgnoreNegativeZero());
 #endif
 
 #if CPU(X86_64)

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -82,6 +82,38 @@ public:
 
 private:
 
+    // ARM64 FJCVTZS performs the double->int32 conversion and sets the Z flag iff the result is exact
+    // and not negative zero. So checking for negative zero is free there. It is a single flag branch,
+    // and is in fact cheaper than the -0-accepting path (which needs an extra convert-back-and-compare tail).
+    // This inverts the usual cost model, under which we drop the negative-zero check whenever the bytecode
+    // permits it. Here we decide whether to keep that check even when the bytecode could ignore it,
+    // because doing so is free.
+    //
+    // We only keep it when profiling has not observed negative zero nor an Int32 overflow at this site.
+    // The overflow signal matters for correctness of the heuristic: the combined FJCVTZS check reports a
+    // negative-zero failure as an Overflow OSR exit, so an actual -0 at this site shows up as NodeMayOverflowInt32
+    // on recompilation. Gating on it both avoids needless exits and prevents a recompilation loop.
+    static bool negativeZeroCheckIsFree(NodeFlags flags)
+    {
+#if CPU(ARM64)
+        return CCallHelpers::supportsDoubleToInt32ConversionUsingJavaScriptSemantics()
+            && !nodeMayNegZero(flags, AllRareCases)
+            && !nodeMayOverflowInt32(flags, AllRareCases);
+#else
+        UNUSED_PARAM(flags);
+        return false;
+#endif
+    }
+
+    // Selects the checked double->int32 arithmetic mode, keeping the negative-zero check when the bytecode requires it or when it is free.
+    static Arith::Mode arithModeForCheckedDoubleToInt32(Node* node)
+    {
+        NodeFlags flags = node->arithNodeFlags();
+        if (!bytecodeCanIgnoreNegativeZero(flags) || negativeZeroCheckIsFree(flags))
+            return Arith::CheckOverflowAndNegativeZero;
+        return Arith::CheckOverflow;
+    }
+
     void fixupArithDivInt32(Node* node, Edge& leftChild, Edge& rightChild)
     {
         if (optimizeForX86() || optimizeForARM64() || optimizeForARMv7IDIVSupported()) {
@@ -114,10 +146,7 @@ private:
 
         node->setOp(DoubleAsInt32);
         node->children.initialize(Edge(newDivision, DoubleRepUse), Edge(), Edge());
-        if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
-            node->setArithMode(Arith::CheckOverflow);
-        else
-            node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+        node->setArithMode(arithModeForCheckedDoubleToInt32(node));
 
     }
 
@@ -910,7 +939,7 @@ private:
 
                 if (isInt32OrBooleanSpeculation(node->getHeapPrediction()) && m_graph.roundShouldSpeculateInt32(node, FixupPass)) {
                     node->setResult(NodeResultInt32);
-                    if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                    if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()) && !negativeZeroCheckIsFree(node->arithNodeFlags()))
                         node->setArithRoundingMode(Arith::RoundingMode::Int32);
                     else
                         node->setArithRoundingMode(Arith::RoundingMode::Int32WithNegativeZeroCheck);
@@ -4298,10 +4327,7 @@ private:
                 // In that case, let's receive the child value as a Double value and convert it to Int32. This case happens in misc-bugs-847389-jpeg2000.
                 fixEdge<DoubleRepUse>(node->child1());
                 node->setOp(DoubleAsInt32);
-                if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
-                    node->setArithMode(Arith::CheckOverflow);
-                else
-                    node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+                node->setArithMode(arithModeForCheckedDoubleToInt32(node));
                 return;
             }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -24997,6 +24997,47 @@ IGNORE_CLANG_WARNINGS_END
 
     LValue doubleToStrictInt52(ExitKind exitKind, Node* node, LValue value, bool canIgnoreNegativeZero)
     {
+#if CPU(ARM64)
+        if (MacroAssemblerARM64::supportsRoundFloatToIntegerFloat()) {
+            // Fuse the integrality, strict-int52-range, and (optionally) negative-zero checks into a
+            // single (f)ccmp chain that OSR-exits on failure, instead of separate B3 speculations that
+            // each become their own compare+branch.
+            PatchpointValue* patchpoint = m_out.patchpoint(Int64);
+            patchpoint->append(ConstrainedValue(value, ValueRep::SomeRegister));
+            patchpoint->clobber(RegisterSet::macroClobberedGPRs());
+            patchpoint->numGPScratchRegisters = 1;
+            patchpoint->numFPScratchRegisters = 1;
+
+            unsigned osrExitArgumentOffset = patchpoint->numChildren() + /* result */ 1;
+            OSRExitDescriptor* exitDescriptor = appendOSRExitDescriptor(doubleValue(value), node);
+            // The conversion writes the result register before branching to the exit, so the exit arguments must use LateColdAny.
+            patchpoint->appendVectorWithRep(buildExitArguments(exitDescriptor, m_origin.forExit, doubleValue(value)), ValueRep::LateColdAny);
+
+            State* state = &m_ftlState;
+            NodeOrigin origin = m_origin;
+            auto nodeIndex = m_nodeIndexInGraph;
+
+            patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+                AllowMacroScratchRegisterUsage allowScratch(jit);
+
+                GPRReg resultGPR = params[0].gpr();
+                FPRReg valueFPR = params[1].fpr();
+                GPRReg scratchGPR = params.gpScratch(0);
+                FPRReg scratchFPR = params.fpScratch(0);
+
+                CCallHelpers::JumpList failureCases;
+                jit.branchConvertDoubleToInt52(valueFPR, resultGPR, failureCases, scratchGPR, scratchFPR, canIgnoreNegativeZero);
+
+                RefPtr<OSRExitHandle> handle = exitDescriptor->emitOSRExitLater(*state, exitKind, origin, params, nodeIndex, osrExitArgumentOffset);
+                RefPtr<FTL::JITCode> jitCode = state->jitCode;
+                jit.addLinkTask([=, protectedJitCode = jitCode] (LinkBuffer& linkBuffer) {
+                    linkBuffer.link(failureCases, linkBuffer.locationOf<NoPtrTag>(handle->label));
+                });
+            });
+            return patchpoint;
+        }
+#endif
+
         LValue integerValue = m_out.doubleToInt64(value);
         LValue integerValueConvertedToDouble = tryDoubleToInt64AsDouble(value);
         if (!integerValueConvertedToDouble)
@@ -25029,6 +25070,46 @@ IGNORE_CLANG_WARNINGS_END
 
     LValue convertDoubleToInt32(LValue value, bool shouldCheckNegativeZero)
     {
+#if CPU(ARM64)
+        if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics()) {
+            PatchpointValue* patchpoint = m_out.patchpoint(Int32);
+            patchpoint->append(ConstrainedValue(value, ValueRep::SomeRegister));
+            patchpoint->clobber(RegisterSet::macroClobberedGPRs());
+            // The negative-zero-accepting path needs an FP scratch for the convert-back-and-compare tail.
+            patchpoint->numFPScratchRegisters = shouldCheckNegativeZero ? 0 : 1;
+
+            unsigned osrExitArgumentOffset = patchpoint->numChildren() + /* result */ 1;
+            OSRExitDescriptor* exitDescriptor = appendOSRExitDescriptor(doubleValue(value), m_node);
+            // FJCVTZS writes the result register before we branch to the exit, so the exit arguments must
+            // use LateColdAny to interfere with the result (and the clobbered registers); plain ColdAny
+            // could be allocated into the result register, which we would have already overwritten by the
+            // time the exit is taken, corrupting OSR reconstruction.
+            patchpoint->appendVectorWithRep(buildExitArguments(exitDescriptor, m_origin.forExit, doubleValue(value)), ValueRep::LateColdAny);
+
+            State* state = &m_ftlState;
+            NodeOrigin origin = m_origin;
+            auto nodeIndex = m_nodeIndexInGraph;
+
+            patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+                AllowMacroScratchRegisterUsage allowScratch(jit);
+
+                GPRReg resultGPR = params[0].gpr();
+                FPRReg valueFPR = params[1].fpr();
+                FPRReg scratchFPR = shouldCheckNegativeZero ? InvalidFPRReg : params.fpScratch(0);
+
+                CCallHelpers::JumpList failureCases;
+                jit.branchConvertDoubleToInt32UsingJavaScriptSemantics(valueFPR, resultGPR, failureCases, scratchFPR, shouldCheckNegativeZero);
+
+                RefPtr<OSRExitHandle> handle = exitDescriptor->emitOSRExitLater(*state, Overflow, origin, params, nodeIndex, osrExitArgumentOffset);
+                RefPtr<FTL::JITCode> jitCode = state->jitCode;
+                jit.addLinkTask([=, protectedJitCode = jitCode] (LinkBuffer& linkBuffer) {
+                    linkBuffer.link(failureCases, linkBuffer.locationOf<NoPtrTag>(handle->label));
+                });
+            });
+            return patchpoint;
+        }
+#endif
+
         LValue integerValue = m_out.doubleToInt32(value);
         LValue int32InDouble = tryDoubleToInt32AsDouble(value);
         if (!int32InDouble)

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1591,15 +1591,42 @@ public:
 
         truncateDoubleToInt64(srcFPR, destGPR);
 
-        bool convertedBack = false;
 #if CPU(ARM64)
         if (supportsRoundFloatToIntegerFloat()) {
-            convertedBack = true;
             roundTowardZeroInt64Double(srcFPR, scratch2FPR);
+
+            // We have several independent failure conditions that all branch to the same target:
+            //   (1) integrality:  srcFPR != scratch2FPR (or unordered)
+            //   (2) strict-int52: (destGPR + 2^51) has any bit set above bit 51
+            //   (3) negative zero (only when !canIgnoreNegativeZero): destGPR == 0 && sign bit of srcFPR set
+            // Fuse them into a single flag-producing chain using (f)ccmp so we emit one branch instead of
+            // two or three. The range test sets Z=1 on success; fccmp then conditionally folds the
+            // integrality compare; a final integer ccmp folds the negative-zero test.
+            //
+            // Range test: Z=1 iff in strict-int52 range.
+            add64(TrustedImm64(0x0008000000000000ULL), destGPR, scratch1GPR);
+            testOnFlags64(scratch1GPR, TrustedImm64(0xFFF0000000000000ULL)); // tst sets Z=1 iff in range
+            // If in range (EQ), perform fcmp(srcFPR, scratch2FPR); otherwise force flags so the final
+            // branch is taken. nzcv = 0 leaves Z=0 (failure) when the range test failed.
+            compareConditionallyOnFlagsDouble(srcFPR, scratch2FPR, TrustedImm32(0), Equal);
+            // Combine the negative-zero test: pass so far iff EQ. If not EQ, force the final branch.
+            //   raw = bitcast(srcFPR); negative zero iff destGPR == 0 && (raw >> 63).
+            // We compute Z = !(destGPR == 0 && rawSignBitSet) only when the prior checks passed.
+            failureCases.append(branchOnFlags(NotEqual));
+
+            if (canIgnoreNegativeZero)
+                return;
+
+            // At this point the value is an integer in strict-int52 range. Reject -0.0.
+            auto valueIsNonZero = branchTest64(NonZero, destGPR);
+            moveDoubleTo64(srcFPR, scratch1GPR);
+            failureCases.append(branchTest64(NonZero, scratch1GPR, TrustedImm64(1ULL << 63)));
+            valueIsNonZero.link(this);
+            return;
         }
 #endif
-        if (!convertedBack)
-            convertInt64ToDouble(destGPR, scratch2FPR);
+
+        convertInt64ToDouble(destGPR, scratch2FPR);
 
         failureCases.append(branchDouble(DoubleNotEqualOrUnordered, srcFPR, scratch2FPR));
 


### PR DESCRIPTION
#### 466c454237671212564866ec799f3456337f429c
<pre>
[JSC] Optimize doubleToStrictInt52 and convertDoubleToInt32 on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=317827">https://bugs.webkit.org/show_bug.cgi?id=317827</a>
<a href="https://rdar.apple.com/180600293">rdar://180600293</a>

Reviewed by NOBODY (OOPS!).

WIP

Tests: JSTests/stress/double-as-int32-fjcvtzs-negative-zero.js
       Source/JavaScriptCore/assembler/testmasm.cpp

* JSTests/stress/double-as-int32-fjcvtzs-negative-zero.js: Added.
(shouldBe):
(shouldBeNegativeZero):
(bitOr):
(viaInt32Array):
(roundIgnoringNegZero):
(roundObservingNegZero):
(test):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::branchConvertDoubleToInt32):
(JSC::MacroAssemblerARM64::branchConvertDoubleToInt32UsingJavaScriptSemantics):
(JSC::MacroAssemblerARM64::testOnFlags64):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testBranchConvertDoubleToInt52IgnoreNegativeZero):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::negativeZeroCheckIsFree):
(JSC::DFG::FixupPhase::arithModeForCheckedDoubleToInt32):
(JSC::DFG::FixupPhase::fixupArithDivInt32):
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::fixupToNumberOrToNumericOrCallNumberConstructor):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::branchConvertDoubleToInt52):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/466c454237671212564866ec799f3456337f429c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170161 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/915619bf-02fc-41c6-8b92-dda7d40b2b09) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132648 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93484 "3 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84194ab3-26fa-43b9-8247-6ff312046319) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113150 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1926cbd-089e-4b7b-8e15-f20a1a33a6ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34424 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28219 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1498 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182120 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31416 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141100 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43741 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140925 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44430 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108806 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36194 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116310 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202840 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42940 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7563 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42475 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->