### PR TITLE
Non-unified build fixes for June 25th, 2026

### DIFF
--- a/Source/WebCore/Modules/webxr/XRCubeLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCubeLayer.cpp
@@ -29,6 +29,8 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "WebXRRigidTransform.h"
+
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -28,6 +28,8 @@
 #include "CSSStyleSheet.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
+#include "MutableStyleProperties.h"
+#include "NodeDocument.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
 #include "StyleSheetContents.h"

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -35,6 +35,7 @@
 #include "Microtasks.h"
 #include "MutationCallback.h"
 #include "MutationObserver.h"
+#include "NodeDocument.h"
 #include "OpportunisticTaskScheduler.h"
 #include "SecurityOrigin.h"
 #include "ThreadGlobalData.h"

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -316,7 +316,7 @@ Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Pr
             pseudoElements = JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>::create();
             for (auto pseudoElementType : allPseudoElementTypes) {
                 // `*::marker` selectors are only applicable to elements with `display: list-item`.
-                if (pseudoElementType == PseudoElementType::Marker && element->computedStyle()->display() != Style::DisplayType::BlockFlowListItem)
+                if (pseudoElementType == PseudoElementType::Marker && !element->computedStyle()->isListItemType())
                     continue;
 
                 if (pseudoElementType == PseudoElementType::Backdrop && !element->isInTopLayer())

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
@@ -280,7 +280,7 @@ Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMa
         if (!includePseudo || *includePseudo) {
             pseudoElements = JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>::create();
             for (auto pseudoElementType : allPseudoElementTypes) {
-                if (pseudoElementType == PseudoElementType::Marker && element->computedStyle()->display() != Style::DisplayType::BlockFlowListItem)
+                if (pseudoElementType == PseudoElementType::Marker && !element->computedStyle()->isListItemType())
                     continue;
                 if (pseudoElementType == PseudoElementType::Backdrop && !element->isInTopLayer())
                     continue;

--- a/Source/WebCore/page/text-extraction/TextExtractionScriptFiltering.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtractionScriptFiltering.cpp
@@ -33,7 +33,7 @@
 #include "DocumentWriter.h"
 #include "EmptyClients.h"
 #include "FrameLoader.h"
-#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
 #include "Page.h"
 #include "PageConfiguration.h"

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -187,6 +187,11 @@ void ComputedStyle::inheritFrom(const ComputedStyle& inheritParent)
         m_svgData.access().inheritFrom(inheritParent.m_svgData.get());
 }
 
+bool ComputedStyle::isListItemType() const
+{
+    return display().isListItemType();
+}
+
 void ComputedStyle::inheritIgnoringCustomPropertiesFrom(const ComputedStyle& inheritParent)
 {
     auto oldCustomProperties = m_inheritedRareData->customProperties;

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -221,6 +221,8 @@ public:
     inline bool isRowFlexDirection() const;
     inline bool isSkippedRootOrSkippedContent() const;
 
+    bool isListItemType() const;
+
     inline bool specifiesColumns() const;
 
     inline bool usesStandardScrollbarStyle() const;

--- a/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp
@@ -32,6 +32,7 @@
 #include "WebBackForwardListMessages.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include <WebCore/DocumentPage.h>
 #include <WebCore/HistoryItem.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>


### PR DESCRIPTION
#### dd078b0a0839c6aa0f808d243a6bb0831e3228d8
<pre>
Non-unified build fixes for June 25th, 2026
<a href="https://bugs.webkit.org/show_bug.cgi?id=317826">https://bugs.webkit.org/show_bug.cgi?id=317826</a>

Unreviewed build fixes.

* Source/WebCore/Modules/webxr/XRCubeLayer.cpp:
* Source/WebCore/css/CSSPageRule.cpp:
* Source/WebCore/dom/WindowEventLoop.cpp:
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp:
* Source/WebCore/page/text-extraction/TextExtractionScriptFiltering.cpp:
* Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp:

Canonical link: <a href="https://commits.webkit.org/315812@main">https://commits.webkit.org/315812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5fa16edecc3c302f164ff25a52c97df4409e049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132657 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173129 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113159 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28228 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182129 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141107 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43750 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140932 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44439 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108820 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25942 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36203 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116319 "Found 1 new failure in inspector/agents/frame/FrameCSSAgent.cpp") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202849 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42949 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7571 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/202849 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->