### PR TITLE
[WPE] REGRESSION(315785@main): Swift-enabled build fails to link libWPEWebKit with multiple-definition errors

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -523,43 +523,37 @@ if (ENABLE_WPE_PLATFORM)
         "${WEBKIT_DIR}/WPEPlatform"
     )
 
-    # CMake's Swift_SHARED_LIBRARY_LINKER rule writes its inputs and libraries
-    # into an rsp file (`rspfile_content = $in_newline $LINK_PATH
-    # $LINK_LIBRARIES`). For OBJECT libraries, CMake adds the target as an
-    # order-only ninja dependency (after `||`) but does not expand the
-    # underlying .o files into either $in or $LINK_LIBRARIES, so the WPEPlatform
-    # objects are missing from the link and every wpe_* symbol used by
-    # UIProcess/API/wpe/WPEWebViewPlatform.cpp et al. comes back as an
-    # undefined reference. Pass `$<TARGET_OBJECTS:...>` directly (the same
-    # workaround WebKitMacros._WEBKIT_FRAMEWORK_LINK uses for OBJECT
-    # frameworks) so the .o files are listed as explicit link inputs.
-    #
-    # Only do this when Swift is actually in the link — the regular CXX linker
-    # rule already expands an OBJECT library's .o files when you link the
-    # target by name, so adding TARGET_OBJECTS on top produces duplicate
-    # symbols.
+    # Link the WPEPlatform OBJECT libraries by name for their link interface.
+    # CMake < 3.29 omits their objects from a Swift link, so pass them
+    # explicitly there. CMake >= 3.29 adds them itself and doing so again
+    # duplicates every symbol.
+    set(_old_cmake_swift_needs_explicit_objects FALSE)
+    if (SWIFT_REQUIRED AND CMAKE_VERSION VERSION_LESS "3.29")
+        set(_old_cmake_swift_needs_explicit_objects TRUE)
+    endif ()
+
     list(APPEND WebKit_PRIVATE_LIBRARIES WPEPlatform)
-    if (SWIFT_REQUIRED)
+    if (_old_cmake_swift_needs_explicit_objects)
         list(APPEND WebKit_PRIVATE_LIBRARIES "$<TARGET_OBJECTS:WPEPlatform>")
     endif ()
 
     if (ENABLE_WPE_PLATFORM_DRM)
         list(APPEND WebKit_PRIVATE_LIBRARIES WPEPlatformDRM)
-        if (SWIFT_REQUIRED)
+        if (_old_cmake_swift_needs_explicit_objects)
             list(APPEND WebKit_PRIVATE_LIBRARIES "$<TARGET_OBJECTS:WPEPlatformDRM>")
         endif ()
     endif ()
 
     if (ENABLE_WPE_PLATFORM_HEADLESS)
         list(APPEND WebKit_PRIVATE_LIBRARIES WPEPlatformHeadless)
-        if (SWIFT_REQUIRED)
+        if (_old_cmake_swift_needs_explicit_objects)
             list(APPEND WebKit_PRIVATE_LIBRARIES "$<TARGET_OBJECTS:WPEPlatformHeadless>")
         endif ()
     endif ()
 
     if (ENABLE_WPE_PLATFORM_WAYLAND)
         list(APPEND WebKit_PRIVATE_LIBRARIES WPEPlatformWayland)
-        if (SWIFT_REQUIRED)
+        if (_old_cmake_swift_needs_explicit_objects)
             list(APPEND WebKit_PRIVATE_LIBRARIES "$<TARGET_OBJECTS:WPEPlatformWayland>")
         endif ()
     endif ()


### PR DESCRIPTION
#### 38985585468bf2f8114d6a3ccc067befb12ae83a
<pre>
[WPE] REGRESSION(315785@main): Swift-enabled build fails to link libWPEWebKit with multiple-definition errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=317833">https://bugs.webkit.org/show_bug.cgi?id=317833</a>

Reviewed by Alicia Boya Garcia.

The Ubuntu 26.04 wkdev-sdk bump (v7 -&gt; v8) upgraded CMake from 3.28.3 to
4.2.3. Since CMake 3.29 the Ninja Swift_SHARED_LIBRARY_LINKER rule expands an
OBJECT library&apos;s .o files onto the link line when the library is linked by
target name -- 3.28.3 did NOT do that...

PlatformWPE.cmake worked around the old behaviour by also passing the
WPEPlatform objects explicitly via $&lt;TARGET_OBJECTS:...&gt; whenever SWIFT_REQUIRED
was activated. From CMake 3.29 on that lists every object a second time, so
linking libWPEWebKit-2.0.so failed with hundreds of multiple-definition
errors from the linker.

The object libraries still have to be linked by name to propagate their link
interface, so the explicit-objects workaround cannot simply be dropped: it is
required on CMake &lt; 3.29 and harmful on CMake &gt;= 3.29.

-&gt; Add a fix that works for both CMake &lt; 3.29 and &gt;= 3.29.

* Source/WebKit/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/315810@main">https://commits.webkit.org/315810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60fda5aef691ade538475bb1be343877bb4a2339

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44096 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179535 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43728 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173132 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/113160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28231 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/34921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/36960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43753 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44442 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108823 "Failed to checkout and rebase branch from PR 67854") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25939 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/36202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42952 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->