### PR TITLE
Some tooling cherry-pick backports for webkitglib/2.52

### DIFF
--- a/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/tests/platform/wpe/TestExpectations
+++ b/Tools/CISupport/build-webkit-org/public_html/dashboard/Scripts/tests/platform/wpe/TestExpectations
@@ -1,0 +1,1 @@
+webkit.org/b/309891 [ arm64 ] index.html [ Failure ]

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1090,7 +1090,13 @@ class RunAPITests(TestWithFailureCount, CustomFlagsMixin, ShellMixin):
         if platform in ['gtk', 'wpe']:
             self.command = ['python3', f'Tools/Scripts/run-{platform}-tests',
                             f'--{self.getProperty("configuration")}',
-                            f'--json-output={self.jsonFileName}']
+                            f'--json-output={self.jsonFileName}',
+                            "--buildbot-master", DNS_NAME,
+                            "--builder-name", self.getProperty("buildername"),
+                            "--build-number", self.getProperty("buildnumber"),
+                            "--buildbot-worker", self.getProperty("workername"),
+                            "--report", RESULTS_WEBKIT_URL,
+                            ]
         else:
             self.appendCustomTestingFlags(platform, self.getProperty('device_model'))
         additionalArguments = self.getProperty("additionalArguments")

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1091,11 +1091,11 @@ class RunAPITests(TestWithFailureCount, CustomFlagsMixin, ShellMixin):
             self.command = ['python3', f'Tools/Scripts/run-{platform}-tests',
                             f'--{self.getProperty("configuration")}',
                             f'--json-output={self.jsonFileName}',
-                            "--buildbot-master", DNS_NAME,
-                            "--builder-name", self.getProperty("buildername"),
-                            "--build-number", self.getProperty("buildnumber"),
-                            "--buildbot-worker", self.getProperty("workername"),
-                            "--report", RESULTS_WEBKIT_URL,
+                            f'--buildbot-master={DNS_NAME}',
+                            f'--builder-name={self.getProperty("buildername")}',
+                            f'--build-number={self.getProperty("buildnumber")}',
+                            f'--buildbot-worker={self.getProperty("workername")}',
+                            f'--report={RESULTS_WEBKIT_URL}',
                             ]
         else:
             self.appendCustomTestingFlags(platform, self.getProperty('device_model'))

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1295,16 +1295,16 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
         return self.successTest('mac', 'mac-highsierra', 'release', expected_command, additional_arguments)
 
     def test_success_gtk(self):
-        expected_command = 'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json'
+        expected_command = f'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
         return self.successTest('gtk', 'gtk', 'release', expected_command)
 
     def test_success_wpe(self):
-        expected_command = 'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json'
+        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
         return self.successTest('wpe', 'wpe', 'release', expected_command)
 
     def test_success_wpe_additional_arguments(self):
         additional_arguments = ['--wpe-legacy-api']
-        expected_command = 'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --wpe-legacy-api'
+        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org --wpe-legacy-api'
         return self.successTest('wpe', 'wpe', 'release', expected_command, additional_arguments)
 
     def test_failure_mac(self):
@@ -1314,13 +1314,13 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
         return self.failureTest('mac', 'mac-highsierra', 'release', expected_command, generated_stderr_output, expected_state_string)
 
     def test_failure_gtk(self):
-        expected_command = 'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json'
+        expected_command = f'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
         generated_stderr_output = 'Random string should not affect\nRan 100 tests of 200 with 90 successful'
         expected_state_string = '10 api tests failed or timed out'
         return self.failureTest('gtk', 'gtk', 'release', expected_command, generated_stderr_output, expected_state_string)
 
     def test_failure_wpe(self):
-        expected_command = 'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json'
+        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
         generated_stderr_output = f'Command failed: {expected_command}\nRandomString no issue\nRan 95 tests of 95 with 90 successful'
         expected_state_string = '5 api tests failed or timed out'
         return self.failureTest('wpe', 'wpe', 'release', expected_command, generated_stderr_output, expected_state_string)

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1295,16 +1295,16 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
         return self.successTest('mac', 'mac-highsierra', 'release', expected_command, additional_arguments)
 
     def test_success_gtk(self):
-        expected_command = f'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
+        expected_command = f'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json --buildbot-master={CURRENT_HOSTNAME} --builder-name=API-Tests --build-number=101 --buildbot-worker=bot100 --report=https://results.webkit.org'
         return self.successTest('gtk', 'gtk', 'release', expected_command)
 
     def test_success_wpe(self):
-        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
+        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master={CURRENT_HOSTNAME} --builder-name=API-Tests --build-number=101 --buildbot-worker=bot100 --report=https://results.webkit.org'
         return self.successTest('wpe', 'wpe', 'release', expected_command)
 
     def test_success_wpe_additional_arguments(self):
         additional_arguments = ['--wpe-legacy-api']
-        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org --wpe-legacy-api'
+        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master={CURRENT_HOSTNAME} --builder-name=API-Tests --build-number=101 --buildbot-worker=bot100 --report=https://results.webkit.org --wpe-legacy-api'
         return self.successTest('wpe', 'wpe', 'release', expected_command, additional_arguments)
 
     def test_failure_mac(self):
@@ -1314,13 +1314,13 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
         return self.failureTest('mac', 'mac-highsierra', 'release', expected_command, generated_stderr_output, expected_state_string)
 
     def test_failure_gtk(self):
-        expected_command = f'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
+        expected_command = f'python3 Tools/Scripts/run-gtk-tests --release --json-output=api_test_results.json --buildbot-master={CURRENT_HOSTNAME} --builder-name=API-Tests --build-number=101 --buildbot-worker=bot100 --report=https://results.webkit.org'
         generated_stderr_output = 'Random string should not affect\nRan 100 tests of 200 with 90 successful'
         expected_state_string = '10 api tests failed or timed out'
         return self.failureTest('gtk', 'gtk', 'release', expected_command, generated_stderr_output, expected_state_string)
 
     def test_failure_wpe(self):
-        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
+        expected_command = f'python3 Tools/Scripts/run-wpe-tests --release --json-output=api_test_results.json --buildbot-master={CURRENT_HOSTNAME} --builder-name=API-Tests --build-number=101 --buildbot-worker=bot100 --report=https://results.webkit.org'
         generated_stderr_output = f'Command failed: {expected_command}\nRandomString no issue\nRan 95 tests of 95 with 90 successful'
         expected_state_string = '5 api tests failed or timed out'
         return self.failureTest('wpe', 'wpe', 'release', expected_command, generated_stderr_output, expected_state_string)

--- a/Tools/Scripts/run-gtk-tests
+++ b/Tools/Scripts/run-gtk-tests
@@ -18,8 +18,10 @@
 # Boston, MA 02110-1301, USA.
 
 import logging
+import optparse
 import os
 import sys
+from webkitpy.results.options import upload_options
 
 from webkitpy.port.linux_container_sdk_utils import maybe_enter_webkit_container_sdk, maybe_use_container_sdk_root_dir
 maybe_enter_webkit_container_sdk()
@@ -90,10 +92,19 @@ class GtkTestRunner(TestRunner):
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)
     check_environment("gtk")
+    option_group_definitions = []
+    option_group_definitions.append(('Upload Options', upload_options()))
+
     option_parser = create_option_parser()
     option_parser.add_option('--display-server', choices=['xvfb', 'xorg', 'weston', 'wayland'], default='xvfb',
                              help='"xvfb": Use a virtualized X11 server. "xorg": Use the current X11 session. '
                                   '"weston": Use a virtualized Weston server. "wayland": Use the current wayland session.'),
+
+    for group_name, group_options in option_group_definitions:
+        option_group = optparse.OptionGroup(option_parser, group_name)
+        option_group.add_options(group_options)
+        option_parser.add_option_group(option_group)
+
     options, args = option_parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/Tools/Scripts/run-wpe-tests
+++ b/Tools/Scripts/run-wpe-tests
@@ -18,8 +18,10 @@
 # Boston, MA 02110-1301, USA.
 
 import logging
+import optparse
 import os
 import sys
+from webkitpy.results.options import upload_options
 
 from webkitpy.port.linux_container_sdk_utils import maybe_enter_webkit_container_sdk, maybe_use_container_sdk_root_dir
 maybe_enter_webkit_container_sdk()
@@ -57,6 +59,9 @@ class WPETestRunner(TestRunner):
 if __name__ == "__main__":
     runner_args = get_runner_args(sys.argv)
     check_environment("wpe")
+    option_group_definitions = []
+    option_group_definitions.append(('Upload Options', upload_options()))
+
     option_parser = create_option_parser()
     option_parser.add_option('--display-server', choices=['headless', 'wayland'], default='headless',
                              help='"headless": Use headless view backend. "wayland": Use the current wayland session.')
@@ -64,6 +69,12 @@ if __name__ == "__main__":
                              help='Use WPE legacy API.')
 
     args = sys.argv[1:]
+
+    for group_name, group_options in option_group_definitions:
+        option_group = optparse.OptionGroup(option_parser, group_name)
+        option_group.add_options(group_options)
+        option_parser.add_option_group(option_group)
+
     options, args = option_parser.parse_args(args)
 
     if options.wpe_legacy_api:

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -23,6 +23,7 @@ import errno
 import json
 import sys
 import re
+import time
 from signal import SIGKILL, SIGSEGV
 from glib_test_runner import GLibTestRunner
 
@@ -37,6 +38,7 @@ from webkitpy.common.host import Host
 from webkitpy.common.test_expectations import TestExpectations
 from webkitpy.port.monadodriver import MonadoDriver  # noqa: E402
 from webkitpy.port.westondriver import WestonDriver
+from webkitpy.results.upload import Upload  # noqa: E402
 from webkitcorepy import Timeout
 
 UNKNOWN_CRASH_STR = "CRASH_OR_PROBLEM_IN_TEST_EXECUTABLE"
@@ -364,7 +366,11 @@ class TestRunner(object):
             self.list_tests()
             return 0
 
+        start_time = time.time()
+
         self._test_env = self._setup_testing_environment_for_driver(self._driver)
+
+        configuration_for_upload = self._port.configuration_for_upload(self._port.target_host(0))
 
         number_of_total_tests = len(self._tests)
         # Remove skipped tests now instead of when we find them, because
@@ -411,12 +417,23 @@ class TestRunner(object):
         failed_tests = {}
         timed_out_tests = {}
         passed_tests = {}
+        tests_to_upload = {}
+        number_of_skipped_tests = 0
+
+        status_to_test_result = {
+            "PASS": None,
+            "FAIL": Upload.Expectations.FAIL,
+            "CRASH": Upload.Expectations.CRASH,
+            "TIMEOUT": Upload.Expectations.TIMEOUT,
+        }
+
         try:
             for test in self._tests:
                 subtests = self._getsubtests_to_run_for_test(test)
                 if UNKNOWN_CRASH_STR in subtests:
                     subtests = []  # The binary runner can't run a subtest named UNKNOWN_CRASH_STR, so run all subtests if this is requested.
                 skipped_subtests = self._test_cases_to_skip(test)
+                number_of_skipped_tests += len(skipped_subtests)
                 number_of_total_tests += len(skipped_subtests if not subtests else set(skipped_subtests).intersection(subtests))
                 results = self._run_test(test, subtests, skipped_subtests)
                 number_of_executed_subtests_for_test = len(results)
@@ -425,6 +442,10 @@ class TestRunner(object):
                     number_of_executed_tests += number_of_executed_subtests_for_test - 1
                     number_of_total_tests += number_of_executed_subtests_for_test - 1
                     for test_case, result in results.items():
+                        # Prepare the results that will be uploaded to the results database.
+                        if result in status_to_test_result:
+                            tests_to_upload.setdefault(test, []).append((test_case, status_to_test_result[result], self._expectations.get_expectation(os.path.basename(test), test_case)))
+
                         if result in self._expectations.get_expectation(os.path.basename(test), test_case):
                             continue
                         if result == "FAIL":
@@ -441,6 +462,8 @@ class TestRunner(object):
                     crashed_tests[test] = [UNKNOWN_CRASH_STR]
         finally:
             self._tear_down_testing_environment()
+
+        end_time = time.time()
 
         def number_of_tests(tests):
             return sum(len(value) for value in tests.values())
@@ -476,6 +499,36 @@ class TestRunner(object):
             result_dictionary['Crashed'] = generate_test_list_for_json_output(crashed_tests)
             result_dictionary['Timedout'] = generate_test_list_for_json_output(timed_out_tests)
             self._port.host.filesystem.write_text_file(self._options.json_output, json.dumps(result_dictionary, indent=4))
+
+        if self._options.report_urls:
+            sys.stderr.write("\n")
+            sys.stderr.write("Preparing upload data ...\n")
+
+            results = {}
+            for test, test_cases in tests_to_upload.items():
+                for test_case in test_cases:
+                    name = "%s:%s" % (self._get_test_short_name(test), test_case[0])
+                    results[name] = Upload.create_test_result(actual=test_case[1], expected=test_case[2])
+
+            upload = Upload(
+                suite=self._options.suite or 'api-tests',
+                configuration=configuration_for_upload,
+                details=Upload.create_details(options=self._options),
+                commits=self._port.commits_for_upload(),
+                run_stats=Upload.create_run_stats(
+                    start_time=start_time,
+                    end_time=end_time,
+                    tests_skipped=number_of_skipped_tests,
+                ), results=results
+            )
+
+            for url in self._options.report_urls:
+                sys.stderr.write(f'Uploading to {url} ...\n')
+                if not upload.upload(url, log_line_func=lambda val: sys.stderr.write(val + '\n')):
+                    sys.stderr.write(f'Failed upload to {url}.\n')
+
+            sys.stderr.write('Uploads completed!\n')
+
 
         number_of_failed_tests = number_of_tests(failed_tests) + number_of_tests(timed_out_tests) + number_of_tests(crashed_tests)
         number_of_successful_tests = number_of_executed_tests - number_of_failed_tests


### PR DESCRIPTION
Some tooling cherry-pick for the 2.52 branch<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be0a0f44716f625a07bc520a6e34ebbd39d19ff3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170174 "Failed to checkout and rebase branch from PR 67856") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44097 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179536 "Failed to checkout and rebase branch from PR 67856") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127886 "The change is no longer eligible for processing.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172040 "Failed to checkout and rebase branch from PR 67856") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45341 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43729 "The change is no longer eligible for processing.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/179536 "Failed to checkout and rebase branch from PR 67856") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127886 "The change is no longer eligible for processing.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173133 "Failed to checkout and rebase branch from PR 67856") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/45341 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/179536 "Failed to checkout and rebase branch from PR 67856") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45341 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43729 "The change is no longer eligible for processing.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/28232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/45341 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/43729 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/169574 "The change is no longer eligible for processing.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/43754 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/44443 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108827 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/44443 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/42953 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/37513 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42345 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/42599 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42488 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->