### PR TITLE
Enable SW VP9 decoder by default on IOS simulators

### DIFF
--- a/LayoutTests/media/media-video-fullrange-offscreen.html
+++ b/LayoutTests/media/media-video-fullrange-offscreen.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ SWVPDecodersAlwaysEnabled=true ] -->
 <html>
 <head>
 <title>videos with full range color offscreen</title>

--- a/LayoutTests/media/media-video-fullrange.html
+++ b/LayoutTests/media/media-video-fullrange.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ SWVPDecodersAlwaysEnabled=true ] -->
 <html>
 <head>
 <title>videos with full range color</title>

--- a/LayoutTests/media/media-video-videorange-offscreen.html
+++ b/LayoutTests/media/media-video-videorange-offscreen.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ SWVPDecodersAlwaysEnabled=true ] -->
 <html>
 <head>
 <title>videos with video range color</title>

--- a/LayoutTests/media/media-video-videorange.html
+++ b/LayoutTests/media/media-video-videorange.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ SWVPDecodersAlwaysEnabled=true ] -->
 <html>
 <head>
 <title>videos with video range color</title>

--- a/LayoutTests/media/media-webm-av1.html
+++ b/LayoutTests/media/media-webm-av1.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ SWVPDecodersAlwaysEnabled=true ] -->
 <html>
 <head>
 <title>webm with Av1 track</title>

--- a/LayoutTests/media/video-webm-canvas-drawing.html
+++ b/LayoutTests/media/video-webm-canvas-drawing.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ MediaContainmentEnabled=true SWVPDecodersAlwaysEnabled=true ] -->
+<!DOCTYPE html>
     <head>
         <title>Drawing to canvas using video</title>
         <script src=media-file.js></script>

--- a/LayoutTests/media/video-webm-seek-multi-audio-tracks.html
+++ b/LayoutTests/media/video-webm-seek-multi-audio-tracks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ SWVPDecodersAlwaysEnabled=true ] -->
+<!DOCTYPE HTML>
 <html>
     <head>
         <script src="video-test.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7023,7 +7023,13 @@ SWVPDecodersAlwaysEnabled:
   webcoreBinding: none
   condition: ENABLE(VP9)
   defaultValue:
+    WebKitLegacy:
+      "PLATFORM(IOS_FAMILY_SIMULATOR)": true
+      default: false
     WebKit:
+      "PLATFORM(IOS_FAMILY_SIMULATOR)": true
+      default: false
+    WebCore:
       default: false
 
 SafeBrowsingEnabled:


### PR DESCRIPTION
#### 92239fde29f9583a571bbf914e64457a621c3d34
<pre>
Enable SW VP9 decoder by default on IOS simulators
<a href="https://bugs.webkit.org/show_bug.cgi?id=317835">https://bugs.webkit.org/show_bug.cgi?id=317835</a>
<a href="https://rdar.apple.com/180609461">rdar://180609461</a>

Reviewed by Eric Carlson.

VP9 codec isn&apos;t available on iOS simulator, we make the preference SWVPDecodersAlwaysEnabled
true by default on simulator.

Covered by existing tests.

* LayoutTests/media/media-video-fullrange-offscreen.html:
* LayoutTests/media/media-video-fullrange.html:
* LayoutTests/media/media-video-videorange-offscreen.html:
* LayoutTests/media/media-video-videorange.html:
* LayoutTests/media/media-webm-av1.html:
* LayoutTests/media/video-webm-canvas-drawing.html:
* LayoutTests/media/video-webm-seek-multi-audio-tracks.html:
* LayoutTests/media/vp9.html:
* LayoutTests/platform/mac/media/mediacapabilities/vp9-decodingInfo-sw.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/315881@main">https://commits.webkit.org/315881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8937b20c7bc94f77f30eff589821a0c6642abe72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127930 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf1aa6b7-a119-41ec-b2ee-9aaa40ed6a3a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccbbebfd-dae3-4737-8d88-ff3fd3faa474) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113210 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38d9626e-da4a-4db0-a3d3-2e15a04fbb65) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28276 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1550 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182177 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31473 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Passed JSC tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37001 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141151 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 14 flakes 8 failures; Running upload-test-results; 3 flakes 3 failures; Compiled WebKit (warnings); 3 flakes 3 failures; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152604 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37990 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44487 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108894 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36245 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116367 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202897 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42997 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7615 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54372 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42389 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42643 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->