### PR TITLE
Cherry-pick 312823@main (02d6f2281384). https://bugs.webkit.org/show_bug.cgi?id=314331

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/documentation.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/documentation.html
@@ -339,7 +339,7 @@ const documentation = {
                     '    "expected": <expected result of run>,\n' +
                     '    "time": <miliseconds it took test to run>\n' +
                     '}'),
-                    `The 'time' element optional. If 'actual' or 'expected' are undefined, they are assumed to be PASS. These results are organized in a list of dictionaries organized like so:`,
+                    `The 'time' element is optional. If 'actual' or 'expected' are undefined, they are assumed to be PASS. Both 'actual' and 'expected' must be space-separated strings of result values (e.g. 'PASS', 'FAIL', or 'PASS FAIL' for multiple expected values). These results are organized in a list of dictionaries organized like so:`,
                     codeBlock('[\n' +
                     '    {\n' +
                     '        "configuration": <configuration-object-a>,\n' +

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -508,7 +508,7 @@ class TestRunner(object):
             for test, test_cases in tests_to_upload.items():
                 for test_case in test_cases:
                     name = "%s:%s" % (self._get_test_short_name(test), test_case[0])
-                    results[name] = Upload.create_test_result(actual=test_case[1], expected=test_case[2])
+                    results[name] = Upload.create_test_result(actual=test_case[1], expected=' '.join(test_case[2]) if test_case[2] else None)
 
             upload = Upload(
                 suite=self._options.suite or 'api-tests',


### PR DESCRIPTION
#### b30184be318db198ce44838c6c3d173da85469af
<pre>
Cherry-pick 312823@main (02d6f2281384). <a href="https://bugs.webkit.org/show_bug.cgi?id=314331">https://bugs.webkit.org/show_bug.cgi?id=314331</a>

    [GLIB] Fix expected value field when uploading API test results to results.webkit.org
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314331">https://bugs.webkit.org/show_bug.cgi?id=314331</a>

    Reviewed by Patrick Griffis.

    When I originally wrote this, I assummed that &apos;expected&apos; could be a list of strings.
    Turns out it needs to be a single string with the expectations separated by spaces.
    Fix this and also add this information to the documentation of results.webkit.org.

    * Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/documentation.html:
    * Tools/glib/api_test_runner.py:
    (TestRunner.run_tests):

    Canonical link: <a href="https://commits.webkit.org/312823@main">https://commits.webkit.org/312823@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.792@webkitglib/2.52">https://commits.webkit.org/305877.792@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1329bccc9bd1dc1d29c4b68ba8609caaced23619

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170179 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44102 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179541 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127891 "The change is no longer eligible for processing.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/172045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45346 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43734 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127891 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173138 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/45346 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/113165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169500 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45346 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43734 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28237 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/45346 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182138 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/43734 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/169579 "The change is no longer eligible for processing.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/43759 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/140939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/44448 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108834 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25943 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/44448 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/42958 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/37518 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42350 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/42604 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42493 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->