### PR TITLE
WebProcess AudioSession may not always stay active when microphone capture is live

### DIFF
--- a/LayoutTests/fast/mediastream/audio-session-active-when-capture-starts-and-stops-expected.txt
+++ b/LayoutTests/fast/mediastream/audio-session-active-when-capture-starts-and-stops-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Removing a media session while microphone capture is active must not deactivate AudioSession
+

--- a/LayoutTests/fast/mediastream/audio-session-active-when-capture-starts-and-stops.html
+++ b/LayoutTests/fast/mediastream/audio-session-active-when-capture-starts-and-stops.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../media/media-file.js"></script>
+</head>
+<body>
+<video id="video"></video>
+<script>
+function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+promise_test(async (test) => {
+    assert_true(!!window.internals, "Test requires window.internals");
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    assert_true(internals.audioSessionActive(), "AudioSession must be active once microphone capture starts");
+
+    await navigator.mediaSession.setMicrophoneActive(false);
+    assert_false(internals.audioSessionActive(), "AudioSession must be inactive once microphone capture stops");
+
+    let promise;
+    internals.withUserGesture(() => {
+        promise = navigator.mediaSession.setMicrophoneActive(true);
+    });
+    await promise;
+
+    assert_true(internals.audioSessionActive(), "AudioSession remains active while video and capture are both running");
+}, "Removing a media session while microphone capture is active must not deactivate AudioSession");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/mediastream/audio-session-stays-active-during-capture-expected.txt
+++ b/LayoutTests/fast/mediastream/audio-session-stays-active-during-capture-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Process suspension while microphone capture is active must not deactivate AudioSession
+

--- a/LayoutTests/fast/mediastream/audio-session-stays-active-during-capture.html
+++ b/LayoutTests/fast/mediastream/audio-session-stays-active-during-capture.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    assert_true(!!window.internals, "Test requires window.internals");
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    assert_true(internals.audioSessionActive(), "AudioSession must be active once microphone capture starts");
+
+    internals.processWillSuspend();
+    assert_false(internals.audioSessionActive(), "AudioSession must remain active during process suspension while capture is ongoing");
+    internals.processDidResume();
+}, "Process suspension while microphone capture is active must not deactivate AudioSession");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-capture-expected.txt
+++ b/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-capture-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Removing a media session while microphone capture is active must not deactivate AudioSession
+

--- a/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-capture.html
+++ b/LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-capture.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../media/media-file.js"></script>
+</head>
+<body>
+<video id="video"></video>
+<script>
+function wait(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+promise_test(async (test) => {
+    assert_true(!!window.internals, "Test requires window.internals");
+    internals.settings.setShouldDeactivateAudioSession(true);
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    assert_true(internals.audioSessionActive(), "AudioSession must be active once microphone capture starts");
+
+    const video = document.getElementById("video");
+    video.src = findMediaFile("video", "../../media/content/test");
+    await video.play();
+
+    assert_true(internals.audioSessionActive(), "AudioSession remains active while video and capture are both running");
+
+    video.src = "";
+    video.remove();
+
+    assert_true(internals.audioSessionActive(), "AudioSession must remain active after the video session is removed because microphone capture is ongoing");
+    await wait(0);
+    assert_true(internals.audioSessionActive(), "AudioSession must still remain active after the video session is removed because microphone capture is ongoing");
+    await wait(10);
+    assert_true(internals.audioSessionActive(), "AudioSession must really remain active after the video session is removed because microphone capture is ongoing");
+}, "Removing a media session while microphone capture is active must not deactivate AudioSession");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3849,6 +3849,9 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html [ WontFix ]
 webkit.org/b/136224 fast/speechrecognition [ Skip ]
 http/tests/media/media-stream/speech-recognition-iframe-allow-attribute.html [ Skip ]
 fast/mediastream/audio-session-stays-active-when-removing-session-during-speech-recognition.html [ Skip ]
+fast/mediastream/audio-session-active-when-capture-starts-and-stops.html [ Skip ]
+fast/mediastream/audio-session-stays-active-during-capture.html [ Skip ]
+fast/mediastream/audio-session-stays-active-when-removing-session-during-capture.html [ Skip ]
 
 # Depends on HTTP Live Streaming (non-supported in non-Apple ports).
 fast/url/data-url-mediatype.html [ Skip ]

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -651,6 +651,7 @@ void MediaSession::updateCaptureState(bool isActive, DOMPromiseDeferred<void>&& 
                 promise.reject(WTF::move(*exception));
                 return;
             }
+
             promise.resolve();
         });
     });

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -547,7 +547,12 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
     if (scriptExecutionContext()->activeDOMObjectsAreStopped() || m_ended)
         return;
 
-    Function<void()> updateMuted = [this, protectedThis = Ref { *this }, muted = m_private->muted()] {
+    bool muted = m_private->muted();
+    if (isAudio() && isCaptureTrack())
+        if (RefPtr manager = mediaSessionManager())
+            manager->audioCaptureSourceStateChanged(muted ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
+
+    Function<void()> updateMuted = [this, protectedThis = Ref { *this }, muted] {
         RefPtr context = scriptExecutionContext();
         if (!context || context->activeDOMObjectsAreStopped())
             return;
@@ -556,10 +561,6 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
             return;
 
         m_muted = muted;
-
-        if (isAudio() && isCaptureTrack())
-            if (RefPtr manager = mediaSessionManager())
-                manager->audioCaptureSourceStateChanged(muted ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
 
         dispatchEvent(Event::create(muted ? eventNames().muteEvent : eventNames().unmuteEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
@@ -651,13 +652,13 @@ RefPtr<WebAudioSourceProvider> MediaStreamTrack::createAudioSourceProvider()
 bool MediaStreamTrack::isCapturingAudio() const
 {
     ASSERT(isCaptureTrack() && m_private->isAudio());
-    return !ended() && !muted();
+    return !ended() && !m_private->muted();
 }
 
 bool MediaStreamTrack::wantsToCaptureAudio() const
 {
     ASSERT(isCaptureTrack() && m_private->isAudio());
-    return !ended() && (!muted() || m_private->interrupted());
+    return !ended() && (!m_private->muted() || m_private->interrupted());
 }
 
 UniqueRef<MediaStreamTrackDataHolder> MediaStreamTrack::detach()

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -36,7 +36,6 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include "AudioSession.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentPage.h"
 #include "ExceptionCode.h"
@@ -207,7 +206,10 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
 
             if (RefPtr audioTrack = stream->getFirstAudioTrack()) {
 #if USE(AUDIO_SESSION)
-                AudioSession::singleton().tryToSetActive(true)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
+                if (RefPtr page = document.page()) {
+                    if (RefPtr manager = page->mediaSessionManager())
+                        manager->audioCaptureSourceStateChanged(MediaSessionManagerInterface::IsCaptureStarting::Yes);
+                }
 #endif
                 if (std::holds_alternative<MediaTrackConstraints>(protectedThis->m_audioConstraints))
                     audioTrack->setConstraints(std::get<MediaTrackConstraints>(WTF::move(protectedThis->m_audioConstraints)));

--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -157,6 +157,7 @@ MediaSessionManagerCocoaSessionCanProduceAudioChanged, "MediaSessionManagerCocoa
 MediaSessionManagerCocoaUpdateSessionState, "MediaSessionManagerCocoa::updateSessionState: AudioCapture(%d), AudioTrack(%d), Video(%d), Audio(%d), VideoAudio(%d), WebAudio(%d), DOMMediaSession(%d)", (int, int, int, int, int, int, int), DEFAULT, Media
 MediaSessionManagerInterfaceAddSession, "MediaSessionManagerInterface::addSession, session ID = %" PRIu64 "", (uint64_t), DEFAULT, Media
 MediaSessionManagerInterfaceMaybeActivateAudioSessionActiveSessionNotRequired, "MediaSessionManagerInterface::maybeActivateAudioSession:  active audio session not required", (), DEFAULT, Media
+MediaSessionManagerInterfaceProcessWillSuspendWhileCapturing, "MediaSessionManagerInterface::processWillSuspend: ongoing active microphone capture", (), ERROR, Media
 MediaSessionManagerInterfaceRemoveSession, "MediaSessionManagerInterface::removeSession, session ID = %" PRIu64 "", (uint64_t), DEFAULT, Media
 MediaSessionManagerInterfaceSessionCanProduceAudioChanged, "MediaSessionManagerInterface::sessionCanProduceAudioChanged", (), DEFAULT, Media
 MediaSessionManagerInterfaceSessionWillEndPlayback, "MediaSessionManagerInterface::sessionWillEndPlayback, session ID = %" PRIu64 "", (uint64_t), DEFAULT, Media

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -346,8 +346,12 @@ void MediaSessionManagerInterface::processWillSuspend()
     });
 #endif
 
+    if (std::ranges::any_of(m_audioCaptureSources, [](auto& source) { return Ref { source }->isCapturingAudio(); }))
+        MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(ProcessWillSuspendWhileCapturing);
+
+
 #if USE(AUDIO_SESSION)
-    maybeDeactivateAudioSession();
+    maybeDeactivateAudioSession(ShouldCheckRequiredSession::No);
 #endif
 }
 
@@ -651,7 +655,7 @@ void MediaSessionManagerInterface::audioCaptureSourceStateChanged(IsCaptureStart
 #if USE(AUDIO_SESSION)
     if (isCaptureStarting == IsCaptureStarting::Yes)
         maybeActivateAudioSession();
-    else if (!activeAudioSessionRequired())
+    else
         maybeDeactivateAudioSession();
 #else
     UNUSED_PARAM(isCaptureStarting);
@@ -742,7 +746,7 @@ void MediaSessionManagerInterface::removeSession(PlatformMediaSessionInterface& 
     MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(RemoveSession, session.logIdentifier());
 #endif
 
-    if (hasNoSession() && !activeAudioSessionRequired())
+    if (hasNoSession())
         maybeDeactivateAudioSession();
 
 #if !RELEASE_LOG_DISABLED && (ENABLE(VIDEO) || ENABLE(WEB_AUDIO))
@@ -765,11 +769,16 @@ bool MediaSessionManagerInterface::computeSupportsSeeking() const
     return false;
 }
 
-void MediaSessionManagerInterface::maybeDeactivateAudioSession()
+void MediaSessionManagerInterface::maybeDeactivateAudioSession(ShouldCheckRequiredSession shouldCheckRequiredSession)
 {
 #if USE(AUDIO_SESSION)
     if (!m_becameActive || !shouldDeactivateAudioSession())
         return;
+
+    if (shouldCheckRequiredSession == ShouldCheckRequiredSession::Yes && activeAudioSessionRequired()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "skipping AudioSession deactivation, capture or media session still requires it");
+        return;
+    }
 
     // Honor an explicit category override (e.g., navigator.audioSession.type =
     // "play-and-record"): the page has expressed intent that the session remain
@@ -787,6 +796,8 @@ void MediaSessionManagerInterface::maybeDeactivateAudioSession()
     ALWAYS_LOG(LOGIDENTIFIER, "tried to set inactive AudioSession");
     AudioSession::singleton().tryToSetActive(false)->whenSettled(RunLoop::mainSingleton(), [](auto&&) { });
     m_becameActive = false;
+#else
+    UNUSED_PARAM(shouldCheckRequiredSession);
 #endif
 }
 

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -183,7 +183,8 @@ protected:
     Vector<WeakPtr<PlatformMediaSessionInterface>> sessionsMatching(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&) const;
     WeakPtr<PlatformMediaSessionInterface> firstSessionMatching(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&) const;
 
-    void maybeDeactivateAudioSession();
+    enum class ShouldCheckRequiredSession : bool { No, Yes };
+    void maybeDeactivateAudioSession(ShouldCheckRequiredSession = ShouldCheckRequiredSession::Yes);
     Ref<GenericPromise> maybeActivateAudioSession();
 
     void nowPlayingMetadataChanged(const NowPlayingMetadata&);


### PR DESCRIPTION
#### 5801e5e98a3ec11f1bbd641dbb39d375f25f3da2
<pre>
WebProcess AudioSession may not always stay active when microphone capture is live
<a href="https://rdar.apple.com/180505014">rdar://180505014</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317747">https://bugs.webkit.org/show_bug.cgi?id=317747</a>

Reviewed by Eric Carlson.

Microphone capture requires the AudioSession to stay active for the duration of the capture.
The WebProcess can drop the AudioSession in two cases that were not properly guarded against ongoing capture:
1. Process suspension. MediaSessionManagerInterface::processWillSuspend() unconditionally calls maybeDeactivateAudioSession(),
   which would teardown the AudioSession even when an audio capture source was active.
   This is not supposed to happen as a process that capture microphone should not get suspended.
2. Removal of the last PlatformMediaSession (e.g. a &lt;video&gt; ending) while capture is ongoing.
   removeSession() called maybeDeactivateAudioSession() guarded by an inline activeAudioSessionRequired() check,
   but the same logic was duplicated at every call site of maybeDeactivateAudioSession.

In addition, UserMediaRequest::allow() activated the AudioSession by calling AudioSession::singleton().tryToSetActive(true) directly,
bypassing MediaSessionManagerInterface entirely. This left m_becameActive out of sync with the actual AudioSession state.

This PR centralizes the &quot;is capture or another session keeping the AudioSession alive?&quot; check inside maybeDeactivateAudioSession() itself,
so every caller (process suspension, session removal, capture state change) is consistently protected.
Call sites that duplicated the check are simplified.
In the process suspension case, we keep deactivating the audio session using ShouldCheckRequiredSession::No to keep existing tests happy,
in particular platform/mac/media/audio-session-deactivated-when-suspended.html.
A future PR should properly mute capture as part of process suspension which would allow to deactivate the audio session without ShouldCheckRequiredSession::No.

The PR routes UserMediaRequest::allow() through MediaSessionManagerInterface via audioCaptureSourceStateChanged(IsCaptureStarting::Yes) so capture activation is tracked by the manager and m_becameActive is correct.
We call MediaStreamTrack::audioCaptureSourceStateChanged() synchronously on mute/unmute (instead of in the deferred event-dispatch task) so the manager observes the new capture state right away.
We switch MediaStreamTrack::isCapturingAudio() and wantsToCaptureAudio() to read m_private-&gt;muted() (the live underlying state) instead of the observer-driven muted() flag, which lags behind by one event-loop turn.
We add a release log when process suspension happens while microphone capture is ongoing, to make follow-up diagnoses on devices easier.

Tests: fast/mediastream/audio-session-active-when-capture-starts-and-stops.html
       fast/mediastream/audio-session-stays-active-during-capture.html
       fast/mediastream/audio-session-stays-active-when-removing-session-during-capture.html

* LayoutTests/fast/mediastream/audio-session-active-when-capture-starts-and-stops-expected.txt: Added.
* LayoutTests/fast/mediastream/audio-session-active-when-capture-starts-and-stops.html: Added.
* LayoutTests/fast/mediastream/audio-session-stays-active-during-capture-expected.txt: Added.
* LayoutTests/fast/mediastream/audio-session-stays-active-during-capture.html: Added.
* LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-capture-expected.txt: Added.
* LayoutTests/fast/mediastream/audio-session-stays-active-when-removing-session-during-capture.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::updateCaptureState):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::trackMutedChanged):
(WebCore::MediaStreamTrack::isCapturingAudio const):
(WebCore::MediaStreamTrack::wantsToCaptureAudio const):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):
* Source/WebCore/platform/LogMessages.in:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::processWillSuspend):
(WebCore::MediaSessionManagerInterface::audioCaptureSourceStateChanged):
(WebCore::MediaSessionManagerInterface::removeSession):
(WebCore::MediaSessionManagerInterface::maybeDeactivateAudioSession):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:

Canonical link: <a href="https://commits.webkit.org/316394@main">https://commits.webkit.org/316394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90003c43e4cab6c109ccb4c69408a25495f06232

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172175 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129729 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e28e6f36-102f-4b0b-ac68-6cc35ead7f97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29f697c9-86b3-4a11-993b-882146d9cb76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37357 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114390 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1df26040-022e-4f46-9635-cba30a09970b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35988 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33973 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184152 "") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36763 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184152 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154051 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184152 "") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38493 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46439 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111122 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37643 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44957 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8910 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44357 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44416 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->