### PR TITLE
Nullptr crash in SharedVideoFrameInfo::writePixelBuffer for protected IOSurface

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-video-frame-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-video-frame-expected.txt
@@ -1,0 +1,8 @@
+
+EVENT(encrypted)
+EVENT(message)
+PROMISE: licenseResponse resolved
+EVENT(canplay)
+isBlack is true
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/fps-video-frame.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-video-frame.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fps-hls</title>
+    <script src=../../../media-resources/video-test.js></script>
+    <script src=eme2016.js></script>
+    <script src=support.js></script>
+    <script>
+    window.addEventListener('load', async event => {
+        startTest().then(endTest).catch(failTest);
+    });
+
+    async function startTest() {
+        var video = document.querySelector('video');
+        video.src = 'content/prog_index.m3u8';
+        event = await waitFor(video, 'encrypted');
+
+        if (event.initDataType !== 'skd') {
+            consoleWrite('FAIL: expected event.initDataType === "skd", got ' + event.initDataType);
+            endTest();
+            return;
+        }
+
+        var initData = event.initData;
+        var keyURI = uInt8ArrayToString(new Uint8Array(initData));
+        var video = event.target;
+        var access = await navigator.requestMediaKeySystemAccess("com.apple.fps", [{
+            initDataTypes: ['skd'],
+            videoCapabilities: [{ contentType: 'application/vnd.apple.mpegurl', robustness: '' }],
+            distinctiveIdentifier: 'not-allowed',
+            persistentState: 'not-allowed',
+            sessionTypes: ['temporary'],
+        }]);
+
+        var keys = await access.createMediaKeys();
+        var certificateResponse = await fetch('resources/cert.der');
+        var arrayBuffer = await certificateResponse.arrayBuffer();
+        await keys.setServerCertificate(arrayBuffer);
+        var session = keys.createSession();
+
+        session.generateRequest('skd', initData);
+        let message = await waitFor(session, 'message');
+
+        let response = await getResponse(message);
+        await session.update(response);
+
+        video.setMediaKeys(keys);
+
+        await waitFor(video, 'canplay');
+        await video.play();
+
+        const width = 480;
+        const height = 360;
+        const frame = new VideoFrame(video);
+        await frame.copyTo(new Uint8Array(10000000));
+        canvas.getContext('2d').drawImage(frame, 0, 0, width,  height);
+        frame.close();
+
+        video.pause();
+
+        const data = canvas.getContext('2d').getImageData(0, 0, width, height).data;
+        let isBlack = true;
+        for (let i = 0; isBlack && i < width * height; ++i) {
+            let index = 4 * i;
+            if (!!data[index++] || !!data[index++] || !!data[index++] || !!data[index]) {
+                isBlack = false;
+                consoleWrite('frame is not black ' + data[4 * i] + ' ' + data[4 * i + 1] + ' ' + data[4 * i + 2] + ' ' + data[4 * i + 3]);
+                break;
+            }
+        }
+        consoleWrite('isBlack is ' + isBlack);
+    }
+    </script>
+</head>
+<body>
+    <video controls width="480"></video>
+    <canvas id=canvas></canvas>
+</body>
+</html>

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -229,6 +229,11 @@ bool SharedVideoFrameInfo::writePixelBuffer(CVPixelBufferRef pixelBuffer, std::s
         CVPixelBufferUnlockBaseAddress(pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
     });
 
+    if (!CVPixelBufferGetBaseAddress(pixelBuffer)) {
+        RELEASE_LOG_FAULT(WebRTC, "SharedVideoFrameInfo::writePixelBuffer pixel buffer is not readable");
+        return false;
+    }
+
     encode(data);
     skip(data, sizeof(SharedVideoFrameInfo));
 


### PR DESCRIPTION
#### d69cba4b8488ce0f698f1e741bce74083e3342d6
<pre>
Nullptr crash in SharedVideoFrameInfo::writePixelBuffer for protected IOSurface
<a href="https://rdar.apple.com/164306288">rdar://164306288</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317842">https://bugs.webkit.org/show_bug.cgi?id=317842</a>

Reviewed by Jean-Yves Avenard.

Some IOSurfaces that are not readable by CPU will have their base address equal to nullptr.
But their base address of plane would not be nullptr since an offset would be added.

This breaks SharedVideoFrameInfo::writePixelBuffer which was only testing for the plan address to not be nullptr.
We add a check that the base address is nullptr to prevent crashing the GPU process.
The web process will then create a black pixel buffer instead in RemoteVideoFrameProxy::pixelBuffer.

Covered by added test.

* LayoutTests/http/tests/media/fairplay/fps-video-frame-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/fps-video-frame.html: Added.
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::writePixelBuffer):

Canonical link: <a href="https://commits.webkit.org/315886@main">https://commits.webkit.org/315886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ece74ce57f5e5855a66dd4fe155aee83926f31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128100 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a651d436-b939-4ccc-904a-465824ebea7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132858 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1afa3e3b-8892-4a41-a108-6bfd2c16c185) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9fa088e-5896-4b61-afbd-a24808adc894) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28446 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182348 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37166 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141310 "Found 1 new test failure: ipc/display-list-recorder-leak.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141128 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37999 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44657 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109116 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36394 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116539 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7772 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42573 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42813 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->