### PR TITLE
Credential.type returns "digital-credential" instead of "digital" for digital credentials

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -47,7 +47,7 @@ String BasicCredential::type() const
 {
     switch (m_type) {
     case Type::DigitalCredential:
-        return "digital-credential"_s;
+        return "digital"_s;
 
     case Type::PublicKey:
         return "public-key"_s;


### PR DESCRIPTION
#### f29b730d742b656438fe81acc51f357fed56cbc5
<pre>
Credential.type returns &quot;digital-credential&quot; instead of &quot;digital&quot; for digital credentials
<a href="https://bugs.webkit.org/show_bug.cgi?id=317840">https://bugs.webkit.org/show_bug.cgi?id=317840</a>
<a href="https://rdar.apple.com/180618646">rdar://180618646</a>

Reviewed by Anne van Kesteren.

DigitalCredential inherits Credential.type, which the Digital Credentials
specification defines (section 8.4) as &quot;digital&quot;. WebKit returned
&quot;digital-credential&quot;, so a page calling navigator.credentials.get({digital})
and reading the resolved credential&apos;s type observed the wrong value. Return
&quot;digital&quot; to match the spec.

The web-platform-test digital-credentials/mdoc/valid-roundtrip.https.html
asserts credential.type === &quot;digital&quot;. It is currently skipped pending the
WebDriver virtual-wallet test infrastructure (bug 306292) and will exercise
this fix once that infrastructure lands and the test is enabled.

* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
(WebCore::BasicCredential::type const):

Canonical link: <a href="https://commits.webkit.org/315891@main">https://commits.webkit.org/315891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ab36d4931c4ea906658b26192924195d4b2e36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179573 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127912 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97c61bd8-3162-4433-a6cd-166a7aa74b99) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132693 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2942f7c-ff6e-4717-a50c-64ab91d6e9a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c584444b-7af9-4c80-8fbb-f34ffb5b0b0d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34457 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32815 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28258 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144940 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinProtocol2 (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182159 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36983 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141134 "Found 1 new test failure: svg/filters/feImage-element-primitive-subregion.svg (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43780 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38003 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44469 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108865 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36226 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116349 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42979 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7597 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42371 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42625 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42514 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->