### PR TITLE
[iOS] MediaStream from a screen capture session doesn't rotate when the iOS device rotates

### DIFF
--- a/LayoutTests/fast/mediastream/getDisplayMedia-orientation-expected.txt
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-orientation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS getDisplayMedia stream continues delivering frames through device orientation changes
+

--- a/LayoutTests/fast/mediastream/getDisplayMedia-orientation.html
+++ b/LayoutTests/fast/mediastream/getDisplayMedia-orientation.html
@@ -1,0 +1,39 @@
+<!doctype html><!-- webkit-test-runner [ UseGPUProcessForDisplayCapture=true ] -->
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>getDisplayMedia stream delivers frames through device orientation changes</title>
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+        <script src="resources/getDisplayMedia-utils.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const stream = await callGetDisplayMedia({ video: true });
+    t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+
+    const [track] = stream.getVideoTracks();
+    internals.observeMediaStreamTrack(track);
+
+    while (!internals.trackVideoSampleCount)
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+    const countBefore = internals.trackVideoSampleCount;
+
+    for (const [intDeg, trDeg] of [[90, 90], [-90, 270], [180, 180], [0, 0]]) {
+        internals.setCameraMediaStreamTrackOrientation(track, intDeg);
+        if (window.testRunner) testRunner.setMockCameraOrientation(trDeg, "");
+    }
+
+    let counter = 100;
+    while (internals.trackVideoSampleCount === countBefore && --counter > 0)
+        await new Promise(resolve => setTimeout(resolve, 50));
+    assert_greater_than(counter, 0, "stream delivers frames after orientation changes");
+}, "getDisplayMedia stream continues delivering frames through device orientation changes");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -322,8 +322,13 @@ void MediaStreamPrivate::trackEnded(MediaStreamTrackPrivate& track)
 void MediaStreamPrivate::monitorOrientation(OrientationNotifier& notifier)
 {
     for (Ref track : m_tracks) {
-        if (track->isCaptureTrack() && track->deviceType() == CaptureDevice::DeviceType::Camera)
-            protect(track->source())->monitorOrientation(notifier);
+        if (track->isCaptureTrack()) {
+            auto type = track->deviceType();
+            if (type == CaptureDevice::DeviceType::Camera
+                || type == CaptureDevice::DeviceType::Screen
+                || type == CaptureDevice::DeviceType::Window)
+                protect(track->source())->monitorOrientation(notifier);
+        }
     }
 }
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -33,6 +33,7 @@
 #include "MediaDeviceHashSalts.h"
 #include "MediaSampleAVFObjC.h"
 #include "NativeImage.h"
+#include "OrientationNotifier.h"
 #include "RealtimeMediaSource.h"
 #include "RealtimeMediaSourceCenter.h"
 #include "RealtimeMediaSourceSettings.h"
@@ -251,6 +252,18 @@ void DisplayCaptureSourceCocoa::setSizeFrameRateAndZoom(const VideoPresetConstra
         setFrameRate(*constraints.frameRate);
 }
 
+void DisplayCaptureSourceCocoa::monitorOrientation(OrientationNotifier& notifier)
+{
+    notifier.addObserver(*this);
+    orientationChanged(notifier.orientation());
+}
+
+void DisplayCaptureSourceCocoa::orientationChanged(IntDegrees orientation)
+{
+    m_capturer->orientationChanged(orientation);
+    notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height });
+}
+
 void DisplayCaptureSourceCocoa::emitFrame()
 {
     if (muted())
@@ -301,19 +314,19 @@ void DisplayCaptureSourceCocoa::emitFrame()
             if (!surface)
                 return nullptr;
 
-            return m_imageTransferSession->createVideoFrame(surface.get(), sampleTime, size());
+            return m_imageTransferSession->createVideoFrame(surface.get(), sampleTime, size(), m_capturer->videoFrameRotation());
         },
         [this, sampleTime](RefPtr<NativeImage>& image) -> RefPtr<VideoFrame> {
             if (!image)
                 return nullptr;
 
-            return m_imageTransferSession->createVideoFrame(image->platformImage().get(), sampleTime, size());
+            return m_imageTransferSession->createVideoFrame(image->platformImage().get(), sampleTime, size(), m_capturer->videoFrameRotation());
         },
         [this, sampleTime](RetainPtr<CMSampleBufferRef>& sample) -> RefPtr<VideoFrame> {
             if (!sample)
                 return nullptr;
 
-            return m_imageTransferSession->createVideoFrame(sample.get(), sampleTime, size());
+            return m_imageTransferSession->createVideoFrame(sample.get(), sampleTime, size(), m_capturer->videoFrameRotation());
         }
     );
 

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
@@ -29,6 +29,7 @@
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
 
 #include <WebCore/CaptureDevice.h>
+#include <WebCore/OrientationNotifier.h>
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceSettings.h>
 #include <WebCore/UserActivity.h>
@@ -71,7 +72,8 @@ public:
 class DisplayCaptureSourceCocoa final
     : public RealtimeMediaSource
     , public CapturerObserver
-    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop> {
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<DisplayCaptureSourceCocoa, WTF::DestructionThread::MainRunLoop>
+    , protected OrientationNotifier::Observer {
     WTF_MAKE_TZONE_ALLOCATED(DisplayCaptureSourceCocoa);
 public:
     using DisplayFrameType = Variant<RefPtr<NativeImage>, RetainPtr<IOSurfaceRef>, RetainPtr<CMSampleBufferRef>>;
@@ -91,6 +93,8 @@ public:
         virtual void commitConfiguration(const RealtimeMediaSourceSettings&) = 0;
         virtual IntSize intrinsicSize() const = 0;
         virtual void whenReady(CompletionHandler<void(CaptureSourceError&&)>&& callback) { callback({ }); }
+        virtual void orientationChanged(IntDegrees) { }
+        virtual VideoFrameRotation videoFrameRotation() const { return { }; }
 
         virtual void setLogger(const Logger&, uint64_t);
         const Logger* loggerPtr() const { return m_logger.get(); }
@@ -154,6 +158,11 @@ private:
     void setSizeFrameRateAndZoom(const VideoPresetConstraints&) final;
     double observedFrameRate() const final;
     void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
+    void monitorOrientation(OrientationNotifier&) final;
+    VideoFrameRotation videoFrameRotation() const final { return m_capturer->videoFrameRotation(); }
+
+    // OrientationNotifier::Observer
+    void orientationChanged(IntDegrees) final;
 
     ASCIILiteral logClassName() const final { return "DisplayCaptureSourceCocoa"_s; }
     void setLogger(const Logger&, uint64_t) final;

--- a/Source/WebCore/platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.h
@@ -96,6 +96,10 @@ private:
     void commitConfiguration(const RealtimeMediaSourceSettings&) final;
     IntSize intrinsicSize() const final;
     void whenReady(CompletionHandler<void(CaptureSourceError&&)>&&) final;
+#if PLATFORM(IOS_FAMILY)
+    void orientationChanged(IntDegrees) final;
+    VideoFrameRotation videoFrameRotation() const final;
+#endif
 
     // LoggerHelper
     ASCIILiteral logClassName() const final { return "ScreenCaptureKitCaptureSource"_s; }
@@ -141,6 +145,10 @@ private:
     bool m_didReceiveVideoFrame { false };
     bool m_isPrewarming { false };
     CompletionHandler<void(CaptureSourceError&&)> m_whenReadyCallback;
+#if PLATFORM(IOS_FAMILY)
+    IntDegrees m_currentOrientation { 0 };
+    VideoFrameRotation m_videoFrameRotation { };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.mm
@@ -626,6 +626,9 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
     if (!m_intrinsicSize || *m_intrinsicSize != IntSize(intrinsicSize)) {
         ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "resetting m_intrinsicSize to ", m_intrinsicSize);
         m_intrinsicSize = IntSize(intrinsicSize);
+#if PLATFORM(IOS_FAMILY)
+        orientationChanged(m_currentOrientation);
+#endif
         configurationChanged();
     }
 
@@ -635,6 +638,31 @@ void ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer(RetainPtr<C
             m_whenReadyCallback({ });
     }
 }
+
+#if PLATFORM(IOS_FAMILY)
+void ScreenCaptureKitCaptureSource::orientationChanged(IntDegrees orientation)
+{
+    m_currentOrientation = orientation;
+
+    auto size = m_intrinsicSize.value_or(IntSize { });
+    if (size.isEmpty())
+        return;
+
+    IntDegrees displayNativeOrientation = (size.width() > size.height()) ? 90 : 0;
+    auto rotationDegrees = ((displayNativeOrientation - m_currentOrientation) + 360) % 360;
+    switch (rotationDegrees) {
+    case 90:  m_videoFrameRotation = VideoFrameRotation::Right; break;
+    case 180: m_videoFrameRotation = VideoFrameRotation::UpsideDown; break;
+    case 270: m_videoFrameRotation = VideoFrameRotation::Left; break;
+    default:  m_videoFrameRotation = VideoFrameRotation::None; break;
+    }
+}
+
+VideoFrameRotation ScreenCaptureKitCaptureSource::videoFrameRotation() const
+{
+    return m_videoFrameRotation;
+}
+#endif
 
 dispatch_queue_t ScreenCaptureKitCaptureSource::captureQueue()
 {

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -780,7 +780,10 @@ void MockRealtimeVideoSource::orientationChanged(IntDegrees orientation)
 
 void MockRealtimeVideoSource::monitorOrientation(OrientationNotifier& notifier)
 {
-    if (!mockCamera() || std::get<MockCameraProperties>(m_device.properties).facingMode == VideoFacingMode::Unknown)
+    if (mockCamera()) {
+        if (std::get<MockCameraProperties>(m_device.properties).facingMode == VideoFacingMode::Unknown)
+            return;
+    } else if (!mockDisplay())
         return;
 
     notifier.addObserver(*this);

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -599,6 +599,8 @@ void UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstrai
     }
 
     auto source = sourceOrError.source();
+    if (device.type() == WebCore::CaptureDevice::DeviceType::Screen || device.type() == WebCore::CaptureDevice::DeviceType::Window)
+        source->monitorOrientation(m_orientationNotifier);
 #if !RELEASE_LOG_DISABLED
     source->setLogger(protect(m_connectionProxy->logger()), LoggerHelper::uniqueLogIdentifier());
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -17628,7 +17628,8 @@ void WebPageProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientation
 #if ENABLE(MEDIA_STREAM)
 #if PLATFORM(COCOA)
     RefPtr gpuProcess = m_configuration->processPool().gpuProcess();
-    if (gpuProcess && protect(preferences())->captureVideoInGPUProcessEnabled())
+    Ref prefs = preferences();
+    if (gpuProcess && (prefs->captureVideoInGPUProcessEnabled() || prefs->useGPUProcessForDisplayCapture()))
         gpuProcess->setOrientationForMediaCapture(orientation);
 #elif USE(GSTREAMER)
     send(Messages::WebPage::SetOrientationForMediaCapture(orientation));


### PR DESCRIPTION
#### 12af25563d618c4ab8a77fc60688db77d475227d
<pre>
[iOS] MediaStream from a screen capture session doesn&apos;t rotate when the iOS device rotates
<a href="https://bugs.webkit.org/show_bug.cgi?id=317849">https://bugs.webkit.org/show_bug.cgi?id=317849</a>
<a href="https://rdar.apple.com/180066775">rdar://180066775</a>

Reviewed by NOBODY (OOPS!).

Screen capture MediaStreams produced via getDisplayMedia did not update
their video frame rotation as the device rotated, so receivers (e.g. a
WebRTC remote peer) saw frames sideways relative to the sender&apos;s screen.

Two gaps caused this:

- MediaStreamPrivate::monitorOrientation() filtered to Camera tracks
  only, so display capture sources were never registered with the
  orientation notifier in the web process.
- UserMediaCaptureManagerProxy similarly registered only camera sources
  with its GPU-process orientation notifier, and
  WebPageProxy::setOrientationForMediaCapture() only forwarded the
  orientation to the GPU process when capture video was enabled in the
  GPU process, not when display capture was.
- DisplayCaptureSourceCocoa had no orientation handling at all, so even
  if the notifier had reached it, nothing would have happened.

DisplayCaptureSourceCocoa now derives from OrientationNotifier::Observer
and forwards orientation changes to its Capturer. The Capturer base
gains virtual orientationChanged() and videoFrameRotation() hooks,
defaulting to no rotation so MockDisplayCapturer keeps working
unchanged. ScreenCaptureKitCaptureSource overrides them on iOS,
computing rotation as (displayNativeOrientation - deviceOrientation),
where displayNativeOrientation is derived from the current frame&apos;s
aspect ratio. The rotation also recomputes whenever the intrinsic size
changes, so it self-corrects after SCKit reconfigures for a new
orientation.

Added test LayoutTests/fast/mediastream/getDisplayMedia-orientation.html

* LayoutTests/fast/mediastream/getDisplayMedia-orientation-expected.txt: Added.
* LayoutTests/fast/mediastream/getDisplayMedia-orientation.html: Added.
* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::monitorOrientation):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::monitorOrientation):
(WebCore::DisplayCaptureSourceCocoa::orientationChanged):
(WebCore::DisplayCaptureSourceCocoa::emitFrame):
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.h:
* Source/WebCore/platform/mediastream/cocoa/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamDidOutputVideoSampleBuffer):
(WebCore::ScreenCaptureKitCaptureSource::orientationChanged):
(WebCore::ScreenCaptureKitCaptureSource::videoFrameRotation const):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::monitorOrientation):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setOrientationForMediaCapture):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12af25563d618c4ab8a77fc60688db77d475227d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f374192-b7ed-4a7a-a431-442c977f8d53) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42094895-96d7-488c-adf1-3528410805bb) 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a25a979f-3432-4cb2-bb9d-771ca2fae922) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->