### PR TITLE
Web Inspector: Emit per-element `Layout Invalidated` events

### DIFF
--- a/LayoutTests/inspector/timeline/timeline-layout-events-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-layout-events-expected.txt
@@ -1,20 +1,24 @@
 Tests Layout Timeline event records.
 
-PASS: Should have 4 Layout record.
-PASS: Record 0 should be invalidate-styles.
+PASS: Should have 5 Layout records.
+PASS: Record 0's event type should be invalidate-styles.
 PASS: Record 0 should have a DOM node.
-PASS: Record 0 should have a document node.
-PASS: Record 0 should have the main document node.
-PASS: Record 1 should be recalculate-styles.
+PASS: Record 0's DOM node's type should be 9.
+PASS: Record 0's DOM node's frame should be the main document frame.
+PASS: Record 1's event type should be recalculate-styles.
 PASS: Record 1 should have a DOM node.
-PASS: Record 1 should have a document node.
-PASS: Record 1 should have the main document node.
-PASS: Record 2 should be invalidate-layout.
+PASS: Record 1's DOM node's type should be 9.
+PASS: Record 1's DOM node's frame should be the main document frame.
+PASS: Record 2's event type should be invalidate-layout.
 PASS: Record 2 should have a DOM node.
-PASS: Record 2 should have a document node.
-PASS: Record 2 should have the main document node.
-PASS: Record 3 should be layout.
+PASS: Record 2's DOM node's type should be 1.
+PASS: Record 2's DOM node's frame should be the main document frame.
+PASS: Record 3's event type should be schedule-layout.
 PASS: Record 3 should have a DOM node.
-PASS: Record 3 should have a document node.
-PASS: Record 3 should have the main document node.
+PASS: Record 3's DOM node's type should be 9.
+PASS: Record 3's DOM node's frame should be the main document frame.
+PASS: Record 4's event type should be layout.
+PASS: Record 4 should have a DOM node.
+PASS: Record 4's DOM node's type should be 9.
+PASS: Record 4's DOM node's frame should be the main document frame.
 

--- a/LayoutTests/inspector/timeline/timeline-layout-events-iframe-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-layout-events-iframe-expected.txt
@@ -1,21 +1,25 @@
 Tests Layout Timeline event records in an iframe.
 
 
-PASS: Should have 4 Layout record.
-PASS: Record 0 should be invalidate-styles.
+PASS: Should have 5 Layout records.
+PASS: Record 0's event type should be invalidate-styles.
 PASS: Record 0 should have a DOM node.
-PASS: Record 0 should have a document node.
-PASS: Record 0 should have the iframe's document node.
-PASS: Record 1 should be recalculate-styles.
+PASS: Record 0's DOM node's type should be 9.
+PASS: Record 0's DOM node's frame should be the iframe's document frame.
+PASS: Record 1's event type should be recalculate-styles.
 PASS: Record 1 should have a DOM node.
-PASS: Record 1 should have a document node.
-PASS: Record 1 should have the iframe's document node.
-PASS: Record 2 should be invalidate-layout.
+PASS: Record 1's DOM node's type should be 9.
+PASS: Record 1's DOM node's frame should be the iframe's document frame.
+PASS: Record 2's event type should be invalidate-layout.
 PASS: Record 2 should have a DOM node.
-PASS: Record 2 should have a document node.
-PASS: Record 2 should have the iframe's document node.
-PASS: Record 3 should be layout.
+PASS: Record 2's DOM node's type should be 1.
+PASS: Record 2's DOM node's frame should be the iframe's document frame.
+PASS: Record 3's event type should be schedule-layout.
 PASS: Record 3 should have a DOM node.
-PASS: Record 3 should have a document node.
-PASS: Record 3 should have the iframe's document node.
+PASS: Record 3's DOM node's type should be 9.
+PASS: Record 3's DOM node's frame should be the iframe's document frame.
+PASS: Record 4's event type should be layout.
+PASS: Record 4 should have a DOM node.
+PASS: Record 4's DOM node's type should be 9.
+PASS: Record 4's DOM node's frame should be the iframe's document frame.
 

--- a/LayoutTests/inspector/timeline/timeline-layout-events-iframe.html
+++ b/LayoutTests/inspector/timeline/timeline-layout-events-iframe.html
@@ -9,7 +9,7 @@ function invalidateLayout() {
     let iframe = document.getElementById("iframe");
     iframe.contentDocument.getElementById("test").style.width = "200px";
 
-    savePageData({invalidatedLayout: true});
+    savePageData({layoutInvalidated: true});
 }
 
 async function test()
@@ -22,28 +22,30 @@ async function test()
         eventType: WI.LayoutTimelineRecord.EventType.Layout,
         silent: true,
     });
-    InspectorTest.assert(pageRecordingData.invalidatedLayout);
+    InspectorTest.assert(pageRecordingData.layoutInvalidated);
 
     let recording = WI.timelineManager.activeRecording;
     let layoutTimeline = recording.timelines.get(WI.TimelineRecord.Type.Layout);
 
-    let expectedEventTypes = [
-        WI.LayoutTimelineRecord.EventType.InvalidateStyles,
-        WI.LayoutTimelineRecord.EventType.RecalculateStyles,
-        WI.LayoutTimelineRecord.EventType.InvalidateLayout,
-        WI.LayoutTimelineRecord.EventType.Layout,
+    let expectedEvents = [
+        { type: WI.LayoutTimelineRecord.EventType.InvalidateStyles, nodeType: Node.DOCUMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.RecalculateStyles, nodeType: Node.DOCUMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.InvalidateLayout, nodeType: Node.ELEMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.ScheduleLayout, nodeType: Node.DOCUMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.Layout, nodeType: Node.DOCUMENT_NODE },
     ];
+    let expectedEventTypes = expectedEvents.map((e) => e.type);
     let records = layoutTimeline.records.filter((x) => expectedEventTypes.includes(x.eventType));
 
-    InspectorTest.expectEqual(records.length, 4, "Should have 4 Layout record.");
+    InspectorTest.expectEqual(records.length, expectedEventTypes.length, `Should have ${expectedEventTypes.length} Layout records.`);
 
-    for (let i = 0; i < expectedEventTypes.length; ++i) {
+    for (let i = 0; i < expectedEvents.length; ++i) {
         let record = records[i];
-        let expectedEventType = expectedEventTypes[i];
-        InspectorTest.expectEqual(record.eventType, expectedEventType, `Record ${i} should be ${expectedEventType}.`);
+        let expectedEvent = expectedEvents[i];
+        InspectorTest.expectEqual(record.eventType, expectedEvent.type, `Record ${i}'s event type should be ${expectedEvent.type}.`);
         InspectorTest.expectNotNull(record.domNode, `Record ${i} should have a DOM node.`);
-        InspectorTest.expectEqual(record.domNode.nodeType(), Node.DOCUMENT_NODE, `Record ${i} should have a document node.`);
-        InspectorTest.expectNotEqual(record.domNode.frame, WI.networkManager.mainFrame, `Record ${i} should have the iframe's document node.`);
+        InspectorTest.expectEqual(record.domNode.nodeType(), expectedEvent.nodeType, `Record ${i}'s DOM node's type should be ${expectedEvent.nodeType}.`);
+        InspectorTest.expectNotEqual(record.domNode.frame, WI.networkManager.mainFrame, `Record ${i}'s DOM node's frame should be the iframe's document frame.`);
     }
 
     InspectorTest.completeTest();

--- a/LayoutTests/inspector/timeline/timeline-layout-events.html
+++ b/LayoutTests/inspector/timeline/timeline-layout-events.html
@@ -8,7 +8,7 @@
 function invalidateLayout() {
     document.getElementById("test").style.width = "200px";
 
-    savePageData({invalidatedLayout: true});
+    savePageData({layoutInvalidated: true});
 }
 
 async function test()
@@ -21,28 +21,30 @@ async function test()
         eventType: WI.LayoutTimelineRecord.EventType.Layout,
         silent: true,
     });
-    InspectorTest.assert(pageRecordingData.invalidatedLayout);
+    InspectorTest.assert(pageRecordingData.layoutInvalidated);
 
     let recording = WI.timelineManager.activeRecording;
     let layoutTimeline = recording.timelines.get(WI.TimelineRecord.Type.Layout);
 
-    let expectedEventTypes = [
-        WI.LayoutTimelineRecord.EventType.InvalidateStyles,
-        WI.LayoutTimelineRecord.EventType.RecalculateStyles,
-        WI.LayoutTimelineRecord.EventType.InvalidateLayout,
-        WI.LayoutTimelineRecord.EventType.Layout,
+    let expectedEvents = [
+        { type: WI.LayoutTimelineRecord.EventType.InvalidateStyles, nodeType: Node.DOCUMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.RecalculateStyles, nodeType: Node.DOCUMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.InvalidateLayout, nodeType: Node.ELEMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.ScheduleLayout, nodeType: Node.DOCUMENT_NODE },
+        { type: WI.LayoutTimelineRecord.EventType.Layout, nodeType: Node.DOCUMENT_NODE },
     ];
+    let expectedEventTypes = expectedEvents.map((e) => e.type);
     let records = layoutTimeline.records.filter((x) => expectedEventTypes.includes(x.eventType));
 
-    InspectorTest.expectEqual(records.length, 4, "Should have 4 Layout record.");
+    InspectorTest.expectEqual(records.length, expectedEventTypes.length, `Should have ${expectedEventTypes.length} Layout records.`);
 
-    for (let i = 0; i < expectedEventTypes.length; ++i) {
+    for (let i = 0; i < expectedEvents.length; ++i) {
         let record = records[i];
-        let expectedEventType = expectedEventTypes[i];
-        InspectorTest.expectEqual(record.eventType, expectedEventType, `Record ${i} should be ${expectedEventType}.`);
+        let expectedEvent = expectedEvents[i];
+        InspectorTest.expectEqual(record.eventType, expectedEvent.type, `Record ${i}'s event type should be ${expectedEvent.type}.`);
         InspectorTest.expectNotNull(record.domNode, `Record ${i} should have a DOM node.`);
-        InspectorTest.expectEqual(record.domNode.nodeType(), Node.DOCUMENT_NODE, `Record ${i} should have a document node.`);
-        InspectorTest.expectEqual(record.domNode.frame, WI.networkManager.mainFrame, `Record ${i} should have the main document node.`);
+        InspectorTest.expectEqual(record.domNode.nodeType(), expectedEvent.nodeType, `Record ${i}'s DOM node's type should be ${expectedEvent.nodeType}.`);
+        InspectorTest.expectEqual(record.domNode.frame, WI.networkManager.mainFrame, `Record ${i}'s DOM node's frame should be the main document frame.`);
     }
 
     InspectorTest.completeTest();

--- a/Source/JavaScriptCore/inspector/protocol/Timeline.json
+++ b/Source/JavaScriptCore/inspector/protocol/Timeline.json
@@ -13,6 +13,7 @@
                 "ScheduleStyleRecalculation",
                 "RecalculateStyles",
                 "InvalidateLayout",
+                "ScheduleLayout",
                 "Layout",
                 "Paint",
                 "Composite",

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -598,10 +598,16 @@ void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumenti
         timelineAgent->didFireTimer();
 }
 
-void InspectorInstrumentation::didInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents, const RenderElement& layoutRoot)
+void InspectorInstrumentation::willInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents, const RenderObject& renderer)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didInvalidateLayout(layoutRoot);
+        pageTimelineAgent->willInvalidateLayout(renderer);
+}
+
+void InspectorInstrumentation::didScheduleLayoutImpl(InstrumentingAgents& instrumentingAgents, const RenderElement& layoutRoot)
+{
+    if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
+        pageTimelineAgent->didScheduleLayout(layoutRoot);
 }
 
 void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumentingAgents)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -45,6 +45,8 @@
 #include "LocalFrame.h"
 #include "NodeDocument.h"
 #include "Page.h"
+#include "RenderElement.h"
+#include "RenderObjectDocument.h"
 #include "ResourceLoader.h"
 #include "ResourceLoaderIdentifier.h"
 #include "ScriptExecutionContext.h"
@@ -193,7 +195,8 @@ public:
     static void didEvaluateScript(WorkerOrWorkletGlobalScope&);
     static void willFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
     static void didFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
-    static void didInvalidateLayout(LocalFrame&, const RenderElement&);
+    static void willInvalidateLayout(const RenderObject&);
+    static void didScheduleLayout(const RenderElement& layoutRoot);
     static void willLayout(LocalFrame&);
     static void didLayout(LocalFrame&, const RenderElement&, const Vector<FloatQuad>&);
     static void didScroll(Page&);
@@ -424,7 +427,8 @@ private:
     static void didEvaluateScriptImpl(InstrumentingAgents&);
     static void willFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
     static void didFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
-    static void didInvalidateLayoutImpl(InstrumentingAgents&, const RenderElement&);
+    static void willInvalidateLayoutImpl(InstrumentingAgents&, const RenderObject&);
+    static void didScheduleLayoutImpl(InstrumentingAgents&, const RenderElement& layoutRoot);
     static void willLayoutImpl(InstrumentingAgents&);
     static void didLayoutImpl(InstrumentingAgents&, const RenderElement&, const Vector<FloatQuad>&);
     static void didScrollImpl(InstrumentingAgents&);
@@ -1006,10 +1010,16 @@ inline void InspectorInstrumentation::didFireTimer(ScriptExecutionContext& conte
         didFireTimerImpl(*agents, timerId, oneShot);
 }
 
-inline void InspectorInstrumentation::didInvalidateLayout(LocalFrame& frame, const RenderElement& layoutRoot)
+inline void InspectorInstrumentation::willInvalidateLayout(const RenderObject& renderer)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    didInvalidateLayoutImpl(protect(instrumentingAgents(frame)), layoutRoot);
+    willInvalidateLayoutImpl(protect(instrumentingAgents(renderer.frame())), protect(renderer));
+}
+
+inline void InspectorInstrumentation::didScheduleLayout(const RenderElement& layoutRoot)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    didScheduleLayoutImpl(protect(instrumentingAgents(layoutRoot.frame())), protect(layoutRoot));
 }
 
 inline void InspectorInstrumentation::willLayout(LocalFrame& frame)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -544,6 +544,8 @@ static Inspector::Protocol::Timeline::EventType NODELETE toProtocol(TimelineReco
         return Inspector::Protocol::Timeline::EventType::RecalculateStyles;
     case TimelineRecordType::InvalidateLayout:
         return Inspector::Protocol::Timeline::EventType::InvalidateLayout;
+    case TimelineRecordType::ScheduleLayout:
+        return Inspector::Protocol::Timeline::EventType::ScheduleLayout;
     case TimelineRecordType::Layout:
         return Inspector::Protocol::Timeline::EventType::Layout;
     case TimelineRecordType::Paint:

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -55,6 +55,7 @@ enum class TimelineRecordType {
     ScheduleStyleRecalculation,
     RecalculateStyles,
     InvalidateLayout,
+    ScheduleLayout,
     Layout,
     Paint,
     Composite,

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -192,14 +192,30 @@ Inspector::Protocol::ErrorStringOr<void> PageTimelineAgent::setAutoCaptureEnable
     return { };
 }
 
-void PageTimelineAgent::didInvalidateLayout(const RenderElement& layoutRoot)
+void PageTimelineAgent::willInvalidateLayout(const RenderObject& renderer)
+{
+    if (renderer.needsLayout())
+        return;
+
+    if (!is<RenderElement>(renderer))
+        return;
+
+    auto data = JSON::Object::create();
+
+    if (auto nodeId = nodeIdForRenderer(renderer))
+        TimelineRecordFactory::appendNodeId(data.get(), nodeId);
+
+    appendRecord(WTF::move(data), TimelineRecordType::InvalidateLayout, true);
+}
+
+void PageTimelineAgent::didScheduleLayout(const RenderElement& layoutRoot)
 {
     auto data = JSON::Object::create();
 
     if (auto nodeId = nodeIdForRenderer(layoutRoot))
         TimelineRecordFactory::appendNodeId(data.get(), nodeId);
 
-    appendRecord(WTF::move(data), TimelineRecordType::InvalidateLayout, true);
+    appendRecord(WTF::move(data), TimelineRecordType::ScheduleLayout, true);
 }
 
 void PageTimelineAgent::willLayout()

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -49,7 +49,8 @@ public:
     Inspector::Protocol::ErrorStringOr<void> setAutoCaptureEnabled(bool) override;
 
     // InspectorInstrumentation
-    void didInvalidateLayout(const RenderElement&);
+    void willInvalidateLayout(const RenderObject&);
+    void didScheduleLayout(const RenderElement&);
     void willLayout();
     void didLayout(const RenderElement&, const Vector<FloatQuad>&);
     void willComposite();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -744,7 +744,7 @@ void LocalFrameViewLayoutContext::scheduleLayout()
 #endif
 
     ASSERT(renderView());
-    InspectorInstrumentation::didInvalidateLayout(protect(frame()), *renderView());
+    InspectorInstrumentation::didScheduleLayout(*renderView());
 
     m_layoutTimer.startOneShot(0_s);
 }
@@ -782,7 +782,7 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     if (!isLayoutPending() && isLayoutSchedulingEnabled()) {
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
         setSubtreeLayoutRoot(layoutRoot);
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()), layoutRoot);
+        InspectorInstrumentation::didScheduleLayout(layoutRoot);
         m_layoutTimer.startOneShot(0_s);
         return;
     }
@@ -794,7 +794,7 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     if (!subtreeLayoutRoot) {
         // We already have a pending (full) layout. Just mark the subtree for layout.
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()), renderView.get());
+        InspectorInstrumentation::didScheduleLayout(renderView);
         return;
     }
 
@@ -810,13 +810,13 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
         subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
         setSubtreeLayoutRoot(layoutRoot);
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()), layoutRoot);
+        InspectorInstrumentation::didScheduleLayout(layoutRoot);
         return;
     }
     // Two disjoint subtrees need layout. Mark both of them and issue a full layout instead.
     convertSubtreeLayoutToFullLayout();
     layoutRoot.markContainingBlocksForLayout(renderView.ptr());
-    InspectorInstrumentation::didInvalidateLayout(protect(frame()), renderView.get());
+    InspectorInstrumentation::didScheduleLayout(renderView);
 }
 
 void LocalFrameViewLayoutContext::layoutTimerFired()

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -48,6 +48,7 @@
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorTextBox.h"
 #include "InlineWalker.h"
+#include "InspectorInstrumentation.h"
 #include "LayoutElementBox.h"
 #include "LayoutIntegrationLineLayout.h"
 #include "LocalFrame.h"
@@ -1333,6 +1334,7 @@ void RenderElement::setNeedsOutOfFlowMovementLayout(const Style::ComputedStyle* 
     ASSERT(!isSetNeedsLayoutForbidden());
     if (needsOutOfFlowMovementLayout())
         return;
+    InspectorInstrumentation::willInvalidateLayout(*this);
     setNeedsOutOfFlowMovementLayoutBit(true);
     scheduleLayout(markContainingBlocksForLayout());
     if (hasLayer()) {
@@ -1377,6 +1379,7 @@ void RenderElement::setNeedsLayoutForOverflowChange()
     }
     if (needsSimplifiedNormalFlowLayout())
         return;
+    InspectorInstrumentation::willInvalidateLayout(*this);
     setNeedsSimplifiedNormalFlowLayoutBit(true);
     scheduleLayout(markContainingBlocksForLayout());
     if (hasLayer())
@@ -1390,6 +1393,7 @@ void RenderElement::setOutOfFlowChildNeedsStaticPositionLayout()
     // It's also assumed that regular, positioned child related bits are already set.
     ASSERT(!isSetNeedsLayoutForbidden());
     ASSERT(outOfFlowChildNeedsLayout() || selfNeedsLayout() || needsSimplifiedNormalFlowLayout() || !parent());
+    InspectorInstrumentation::willInvalidateLayout(*this);
     setOutOfFlowChildNeedsStaticPositionLayoutBit(true);
 }
 

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -154,7 +154,7 @@ public:
     virtual void dirtyLineFromChangedChild() { }
 
     void setChildNeedsLayout(MarkingBehavior = MarkingBehavior::MarkContainingBlockChain);
-    void NODELETE setOutOfFlowChildNeedsStaticPositionLayout();
+    void setOutOfFlowChildNeedsStaticPositionLayout();
     void NODELETE clearChildNeedsLayout();
     void setNeedsOutOfFlowMovementLayout(const Style::ComputedStyle* oldStyle);
     void setNeedsLayoutForStyleDifference(Style::Difference, const Style::ComputedStyle* oldStyle);

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -43,6 +43,7 @@
 #include "HTMLBRElement.h"
 #include "HTMLNames.h"
 #include "HitTestResult.h"
+#include "InspectorInstrumentation.h"
 #include "LayoutBox.h"
 #include "LayoutIntegrationCoverage.h"
 #include "LegacyRenderSVGModelObject.h"
@@ -703,6 +704,11 @@ void RenderObject::invalidateContainerContentLogicalWidths(const RenderBlock* an
         }
         ancestor = WTF::move(container);
     }
+}
+
+void RenderObject::notifyInspectorOfLayoutInvalidate()
+{
+    InspectorInstrumentation::willInvalidateLayout(*this);
 }
 
 void RenderObject::setLayerNeedsFullRepaint()

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -761,6 +761,8 @@ public:
     void clearNeedsLayout(HadSkippedLayout = HadSkippedLayout::No);
     void invalidateContentLogicalWidths(MarkingBehavior = MarkingBehavior::MarkContainingBlockChain, const RenderBlock* ancestorUpdateBoundary = nullptr);
     void clearContentLogicalWidthsInvalidation() { m_stateBitfields.setFlag(StateFlag::ContentLogicalWidthsInvalidated, { }); }
+
+    void notifyInspectorOfLayoutInvalidate();
     
     inline void setNeedsLayoutAndInvalidateContentLogicalWidths();
 

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -22,6 +22,7 @@
 #include <WebCore/DocumentPage.h>
 #include <WebCore/FloatQuad.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
+#include <WebCore/InspectorInstrumentationPublic.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/RenderElement.h>
@@ -89,6 +90,8 @@ inline void RenderObject::setNeedsLayout(MarkingBehavior markParents)
     ASSERT(!isSetNeedsLayoutForbidden());
     if (selfNeedsLayout())
         return;
+    if (InspectorInstrumentationPublic::hasFrontends()) [[unlikely]]
+        notifyInspectorOfLayoutInvalidate();
     m_stateBitfields.setFlag(StateFlag::NeedsLayout);
     if (markParents == MarkingBehavior::MarkContainingBlockChain)
         scheduleLayout(CheckedPtr { markContainingBlocksForLayout() });

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1015,6 +1015,7 @@ localizedStrings["Layout @ Styles Sidebar"] = "Layout";
 /* Layout phase timeline records */
 localizedStrings["Layout @ Timeline record"] = "Layout";
 localizedStrings["Layout Invalidated"] = "Layout Invalidated";
+localizedStrings["Layout Scheduled"] = "Layout Scheduled";
 /* Property title for `font-variant-ligatures`. */
 localizedStrings["Ligatures @ Font Details Sidebar Property"] = "Ligatures";
 /* Label of dropdown item used for forcing Web Inspector to be shown using a light theme */

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -860,6 +860,14 @@ WI.TimelineManager = class TimelineManager extends WI.Object
                 domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
             });
 
+        case InspectorBackend.Enum.Timeline.EventType.ScheduleLayout:
+            console.assert(isNaN(endTime));
+
+            // Pass the startTime as the endTime since this record type has no duration.
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.ScheduleLayout, startTime, startTime, stackTrace, sourceCodeLocation, {
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
+            });
+
         case InspectorBackend.Enum.Timeline.EventType.Layout:
             var layoutRecordType = sourceCodeLocation ? WI.LayoutTimelineRecord.EventType.ForcedLayout : WI.LayoutTimelineRecord.EventType.Layout;
             return new WI.LayoutTimelineRecord(layoutRecordType, startTime, endTime, stackTrace, sourceCodeLocation, {

--- a/Source/WebInspectorUI/UserInterface/Models/LayoutTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/LayoutTimelineRecord.js
@@ -52,6 +52,8 @@ WI.LayoutTimelineRecord = class LayoutTimelineRecord extends WI.TimelineRecord
             return WI.UIString("Styles Recalculated");
         case WI.LayoutTimelineRecord.EventType.InvalidateLayout:
             return WI.UIString("Layout Invalidated");
+        case WI.LayoutTimelineRecord.EventType.ScheduleLayout:
+            return WI.UIString("Layout Scheduled");
         case WI.LayoutTimelineRecord.EventType.ForcedLayout:
             return WI.UIString("Forced Layout", "Layout phase records that were imperative (forced)");
         case WI.LayoutTimelineRecord.EventType.Layout:
@@ -134,6 +136,7 @@ WI.LayoutTimelineRecord.EventType = {
     InvalidateStyles: "invalidate-styles",
     RecalculateStyles: "recalculate-styles",
     InvalidateLayout: "invalidate-layout",
+    ScheduleLayout: "schedule-layout",
     ForcedLayout: "forced-layout",
     Layout: "layout",
     Paint: "paint",

--- a/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js
@@ -1260,6 +1260,7 @@ WI.CPUTimelineView = class CPUTimelineView extends WI.TimelineView
 
             case WI.LayoutTimelineRecord.EventType.InvalidateStyles:
             case WI.LayoutTimelineRecord.EventType.InvalidateLayout:
+            case WI.LayoutTimelineRecord.EventType.ScheduleLayout:
             case WI.LayoutTimelineRecord.EventType.FirstContentfulPaint:
             case WI.LayoutTimelineRecord.EventType.LargestContentfulPaint:
                 // These event types have no time range.
@@ -1583,6 +1584,7 @@ WI.CPUTimelineView = class CPUTimelineView extends WI.TimelineView
                 return true;
             case WI.LayoutTimelineRecord.EventType.InvalidateStyles:
             case WI.LayoutTimelineRecord.EventType.InvalidateLayout:
+            case WI.LayoutTimelineRecord.EventType.ScheduleLayout:
             case WI.LayoutTimelineRecord.EventType.FirstContentfulPaint:
             case WI.LayoutTimelineRecord.EventType.LargestContentfulPaint:
                 return false;

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js
@@ -206,6 +206,7 @@ WI.TimelineTabContentView = class TimelineTabContentView extends WI.ContentBrows
             case WI.LayoutTimelineRecord.EventType.RecalculateStyles:
                 return WI.TimelineRecordTreeElement.StyleRecordIconStyleClass;
             case WI.LayoutTimelineRecord.EventType.InvalidateLayout:
+            case WI.LayoutTimelineRecord.EventType.ScheduleLayout:
             case WI.LayoutTimelineRecord.EventType.ForcedLayout:
             case WI.LayoutTimelineRecord.EventType.Layout:
                 return WI.TimelineRecordTreeElement.LayoutRecordIconStyleClass;


### PR DESCRIPTION
#### 7af6d5a321879450ab6d21f113e233e957caf14f
<pre>
Web Inspector: Emit per-element `Layout Invalidated` events
<a href="https://bugs.webkit.org/show_bug.cgi?id=317852">https://bugs.webkit.org/show_bug.cgi?id=317852</a>

Reviewed by Devin Rousso.

Currently, the `Layout Invalidated` event is emitted only when layout is
scheduled, with the layout root element set as the associated node. This
event does not reflect the number of subnodes that actually require
relayout.

If we have the following node tree:
```
  A
 / \
B   C
```
Where both `B` and `C` require relayout, the timeline will show:
```
Layout Invalidated: B (layout root)
Layout Invalidated: A (layout root - common ancestor for B and C)
Layout:             A (layout root)
```

This is indistinguishable from a case where many more subnodes of `A`
require relayout:
```
  A
/ | \ \
B C D...Z
```

The timeline will look the same, but layout will take much longer.

This patch makes the `Layout Invalidated` event fire on every
`setNeedsLayout*` call of each `RenderElement`, using its element as the
associated node. The original `Layout Invalidated` event is renamed to
`Layout Scheduled` to better reflect the actual logic.

To avoid event flooding, `Layout Invalidated` is only emitted the first
time an element is marked as needing layout within a given layout cycle.
Subsequent `setNeedsLayout*` calls on the same element before layout
runs are silently skipped.

With this patch, the timeline will look like this:
```
Layout Invalidated: B
Layout Scheduled:   B (layout root)
Layout Invalidated: C
Layout Scheduled:   A (layout root - common ancestor for B and C)
Layout Invalidated: D
Layout Invalidated: ...
Layout Invalidated: Z
Layout:             A (layout root)
```

While more verbose, this provides much more detailed insight into the
engine internals, making it easier for web developers to debug layout
issues.

* LayoutTests/inspector/timeline/timeline-layout-events-expected.txt:
* LayoutTests/inspector/timeline/timeline-layout-events-iframe-expected.txt:
* LayoutTests/inspector/timeline/timeline-layout-events-iframe.html:
* LayoutTests/inspector/timeline/timeline-layout-events.html:
* Source/JavaScriptCore/inspector/protocol/Timeline.json:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::willInvalidateLayoutImpl):
(WebCore::InspectorInstrumentation::didScheduleLayoutImpl):
(WebCore::InspectorInstrumentation::didInvalidateLayoutImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::willInvalidateLayout):
(WebCore::InspectorInstrumentation::didScheduleLayout):
(WebCore::InspectorInstrumentation::didInvalidateLayout):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::toProtocol):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::willInvalidateLayout):
(WebCore::PageTimelineAgent::didScheduleLayout):
(WebCore::PageTimelineAgent::didInvalidateLayout):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::scheduleSubtreeLayout):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::setNeedsOutOfFlowMovementLayout):
(WebCore::RenderElement::setNeedsLayoutForOverflowChange):
(WebCore::RenderElement::setOutOfFlowChildNeedsStaticPositionLayout):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::notifyInspectorOfLayoutInvalidate):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::setNeedsLayout):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype._processRecord):
* Source/WebInspectorUI/UserInterface/Models/LayoutTimelineRecord.js:
(WI.LayoutTimelineRecord.displayNameForEventType):
* Source/WebInspectorUI/UserInterface/Views/CPUTimelineView.js:
(WI.CPUTimelineView.prototype._attemptSelectIndicatatorTimelineRecord):
* Source/WebInspectorUI/UserInterface/Views/TimelineTabContentView.js:
(WI.TimelineTabContentView.iconClassNameForRecord):

Canonical link: <a href="https://commits.webkit.org/317302@main">https://commits.webkit.org/317302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78f9df5d2122c73a66ceee066b9f2fb5a4ad5db4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136002 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38080 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36455 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32830 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5302 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186777 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/36034 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/40244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144928 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39046 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49052 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32906 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114831 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39662 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/121105 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47558 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11255 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55260 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46960 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->