### PR TITLE
Scroll anchoring ignores text-node anchors because inline geometry is destroyed before anchor selection runs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-001-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-002-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-003-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl-expected.txt
@@ -6,5 +6,5 @@ FAIL
 FAIL
 line
 
-FAIL Line at edge of scrollport shouldn't jump visually when content is inserted before assert_equals: expected -400 but got -300
+PASS Line at edge of scrollport shouldn't jump visually when content is inserted before
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/wrapped-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/wrapped-text-expected.txt
@@ -1,4 +1,4 @@
 abcd efg def ghi
 
-FAIL Anchoring with text wrapping changes. assert_equals: expected 250 but got 150
+PASS Anchoring with text wrapping changes.
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -126,6 +126,43 @@ void ScrollAnchoringController::scrollPositionDidChange()
 
     clearAnchor();
     updateScrollableAreaRegistration();
+
+    selectAnchorWhileTreeIsClean();
+}
+
+// A content mutation eagerly destroys the block's inline content (RenderBlockFlow::invalidateLineLayout),
+// so by updateBeforeLayout() a RenderText anchor's geometry is gone and anchoring falls back to a pinned
+// ancestor box. Programmatic scrolls flush layout first, so capture the anchor here while it's still valid.
+void ScrollAnchoringController::selectAnchorWhileTreeIsClean()
+{
+    if (m_anchorObject)
+        return;
+
+    // Skip the hot user-scroll path; lazy before-layout selection still covers box anchors there.
+    if (m_owningScrollableArea->currentScrollType() == ScrollType::User)
+        return;
+
+    CheckedPtr scrollerBox = scrollableAreaBox();
+    if (!scrollerBox)
+        return;
+
+    auto& layoutContext = frameView().layoutContext();
+    if (layoutContext.isInLayout() || layoutContext.isLayoutPending() || scrollerBox->view().needsLayout())
+        return;
+
+    // Mirror updateBeforeLayout()'s precondition, not shouldMaintainScrollAnchor() (its
+    // hasPotentiallyScrollableOverflow() check is false for the main-frame RenderView here).
+    auto scrollPosition = m_owningScrollableArea->scrollPosition();
+    if (!hasScrolledFromOriginInBlockDirection(scrollPosition, scrollerBox->writingMode()))
+        return;
+    if (m_owningScrollableArea->constrainedScrollPosition(scrollPosition) != scrollPosition)
+        return;
+
+    RefPtr document = frameView().frame().document();
+    if (!document)
+        return;
+
+    chooseAnchorElement(*document, *scrollerBox);
 }
 
 void ScrollAnchoringController::scrollerDidLayout()

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -124,6 +124,7 @@ private:
 
     void invalidate();
     void chooseAnchorElement(Document&, RenderBox& scrollerBox);
+    void selectAnchorWhileTreeIsClean();
     bool NODELETE anchoringSuppressedByStyleChange() const;
     void updateScrollableAreaRegistration();
 

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -37,6 +37,7 @@
 #include "LayoutSize.h"
 #include "Logging.h"
 #include "PlatformWheelEvent.h"
+#include "ScrollAnchoringController.h"
 #include "ScrollExtents.h"
 #include "ScrollableArea.h"
 #include "ScrollbarsController.h"
@@ -249,6 +250,12 @@ bool ScrollAnimator::handleTouchEvent(const PlatformTouchEvent&)
 
 static void notifyScrollAnchoringControllerOfScroll(ScrollableArea& scrollableArea)
 {
+    // Route through scrollPositionDidChange() so the controller can re-select an anchor from clean
+    // geometry; a bare clearScrollAnchor() here would discard one captured earlier in the same scroll.
+    if (CheckedPtr controller = scrollableArea.scrollAnchoringController()) {
+        controller->scrollPositionDidChange();
+        return;
+    }
     scrollableArea.clearScrollAnchor();
 }
 


### PR DESCRIPTION
#### a49c7ea3e55a021ea69872adf5a067540833e4e8
<pre>
Scroll anchoring ignores text-node anchors because inline geometry is destroyed before anchor selection runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=317854">https://bugs.webkit.org/show_bug.cgi?id=317854</a>
<a href="https://rdar.apple.com/180632754">rdar://180632754</a>

Reviewed by NOBODY (OOPS!).

Scroll anchoring produced no adjustment when the anchor should be a text node:
it fell back to a non-moving ancestor box, so scrolling didn&apos;t compensate for
content shifts.

The anchor is chosen in updateBeforeLayout() (from willDoLayout()), before the
layout a content mutation triggers. By then invalidateLineLayout() has eagerly
destroyed the block&apos;s inline content, so RenderText::linesBoundingBox() is
empty, examineAnchorCandidate() rejects every text node, and anchoring falls
back to a pinned box (zero adjustment). RenderBox anchors are unaffected since
their frame rect survives invalidation.

Fix by capturing the anchor while the tree is still clean: programmatic scrolls
flush layout before updating the scroll position, so selectAnchorWhileTreeIsClean()
records the correct pre-mutation offset from the scroll-change notification
(gated to non-user scrolls + a clean tree to avoid a per-frame tree walk). On
the async path the main frame reconciles via setCurrentPosition(.., No), whose
notifyScrollAnchoringControllerOfScroll() did a bare clearScrollAnchor() last,
discarding that anchor; route it through scrollPositionDidChange() so the
controller re-selects from clean geometry, matching the Yes path.

Covered by existing imported WPT that now pass.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-001-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-002-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-in-multicol-003-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/text-anchor-in-vertical-rl-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/wrapped-text-expected.txt: Ditto
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::scrollPositionDidChange):
(WebCore::ScrollAnchoringController::selectAnchorWhileTreeIsClean):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::notifyScrollAnchoringControllerOfScroll):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a49c7ea3e55a021ea69872adf5a067540833e4e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127925 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25e229aa-a85a-4995-b63e-59de2224f412) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43768 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132704 "Found 2 new test failures: fast/repaint/layout-state-scrolloffset2.html svg/custom/getscreenctm-in-scrollable-div-area-nested.xhtml (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93528 "12 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2ef3400-ce07-4829-b839-245e2a9991e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f98c11d-8f9c-41eb-82a2-cce294f7175e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32826 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28271 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144950 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32523 "Found 2 new test failures: fast/repaint/layout-state-scrolloffset2.html svg/custom/getscreenctm-in-scrollable-div-area-nested.xhtml (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182172 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34961 "Found 1 new failure in page/scrolling/ScrollAnchoringController.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36995 "Found 3 new test failures: fast/repaint/layout-state-scrolloffset2.html http/tests/site-isolation/frame-index.html svg/custom/getscreenctm-in-scrollable-div-area-nested.xhtml (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141145 "Found 1 new test failure: svg/custom/getscreenctm-in-scrollable-div-area-nested.xhtml (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43793 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140969 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44482 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29507 "Found 1 new test failure: svg/custom/getscreenctm-in-scrollable-div-area-nested.xhtml (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108885 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36237 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116362 "Found 1 new failure in page/scrolling/ScrollAnchoringController.cpp") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42992 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7606 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42384 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42527 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->