### PR TITLE
Remove unneeded fontSelector workaround in SizesAttributeParser

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -60,7 +60,6 @@ css/CSSStyleSheet.cpp
 css/CSSToLengthConversionData.cpp
 css/SelectorCheckerTestFunctions.h
 css/StyleAttributeMutationScope.h
-css/parser/SizesAttributeParser.cpp
 dom/Attr.cpp
 dom/CollectionIndexCacheInlines.h
 dom/ComposedTreeIterator.h

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -43,8 +43,6 @@
 #include "CSSPropertyParserState.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSTokenizer.h"
-#include "FontCascadeInlines.h"
-#include "FontSelector.h"
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
@@ -153,19 +151,6 @@ std::optional<float> SizesAttributeParser::parseDimension(CSSParserTokenRange to
         return result;
     };
 
-    // Because we evaluate "sizes" at parse time (before style has been resolved), the font metrics used for these specific units
-    // are not available. The font selector's internal consistency isn't guaranteed just yet, so we can just temporarily clear
-    // the pointer to it for the duration of the unit evaluation. This is acceptable because the style always comes from the
-    // RenderView, which has its font information hardcoded in resolveForDocument() to be -webkit-standard, whose operations
-    // don't require a font selector.
-    if (unit == CSS::LengthUnit::Ex || unit == CSS::LengthUnit::Cap || unit == CSS::LengthUnit::Ch || unit == CSS::LengthUnit::Ic) {
-        RefPtr fontSelector = conversionData->style()->fontCascade().fontSelector();
-        conversionData->style()->fontCascade().update(nullptr);
-        auto resetFontSelectorScope = makeScopeExit([&] { conversionData->style()->fontCascade().update(fontSelector.get()); });
-
-        return resolve();
-    }
-
     return resolve();
 }
 
@@ -200,14 +185,6 @@ std::optional<float> SizesAttributeParser::parseFunction(CSSParserTokenRange tok
         .symbolTable = { },
         .allowZeroValueLengthRemovalFromSum = true,
     };
-
-    // See `parseDimension` for why this unset/set of the font selector is needed.
-    // FIXME: This could be made more efficient if we only did this when actually
-    // needed. That could be accomplished via new simplification/evaluation options
-    // or by adding delegation for dimension resolution.
-    RefPtr fontSelector = conversionData->style()->fontCascade().fontSelector();
-    conversionData->style()->fontCascade().update(nullptr);
-    auto resetFontSelectorScope = makeScopeExit([&] { conversionData->style()->fontCascade().update(fontSelector.get()); });
 
     auto tree = CSSCalc::parseAndSimplify(tokens, parserState, parserOptions, simplificationOptions);
     if (!tree)


### PR DESCRIPTION
#### 2d22c1da95f8164c6a2d57b0e391116ca733ce4d
<pre>
Remove unneeded fontSelector workaround in SizesAttributeParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=317858">https://bugs.webkit.org/show_bug.cgi?id=317858</a>

Reviewed by Darin Adler.

The fontSelector unset/set workaround in SizesAttributeParser is no longer
needed now that SizesAttributeParser&apos;s conversion data uses Document::initialStyle().

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/css/parser/SizesAttributeParser.cpp:

Canonical link: <a href="https://commits.webkit.org/315970@main">https://commits.webkit.org/315970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc9e86bc40f85a65224ab53f926c883780af65b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133030 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34838 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33180 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182546 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141488 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44166 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141305 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38056 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44855 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109404 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36572 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116744 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43365 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->