### PR TITLE
Don't disable compiler cache by default in build-and-analyze

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -180,8 +180,9 @@ def main(args):
         xcodebuild_args['TOOLCHAINS'] = args.toolchains
     if args.swift_conditions:
         xcodebuild_args['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = args.swift_conditions
-    xcodebuild_args['COMPILATION_CACHE_ENABLE_CACHING'] = 'YES' if args.enable_compile_cache else 'NO'
-    xcodebuild_args['CLANG_ENABLE_COMPILE_CACHE'] = 'YES' if args.enable_compile_cache else 'NO'
+    if args.enable_compile_cache is not None:
+        xcodebuild_args['COMPILATION_CACHE_ENABLE_CACHING'] = 'YES' if args.enable_compile_cache else 'NO'
+        xcodebuild_args['CLANG_ENABLE_COMPILE_CACHE'] = 'YES' if args.enable_compile_cache else 'NO'
     if len(xcodebuild_args):
         make_command.extend(['ARGS={}'.format(' '.join(["{}=\"{}\"".format(key, xcodebuild_args[key]) for key in xcodebuild_args]))])
 
@@ -249,11 +250,11 @@ def parse_args():
     parser.add_argument('--configuration', default='debug', choices=['debug', 'release'], dest='configuration', help='Set the build configuration (default: debug).')
     compile_cache_group = parser.add_mutually_exclusive_group()
     compile_cache_group.add_argument('--enable-compile-cache', dest='enable_compile_cache',
-                        action='store_true', default=False,
+                        action='store_true', default=None,
                         help='Enable Xcode compilation caching (CAS).')
     compile_cache_group.add_argument('--disable-compile-cache', dest='enable_compile_cache',
-                        action='store_false', default=False,
-                        help='Disable Xcode compilation caching (CAS) (default).')
+                        action='store_false', default=None,
+                        help='Disable Xcode compilation caching (CAS).')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
#### 90670404d29bc49d60646e36d2bddb14bdd57bdd
<pre>
Don&apos;t disable compiler cache by default in build-and-analyze
<a href="https://bugs.webkit.org/show_bug.cgi?id=317861">https://bugs.webkit.org/show_bug.cgi?id=317861</a>
<a href="https://rdar.apple.com/180638311">rdar://180638311</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/315540@main">https://commits.webkit.org/315540@main</a> disabled compiler caching by default in
the `build-and-analyze` script. Instead, we should leave this as a flag for
consumers of the script to chose to enable.

Restores behavior to before that commit by passing in no compiler
caching flags by default.

If the caller adds `--enable-compile-cache` then the following
two flags get passed into xcodebuild:
- COMPILATION_CACHE_ENABLE_CACHING=YES
- CLANG_ENABLE_COMPILE_CACHE=YES
If the caller adds `--disable-compile-cache` then the two
flags get set to &quot;NO&quot;.

* Tools/Scripts/build-and-analyze:
(main):
(parse_args):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90670404d29bc49d60646e36d2bddb14bdd57bdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127935 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa626f35-41bb-4ae0-8a30-78f79f5c3c77) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132715 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/852bdf35-d9cc-43d4-8dcd-59af42528356) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173182 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113216 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2830ac42-ae71-4123-a2a1-5f6d5ae52936) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28281 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182182 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34971 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141155 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43803 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140979 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44492 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108899 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36248 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116372 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43002 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7617 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42394 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->