### PR TITLE
REGRESSION(315733@main): [iOS]TestWebKitAPI.ModalDialogDuringOverlappingFocus.AlertNotDeferredAfterFIFOAsyncFocusCompletions is constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm
@@ -74,7 +74,11 @@ TEST(ModalDialogDuringOverlappingFocus, AlertNotDeferredAfterFIFOAsyncFocusCompl
         "<input id='a'></input>"
         "<input id='b'></input>"];
 
-    [webView evaluateJavaScript:@"document.getElementById('a').focus(); document.getElementById('b').focus();" completionHandler:nil];
+    // ElementDidFocus IPCs can be deferred until the next rendering update, so make two explicit
+    // evaluateJavaScript calls for focus() to force any pending ElementDidFocus IPC to be sent.
+    // Both focus() calls in one script would send only one IPC (the last).
+    [webView evaluateJavaScript:@"document.getElementById('a').focus();" completionHandler:nil];
+    [webView evaluateJavaScript:@"document.getElementById('b').focus();" completionHandler:nil];
     Util::run(&gotBothCompletions);
 
     // Invoke the completion handlers in FIFO order, releasing each block immediately afterwards. The


### PR DESCRIPTION
#### 13f0b855614682b002820fa2c726acefbeb423b7
<pre>
REGRESSION(315733@main): [iOS]TestWebKitAPI.ModalDialogDuringOverlappingFocus.AlertNotDeferredAfterFIFOAsyncFocusCompletions is constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=317810">https://bugs.webkit.org/show_bug.cgi?id=317810</a>
<a href="https://rdar.apple.com/180581088">rdar://180581088</a>

Reviewed by Ryan Reno.

Following 315733@main, an ElementDidFocus IPC can be deferred until the next
rendering update, except at a few flush points where any pending ElementDidFocus
IPC is forced out (e.g. when an evaluateJavaScript or synthetic click completes).

The test ModalDialogDuringOverlappingFocus.mm (introduced in 314318@main) assumed
that a script calling element.focus() on two elements in a row would send two
ElementDidFocus IPCs.

After 315733@main this test times out, because the two focus() calls coalesce into
a single ElementDidFocus IPC (carrying focus info for only the second element).
Only one of the two strong-password-assistance completion handlers the test waits
on is delivered, so the test blocks forever waiting for the second.

Fix the test by issuing each element.focus() in its own evaluateJavaScript call.
Each evaluateJavaScript forces any pending ElementDidFocus IPC to be sent when it
completes, so both focus completions are delivered and the test proceeds.

315733@main does not re-introduce the regression that 314318@main fixed.
314318@main fixed a hang caused by two overlapping _elementDidFocus: completion
scopes unwinding in non-LIFO order. The second-to-fire scope wrote its stale
captured YES over the first&apos;s correct NO, leaving _isFocusingElementWithKeyboard
stuck and deferring every later modal dialog forever. 315733@main only ever
reduces the number of ElementDidFocus IPCs. It coalesces multiple same-turn
focus() calls into one, producing fewer scopes and never more, so it makes the
ordering problem less likely rather than more. When two focus() calls land in
separate rendering updates, two scopes are still created, and 314318@main&apos;s
generation-counter fix still resolves the unwind correctly.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/ModalDialogDuringOverlappingFocus.mm:
(TestWebKitAPI::TEST(ModalDialogDuringOverlappingFocus, AlertNotDeferredAfterFIFOAsyncFocusCompletions)):

Canonical link: <a href="https://commits.webkit.org/315836@main">https://commits.webkit.org/315836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9aaff607d8ac0a679ba8a9cf6a8fb6884abcdecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179605 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127944 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173191 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113221 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28290 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182191 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141161 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43812 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140985 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37959 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44501 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108910 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36253 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43011 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7621 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42403 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->