### PR TITLE
Cherry-pick 309066@main (3beb04a4553f). https://bugs.webkit.org/show_bug.cgi?id=309580

### DIFF
--- a/Tools/Scripts/webkitpy/common/test_expectations.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations.py
@@ -37,9 +37,10 @@ def check_repeated_keys(args):
 
 class TestExpectations(object):
 
-    def __init__(self, port_name, expectations_file, build_type='Release'):
+    def __init__(self, port_name, expectations_file, build_type='Release', architecture=None):
         self._port_name = port_name
         self._build_type = build_type
+        self._architecture = architecture
         if os.path.isfile(expectations_file):
             with open(expectations_file, 'r') as fd:
                 self._expectations = self._load_expectation_string(fd.read())
@@ -50,20 +51,17 @@ class TestExpectations(object):
         return json.loads(expectations, object_pairs_hook=check_repeated_keys)
 
     def _port_name_for_expected(self, expected):
-        if self._port_name in expected:
-            return self._port_name
-
-        name_with_build = self._port_name + '@' + self._build_type
-        if name_with_build in expected:
-            return name_with_build
-
-        if 'all' in expected:
-            return 'all'
-
-        name_with_build = 'all@' + self._build_type
-        if name_with_build in expected:
-            return name_with_build
-
+        for port in [self._port_name, 'all']:
+            candidates = [port]
+            if self._build_type:
+                candidates.append('%s@%s' % (port, self._build_type))
+            if self._architecture:
+                candidates.append('%s:%s' % (port, self._architecture))
+            if self._build_type and self._architecture:
+                candidates.append('%s@%s:%s' % (port, self._build_type, self._architecture))
+            for key in reversed(candidates):
+                if key in expected:
+                    return key
         return None
 
     def _expected_value(self, expected, value, default):

--- a/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
@@ -28,11 +28,12 @@ from webkitpy.common.test_expectations import TestExpectations
 
 class MockTestExpectations(TestExpectations):
 
-    def __init__(self, port, expectations, build_type='Release'):
+    def __init__(self, port, expectations, build_type='Release', architecture=None):
         host = MockHost()
         port = host.port_factory.get(port)
         self._port_name = port.name()
         self._build_type = build_type
+        self._architecture = architecture
         self._expectations = self._load_expectation_string(expectations)
 
     def is_skip(self, test, subtest):
@@ -181,6 +182,93 @@ class ExpectationsTest(unittest.TestCase):
     }
 }"""
 
+    ARCHITECTURE = """
+{
+    "TestWebKit": {
+        "subtests": {
+            "WebKit.ArmCrash": {
+                "expected": {"all:arm64": {"status": ["CRASH"], "bug": "1234"}}
+            },
+            "WebKit.GtkArmTimeout": {
+                "expected": {"gtk:arm64": {"status": ["TIMEOUT"], "bug": "1234"}}
+            },
+            "WebKit.AllFail": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "1234"}}
+            }
+        }
+    }
+}"""
+
+    SPECIFICITY = """
+{
+    "TestWebKit": {
+        "subtests": {
+            "WebKit.PortVsAll": {
+                "expected": {
+                    "all:arm64": {"status": ["TIMEOUT"], "bug": "1234"},
+                    "gtk": {"status": ["FAIL"], "bug": "1234"}
+                }
+            },
+            "WebKit.ArchVsPlain": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "gtk:arm64": {"status": ["CRASH"], "bug": "1234"}
+                }
+            },
+            "WebKit.BuildVsPlain": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "gtk@Release": {"status": ["TIMEOUT"], "bug": "1234"}
+                }
+            },
+            "WebKit.FullyQualified": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "gtk:arm64": {"status": ["TIMEOUT"], "bug": "1234"},
+                    "gtk@Debug:arm64": {"status": ["CRASH"], "bug": "1234"}
+                }
+            },
+            "WebKit.PortVsAllFullyQualified": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "all@Release:arm64": {"status": ["TIMEOUT"], "bug": "1234"}
+                }
+            }
+        }
+    }
+}"""
+
+    ARCHITECTURE_SLOW = """
+{
+    "TestWebKit": {
+        "expected": {"all": {"slow": true}},
+        "subtests": {
+            "WebKit.FastOnArm": {
+                "expected": {"all:arm64": {"slow": false}}
+            }
+        }
+    }
+}"""
+
+    ARCHITECTURE_SKIP = """
+{
+    "TestSkipArch": {
+        "expected": {"all:arm64": {"status": ["SKIP"], "bug": "1234"}},
+        "subtests": {
+            "TestSkipArch.PassOnArm": {
+                "expected": {"all": {"status": ["PASS"]}}
+            }
+        }
+    },
+    "TestSkipArchSubtest": {
+        "subtests": {
+            "sub1": {
+                "expected": {"all:arm64": {"status": ["SKIP"], "bug": "1234"}}
+            }
+        }
+    }
+}"""
+
     REPEATED_KEYS = """
 {
     "TestDummy": {
@@ -301,6 +389,80 @@ class ExpectationsTest(unittest.TestCase):
         self.assert_slow('TestWebKit', 'WebKit.WKView', False)
         self.assert_slow('TestWebKit', 'WebKit.MouseMoveAfterCrash', True)
         self.assert_slow('TestWebKit', 'WebKit.WKConnection', False)
+
+    def test_architecture(self):
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE, architecture='arm64')
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'CRASH')
+        self.assert_exp('TestWebKit', 'WebKit.GtkArmTimeout', 'TIMEOUT')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE, architecture='x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.GtkArmTimeout', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+        self.expectations = MockTestExpectations('wpe', self.ARCHITECTURE, architecture='arm64')
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'CRASH')
+        self.assert_exp('TestWebKit', 'WebKit.GtkArmTimeout', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE)
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+    def test_specificity(self):
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAll', 'FAIL')
+        self.expectations = MockTestExpectations('wpe', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAll', 'TIMEOUT')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.ArchVsPlain', 'CRASH')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.ArchVsPlain', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.BuildVsPlain', 'TIMEOUT')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Debug', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.BuildVsPlain', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Debug', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.FullyQualified', 'CRASH')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.FullyQualified', 'TIMEOUT')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.FullyQualified', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAllFullyQualified', 'FAIL')
+        self.expectations = MockTestExpectations('wpe', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAllFullyQualified', 'TIMEOUT')
+        self.expectations = MockTestExpectations('wpe', self.SPECIFICITY, 'Debug', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAllFullyQualified', 'PASS')
+
+    def test_architecture_slow(self):
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SLOW, architecture='arm64')
+        self.assert_slow('TestWebKit', None, True)
+        self.assert_slow('TestWebKit', 'WebKit.FastOnArm', False)
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SLOW, architecture='x86_64')
+        self.assert_slow('TestWebKit', None, True)
+        self.assert_slow('TestWebKit', 'WebKit.FastOnArm', True)
+
+    def test_architecture_skip(self):
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='arm64')
+        self.assert_skip('TestSkipArch', None, True)
+        self.assert_exp('TestSkipArch', 'TestSkipArch.PassOnArm', 'PASS')
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='x86_64')
+        self.assert_skip('TestSkipArch', None, False)
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='arm64')
+        self.assert_skip('TestSkipArchSubtest', None, False)
+        self.assert_skip('TestSkipArchSubtest', 'sub1', True)
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='x86_64')
+        self.assert_skip('TestSkipArchSubtest', 'sub1', False)
 
     def test_repeated_keys(self):
         self.assertRaises(ValueError, lambda: MockTestExpectations('gtk', self.REPEATED_KEYS))

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -34,6 +34,7 @@ import re
 import uuid
 
 from webkitpy.common.memoized import memoized
+from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.base import Port
 from webkitpy.port.leakdetector_valgrind import LeakDetectorValgrind
 from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
@@ -42,6 +43,8 @@ _log = logging.getLogger(__name__)
 
 
 class GLibPort(Port):
+
+    ARCHITECTURES = ['x86_64', 'arm64']
 
     def __init__(self, *args, **kwargs):
         super(GLibPort, self).__init__(*args, **kwargs)
@@ -68,6 +71,19 @@ class GLibPort(Port):
         if self.get_option('configuration') == 'Debug':
             multiplier *= 2
         return multiplier * default_timeout
+
+    def architecture(self):
+        result = self.get_option('architecture') or self.host.platform.architecture()
+        if result == 'aarch64':
+            return 'arm64'
+        return result
+
+    def _generate_all_test_configurations(self):
+        configurations = []
+        for build_type in self.ALL_BUILD_TYPES:
+            for architecture in self.ARCHITECTURES:
+                configurations.append(TestConfiguration(version=self.version_name(), architecture=architecture, build_type=build_type))
+        return configurations
 
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -169,7 +169,10 @@ class GtkPort(GLibPort):
     def configuration_for_upload(self, host=None):
         configuration = super(GtkPort, self).configuration_for_upload(host=host)
         configuration['platform'] = 'GTK'
-        configuration['version_name'] = self._display_server.capitalize() if self._display_server else 'Xvfb'
+        # resultsdbpy frontend tends to group multiple versions in a single timeline
+        # when they share a version name. As we are using stable versions since 305707@main,
+        # let's avoid this grouping for now due to issues like https://webkit.org/b/306091.
+        configuration.pop('version_name', None)
         return configuration
 
     def get_browser_path(self, browser_name):

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -37,7 +37,6 @@ import webkitpy
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
 from webkitpy.common.system.executive import ScriptError
-from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.glib import GLibPort
 from webkitpy.port.xvfbdriver import XvfbDriver
 from webkitpy.port.westondriver import WestonDriver
@@ -96,12 +95,6 @@ class GtkPort(GLibPort):
                 _log.warning("Can't find Gallium llvmpipe driver. Try to run update-webkitgtk-libs")
 
         return environment
-
-    def _generate_all_test_configurations(self):
-        configurations = []
-        for build_type in self.ALL_BUILD_TYPES:
-            configurations.append(TestConfiguration(version=self.version_name(), architecture='x86', build_type=build_type))
-        return configurations
 
     def _path_to_driver(self):
         return self._built_executables_path(self.driver_name())

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -99,7 +99,7 @@ class GtkPortTest(port_testcase.PortTestCase):
         self.assertEqual(configuration['is_simulator'], False)
         self.assertEqual(configuration['platform'], 'GTK')
         self.assertEqual(configuration['style'], 'release')
-        self.assertEqual(configuration['version_name'], 'Xvfb')
+        self.assertNotIn('version_name', configuration)
         self.assertEqual(configuration['version'], '2.51')
 
     def test_gtk4_expectations_binary_only(self):

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -84,6 +84,29 @@ class GtkPortTest(port_testcase.PortTestCase):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release', leaks=True, wrapper="valgrind")).default_timeout_ms(), 300000)
         self.assertEqual(self.make_port(options=MockOptions(configuration='Debug', leaks=True, wrapper="valgrind")).default_timeout_ms(), 600000)
 
+    def test_architecture_default(self):
+        port = self.make_port()
+        self.assertEqual(port.architecture(), port.host.platform.architecture())
+
+    def test_architecture_cli_override(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='custom_arch'))
+        self.assertEqual(port.architecture(), 'custom_arch')
+
+    def test_architecture_aarch64_normalization(self):
+        port = self.make_port()
+        port.host.platform._architecture = 'aarch64'
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_architecture_cli_override_aarch64(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='aarch64'))
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_all_test_configurations_architectures(self):
+        port = self.make_port()
+        configurations = port.all_test_configurations()
+        architectures = {config.architecture for config in configurations}
+        self.assertEqual(architectures, {'x86_64', 'arm64'})
+
     def test_get_crash_log(self):
         # This function tested in linux_get_crash_log_unittest.py
         pass

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -126,6 +126,10 @@ class WPEPort(GLibPort):
     def configuration_for_upload(self, host=None):
         configuration = super(WPEPort, self).configuration_for_upload(host=host)
         configuration['platform'] = 'WPE'
+        # resultsdbpy frontend tends to group multiple versions in a single timeline
+        # when they share a version name. As we are using stable versions since 305707@main,
+        # let's avoid this grouping for now due to issues like https://webkit.org/b/306091.
+        configuration.pop('version_name', None)
         return configuration
 
     def cog_path_to(self, *components):

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -33,7 +33,6 @@ import shlex
 
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
-from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.glib import GLibPort
 from webkitpy.port.headlessdriver import HeadlessDriver
 from webkitpy.port.westondriver import WestonDriver
@@ -88,12 +87,6 @@ class WPEPort(GLibPort):
 
     def check_sys_deps(self):
         return super(WPEPort, self).check_sys_deps() and self._driver_class().check_driver(self)
-
-    def _generate_all_test_configurations(self):
-        configurations = []
-        for build_type in self.ALL_BUILD_TYPES:
-            configurations.append(TestConfiguration(version=self.version_name(), architecture='x86', build_type=build_type))
-        return configurations
 
     def _path_to_driver(self):
         return self._built_executables_path(self.driver_name())

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -95,6 +95,7 @@ class WPEPortTest(port_testcase.PortTestCase):
         self.assertEqual(configuration['platform'], 'WPE')
         self.assertEqual(configuration['style'], 'release')
         self.assertEqual(configuration['version'], '2.51')
+        self.assertNotIn('version_name', configuration)
 
     def test_browser_name_default_wihout_cog_built(self):
         port = self.make_port()

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -79,6 +79,29 @@ class WPEPortTest(port_testcase.PortTestCase):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release', leaks=True, wrapper="valgrind")).default_timeout_ms(), 300000)
         self.assertEqual(self.make_port(options=MockOptions(configuration='Debug', leaks=True, wrapper="valgrind")).default_timeout_ms(), 600000)
 
+    def test_architecture_default(self):
+        port = self.make_port()
+        self.assertEqual(port.architecture(), port.host.platform.architecture())
+
+    def test_architecture_cli_override(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='custom_arch'))
+        self.assertEqual(port.architecture(), 'custom_arch')
+
+    def test_architecture_aarch64_normalization(self):
+        port = self.make_port()
+        port.host.platform._architecture = 'aarch64'
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_architecture_cli_override_aarch64(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='aarch64'))
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_all_test_configurations_architectures(self):
+        port = self.make_port()
+        configurations = port.all_test_configurations()
+        architectures = {config.architecture for config in configurations}
+        self.assertEqual(architectures, {'x86_64', 'arm64'})
+
     def test_get_crash_log(self):
         # This function tested in linux_get_crash_log_unittest.py
         pass

--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
@@ -91,7 +91,7 @@ class WebDriverTestRunner(object):
         else:
             expectations_file = os.path.join(self._tests_dir, 'TestExpectations.json')
         build_type = 'Debug' if self._port.get_option('debug') else 'Release'
-        self._expectations = TestExpectations(self._port.name(), expectations_file, build_type)
+        self._expectations = TestExpectations(self._port.name(), expectations_file, build_type, self._port.architecture())
         for test in self._expectations._expectations.keys():
             if not os.path.isfile(os.path.join(self._tests_dir, test)):
                 _log.warning('Test %s does not exist' % test)

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -69,7 +69,8 @@ class TestRunner(object):
 
         self._programs_path = common.binary_build_path(self._port)
         expectations_file = os.path.join(common.top_level_path(), "Tools", "TestWebKitAPI", "glib", "TestExpectations.json")
-        self._expectations = TestExpectations(self._port.name(), expectations_file, self._build_type)
+        self._expectations = TestExpectations(self._port.name(), expectations_file, self._build_type, self._port.architecture())
+        print("Test expectations: port=%s, build_type=%s, architecture=%s" % (self._port.name(), self._build_type, self._port.architecture()))
         self._initial_test_list = tests
         self._tests = self._get_tests(tests)
         self._disabled_tests = []


### PR DESCRIPTION
#### a8c7fc7d1b730104351bf740199ec5ab3839b1b2
<pre>
Cherry-pick 309066@main (3beb04a4553f). <a href="https://bugs.webkit.org/show_bug.cgi?id=309580">https://bugs.webkit.org/show_bug.cgi?id=309580</a>

    [webkitpy][GLIB] Add support to architecture markers in TestExpectations.json
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309580">https://bugs.webkit.org/show_bug.cgi?id=309580</a>

    Reviewed by Carlos Alberto Lopez Perez.

    Follow-up of 308721@main, which replaced the hardcoded x86 architecture
    for glib ports with runtime detection.

    TestExpectations.json uses a string as the key selector to decide
    whether to apply or not a given expectation. This is typically one of
    &apos;all&apos;, &apos;gtk&apos;, and &apos;wpe&apos;, followed by an optional &apos;@BuildType&apos; suffix.

    This commit extends the expectation syntax in TestExpectations.json,
    adding a marker for the architecture, after the &apos;:&apos; wildcard, to
    contrast with the &apos;@&apos; used for the build type. So, an expectation that
    targets WPE Debug ARM64 would be written as &apos;wpe@Debug:arm64&apos;.

    With the addition of this new parameter, to account for the various
    possible configurations, we also changed the precedence check to roughly
    match the LayoutTests scheme, where the most specific expectation wins.
    Previously, &apos;gtk&apos; would be selected over &apos;gtk@Release&apos;, for example.
    Note that &apos;all&apos; is a fallback port name, so &apos;all@Debug:x86_64&apos; would
    still lose over a proper port name like &apos;gtk&apos; or &apos;wpe&apos;.

    As these extended configurations were rarely used (~9 commits in 8
    years) and the new precedence did not break the existing tests, this
    should not be a problem. The new checks are also covered by new tests.

    * Tools/Scripts/webkitpy/common/test_expectations.py:
    (TestExpectations.__init__):
    (TestExpectations._port_name_for_expected):
    * Tools/Scripts/webkitpy/common/test_expectations_unittest.py:
    (MockTestExpectations.__init__):
    (test_architecture):
    (test_specificity):
    (test_architecture_slow):
    (test_architecture_skip):
    * Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py:
    (WebDriverTestRunner.__init__):
    * Tools/glib/api_test_runner.py:
    (TestRunner.__init__):

    Canonical link: <a href="https://commits.webkit.org/309066@main">https://commits.webkit.org/309066@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.795@webkitglib/2.52">https://commits.webkit.org/305877.795@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 266f66a82469266b6a2484006acd39c4449e7875
<pre>
Cherry-pick 308721@main (1927f6c9ffc4). <a href="https://bugs.webkit.org/show_bug.cgi?id=309249">https://bugs.webkit.org/show_bug.cgi?id=309249</a>

    [webkitpy][GLIB] Fix architecture field value for glib Port classes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309249">https://bugs.webkit.org/show_bug.cgi?id=309249</a>

    Reviewed by Carlos Alberto Lopez Perez.

    Replace the currently hardcoded x86 architecture with runtime detection.

    This fixes the results uploaded by the new ARM64 testers (307868@main).
    Currently, they have the same x86 architecture as the x86_64, making it
    hard to follow the history, especially when the outcome differ. For
    example, while the x86_64 bot is in a good shape, queries to the
    results database showed alternating green and red runs.

    This commit also expands the list of test configurations for the glib
    ports, covering both the default x86_64 and arm64 architectures, and
    enabling architecture-specific expectations within the same expectation
    file, for example:

    [ arm64 ] some/test.html [ Crash ]

    * Tools/Scripts/webkitpy/port/glib.py:
    (GLibPort):
    (GLibPort.architecture):
    (GLibPort._generate_all_test_configurations):
    * Tools/Scripts/webkitpy/port/gtk.py:
    (GtkPort.setup_environ_for_server):
    (GtkPort._generate_all_test_configurations): Deleted.
    * Tools/Scripts/webkitpy/port/gtk_unittest.py:
    (GtkPortTest.test_architecture_default):
    (GtkPortTest):
    (GtkPortTest.test_architecture_cli_override):
    (GtkPortTest.test_architecture_aarch64_normalization):
    (GtkPortTest.test_architecture_cli_override_aarch64):
    (GtkPortTest.test_all_test_configurations_architectures):
    * Tools/Scripts/webkitpy/port/wpe.py:
    (WPEPort.check_sys_deps):
    (WPEPort._generate_all_test_configurations): Deleted.
    * Tools/Scripts/webkitpy/port/wpe_unittest.py:
    (WPEPortTest.test_architecture_default):
    (WPEPortTest):
    (WPEPortTest.test_architecture_cli_override):
    (WPEPortTest.test_architecture_aarch64_normalization):
    (WPEPortTest.test_architecture_cli_override_aarch64):
    (WPEPortTest.test_all_test_configurations_architectures):

    Canonical link: <a href="https://commits.webkit.org/308721@main">https://commits.webkit.org/308721@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.794@webkitglib/2.52">https://commits.webkit.org/305877.794@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9309302557c960412c65a6da7aa576268548d983
<pre>
Cherry-pick 306101@main (6a1eadfc3e3e). <a href="https://bugs.webkit.org/show_bug.cgi?id=214511">https://bugs.webkit.org/show_bug.cgi?id=214511</a>

    [GTK][resultsdb] Remove version_name from the uploaded results
    <a href="https://bugs.webkit.org/show_bug.cgi?id=214511">https://bugs.webkit.org/show_bug.cgi?id=214511</a>

    Reviewed by Carlos Alberto Lopez Perez.

    305707@main changed WPE and GTK to use the project version as the result
    upload version instead of the kernel version, resulting in more stable
    versioning.

    Meanwhile, GTK still uses the display server name as the version_name.
    This causes the frontend code to group different configurations with
    different versions together in a single timeline, also dropping the
    platform name and version, as it&apos;s implied from the version_name. Thus
    for GTK we had rows with the cryptic title `Xvfb wk2 Debug...`.

    On top of that, we have bugs like bug306091, where markers are not
    rendered when configurations are grouped out of order. As the default
    GTK timelines were grouped by version_name, it was more prone to be
    affected by this problem than WPE.

    This commit ensures we send an empty version_name field for both WPE and
    GTK, aligning their behavior.

    In fact, if we need the display server name in the future, we can add it
    back as a different flavor.

    Note that with the current resultsdbpy frontend code, this will create a
    new result series for GTK on front page (i.e. decoupled from the
    &apos;Xvfb&apos; group). But over time, the old configurations will be archived
    out of the front page. And for long term history of GTK/WPE, we can use
    tools like webkit-testhunter.

    * Tools/Scripts/webkitpy/port/gtk.py:
    (GtkPort.configuration_for_upload):
    * Tools/Scripts/webkitpy/port/gtk_unittest.py:
    (GtkPortTest.test_default_upload_configuration):
    * Tools/Scripts/webkitpy/port/wpe.py:
    (WPEPort.configuration_for_upload):
    * Tools/Scripts/webkitpy/port/wpe_unittest.py:
    (WPEPortTest.test_default_upload_configuration):

    Canonical link: <a href="https://commits.webkit.org/306101@main">https://commits.webkit.org/306101@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.793@webkitglib/2.52">https://commits.webkit.org/305877.793@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b871e5b784a5ed3551a9b7887835eec37c91e42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170233 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44156 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179606 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127945 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172099 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45400 "Build is in progress. Recent messages:") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43788 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132721 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127945 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173192 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/45400 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113222 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169554 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/45400 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/43788 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28291 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/45400 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182192 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/43788 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141162 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/43813 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140986 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/44502 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108913 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25955 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/44502 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/43012 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/37573 "The change is no longer eligible for processing.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42404 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/42658 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42547 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->