### PR TITLE
[ews] Failures when querying results-db can cause false positives to be reported

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -76,13 +76,13 @@ class ResultsDatabase(object):
 
         if not response:
             logger(f'No response from {cls.HOSTNAME}\n')
-        elif response.status_code == 200:
+            defer.returnValue(None)
+            return
+        if response.status_code == 200:
             defer.returnValue(response.json())
             return
-        else:
-            logger(f'Failed to query results summary with status code {response.status_code}\n')
-
-        defer.returnValue({})
+        logger(f'Failed to query results summary with status code {response.status_code}\n')
+        defer.returnValue(None)
 
     @classmethod
     @defer.inlineCallbacks
@@ -105,6 +105,8 @@ class ResultsDatabase(object):
     def is_test_pre_existing_failure(cls, test, commit=None, configuration=None, suite=None):
         logs = []
         data = yield cls.get_results_summary(test, commit, configuration, logger=lambda log: logs.append(log), suite=suite)
+        request_failed = data is None
+        data = data or {}
         pass_rate = data.get('pass', 100) + data.get('warning', 0)
         is_existing_failure = (pass_rate <= cls.PERCENT_SUCCESS_RATE_FOR_PRE_EXISTING_FAILURE)
         output = {
@@ -112,6 +114,7 @@ class ResultsDatabase(object):
             'pass_rate': data.get('pass', 'Unknown'),
             'raw_data': data,
             'logs': ''.join(logs),
+            'request_failed': request_failed,
         }
         defer.returnValue(output)
 
@@ -120,6 +123,9 @@ class ResultsDatabase(object):
     def does_result_match(cls, test, result_type=None, commit=None, configuration=None, suite=None, default=None):
         logs = []
         data = yield cls.get_results(suite, test, commit, configuration, logger=lambda log: logs.append(log))
+        if data is None:
+            defer.returnValue(None)
+            return
         if not data:
             if not default:
                 defer.returnValue(None)

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -11376,5 +11376,63 @@ class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
         self.assertEqual(step.schedulerNames, ['scheduler1', 'scheduler2'])
 
 
+class TestResultsDatabaseFailureHandling(unittest.TestCase):
+    def _mock_twisted_request(self, response):
+        return patch('ews-build.results_db.TwistedAdditions.request', lambda *args, **kwargs: defer.succeed(response))
+
+    def _ok_response(self, payload):
+        return TwistedAdditions.Response(status_code=200, content=json.dumps(payload).encode('utf-8'))
+
+    @defer.inlineCallbacks
+    def test_make_request_returns_none_on_no_response(self):
+        with self._mock_twisted_request(None):
+            result = yield ResultsDatabase.make_request('results-summary', suite='layout-tests', test='foo')
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_make_request_returns_none_on_non_200(self):
+        with self._mock_twisted_request(TwistedAdditions.Response(status_code=500)):
+            result = yield ResultsDatabase.make_request('results-summary', suite='layout-tests', test='foo')
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_make_request_returns_payload_on_success(self):
+        with self._mock_twisted_request(self._ok_response({'pass': 95})):
+            result = yield ResultsDatabase.make_request('results-summary', suite='layout-tests', test='foo')
+        self.assertEqual(result, {'pass': 95})
+
+    @defer.inlineCallbacks
+    def test_does_result_match_returns_none_on_request_failure_even_with_default(self):
+        with self._mock_twisted_request(None):
+            result = yield ResultsDatabase.does_result_match(
+                'JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp/NoDeleteChecker',
+                result_type='FAIL', suite='safer-cpp-checks', default='PASS',
+            )
+        self.assertIsNone(result)
+
+    @defer.inlineCallbacks
+    def test_does_result_match_uses_default_on_empty_success(self):
+        with self._mock_twisted_request(self._ok_response([])):
+            result = yield ResultsDatabase.does_result_match(
+                'foo.cpp/Checker', result_type='FAIL', suite='safer-cpp-checks', default='PASS',
+            )
+        self.assertIsNotNone(result)
+        self.assertFalse(result['does_result_match'])
+
+    @defer.inlineCallbacks
+    def test_is_test_pre_existing_failure_flags_request_failure(self):
+        with self._mock_twisted_request(None):
+            result = yield ResultsDatabase.is_test_pre_existing_failure('layout/test.html', suite='layout-tests')
+        self.assertTrue(result['request_failed'])
+        self.assertFalse(result['is_existing_failure'])
+
+    @defer.inlineCallbacks
+    def test_is_test_pre_existing_failure_on_success(self):
+        with self._mock_twisted_request(self._ok_response({'pass': 10, 'warning': 0})):
+            result = yield ResultsDatabase.is_test_pre_existing_failure('layout/test.html', suite='layout-tests')
+        self.assertFalse(result['request_failed'])
+        self.assertTrue(result['is_existing_failure'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -284,14 +284,12 @@ class TwistedAdditions(object):
 
             body = cls.JSONProducer(json) if json else None
             response_d = agent.request(typ, url.encode('utf-8'), Headers(headers), body)
-            response_d.addTimeout(timeout, reactor, onTimeoutCancel=lambda _1, _2: None)
+            response_d.addTimeout(timeout, reactor)
             response = yield response_d
             finished = defer.Deferred()
             response.deliverBody(cls.Printer(finished))
 
-            # Add timeout to response body delivery to prevent indefinite hanging
-            # This covers the entire response phase, not just connection establishment
-            finished.addTimeout(timeout, reactor, onTimeoutCancel=lambda _1, _2: None)
+            finished.addTimeout(timeout, reactor)
             data = yield finished
 
             headers = {}


### PR DESCRIPTION
#### 6db6903f7c0e7685fb65b6cfa8537c27e32c48db
<pre>
[ews] Failures when querying results-db can cause false positives to be reported
<a href="https://bugs.webkit.org/show_bug.cgi?id=317856">https://bugs.webkit.org/show_bug.cgi?id=317856</a>
<a href="https://rdar.apple.com/180634688">rdar://180634688</a>

Reviewed by Jonathan Bedard and Aakash Jain.

When TwistedAdditions.request hit the response-header timeout added in 309004@main, the
swallowing onTimeoutCancel callback left the deferred fulfilled with None. The next line
then called response.deliverBody on None and the catch-all `except Exception` logged the
misleading &quot;&apos;NoneType&apos; object has no attribute &apos;deliverBody&apos;&quot; message instead of the
existing defer.TimeoutError handler running. The same pattern was in place on the
body-delivery timeout.

Downstream, ResultsDatabase.make_request collapsed both &quot;request failed&quot; and &quot;successful
empty response&quot; to `{}`. For the SaferCPP path, that resulted in a normal-looking dict with
does_result_match=False on network failures, and FindUnexpectedStaticAnalyzerResults.check_results_db
then attributed the failing files to the PR author. The protective &quot;fall back to tip-of-tree&quot;
branch in filter_results_using_results_db (which runs ScanBuildWithoutChange) was unreachable
because the returned dict was truthy.

* Tools/CISupport/ews-build/twisted_additions.py:
(TwistedAdditions.request): Drop the swallowing onTimeoutCancel callbacks so addTimeout
default-translates the cancel into a defer.TimeoutError that the existing handler logs cleanly.
* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.make_request): Return None on infrastructure failure (no response or non-200)
and preserve the response payload on 200.
(ResultsDatabase.does_result_match): When the request failed, return None even if a `default`
is provided. This triggers the existing `if not data:` fallback in check_results_db, which
routes to the rebuild-without-change verification step instead of blaming the PR.
(ResultsDatabase.is_test_pre_existing_failure): Guard against None data and expose a
request_failed flag in the output dict for future call sites.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestResultsDatabaseFailureHandling): Cover make_request, does_result_match, and
is_test_pre_existing_failure behavior on both infrastructure failure and successful empty
responses.

Canonical link: <a href="https://commits.webkit.org/315901@main">https://commits.webkit.org/315901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f74fcd78fc5aad757eaec61ee98afba06ed6fbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170430 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128146 "Build is in progress. Recent messages:") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/172296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45598 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43986 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/179805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/128146 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173389 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/45598 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/45598 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/28488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/45598 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/169831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/44010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44699 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25976 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/36437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43209 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42855 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/42748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->