### PR TITLE
[GStreamer] Chroma site validation failing for DMABuf caps

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -39,8 +39,6 @@
 #include "VideoSinkGStreamer.h"
 #include "WebKitAudioSinkGStreamer.h"
 #include <fnmatch.h>
-#include <gst/audio/audio-info.h>
-#include <gst/gst.h>
 #include <mutex>
 #include <wtf/FileSystem.h>
 #include <wtf/HashMap.h>
@@ -150,11 +148,20 @@ bool getVideoSizeAndFormatFromCaps(const GstCaps* caps, WebCore::IntSize& size, 
         return false;
     }
 
+    GstVideoInfo info;
+    gst_video_info_init(&info);
+
+#if GST_CHECK_VERSION(1, 24, 0)
+    if (gst_video_is_dma_drm_caps(caps)) {
+        GstVideoInfoDmaDrm drmVideoInfo;
+        if (!gst_video_info_dma_drm_from_caps(&drmVideoInfo, caps) || !gst_video_info_dma_drm_to_video_info(&drmVideoInfo, &info))
+            return false;
+    }
+#endif
+
     GstStructure* structure = gst_caps_get_structure(caps, 0);
     if (!areEncryptedCaps(caps) && (!gst_structure_has_name(structure, "video/x-raw") || gst_structure_has_field(structure, "format"))) {
-        GstVideoInfo info;
-        gst_video_info_init(&info);
-        if (!gst_video_info_from_caps(&info, caps))
+        if (!GST_VIDEO_INFO_WIDTH(&info) && !gst_video_info_from_caps(&info, caps))
             return false;
 
         if (GST_VIDEO_INFO_FPS_N(&info))
@@ -209,11 +216,19 @@ std::optional<FloatSize> getVideoResolutionFromCaps(const GstCaps* caps)
     int width = 0, height = 0;
     int pixelAspectRatioNumerator = 1, pixelAspectRatioDenominator = 1;
 
+    GstVideoInfo info;
+    gst_video_info_init(&info);
+
+#if GST_CHECK_VERSION(1, 24, 0)
+    if (gst_video_is_dma_drm_caps(caps)) {
+        GstVideoInfoDmaDrm drmVideoInfo;
+        if (!gst_video_info_dma_drm_from_caps(&drmVideoInfo, caps) || !gst_video_info_dma_drm_to_video_info(&drmVideoInfo, &info))
+            return std::nullopt;
+    }
+#endif
     GstStructure* structure = gst_caps_get_structure(caps, 0);
     if (!areEncryptedCaps(caps) && (gst_structure_has_name(structure, "video/x-raw") || gst_structure_has_field(structure, "format"))) {
-        GstVideoInfo info;
-        gst_video_info_init(&info);
-        if (!gst_video_info_from_caps(&info, caps))
+        if (!GST_VIDEO_INFO_WIDTH(&info) && !gst_video_info_from_caps(&info, caps))
             return std::nullopt;
 
         width = GST_VIDEO_INFO_WIDTH(&info);
@@ -242,18 +257,24 @@ std::optional<FloatSize> getVideoResolutionFromCaps(const GstCaps* caps)
 
 bool getSampleVideoInfo(GstSample* sample, GstVideoInfo& videoInfo)
 {
-    if (!GST_IS_SAMPLE(sample))
+    if (!GST_IS_SAMPLE(sample)) [[unlikely]]
         return false;
 
     GstCaps* caps = gst_sample_get_caps(sample);
-    if (!caps)
+    if (!caps) [[unlikely]]
         return false;
+
+#if GST_CHECK_VERSION(1, 24, 0)
+    if (gst_video_is_dma_drm_caps(caps)) {
+        GstVideoInfoDmaDrm drmVideoInfo;
+        if (!gst_video_info_dma_drm_from_caps(&drmVideoInfo, caps))
+            return false;
+        return gst_video_info_dma_drm_to_video_info(&drmVideoInfo, &videoInfo);
+    }
+#endif
 
     gst_video_info_init(&videoInfo);
-    if (!gst_video_info_from_caps(&videoInfo, caps))
-        return false;
-
-    return true;
+    return gst_video_info_from_caps(&videoInfo, caps);
 }
 
 std::optional<WebCore::IntSize> getDisplaySize(WebCore::IntSize originalSize, int pixelAspectRatioNumerator, int pixelAspectRatioDenominator)
@@ -839,7 +860,7 @@ GstMappedFrame::GstMappedFrame(GstMappedFrame&& other)
 GstMappedFrame::GstMappedFrame(const GRefPtr<GstSample>& sample, GstMapFlags flags)
 {
     GstVideoInfo info;
-    if (!gst_video_info_from_caps(&info, gst_sample_get_caps(sample.get())))
+    if (!getSampleVideoInfo(sample.get(), info))
         return;
 
     if (!gst_video_frame_map(&m_frame, &info, gst_sample_get_buffer(sample.get()), flags))
@@ -1629,6 +1650,18 @@ GstClockTime webkitGstInitTime()
 
 PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps* caps)
 {
+#if GST_CHECK_VERSION(1, 24, 0)
+    if (gst_video_is_dma_drm_caps(caps)) {
+        GstVideoInfoDmaDrm drmInfo;
+        if (!gst_video_info_dma_drm_from_caps(&drmInfo, caps))
+            return { };
+
+        GstVideoInfo info;
+        if (!gst_video_info_dma_drm_to_video_info(&drmInfo, &info))
+            return { };
+        return videoColorSpaceFromInfo(info);
+    }
+#endif
     GstVideoInfo info;
     if (!gst_video_info_from_caps(&info, caps))
         return { };

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -114,27 +114,33 @@ static std::optional<uint32_t> videoFormatToDRMFourcc(GstVideoFormat format)
 VideoFrameGStreamer::Info VideoFrameGStreamer::infoFromCaps(const GRefPtr<GstCaps>& caps)
 {
     GstVideoInfo videoInfo;
-    gst_video_info_from_caps(&videoInfo, caps.get());
 
-    std::optional<DMABufFormat> dmabufFormat;
 #if USE(GBM)
+    std::optional<DMABufFormat> dmabufFormat;
 #if GST_CHECK_VERSION(1, 24, 0)
     if (gst_video_is_dma_drm_caps(caps.get())) {
         GstVideoInfoDmaDrm drmVideoInfo;
-        if (!gst_video_info_dma_drm_from_caps(&drmVideoInfo, caps.get()))
+        if (!gst_video_info_dma_drm_from_caps(&drmVideoInfo, caps.get())) {
+            gst_video_info_from_caps(&videoInfo, caps.get());
             return { videoInfo, std::nullopt };
-
-        if (!gst_video_info_dma_drm_to_video_info(&drmVideoInfo, &videoInfo))
+        }
+        if (!gst_video_info_dma_drm_to_video_info(&drmVideoInfo, &videoInfo)) {
+            gst_video_info_from_caps(&videoInfo, caps.get());
             return { videoInfo, std::nullopt };
-
+        }
         dmabufFormat = { drmVideoInfo.drm_fourcc, drmVideoInfo.drm_modifier };
+        return { videoInfo, dmabufFormat };
     }
 #else
+    gst_video_info_from_caps(&videoInfo, caps.get());
     if (auto fourccFromFormat = videoFormatToDRMFourcc(GST_VIDEO_INFO_FORMAT(&videoInfo)))
         dmabufFormat = { *fourccFromFormat, DRM_FORMAT_MOD_INVALID };
+    return { videoInfo, dmabufFormat };
 #endif // GST_CHECK_VERSION(1, 24, 0)
 #endif // USE(GBM)
-    return { videoInfo, dmabufFormat };
+
+    gst_video_info_from_caps(&videoInfo, caps.get());
+    return { videoInfo, { } };
 }
 
 RefPtr<VideoFrame> VideoFrame::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuffer, PlatformVideoColorSpace&& colorSpace)


### PR DESCRIPTION
#### 97ff7579360cff11f3e08931d8c06f22a3d877d4
<pre>
[GStreamer] Chroma site validation failing for DMABuf caps
<a href="https://bugs.webkit.org/show_bug.cgi?id=317866">https://bugs.webkit.org/show_bug.cgi?id=317866</a>

Reviewed by Xabier Rodriguez-Calvar.

Build GstVideoInfoDmaDrm for DRM caps and translate them to traditional GstVideoInfo when needed in
order to avoid colorspace chroma-site validation issues.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getVideoSizeAndFormatFromCaps):
(WebCore::getVideoResolutionFromCaps):
(WebCore::getSampleVideoInfo):
(WebCore::GstMappedFrame::GstMappedFrame):
(WebCore::videoColorSpaceFromCaps):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::infoFromCaps):

Canonical link: <a href="https://commits.webkit.org/316011@main">https://commits.webkit.org/316011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1022cdde8db6869207b5750b0b7ac7516e4e6ef7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132843 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93647 "13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32982 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28430 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182332 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141295 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43952 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38090 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29656 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109088 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36380 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116523 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43151 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7759 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42557 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->