### PR TITLE
[Cleanup] Stray references to preferred widths in LFC code

### DIFF
--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.cpp
@@ -569,7 +569,7 @@ IntrinsicWidthConstraints BlockFormattingContext::computedIntrinsicWidthConstrai
             // <div></div>
             // <div style="float: left; width: 40px;"></div>
             // ...will produce a max width of 40px which makes the floats vertically stacked.
-            // Vertically stacked floats makes me think we haven't managed to provide the maximum preferred width for the content.
+            // Vertically stacked floats makes me think we haven't managed to provide the maximum width contribution for the content.
             maximumHorizontalStackingWidth = std::max(currentHorizontalStackingWidth, maximumHorizontalStackingWidth);
             currentHorizontalStackingWidth = { };
             // Already has computed intrinsic constraints.

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -412,13 +412,13 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
 LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
 {
     UNUSED_PARAM(blockAxisConstraint);
-    return integrationUtils.preferredMinWidth(gridItem.layoutBox());
+    return integrationUtils.minContentLogicalWidthContribution(gridItem.layoutBox());
 }
 
 LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
 {
     UNUSED_PARAM(blockAxisConstraint);
-    return integrationUtils.preferredMaxWidth(gridItem.layoutBox());
+    return integrationUtils.maxContentLogicalWidthContribution(gridItem.layoutBox());
 }
 
 GridItemSizingFunctions inlineAxisGridItemSizingFunctions(const IntegrationUtils& integrationUtils)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -472,7 +472,7 @@ void LineBuilder::initialize(const InlineRect& initialLineLogicalRect, const Inl
     // This is by how much intrusive floats (coming from parent/sibling FCs) initially offset the line.
     m_initialIntrusiveFloatsWidth = m_lineLogicalRect.left() - initialLineLogicalRect.left();
     m_lineLogicalRect.moveHorizontally(m_lineMarginStart);
-    // While negative margins normally don't expand the available space, preferred width computation gets confused by negative text-indent
+    // While negative margins normally don't expand the available space, intrinsic width contribution computation gets confused by negative text-indent
     // (shrink the space needed for the content) which we have to balance it here.
     m_lineLogicalRect.expandHorizontally(-m_lineMarginStart);
     m_lineContentEdgeOffset = m_lineLogicalRect.left() - initialLineLogicalRect.left();
@@ -1172,7 +1172,7 @@ void LineBuilder::candidateContentForLine(LineCandidate& lineCandidate, std::pai
 static inline InlineLayoutUnit NODELETE availableWidth(const Line& line, InlineLayoutUnit lineWidth, std::optional<IntrinsicWidthMode> intrinsicWidthMode)
 {
 #if USE_FLOAT_AS_INLINE_LAYOUT_UNIT
-    // 1. Preferred width computation sums up floats while line breaker subtracts them.
+    // 1. Intrinsic width contribution computation sums up floats while line breaker subtracts them.
     // 2. Available space is inherently a LayoutUnit based value (coming from block/flex etc layout) and it is the result of a floored float.
     // These can all lead to epsilon-scale differences.
     if (!intrinsicWidthMode || *intrinsicWidthMode == IntrinsicWidthMode::Maximum)

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -682,8 +682,8 @@ void BoxGeometryUpdater::updateLayoutBoxDimensions(const RenderBox& renderBox, s
     if (intrinsicWidthMode) {
         boxGeometry.setHorizontalSpaceForScrollbar(scrollbarSize.width());
         auto contentBoxLogicalWidth = [&] {
-            auto preferredWidth = *intrinsicWidthMode == Layout::IntrinsicWidthMode::Minimum ? renderBox.minContentLogicalWidthContribution() : renderBox.maxContentLogicalWidthContribution();
-            return preferredWidth - (border.horizontal.start + border.horizontal.end + padding.horizontal.start + padding.horizontal.end);
+            auto widthContribution = *intrinsicWidthMode == Layout::IntrinsicWidthMode::Minimum ? renderBox.minContentLogicalWidthContribution() : renderBox.maxContentLogicalWidthContribution();
+            return widthContribution - (border.horizontal.start + border.horizontal.end + padding.horizontal.start + padding.horizontal.end);
         };
         boxGeometry.setContentBoxWidth(contentBoxLogicalWidth());
         boxGeometry.setHorizontalMargin(inlineMargin);

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -218,9 +218,9 @@ LayoutUnit formattingContextRootLogicalWidthForType(const Layout::ElementBox& bo
 
     CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
     switch (logicalWidthType) {
-    case LogicalWidthType::PreferredMaximum:
+    case LogicalWidthType::MaxContentContribution:
         return renderer->maxContentLogicalWidthContribution();
-    case LogicalWidthType::PreferredMinimum:
+    case LogicalWidthType::MinContentContribution:
         return renderer->minContentLogicalWidthContribution();
     case LogicalWidthType::MaxContent:
     case LogicalWidthType::MinContent: {

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
@@ -43,8 +43,8 @@ namespace LayoutIntegration {
 void layoutWithFormattingContextForBox(const Layout::ElementBox&, std::optional<LayoutUnit> widthConstraint, std::optional<LayoutUnit> heightConstraint, Layout::LayoutState&);
 
 enum class LogicalWidthType : uint8_t  {
-    PreferredMaximum,
-    PreferredMinimum,
+    MaxContentContribution,
+    MinContentContribution,
     MaxContent,
     MinContent
 };

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -69,17 +69,17 @@ LayoutUnit IntegrationUtils::minContentHeight(const ElementBox& box, LayoutUnit 
     return m_globalLayoutState->geometryForBox(box).borderBoxHeight();
 }
 
-LayoutUnit IntegrationUtils::preferredMinWidth(const ElementBox& box) const
+LayoutUnit IntegrationUtils::minContentLogicalWidthContribution(const ElementBox& box) const
 {
     ASSERT(box.isGridItem());
-    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::PreferredMinimum);
+    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MinContentContribution);
 }
 
 
-LayoutUnit IntegrationUtils::preferredMaxWidth(const ElementBox& box) const
+LayoutUnit IntegrationUtils::maxContentLogicalWidthContribution(const ElementBox& box) const
 {
     ASSERT(box.isGridItem());
-    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::PreferredMaximum);
+    return m_globalLayoutState->logicalWidthWithFormattingContextForBox(box, LayoutIntegration::LogicalWidthType::MaxContentContribution);
 }
 
 void IntegrationUtils::layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState& inlineLayoutState) const

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -49,8 +49,8 @@ public:
     LayoutUnit minContentWidth(const ElementBox&) const;
     LayoutUnit minContentHeight(const ElementBox&) const;
     LayoutUnit minContentHeight(const ElementBox&, LayoutUnit inlineConstraint) const;
-    LayoutUnit preferredMinWidth(const ElementBox&) const;
-    LayoutUnit preferredMaxWidth(const ElementBox&) const;
+    LayoutUnit minContentLogicalWidthContribution(const ElementBox&) const;
+    LayoutUnit maxContentLogicalWidthContribution(const ElementBox&) const;
     void layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState&) const;
 
     static BlockLayoutState::MarginState NODELETE toMarginState(const RenderBlockFlow::MarginInfo&);


### PR DESCRIPTION
#### f18d94d48d0d726f6f79a95f6273271fdd84654e
<pre>
[Cleanup] Stray references to preferred widths in LFC code
<a href="https://bugs.webkit.org/show_bug.cgi?id=317868">https://bugs.webkit.org/show_bug.cgi?id=317868</a>
<a href="https://rdar.apple.com/180651355">rdar://180651355</a>

Reviewed by Alan Baradlay.

The modern layout (LFC) code still referred to a box&apos;s min/max-content
contribution as its &quot;preferred&quot; width, even though it computes exactly that
contribution (per css-sizing-3 §4.3). Bring it in line with the rendering-side
cleanup (314036@main, bug 315891):

- LogicalWidthType::Preferred{Maximum,Minimum} -&gt; {Max,Min}ContentContribution.
  Max/MinContent stays as-is — those are the content *size*
  (computeIntrinsicLogicalWidths), not the contribution.
- IntegrationUtils::preferred{Min,Max}Width -&gt;
  {min,max}ContentLogicalWidthContribution, matching the
  RenderBox::{min,max}ContentLogicalWidthContribution they forward to, plus
  the grid callers in GridLayoutUtils.
- Reword the comments in block/inline formatting contexts describing the
  intrinsic width contribution computation.

The CSS 2.2 table-layout / shrink-to-fit / aspect-ratio &quot;preferred&quot; spec terms
are intentionally left unchanged.

No behavior change.

Canonical link: <a href="https://commits.webkit.org/315845@main">https://commits.webkit.org/315845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e018d0d3c63e344d4d5269fc5f3ce4417611378

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179631 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/133c7e8b-c92b-474f-989d-2a8c6210cdc3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172124 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45425 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43813 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9c23773-2024-4f39-b60e-504f7534232c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173217 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113242 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92aaaf3f-a543-44d5-a158-48c70399ea9c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28316 "Built successfully") | | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/JSC-Tests-x86-64-EWS "Waiting to run tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182217 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35007 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141187 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43838 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141010 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37963 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44527 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108940 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36279 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116409 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43037 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7650 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42443 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->