### PR TITLE
[EWS] Moving Sequoia builders to iOS wpt queue to add extra bot resources

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -63,7 +63,7 @@
     { "name": "ews100", "platform": "mac-sequoia" },
     { "name": "ews101", "platform": "mac-sequoia" },
     { "name": "ews102", "platform": "mac-sequoia" },
-    { "name": "ews103", "platform": "mac-sequoia" },
+    { "name": "ews103", "platform": "ios-simulator-26" },
     { "name": "ews104", "platform": "mac-sequoia" },
     { "name": "ews105", "platform": "mac-sequoia" },
     { "name": "ews106", "platform": "mac-sequoia" },
@@ -76,11 +76,11 @@
     { "name": "ews113", "platform": "mac-sequoia" },
     { "name": "ews114", "platform": "mac-tahoe" },
     { "name": "ews115", "platform": "mac-sequoia" },
-    { "name": "ews116", "platform": "mac-sequoia" },
-    { "name": "ews117", "platform": "mac-sequoia" },
+    { "name": "ews116", "platform": "ios-simulator-26" },
+    { "name": "ews117", "platform": "ios-simulator-26" },
     { "name": "ews118", "platform": "mac-sequoia" },
     { "name": "ews119", "platform": "mac-sequoia" },
-    { "name": "ews120", "platform": "mac-sequoia" },
+    { "name": "ews120", "platform": "ios-simulator-26" },
     { "name": "ews129", "platform": "mac-sequoia" },
     { "name": "ews169", "platform": "mac-sequoia" },
     { "name": "ews121", "platform": "ios-simulator-26" },
@@ -106,7 +106,7 @@
     { "name": "ews142", "platform": "mac-sequoia" },
     { "name": "ews143", "platform": "mac-sequoia" },
     { "name": "ews144", "platform": "mac-sequoia" },
-    { "name": "ews145", "platform": "mac-sequoia" },
+    { "name": "ews145", "platform": "ios-simulator-26" },
     { "name": "ews146", "platform": "mac-sequoia" },
     { "name": "ews147", "platform": "mac-sequoia" },
     { "name": "ews148", "platform": "mac-sequoia" },
@@ -123,7 +123,7 @@
     { "name": "ews159", "platform": "*" },
     { "name": "ews160", "platform": "*" },
     { "name": "ews161", "platform": "mac-sequoia" },
-    { "name": "ews162", "platform": "mac-sequoia" },
+    { "name": "ews162", "platform": "ios-simulator-26" },
     { "name": "ews163", "platform": "*" },
     { "name": "ews164", "platform": "*" },
     { "name": "ews165", "platform": "*" },
@@ -317,7 +317,7 @@
       "configuration": "release",
       "triggered_by": ["ios-26-sim-build-ews"],
       "additionalArguments": ["--child-processes=4", "imported/w3c/web-platform-tests"],
-      "workernames": ["ews191", "ews192", "ews193", "ews194", "ews195", "ews196", "ews197", "ews198"]
+      "workernames": ["ews191", "ews192", "ews193", "ews194", "ews195", "ews196", "ews197", "ews198", "ews162", "ews145", "ews120", "ews103", "ews117", "ews116"]
     },
     {
       "name": "macOS-Tahoe-Debug-Build-EWS", "shortname": "mac-AS-debug", "icon": "buildOnly",
@@ -348,7 +348,7 @@
       "deployment_target": "15.4",
       "rebuild_without_change_on_builder": true,
       "triggers": ["api-tests-mac-ews", "macos-sequoia-release-wk2-tests-ews", "macos-sequoia-release-wk2-intel-tests-ews", "macos-release-wk2-stress-tests-ews", "macos-sequoia-release-site-isolation-tests-ews", "jsc-tests-x86-64-ews"],
-      "workernames": ["ews101", "ews102", "ews103", "ews105", "ews116", "ews117", "ews118", "ews119", "ews120", "ews141", "ews145", "ews147", "ews148", "ews161", "ews162"]
+      "workernames": ["ews101", "ews102", "ews105", "ews118", "ews119", "ews141", "ews147", "ews148", "ews161"]
     },
     {
       "name": "macOS-Sequoia-Release-WK2-Tests-EWS", "shortname": "mac-wk2", "icon": "testOnly",


### PR DESCRIPTION
#### 4b4b5e7c36b7a99504cdbf5fbe3590231dac6ea0
<pre>
[EWS] Moving Sequoia builders to iOS wpt queue to add extra bot resources
<a href="https://rdar.apple.com/180652415">rdar://180652415</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317869">https://bugs.webkit.org/show_bug.cgi?id=317869</a>

Reviewed by Ryan Haddad.

Due to the large backlog in iOS queues it needs additional bots to speed up the test requests.

* Tools/CISupport/ews-build/config.json:

Canonical link: <a href="https://commits.webkit.org/315839@main">https://commits.webkit.org/315839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bff8787cab7676778ec0cfbc4c5df51dbae6b737

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170260 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44183 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43815 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/179633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173219 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/179633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28318 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182219 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/169660 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43840 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/141011 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44529 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108944 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25957 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/36280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43039 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42444 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42685 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->