### PR TITLE
[CMake][Mac] Unreviewed build fix after 315816@main, 315823@main and 315833@main

### DIFF
--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -249,6 +249,7 @@ if (SWIFT_REQUIRED)
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level spi>"
         "$<$<COMPILE_LANGUAGE:Swift>:-no-verify-emitted-module-interface>"
         "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-access-control>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -clang-header-expose-decls=has-expose-attr-or-stdlib>"
     )
 
     if (APPLE)
@@ -258,7 +259,7 @@ if (SWIFT_REQUIRED)
         set(WebGPU_SWIFT_EXPLICIT_MODULE_BUILD TRUE)
     endif ()
 
-    set(WebGPU_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS public)
+    set(WebGPU_SWIFT_EMIT_CLANG_HEADER_MIN_ACCESS internal)
 
     # FIXME(rdar://177840132): swiftc -emit-dependencies records imported
     # clang modulemaps, but sometimes skips individual C++ headers.

--- a/Source/WebKitLegacy/CMakeLists.txt
+++ b/Source/WebKitLegacy/CMakeLists.txt
@@ -45,8 +45,10 @@ WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 WEBKIT_FRAMEWORK(WebKitLegacy)
 set_target_properties(WebKitLegacy PROPERTIES LINKER_LANGUAGE CXX)
 
+# No PRUNE_STALE: on Mac this destination is co-owned by PlatformMac.cmake's
+# file(WRITE) forwarding-header loop, and WebKitLegacy_PUBLIC_FRAMEWORK_HEADERS
+# is empty there, so pruning wipes the entire staged header set.
 WEBKIT_COPY_FILES(WebKitLegacy_CopyHeaders
-    PRUNE_STALE
     DESTINATION ${WebKitLegacy_FRAMEWORK_HEADERS_DIR}/WebKitLegacy
     FILES ${WebKitLegacy_PUBLIC_FRAMEWORK_HEADERS}
     FLATTENED

--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -193,6 +193,7 @@ list(APPEND TestIPC_SOURCES
     Tests/IPC/TransferStringObjCTests.mm
 
     ${_ipc_core_sources}
+    ${WEBKIT_DIR}/Platform/EditingRangeClamping.cpp
     ${WEBKIT_DIR}/Platform/Logging.cpp
     ${WEBKIT_DIR}/Platform/mac/MachUtilities.cpp
     ${WebKit_DERIVED_SOURCES_DIR}/MessageNames.cpp


### PR DESCRIPTION
#### 53297d97056f4fe7e05f5c3bccf744da567fb530
<pre>
[CMake][Mac] Unreviewed build fix after 315816@main, 315823@main and 315833@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=317870">https://bugs.webkit.org/show_bug.cgi?id=317870</a>

Unreviewed build fix.

315833@main (7581588fd861) made WebGPU&apos;s Swift interop functions internal +
@_expose(Cxx) and added -emit-clang-header-min-access internal /
-clang-header-expose-decls=has-expose-attr-or-stdlib to WebGPU.xcconfig only.
The CMake build still requested min-access public and lacked the expose-decls
flag, so WebGPUSwift-Generated.h came out empty and Buffer.mm / Queue.mm /
CommandEncoder.mm failed with undeclared identifiers.

315823@main (adf29ea7ecf4) added PRUNE_STALE to WebKitLegacy_CopyHeaders. On
macOS WebKitLegacy_PUBLIC_FRAMEWORK_HEADERS is empty and the destination is
populated by PlatformMac.cmake&apos;s file(WRITE) forwarding-header loop, so the
prune step deleted every staged WebKitLegacy header at configure time, breaking
all &lt;WebKit/DOM.h&gt;, &lt;WebKit/WebFeature.h&gt;, &lt;WebKitLegacy/WebArchive.h&gt; etc.
includes.

315816@main (d0b94cb5b4a4) moved EditingRange::clampedFirstLineRange into
Platform/EditingRangeClamping.cpp so it lands in libWebKitPlatform.a for
Xcode&apos;s TestIPC. The CMake TestIPC target compiles a hand-picked source list
instead, which was missing the new file and failed to link.

* Source/WebGPU/WebGPU/CMakeLists.txt:
* Source/WebKitLegacy/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/315847@main">https://commits.webkit.org/315847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d2ec82b47a0bb3a1e0b7080e56958a789b038c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44184 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179634 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f3a4a43-ef03-47d5-b39d-cb320d6b7813) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43816 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132742 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 10 flakes 2 failures; Uploaded test results; 1 flakes; Compiled WebKit (warnings); 1 flakes; Running analyze-layout-tests-results") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/211059fe-9fea-4711-96e8-9e672ce72601) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173220 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113243 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26048973-b151-4df6-bae2-7fd4a8303b05) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28319 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182220 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35010 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43841 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44530 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108945 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25961 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36281 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116412 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43040 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->