### PR TITLE
[Site Isolation] Replace FrameState payload in place instead of swapping the whole struct

### DIFF
--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -160,6 +160,42 @@ Ref<FrameState> FrameState::copy()
     ));
 }
 
+void FrameState::replacePayloadFrom(Ref<FrameState>&& other)
+{
+    // frameItemID and itemID are the position of this FrameState in the BF list tree
+    // owned by the surrounding WebBackForwardListFrameItem and are fixed at construction.
+    // children is the parallel data path of WebBackForwardListFrameItem::m_children and
+    // is maintained there. Neither is affected by a payload replacement.
+    urlString = WTF::move(other->urlString);
+    originalURLString = WTF::move(other->originalURLString);
+    referrer = WTF::move(other->referrer);
+    target = WTF::move(other->target);
+    frameID = other->frameID;
+    stateObjectData = WTF::move(other->stateObjectData);
+    documentSequenceNumber = other->documentSequenceNumber;
+    itemSequenceNumber = other->itemSequenceNumber;
+    navigationAPIKey = other->navigationAPIKey;
+    scrollPosition = other->scrollPosition;
+    shouldRestoreScrollPosition = other->shouldRestoreScrollPosition;
+    pageScaleFactor = other->pageScaleFactor;
+    httpBody = WTF::move(other->httpBody);
+    title = WTF::move(other->title);
+    shouldOpenExternalURLsPolicy = other->shouldOpenExternalURLsPolicy;
+    sessionStateObject = WTF::move(other->sessionStateObject);
+    wasCreatedByJSWithoutUserInteraction = other->wasCreatedByJSWithoutUserInteraction;
+    wasRestoredFromSession = other->wasRestoredFromSession;
+    policyContainer = WTF::move(other->policyContainer);
+#if PLATFORM(IOS_FAMILY)
+    exposedContentRect = other->exposedContentRect;
+    unobscuredContentRect = other->unobscuredContentRect;
+    minimumLayoutSizeInScrollViewCoordinates = other->minimumLayoutSizeInScrollViewCoordinates;
+    contentSize = other->contentSize;
+    scaleIsInitial = other->scaleIsInitial;
+    obscuredInsets = other->obscuredInsets;
+#endif
+    m_documentState = WTF::move(other->m_documentState);
+}
+
 bool FrameState::validateDocumentState(const Vector<AtomString>& documentState)
 {
     for (auto& stateString : documentState) {

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -83,6 +83,8 @@ public:
 
     Ref<FrameState> copy();
 
+    void replacePayloadFrom(Ref<FrameState>&& other);
+
     const Vector<AtomString>& documentState() const LIFETIME_BOUND { return m_documentState; }
     enum class ShouldValidate : bool { No, Yes };
     void setDocumentState(const Vector<AtomString>&, ShouldValidate = ShouldValidate::No);

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -139,10 +139,9 @@ void WebBackForwardListFrameItem::setWasRestoredFromSession()
         child->setWasRestoredFromSession();
 }
 
-void WebBackForwardListFrameItem::setFrameState(Ref<FrameState>&& frameState)
+void WebBackForwardListFrameItem::updateFrameStatePayload(Ref<FrameState>&& frameState)
 {
-    m_frameState = WTF::move(frameState);
-    m_frameState->children.clear();
+    m_frameState->replacePayloadFrom(WTF::move(frameState));
 }
 
 void WebBackForwardListFrameItem::updateFrameID(FrameIdentifier newFrameID)

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -44,7 +44,7 @@ public:
     static WebBackForwardListFrameItem* NODELETE itemForID(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
 
     FrameState& frameState() const { return m_frameState; }
-    void setFrameState(Ref<FrameState>&&);
+    void updateFrameStatePayload(Ref<FrameState>&&);
 
     Ref<FrameState> copyFrameState();
     Ref<FrameState> copyFrameStateWithChildren();

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -843,7 +843,7 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
         ASSERT(webPageProxy->identifier() == item->pageID() && frameState->itemID == item->identifier());
 
         auto oldFrameID = frameItem->frameID();
-        frameItem->setFrameState(WTF::move(frameState));
+        frameItem->updateFrameStatePayload(WTF::move(frameState));
         auto newFrameID = frameItem->frameID();
 
         if (oldFrameID && newFrameID && oldFrameID != newFrameID)
@@ -865,7 +865,7 @@ void WebBackForwardList::replaceFrameStateForChild(WebBackForwardListItem& item,
     if (!targetFrameItem)
         return;
 
-    targetFrameItem->setFrameState(WTF::move(newFrameState));
+    targetFrameItem->updateFrameStatePayload(WTF::move(newFrameState));
 }
 
 void WebBackForwardList::backForwardGoToItem(BackForwardItemIdentifier itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -1123,7 +1123,7 @@ final class WebBackForwardList {
         // We can't use == here due to rdar://162357139
         assert(contentsMatch(webPageProxy.identifier(), item.pageID()) && contentsMatch(itemID, item.identifier()))
         let oldFrameID = frameItem.frameID()
-        frameItem.setFrameState(consuming: frameState)
+        frameItem.updateFrameStatePayload(consuming: frameState)
         let newFrameID = frameItem.frameID()
         if let oldFrameID = Optional(fromCxx: oldFrameID) {
             if let newFrameID = Optional(fromCxx: newFrameID) {
@@ -1153,7 +1153,7 @@ final class WebBackForwardList {
             return
         }
 
-        targetFrameItem.setFrameState(consuming: newFrameState)
+        targetFrameItem.updateFrameStatePayload(consuming: newFrameState)
     }
 
     @used


### PR DESCRIPTION
#### 70105ea38f3a66d38594250c3d5016c29976ccc5
<pre>
[Site Isolation] Replace FrameState payload in place instead of swapping the whole struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=317857">https://bugs.webkit.org/show_bug.cgi?id=317857</a>
<a href="https://rdar.apple.com/180635604">rdar://180635604</a>

Reviewed by Sihui Liu.

WebBackForwardListFrameItem registers itself in the process-wide allItems()
map at construction under the key {m_frameState-&gt;frameItemID,
m_frameState-&gt;itemID}; the destructor reads the same key to assert
identity and remove the entry. The constructor overrides
m_frameState-&gt;itemID with the owning WebBackForwardListItem&apos;s identifier
(the UIProcess-authoritative value), so the registration key is stable
for the FrameItem&apos;s lifetime as long as those two FrameState fields are
not later mutated.

setFrameState was implemented as a wholesale replacement of m_frameState
with an incoming FrameState regenerated by the WebProcess from its own
HistoryItem. The WebProcess iframe HistoryItem carries process-local
identifiers, and its m_itemID does not necessarily match the
WebBackForwardListItem identifier of the UIProcess BF list entry that
owns this child FrameItem (the same iframe HistoryItem can be referenced
across multiple BF list entries with distinct itemIDs UIProcess-side).
Letting the wholesale replace through clobbered the registered identity;
the destructor&apos;s allItems() lookup then returned null or a different
pointer and the assertion at line 58 fired:

  ASSERTION FAILED: allItems().get({ *m_frameState-&gt;frameItemID, *m_frameState-&gt;itemID }) == this
  Source/WebKit/Shared/WebBackForwardListFrameItem.cpp(58) : WebKit::WebBackForwardListFrameItem::~WebBackForwardListFrameItem()

with the cascade rooted at WebBackForwardList::addItem forward-list
eviction.

Stop swapping the whole FrameState. Add FrameState::replacePayloadFrom,
which moves every payload field (URL, sequence numbers, scroll, title,
documentState, etc.) from the source onto the destination but leaves
frameItemID, itemID, and children alone — the identity fields are fixed
at construction by the surrounding WebBackForwardListFrameItem, and
children is maintained in parallel on WebBackForwardListFrameItem::m_children.
WebBackForwardListFrameItem::setFrameState is renamed to
updateFrameStatePayload to reflect the partial-update semantics and is a
one-liner that delegates to replacePayloadFrom. The children.clear()
that used to undo the wholesale swap is no longer needed.

Covered by existing site-isolation tests; the EWS macOS Debug flake at
http/tests/site-isolation/frame-index.html previously reported as this
assertion stops firing with this change.

* Source/WebKit/Shared/SessionState.h:
(WebKit::FrameState::replacePayloadFrom):
* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::replacePayloadFrom):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::updateFrameStatePayload):
(WebKit::WebBackForwardListFrameItem::setFrameState): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardUpdateItem):
(WebKit::WebBackForwardList::replaceFrameStateForChild):
* Source/WebKit/UIProcess/WebBackForwardList.swift:

Canonical link: <a href="https://commits.webkit.org/315858@main">https://commits.webkit.org/315858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61b994edaefa695dd450e71f7386d611e80a6974

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128009 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1539c2d6-be07-4c7b-99ad-b0fa5c492a72) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43852 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ece43a3f-1016-408a-b0bf-e1a7348163c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113280 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3b222ae-e4fb-483f-bc7c-f16444ca75fa) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28355 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182256 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43877 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141047 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37969 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44566 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108988 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36315 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116448 "Found 1 new failure in Shared/WebBackForwardListFrameItem.cpp") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43076 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7689 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42482 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42722 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->