### PR TITLE
App-provided NSURLRequest properties are lost

### DIFF
--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -97,6 +97,8 @@
 [Legacy] AliasParam FileSystem::Salt std::array<uint8_t, 8>
 [Legacy] AliasParam WebCore::GraphicsContextGL::ExternalSyncSource std::tuple<MachSendRight, uint64_t>
 [Legacy] AliasParam WebKit::CoreIPCNSURLRequestData::BodyParts Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>
+[NeedsReview] AliasParam WebKit::ProtocolProperties::AppPropertyValue Variant<bool, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCData>
+[NeedsReview] StructureParam WebKit::ProtocolProperties.appProperties HashMap<String, WebKit::ProtocolProperties::AppPropertyValue>
 [Legacy] AliasParam WebKit::CoreIPCSecTrustData::ExceptionType Vector<std::pair<WebKit::CoreIPCString, Variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, bool>>>
 [NeedsReview] AliasParam WebKit::CoreIPCSecTrustData::RevocationInfoSubDictValue Variant<WebKit::CoreIPCNumber, WebKit::CoreIPCData, WebKit::CoreIPCDate, bool>
 [NeedsReview] AliasParam WebKit::CoreIPCSecTrustData::RevocationInfoSubDict Vector<std::pair<WebKit::CoreIPCString, WebKit::CoreIPCSecTrustData::RevocationInfoSubDictValue>>

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -36,9 +36,11 @@
 #import "CoreIPCString.h"
 #import "CoreIPCURL.h"
 
+#import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/Vector.h>
+#import <wtf/text/WTFString.h>
 
 OBJC_CLASS NSURLRequest;
 
@@ -116,6 +118,9 @@ struct ProtocolProperties {
     std::optional<CoreIPCNumber> maximumRequestCount;
     std::optional<bool> apProxyIsRecursive;
     std::optional<APProxyRequestType> requestType;
+
+    using AppPropertyValue = Variant<bool, CoreIPCNumber, CoreIPCString, CoreIPCData>;
+    HashMap<String, AppPropertyValue> appProperties;
 };
 
 struct CoreIPCNSURLRequestData {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -27,6 +27,7 @@
 #import "CoreIPCNSURLRequest.h"
 
 #import "GeneratedSerializers.h"
+#import "Logging.h"
 #import <WebCore/ResourceLoadPriority.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -85,6 +86,99 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CoreIPCNSURLRequest);
 
+
+// [NSURLProtocol setProperty:forKey:inRequest] allows tagging a request with app-provided
+// data that can be used to track specific requests across time
+//
+// The mechanism is meant for stashing small bits of metadata, not large or complicated blobs.
+// So we restrict the size of keys and properties that can be stashed, as well as not allowing
+// collections like dictionaries or arrays.
+//
+// We also don't allow keys with prefixes that are likely (or even guaranteed) to collide
+// with Apple internal keys.
+
+static constexpr size_t maxAppPropertyKeyLength = 256;
+static constexpr size_t maxAppPropertyStringLength = 64 * 1024;
+static constexpr size_t maxAppPropertyDataLength = 64 * 1024;
+
+static bool isReservedProtocolPropertyKeyPrefix(NSString *key)
+{
+    static NSArray<NSString *> *prefixes = @[
+        @"_kCF",
+        @"kCF",
+        @"WK",
+        @"NS",
+        @"com.apple.",
+    ];
+    for (NSString *prefix in prefixes) {
+        if ([key hasPrefix:prefix])
+            return true;
+    }
+    return false;
+}
+
+static bool isTypedAllowlistKey(NSString *key)
+{
+    static NSSet<NSString *> *allowlist = [[NSSet alloc] initWithArray:@[
+        @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation",
+        @"kCFURLRequestAllowAllPOSTCaching",
+        @"_kCFHTTPCookiePolicyPropertySiteForCookies",
+        @"_kCFURLCachePartitionKey",
+        @"WKVeryLowLoadPriority",
+        @"NSURLRequestFileProtocolExpectedDevice",
+        @"_kCFURLConnectionPropertyShouldSniff",
+        @"kCFURLRequestContentDecoderSkipURLCheck",
+        @"adIdentifier",
+        @"maximumRequestCount",
+        @"com.apple.ap.pc.proxy-is-recursive",
+        @"requestType",
+    ]];
+    return [allowlist containsObject:key];
+}
+
+static void populateAppProperties(NSDictionary *protocolPropertiesDict, ProtocolProperties& props)
+{
+    for (id rawKey in protocolPropertiesDict) {
+        RetainPtr key = dynamic_objc_cast<NSString>(rawKey);
+        if (!key)
+            continue;
+
+        if (isReservedProtocolPropertyKeyPrefix(key.get()) || isTypedAllowlistKey(key.get())) {
+            RELEASE_LOG_ERROR(API, "NSURLRequest property key '%@' not allowed. Skipping this property.", key.get());
+            continue;
+        }
+
+        if ([key length] > maxAppPropertyKeyLength) {
+            RELEASE_LOG_ERROR(API, "NSURLRequest property key '%@' is longer than the allowable %zu characters. Skipping this property.", key.get(), maxAppPropertyKeyLength);
+            continue;
+        }
+
+        RetainPtr<id> value = [protocolPropertiesDict objectForKey:key.get()];
+        if (RetainPtr number = dynamic_objc_cast<NSNumber>(value.get())) {
+            if (CFGetTypeID((__bridge CFTypeRef)number.get()) == CFBooleanGetTypeID()) {
+                props.appProperties.set(String(key.get()), ProtocolProperties::AppPropertyValue { static_cast<bool>([number boolValue]) });
+                continue;
+            }
+            props.appProperties.set(String(key.get()), ProtocolProperties::AppPropertyValue { CoreIPCNumber(number.get()) });
+            continue;
+        }
+        if (RetainPtr string = dynamic_objc_cast<NSString>(value.get())) {
+            if ([string length] > maxAppPropertyStringLength)
+                continue;
+            props.appProperties.set(String(key.get()), ProtocolProperties::AppPropertyValue { CoreIPCString(string.get()) });
+            continue;
+        }
+        if (RetainPtr data = dynamic_objc_cast<NSData>(value.get())) {
+            if ([data length] > maxAppPropertyDataLength)
+                continue;
+            props.appProperties.set(String(key.get()), ProtocolProperties::AppPropertyValue { CoreIPCData(data.get()) });
+            continue;
+        }
+
+        RELEASE_LOG_ERROR(API, "NSURLRequest property value of type '%@' is not allowed. Skipping this property.", NSStringFromClass([value class]));
+    }
+}
+
 CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
 {
     RetainPtr dict = [request _webKitPropertyListData];
@@ -106,6 +200,8 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
             if (auto integerValue = [value integerValue]; isValidEnum<APProxyRequestType>(integerValue))
                 props.requestType = static_cast<APProxyRequestType>(integerValue);
         }
+
+        populateAppProperties(protocolPropertiesDict.get(), props);
 
         m_data.protocolProperties = WTF::move(props);
     }
@@ -276,6 +372,25 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
         SET_PROTOCOL_DICT_BOOL(protocolPropertiesDict, @"com.apple.ap.pc.proxy-is-recursive", m_data.protocolProperties->apProxyIsRecursive);
         if (m_data.protocolProperties->requestType)
             [protocolPropertiesDict setObject:[NSNumber numberWithInteger:static_cast<NSInteger>(*m_data.protocolProperties->requestType)] forKey:@"requestType"];
+
+        for (auto& entry : m_data.protocolProperties->appProperties) {
+            RetainPtr key = entry.key.createNSString();
+            if (!key)
+                continue;
+
+            // Prevent re-materialzing any key that might conflict with an Apple internal key.
+            if (isTypedAllowlistKey(key.get()) || isReservedProtocolPropertyKeyPrefix(key.get()))
+                continue;
+
+            RetainPtr<id> value = WTF::switchOn(entry.value,
+                [] (bool b) -> RetainPtr<id> { return [NSNumber numberWithBool:b]; },
+                [] (const CoreIPCNumber& n) -> RetainPtr<id> { return n.toID(); },
+                [] (const CoreIPCString& s) -> RetainPtr<id> { return s.toID(); },
+                [] (const CoreIPCData& d) -> RetainPtr<id> { return d.toID(); }
+            );
+            if (value)
+                [protocolPropertiesDict setObject:value.get() forKey:key.get()];
+        }
 
         [dict setObject:protocolPropertiesDict.get() forKey:@"protocolProperties"];
     }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
@@ -95,6 +95,7 @@ header: "CoreIPCNSURLRequest.h"
 
 using WebKit::CoreIPCNSURLRequestData::BodyParts = Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>;
 using WebKit::CoreIPCNSURLRequestData::HeaderField = std::pair<String, Variant<String, Vector<String>>>;
+using WebKit::ProtocolProperties::AppPropertyValue = Variant<bool, WebKit::CoreIPCNumber, WebKit::CoreIPCString, WebKit::CoreIPCData>;
 
 header: "CoreIPCNSURLRequest.h"
 [CustomHeader, WebKitPlatform] enum class WebKit::APProxyRequestType : uint8_t {
@@ -116,6 +117,7 @@ header: "CoreIPCNSURLRequest.h"
     std::optional<WebKit::CoreIPCNumber> maximumRequestCount;
     std::optional<bool> apProxyIsRecursive;
     std::optional<WebKit::APProxyRequestType> requestType;
+    HashMap<String, WebKit::ProtocolProperties::AppPropertyValue> appProperties;
 }
 
 header: "CoreIPCNSURLRequest.h"

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1850,6 +1850,58 @@ TEST(IPCSerialization, NSURLRequestNSURLProtocolProperties)
     runTestNS({ request.get() });
 }
 
+TEST(IPCSerialization, NSURLRequestArbitraryAppProperties)
+{
+    // App-supplied properties via NSURLProtocol +setProperty:forKey:inRequest: that are
+    // not in the typed allowlist must still round-trip through IPC, but only when they
+    // are plist-primitive values (NSNumber/NSString/NSData) and the key is not in a
+    // reserved CFNetwork/Foundation/WebKit/Apple namespace.
+
+    RetainPtr request = adoptNS([[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+
+    // Allowed app-supplied entries: number, string, bool (NSNumber), data.
+    [NSURLProtocol setProperty:@"hello" forKey:@"com.example.appName" inRequest:request.get()];
+    [NSURLProtocol setProperty:@42 forKey:@"com.example.requestCount" inRequest:request.get()];
+    [NSURLProtocol setProperty:@YES forKey:@"com.example.featureFlag" inRequest:request.get()];
+    RetainPtr<NSData> blob = [NSData dataWithBytes:"\x01\x02\x03\x04" length:4];
+    [NSURLProtocol setProperty:blob.get() forKey:@"com.example.blob" inRequest:request.get()];
+
+    // Disallowed values: complex container types must be dropped on the wire.
+    [NSURLProtocol setProperty:@{ @"nested": @1 } forKey:@"com.example.dictValue" inRequest:request.get()];
+    [NSURLProtocol setProperty:@[ @"a", @"b" ] forKey:@"com.example.arrayValue" inRequest:request.get()];
+
+    // Disallowed key: reserved-prefix keys an app should not be able to spoof over IPC.
+    [NSURLProtocol setProperty:@"injected" forKey:@"_kCFFutureInternalProperty" inRequest:request.get()];
+    [NSURLProtocol setProperty:@"injected" forKey:@"NSURLRequestFutureInternalProperty" inRequest:request.get()];
+    [NSURLProtocol setProperty:@"injected" forKey:@"com.apple.something-private" inRequest:request.get()];
+
+    WebKit::CoreIPCNSURLRequest wrapper(request.get());
+    RetainPtr reconstructed = dynamic_objc_cast<NSURLRequest>(wrapper.toID().get());
+    EXPECT_TRUE(reconstructed);
+
+    EXPECT_TRUE([[NSURLProtocol propertyForKey:@"com.example.appName" inRequest:reconstructed.get()] isEqualToString:@"hello"]);
+    EXPECT_EQ([[NSURLProtocol propertyForKey:@"com.example.requestCount" inRequest:reconstructed.get()] intValue], 42);
+    EXPECT_TRUE([[NSURLProtocol propertyForKey:@"com.example.featureFlag" inRequest:reconstructed.get()] boolValue]);
+    EXPECT_TRUE([[NSURLProtocol propertyForKey:@"com.example.blob" inRequest:reconstructed.get()] isEqualToData:blob.get()]);
+
+    EXPECT_NULL([NSURLProtocol propertyForKey:@"com.example.dictValue" inRequest:reconstructed.get()]);
+    EXPECT_NULL([NSURLProtocol propertyForKey:@"com.example.arrayValue" inRequest:reconstructed.get()]);
+
+    EXPECT_NULL([NSURLProtocol propertyForKey:@"_kCFFutureInternalProperty" inRequest:reconstructed.get()]);
+    EXPECT_NULL([NSURLProtocol propertyForKey:@"NSURLRequestFutureInternalProperty" inRequest:reconstructed.get()]);
+    EXPECT_NULL([NSURLProtocol propertyForKey:@"com.apple.something-private" inRequest:reconstructed.get()]);
+
+    // Full wire-format round-trip on a request containing only the allowed entries —
+    // runTestNS asserts that the original and the round-tripped request compare equal,
+    // so we cannot include the keys we expect to be stripped above.
+    RetainPtr cleanRequest = adoptNS([[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    [NSURLProtocol setProperty:@"hello" forKey:@"com.example.appName" inRequest:cleanRequest.get()];
+    [NSURLProtocol setProperty:@42 forKey:@"com.example.requestCount" inRequest:cleanRequest.get()];
+    [NSURLProtocol setProperty:@YES forKey:@"com.example.featureFlag" inRequest:cleanRequest.get()];
+    [NSURLProtocol setProperty:blob.get() forKey:@"com.example.blob" inRequest:cleanRequest.get()];
+    runTestNS({ cleanRequest.get() });
+}
+
 TEST(IPCSerialization, NSURLRequestAttribution)
 {
     WebKit::CoreIPCNSURLRequestData requestData;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm
@@ -242,6 +242,40 @@ TEST(URLSchemeHandler, BasicWithAsyncPolicyDelegate)
     EXPECT_EQ([handler.get().stoppedURLs count], 0u);
 }
 
+TEST(URLSchemeHandler, RequestProtocolPropertyPreserved)
+{
+    RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr<TestURLSchemeHandler> handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"testing"];
+
+    // Well past the 256-byte key cap enforced in CoreIPCNSURLRequest's app-property bucket;
+    // this entry must be dropped on the wire even though the short-key entry survives.
+    NSString *overlongKey = [@"com.example.padded." stringByPaddingToLength:300 withString:@"x" startingAtIndex:0];
+
+    __block bool received = false;
+    __block RetainPtr<id> shortKeyValue;
+    __block RetainPtr<id> overlongKeyValue;
+    handler.get().startURLSchemeTaskHandler = ^(WKWebView *, id<WKURLSchemeTask> task) {
+        shortKeyValue = [NSURLProtocol propertyForKey:@"com.example.appName" inRequest:task.request];
+        overlongKeyValue = [NSURLProtocol propertyForKey:overlongKey inRequest:task.request];
+        respond(task, "<html></html>");
+        received = true;
+    };
+
+    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr<NSMutableURLRequest> request = adoptNS([[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"testing:main"]]);
+    [NSURLProtocol setProperty:@"hello-roundtrip" forKey:@"com.example.appName" inRequest:request.get()];
+    [NSURLProtocol setProperty:@"should-be-dropped" forKey:overlongKey inRequest:request.get()];
+
+    [webView loadRequest:request.get()];
+    TestWebKitAPI::Util::run(&received);
+
+    EXPECT_TRUE([shortKeyValue.get() isKindOfClass:[NSString class]]);
+    EXPECT_TRUE([(NSString *)shortKeyValue.get() isEqualToString:@"hello-roundtrip"]);
+    EXPECT_NULL(overlongKeyValue.get());
+}
+
 TEST(URLSchemeHandler, NoMIMEType)
 {
     // Since there's no MIMEType, and no NavigationDelegate to tell WebKit to do the load anyways, WebKit will ignore (silently fail) the load.


### PR DESCRIPTION
#### 9e19f52c9a059de81e3d8cdd039e38772f955c8f
<pre>
App-provided NSURLRequest properties are lost
<a href="https://rdar.apple.com/180635166">rdar://180635166</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317872">https://bugs.webkit.org/show_bug.cgi?id=317872</a>

Reviewed by Alex Christensen.

In IPC hardening, we prevented app-provided NSURLRequest properties from serializing.
Setting such properties is well established and supported API, so let&apos;s restore it.

In the spirit of the original hardening, we still prevent app-provided properties from
overriding keys that are likely to be Apple internally used.

These properties are for setting small bits of metadata, and not moving blobs around.
So we also restrict the value types to simple ones, as well as the size of the values

Tests: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm

* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::isReservedProtocolPropertyKeyPrefix):
(WebKit::isTypedAllowlistKey):
(WebKit::populateAppProperties):
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSURLRequestArbitraryAppProperties)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKURLSchemeHandler-1.mm:
(TEST(URLSchemeHandler, RequestProtocolPropertyPreserved)):

Canonical link: <a href="https://commits.webkit.org/315856@main">https://commits.webkit.org/315856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9054fe3f450024fb3c6e069cf99fc4fce032e637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127996 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d2b9754-6f4b-43cf-bae9-a25565b7efce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132764 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5625ad3b-85aa-4726-8851-f67bade3d977) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173243 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113265 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01df003b-e904-49e7-83bb-a095fcae8762) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169605 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28342 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182243 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141212 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43864 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37968 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44553 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108972 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36299 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116435 "Found 1 new failure in Shared/Cocoa/CoreIPCNSURLRequest.mm") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43063 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7674 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42469 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->