### PR TITLE
Hide navigator.globalPrivacyControl if the feature is not enabled

### DIFF
--- a/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,7 +10,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -41,7 +40,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,7 +7,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -44,7 +43,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,7 +10,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK
@@ -53,7 +52,6 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK

--- a/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,7 +7,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -41,7 +40,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,7 +7,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -44,7 +43,6 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
-navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3501,7 +3501,7 @@ GetUserMediaRequiresFocus:
 
 GlobalPrivacyControlFeatureEnabled:
   type: bool
-  status: testable
+  status: embedder
   category: privacy
   humanReadableName: "Global Privacy Control Feature"
   humanReadableDescription: "Enable Global Privacy Control (GPC) Feature"

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
@@ -25,6 +25,7 @@
 
 // https://www.w3.org/TR/gpc/
 [
+    EnabledBySetting=GlobalPrivacyControlFeatureEnabled,
     ImplementedBy=NavigatorGlobalPrivacyControl
 ] interface mixin NavigatorGlobalPrivacyControl {
     [ImplementedAs=globalPrivacyControlStatus] readonly attribute boolean globalPrivacyControl;

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -162,6 +162,11 @@ static bool shouldEnableTouchEventRegions(const std::string& pathOrURL)
     return pathContains(pathOrURL, "touch-event-regions-layer-tree/");
 }
 
+static bool shouldEnableGlobalPrivacyControl(const std::string& pathOrURL)
+{
+    return pathContains(pathOrURL, "/gpc/");
+}
+
 TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
 {
     TestFeatures features;
@@ -197,6 +202,8 @@ TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
         features.boolWebPreferenceFeatures.insert({ "MutationEventsEnabled", false });
     if (shouldEnableTouchEventRegions(command.pathOrURL))
         features.boolWebPreferenceFeatures.insert({ "AlwaysUseTouchEventRegions", true });
+    if (shouldEnableGlobalPrivacyControl(command.pathOrURL))
+        features.boolWebPreferenceFeatures.insert({ "GlobalPrivacyControlFeatureEnabled", true });
 
     return features;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -2285,7 +2285,10 @@ TEST(WebpagePreferences, LoadHTMLString)
 
 TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPI)
 {
-    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("GlobalPrivacyControlFeatureEnabled"));
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
 
     __block BOOL nextNavigationGPC = YES;
@@ -2362,7 +2365,10 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPIInSubframe)
         { "/sub.html"_s, { "<script>alert(String(navigator.globalPrivacyControl))</script>"_s } },
     }, HTTPServer::Protocol::Http);
 
-    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("GlobalPrivacyControlFeatureEnabled"));
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
     RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)


### PR DESCRIPTION
#### f7a2c905407baaaad8e38817f1577f48ab0d58df
<pre>
Hide navigator.globalPrivacyControl if the feature is not enabled
<a href="https://rdar.apple.com/179490155">rdar://179490155</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=317873">https://bugs.webkit.org/show_bug.cgi?id=317873</a>

Reviewed by NOBODY (OOPS!).

adding a EnabledBySetting=GlobalPrivacyControlEnabled to control whether or not the feature is exposed.

* LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/NavigatorGlobalPrivacyControl.idl:
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::shouldEnableGlobalPrivacyControl):
(WTR::hardcodedFeaturesBasedOnPathForTest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7a2c905407baaaad8e38817f1577f48ab0d58df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129870 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/304cd3fc-ee3f-4a2e-b801-e19dfc90e4de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134019 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94549 "1 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea63c270-f7b6-44e6-94ac-29bde497260f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114490 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eff36489-2285-4bd2-99d8-4d563c080d8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36079 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34424 "Found 1 new API test failure: TestWebKitAPI.WebPageTests/globalPrivacyControlStatusForNavigation(enabled:) (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30371 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3108 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146509 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce, TestWebKitAPI.WebPageTests/globalPrivacyControlStatusForNavigation(enabled:) (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184299 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33575 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142786 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45904 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142667 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46582 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111309 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37731 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118333 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204992 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45099 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9024 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44558 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->