### PR TITLE
run-webkit-tests should support recursive globs

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/filesystem.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem.py
@@ -156,8 +156,8 @@ class FileSystem(object):
     def getcwd(self):
         return os.getcwd()
 
-    def glob(self, path):
-        return glob.glob(path)
+    def glob(self, path, recursive=False):
+        return glob.glob(path, recursive=recursive)
 
     def isabs(self, path):
         return os.path.isabs(path)

--- a/Tools/Scripts/webkitpy/common/system/filesystem_mock.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_mock.py
@@ -180,13 +180,16 @@ class MockFileSystem(object):
             raise OSError("%s is not a file" % path)
         return len(self.files[path])
 
-    def glob(self, glob_string):
+    def glob(self, glob_string, recursive=False):
         # Normalize the glob string to handle '..' before matching
         glob_string = self.normpath(glob_string)
         # FIXME: This handles '*', but not '?', '[', or ']'.
         glob_string = re.escape(glob_string)
-        glob_string = glob_string.replace('\\*', '[^\\/]*') + '$'
-        glob_string = glob_string.replace('\\/', '/')
+        if recursive:
+            # Replace '**' (escaped as \*\*) with .* before replacing single '*'.
+            glob_string = glob_string.replace(r'\*\*', '.*')
+        glob_string = glob_string.replace(r'\*', r'[^\/]*') + '$'
+        glob_string = glob_string.replace(r'\/', '/')
         path_filter = lambda path: re.match(glob_string, path)
 
         # We could use fnmatch.fnmatch, but that might not do the right thing on windows.

--- a/Tools/Scripts/webkitpy/common/system/filesystem_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_unittest.py
@@ -51,6 +51,8 @@ class GenericFileSystemTests(object):
         fs.write_text_file('foobar', 'foobar')
         fs.maybe_make_directory('foodir')
         fs.write_text_file(fs.join('foodir', 'baz'), 'baz')
+        fs.maybe_make_directory(fs.join('foodir', 'subdir'))
+        fs.write_text_file(fs.join('foodir', 'subdir', 'deep'), 'deep')
         fs.chdir(self.orig_cwd)
 
     def teardown_generic_test_dir(self):
@@ -73,6 +75,16 @@ class GenericFileSystemTests(object):
     def test_glob__period_is_escaped(self):
         self.fs.chdir(self.generic_test_dir)
         self.assertEqual(set(self.fs.glob('foo.*')), set(['foo.txt']))
+
+    def test_glob__double_star_recursive(self):
+        self.fs.chdir(self.generic_test_dir)
+        self.addCleanup(self.fs.chdir, self.orig_cwd)
+        self.assertEqual(set(self.fs.glob('**/deep', recursive=True)), {'foodir/subdir/deep'})
+
+    def test_glob__double_star_default_non_recursive(self):
+        self.fs.chdir(self.generic_test_dir)
+        self.addCleanup(self.fs.chdir, self.orig_cwd)
+        self.assertEqual(self.fs.glob('**/deep'), [])
 
 
 class RealFileSystemTest(unittest.TestCase, GenericFileSystemTests):

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
@@ -198,7 +198,8 @@ class LayoutTestFinder(object):
                     {
                         self._canonicalize_test_path(p)
                         for p in self.fs.glob(
-                            self.fs.join(self.layout_tests_base_dir, dirname)
+                            self.fs.join(self.layout_tests_base_dir, dirname),
+                            recursive=True,
                         )
                         if self.fs.isdir(p)
                     },

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_unittest.py
@@ -103,3 +103,10 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
 
         v = list(self.finder._split_glob("a/#b"))
         self.assertEqual([], v)
+
+    def test_get_tests__double_star_glob(self):
+        tests = list(self.finder.get_tests(['**/*test-crash-crash*']))
+        self.assertEqual(
+            [t.test_path for t in tests],
+            ['imported/w3c/web-platform-tests/some/test-crash-crash.html'],
+        )


### PR DESCRIPTION
#### ae0d4f1fea8977763cd51f6b63d0d5cc4be18587
<pre>
run-webkit-tests should support recursive globs
<a href="https://bugs.webkit.org/show_bug.cgi?id=317871">https://bugs.webkit.org/show_bug.cgi?id=317871</a>

Reviewed by Elliott Williams.

Patterns using ** passed to run-webkit-tests silently matched nothing
below the top level of LayoutTests because LayoutTestFinder.get_tests()
did not pass recursive=True when expanding the directory portion of glob
patterns via fs.glob().

* Tools/Scripts/webkitpy/common/system/filesystem.py:
(FileSystem.glob):
* Tools/Scripts/webkitpy/common/system/filesystem_mock.py:
(MockFileSystem.glob):
* Tools/Scripts/webkitpy/common/system/filesystem_unittest.py:
(GenericFileSystemTests.setup_generic_test_dir):
(GenericFileSystemTests.test_glob__double_star_recursive):
(GenericFileSystemTests.test_glob__double_star_default_non_recursive):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py:
(LayoutTestFinder.get_tests):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_unittest.py:
(LayoutTestFinderTests.test_get_tests__double_star_glob):

Canonical link: <a href="https://commits.webkit.org/315857@main">https://commits.webkit.org/315857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32a90febd54956bde28a68a2883797893216d711

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127985 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ac880f3-8aba-4a09-b9e6-acefe801812a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132755 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/103c7f9a-5745-4d43-a813-c2fdd52e9e93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113256 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2939fe1d-498b-40cd-8d8f-06506653c795) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169594 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28331 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182232 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43853 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141025 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44542 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108958 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25967 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36291 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43052 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7664 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42698 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->