### PR TITLE
[CMake] Build fails with ObjC type redefinition errors with multiple WebKit checkouts

### DIFF
--- a/Source/cmake/WebKitCCache.cmake
+++ b/Source/cmake/WebKitCCache.cmake
@@ -23,6 +23,11 @@ export CCACHE_BASEDIR='${CMAKE_SOURCE_DIR}'
 export CCACHE_NOHASHDIR=true
 export CCACHE_PCH_EXTSUM=true
 export CCACHE_SLOPPINESS='pch_defines,time_macros,include_file_mtime,include_file_ctime'
+for arg; do
+    if [ \"$arg\" = \"-emit-pch\" ]; then
+        exec \"$@\"
+    fi
+done
 exec '${CCACHE_FOUND}' \"$@\"
 ")
             file(CHMOD "${_ccache_launcher}" PERMISSIONS


### PR DESCRIPTION
#### e4b1a3ecdf51f26bc0b194212dcbe35e7e1d2e9c
<pre>
[CMake] Build fails with ObjC type redefinition errors with multiple WebKit checkouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=317875">https://bugs.webkit.org/show_bug.cgi?id=317875</a>

Reviewed by Geoffrey Garen.

The cmake-generated ccache-launcher sets CCACHE_BASEDIR and
CCACHE_NOHASHDIR=true to share object-file cache entries across
checkouts. This also makes the PCH cache key identical across checkouts.
Unlike regular object files, binary PCHs have absolute source paths
embedded in the clang AST that ccache cannot rewrite on retrieval, so a
PCH from checkout A gets served to checkout B verbatim, causing the ObjC
declarations to appear twice and triggering the redefinition errors.

Bypass ccache when the compiler is invoked with -emit-pch. PCHs are
compiled infrequently, so the performance impact should be minimal.

No new tests: build system changes only.

* Source/cmake/WebKitCCache.cmake:

Canonical link: <a href="https://commits.webkit.org/315854@main">https://commits.webkit.org/315854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23eee4cc040ee34ffd81398769035cb477643a80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127986 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/443c8cc0-596f-4abd-b472-a1fe3adebe5d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5c0399d-72ce-4ac2-b591-27c32347beb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173233 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153183 "Build is in progress. Recent messages:") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113255 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8568aba-f8bd-4a66-9fcb-18c29550951a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28332 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1599 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182233 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31529 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141204 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43854 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141024 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44543 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108959 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36292 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202953 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43053 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7666 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54383 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42459 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->