### PR TITLE
[Swift in WebKit] Remove some `unsafe`s that aren't needed anymore

### DIFF
--- a/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift
@@ -34,7 +34,7 @@ private enum UnsafeErrors: Error {
 
 extension Data {
     fileprivate static func temporaryDataFromSpan(spanNoCopy: PAL.Crypto.SpanConstUInt8) -> Data {
-        guard unsafe spanNoCopy.empty() else {
+        guard spanNoCopy.empty() else {
             return unsafe Data(
                 bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
                 count: spanNoCopy.size(),
@@ -49,7 +49,7 @@ extension Data {
 
 extension CryptoKit.HashFunction {
     mutating func update(data: PAL.Crypto.SpanConstUInt8) {
-        if unsafe data.empty() {
+        if data.empty() {
             self.update(data: Data())
         } else {
             unsafe self.update(
@@ -69,7 +69,7 @@ extension AES.GCM {
         iv: PAL.Crypto.SpanConstUInt8,
         ad: PAL.Crypto.SpanConstUInt8
     ) throws -> AES.GCM.SealedBox {
-        guard unsafe ad.size() > 0 else {
+        guard ad.size() > 0 else {
             return try unsafe AES.GCM.seal(
                 Data.temporaryDataFromSpan(spanNoCopy: message),
                 using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
@@ -105,7 +105,7 @@ extension AES.KeyWrap {
 
 extension P256.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -114,7 +114,7 @@ extension P256.Signing.ECDSASignature {
 
 extension P384.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -123,7 +123,7 @@ extension P384.Signing.ECDSASignature {
 
 extension P521.Signing.ECDSASignature {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -132,14 +132,14 @@ extension P521.Signing.ECDSASignature {
 
 extension P256.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -150,14 +150,14 @@ extension P256.Signing.PublicKey {
 
 extension P384.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -168,14 +168,14 @@ extension P384.Signing.PublicKey {
 
 extension P521.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     init(spanCompressed: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe spanCompressed.empty() {
+        if spanCompressed.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(
@@ -186,7 +186,7 @@ extension P521.Signing.PublicKey {
 
 extension P256.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -195,7 +195,7 @@ extension P256.Signing.PrivateKey {
 
 extension P384.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -204,7 +204,7 @@ extension P384.Signing.PrivateKey {
 
 extension P521.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -213,14 +213,14 @@ extension P521.Signing.PrivateKey {
 
 extension Curve25519.Signing.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func signature(span: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
-        if unsafe span.empty() {
+        if span.empty() {
             return try self.signature(for: Data()).copyToVectorUInt8()
         }
         return try unsafe self.signature(for: Data.temporaryDataFromSpan(spanNoCopy: span))
@@ -230,14 +230,14 @@ extension Curve25519.Signing.PrivateKey {
 
 extension Curve25519.Signing.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func isValidSignature(signature: PAL.Crypto.SpanConstUInt8, data: PAL.Crypto.SpanConstUInt8) -> Bool {
-        if unsafe (signature.empty() || data.empty()) {
+        if signature.empty() || data.empty() {
             return false
         }
 
@@ -250,14 +250,14 @@ extension Curve25519.Signing.PublicKey {
 
 extension Curve25519.KeyAgreement.PrivateKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
     }
 
     func sharedSecretFromKeyAgreement(pubSpan: PAL.Crypto.SpanConstUInt8) throws -> PAL.Crypto.VectorUInt8 {
-        if unsafe pubSpan.empty() {
+        if pubSpan.empty() {
             throw UnsafeErrors.emptySpan
         }
         let pub = try unsafe Curve25519.KeyAgreement.PublicKey(
@@ -269,7 +269,7 @@ extension Curve25519.KeyAgreement.PrivateKey {
 
 extension Curve25519.KeyAgreement.PublicKey {
     init(span: PAL.Crypto.SpanConstUInt8) throws {
-        if unsafe span.empty() {
+        if span.empty() {
             throw UnsafeErrors.emptySpan
         }
         try unsafe self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))

--- a/Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/crypto/CryptoKitShim.swift
@@ -46,7 +46,7 @@ public final class AesGcm {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe iv.size() == 0 {
+            if iv.size() == 0 {
                 returnValue.errorCode = .InvalidArgument
                 return returnValue
             }
@@ -529,7 +529,7 @@ public final class EdKey {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe privateKey.size() != 32 {
+            if privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -558,7 +558,7 @@ public final class EdKey {
     ) -> PAL.Crypto.CryptoOperationReturnValue {
         var returnValue = PAL.Crypto.CryptoOperationReturnValue()
         do {
-            if unsafe privateKey.size() != 32 {
+            if privateKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -587,7 +587,7 @@ public final class EdKey {
         publicKey: PAL.Crypto.SpanConstUInt8
     ) -> Bool {
         do {
-            if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
+            if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {
@@ -612,7 +612,7 @@ public final class EdKey {
         publicKey: PAL.Crypto.SpanConstUInt8
     ) -> Bool {
         do {
-            if unsafe (privateKey.size() != 32 || publicKey.size() != 32) {
+            if privateKey.size() != 32 || publicKey.size() != 32 {
                 throw LocalErrors.invalidArgument
             }
             switch algo {


### PR DESCRIPTION
#### 338840b5d11cbd20ef7bb82a538997c0bfe1575f
<pre>
[Swift in WebKit] Remove some `unsafe`s that aren&apos;t needed anymore
<a href="https://bugs.webkit.org/show_bug.cgi?id=317878">https://bugs.webkit.org/show_bug.cgi?id=317878</a>
<a href="https://rdar.apple.com/180661557">rdar://180661557</a>

Reviewed by Abrar Rahman Protyasha and Pascoe.

* Source/WebCore/PAL/pal/crypto/CryptoKit+UnsafeOverlays.swift:
(Data.temporaryDataFromSpan(_:)):
(CryptoKit.update(_:)):
(Curve25519.signature(_:)):
(Curve25519.isValidSignature(_:data:)):
(Curve25519.sharedSecretFromKeyAgreement(_:)):

Canonical link: <a href="https://commits.webkit.org/315853@main">https://commits.webkit.org/315853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65c9c56cf9690cb11598a1e97c4a793e1ae8cd5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51f98afc-c0ee-484c-85b9-37b126406d62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43835 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8f429a6-0178-49cc-8dd9-2e63f95e5ada) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173239 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f2b6621-e269-4eec-b216-1aa23afea0c9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28338 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182239 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43860 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37967 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44549 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108965 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36300 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116431 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43059 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7668 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42465 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->