### PR TITLE
[JSC][Temporal] Polish Temporal.Duration round and total spec alignment

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -213,6 +213,7 @@ static Int128 add24HourDaysToTimeDuration(JSGlobalObject* globalObject, Int128 d
     return *result;
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
 static ISO8601::PlainDate resolvePlainDateFromFields(JSGlobalObject* globalObject, CalendarID calendarId,
     bool calHasEras, const std::optional<String>& era, const std::optional<double>& eraYear,
     bool yearAbsent, double year, double month, double day, std::optional<ParsedMonthCode> monthCode)
@@ -706,13 +707,6 @@ ISO8601::InternalDuration TemporalDuration::toInternalDurationRecordWith24HourDa
     return *result;
 }
 
-// Thin shim: delegates to TemporalCore::regulateISODate and converts TemporalResult → optional.
-std::optional<ISO8601::PlainDate> TemporalDuration::regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow overflow)
-{
-    auto result = TemporalCore::regulateISODate(year, month, day, overflow);
-    return result ? std::optional(*result) : std::nullopt;
-}
-
 // https://tc39.es/proposal-temporal/#sec-temporal-todatedurationrecordwithouttime
 ISO8601::Duration TemporalDuration::toDateDurationRecordWithoutTime(JSGlobalObject* globalObject, const ISO8601::Duration& duration)
 {
@@ -784,8 +778,8 @@ ISO8601::Duration TemporalDuration::addDurations(JSGlobalObject* globalObject, J
 template ISO8601::Duration TemporalDuration::addDurations<AddOrSubtract::Add>(JSGlobalObject*, JSValue) const;
 template ISO8601::Duration TemporalDuration::addDurations<AddOrSubtract::Subtract>(JSGlobalObject*, JSValue) const;
 
-// RoundDuration ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, increment, unit, roundingMode [ , relativeTo ] )
-// https://tc39.es/proposal-temporal/#sec-temporal-roundduration
+// Day/time rounding dispatcher for the no-relativeTo path of round/total, and the time-only ZDT fast path.
+// https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round
 ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, ISO8601::InternalDuration internalDuration, double increment, TemporalUnit unit, RoundingMode mode)
 {
     VM& vm = globalObject->vm();
@@ -793,22 +787,146 @@ ISO8601::InternalDuration TemporalDuration::round(JSGlobalObject* globalObject, 
 
     ASSERT(unit >= TemporalUnit::Day);
 
+    // Step 32: smallestUnit is ~day~.
     if (unit == TemporalUnit::Day) {
         double fractionalDays = TemporalCore::totalTimeDuration(internalDuration.time(), TemporalUnit::Day);
         double days = TemporalCore::roundNumberToIncrementDouble(fractionalDays, increment, mode);
         return ISO8601::InternalDuration::combineDateAndTimeDuration(
             ISO8601::Duration { 0LL, 0LL, 0LL, static_cast<int64_t>(days), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0) },
             0);
-    } else  {
-        std::optional<Int128> timeDuration =
-            ISO8601::roundTimeDuration(globalObject, internalDuration.time(), increment, unit, mode);
-        RETURN_IF_EXCEPTION(scope, { });
-        if (!timeDuration) [[unlikely]] {
-            throwRangeError(globalObject, scope, "Rounded duration exceeds maximum time duration"_s);
-            return { };
-        }
-        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), timeDuration.value());
     }
+
+    // Step 33: time unit — RoundTimeDuration + CombineDateAndTimeDuration.
+    std::optional<Int128> timeDuration = ISO8601::roundTimeDuration(globalObject, internalDuration.time(), increment, unit, mode);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!timeDuration) [[unlikely]] {
+        throwRangeError(globalObject, scope, "Rounded duration exceeds maximum time duration"_s);
+        return { };
+    }
+    return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), timeDuration.value());
+}
+
+struct PlainRelativeTarget {
+    ISO8601::PlainDate targetDate;
+    ISO8601::PlainTime targetTime;
+};
+
+static std::optional<PlainRelativeTarget> computePlainRelativeTarget(JSGlobalObject* globalObject, CalendarID calendarId, const ISO8601::PlainDate& plainDate, const ISO8601::InternalDuration& internalDuration)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto intermediateDate = calendarAwareDateAdd(globalObject, calendarId, plainDate, internalDuration.dateDuration(), TemporalOverflow::Constrain);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    auto [overflowDays, subdayNs] = TemporalCore::splitTimeDuration(internalDuration.time());
+    ISO8601::Duration dayDuration(0LL, 0LL, 0LL, static_cast<int64_t>(overflowDays), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
+    auto targetDate = calendarAwareDateAdd(globalObject, calendarId, intermediateDate, dayDuration, TemporalOverflow::Constrain);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+
+    return PlainRelativeTarget { WTF::move(targetDate), TemporalCore::plainTimeFromSubdayNs(subdayNs) };
+}
+
+struct ZonedRelativeEndpoints {
+    ISO8601::ExactTime startExact;
+    ISO8601::ExactTime endExact;
+    Int128 nsA;
+    Int128 nsB;
+};
+
+static std::optional<ZonedRelativeEndpoints> computeZonedRelativeEndpoints(JSGlobalObject* globalObject, TemporalZonedDateTime* zdt, const ISO8601::Duration& duration)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto startExact = zdt->exactTime();
+    auto& tz = zdt->timeZone();
+    auto endExactResult = TemporalCore::addZonedDateTime(startExact, tz, duration, TemporalOverflow::Constrain, zdt->calendarID());
+    if (!endExactResult) [[unlikely]] {
+        throwRangeError(globalObject, scope, endExactResult.error().message);
+        return std::nullopt;
+    }
+    auto endExact = *endExactResult;
+    return ZonedRelativeEndpoints { startExact, endExact, startExact.epochNanoseconds(), endExact.epochNanoseconds() };
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetimewithtotal
+static std::optional<double> differenceZonedDateTimeWithTotal(JSGlobalObject* globalObject, TemporalZonedDateTime* zdt, const ZonedRelativeEndpoints& endpoints, TemporalUnit unit)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Step 1: If TemporalUnitCategory(unit) is ~time~, return TotalTimeDuration.
+    if (unit > TemporalUnit::Day)
+        return TemporalCore::totalTimeDuration(endpoints.nsB - endpoints.nsA, unit);
+
+    auto& tz = zdt->timeZone();
+    // Step 2: difference = ? DifferenceZonedDateTime(nsA, nsB, tz, cal, unit).
+    auto zdtDiffResult = TemporalCore::differenceZonedDateTimeWithRounding(endpoints.startExact, endpoints.endExact, tz, unit, unit, RoundingMode::Trunc, 1.0, zdt->calendarID());
+    if (!zdtDiffResult) [[unlikely]] {
+        throwTemporalError(globalObject, scope, zdtDiffResult.error());
+        return std::nullopt;
+    }
+
+    // Step 3: dateTime = GetISODateTimeFor(tz, nsA).
+    ISO8601::PlainDate startDate;
+    ISO8601::PlainTime startTime;
+    auto offsetResult = TemporalCore::getOffsetNanosecondsFor(tz, endpoints.startExact);
+    if (!offsetResult) [[unlikely]] {
+        throwRangeError(globalObject, scope, offsetResult.error().message);
+        return std::nullopt;
+    }
+    TemporalCore::exactTimeToLocalDateAndTime(endpoints.startExact, *offsetResult, startDate, startTime);
+
+    // Step 4: Return ? TotalRelativeDuration — via nudgeToCalendarUnit with Trunc/1.0.
+    int32_t sign = (endpoints.nsB > endpoints.nsA) ? 1 : (endpoints.nsB < endpoints.nsA) ? -1 : 1;
+    auto nudgedResult = TemporalCore::nudgeToCalendarUnit(sign, *zdtDiffResult, endpoints.nsA, endpoints.nsB, startDate, startTime, 1.0, unit, RoundingMode::Trunc, &tz, zdt->calendarID());
+    if (!nudgedResult) [[unlikely]] {
+        throwTemporalError(globalObject, scope, nudgedResult.error());
+        return std::nullopt;
+    }
+    return nudgedResult->total;
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal-differenceplaindatetimewithtotal
+static std::optional<double> differencePlainDateTimeWithTotal(JSGlobalObject* globalObject, CalendarID calendarId, const ISO8601::PlainDate& plainDate, const PlainRelativeTarget& target, TemporalUnit unit)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Steps 5-6: epoch-ns for dt1 and dt2 (hoisted; reused by the CompareISODateTime check below).
+    ISO8601::PlainTime midnight;
+    Int128 originEpochNs = TemporalCore::getUTCEpochNanoseconds(plainDate, midnight);
+    Int128 destEpochNs = TemporalCore::getUTCEpochNanoseconds(target.targetDate, target.targetTime);
+
+    // Step 1: If CompareISODateTime(dt1, dt2) = 0, return 0.
+    if (originEpochNs == destEpochNs)
+        return 0.0;
+
+    // Step 2: If !ISODateTimeWithinLimits(dt1) || !ISODateTimeWithinLimits(dt2), throw RangeError.
+    bool dtOutOfRange = !ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 0, 0, 0, 0, 0, 0)
+        || !ISO8601::isDateTimeWithinLimits(target.targetDate.year(), target.targetDate.month(), target.targetDate.day(),
+            target.targetTime.hour(), target.targetTime.minute(), target.targetTime.second(),
+            target.targetTime.millisecond(), target.targetTime.microsecond(), target.targetTime.nanosecond());
+    if (dtOutOfRange) [[unlikely]] {
+        throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
+        return std::nullopt;
+    }
+
+    // Step 7: Return ? TotalRelativeDuration(diff, origin, dest, dt1, ~unset~, calendar, unit).
+    //   PlainDateTime relativeTo has no timeZone, so Day falls into the non-calendar (epoch-ns) path.
+    if (unit >= TemporalUnit::Day)
+        return TemporalCore::totalTimeDuration(destEpochNs - originEpochNs, unit);
+
+    auto diff = TemporalCore::diffISODateTime(plainDate, midnight, target.targetDate, target.targetTime, unit);
+    int32_t sign = (destEpochNs > originEpochNs) ? 1 : (destEpochNs < originEpochNs) ? -1 : 1;
+    auto nudgedResult = TemporalCore::nudgeToCalendarUnit(sign, diff, originEpochNs, destEpochNs,
+        plainDate, midnight, 1.0, unit, RoundingMode::Trunc, nullptr, calendarId);
+    if (!nudgedResult) [[unlikely]] {
+        throwTemporalError(globalObject, scope, nudgedResult.error());
+        return std::nullopt;
+    }
+    return nudgedResult->total;
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.duration.prototype.round
@@ -930,20 +1048,15 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
     // Step 27: If zonedRelativeTo is not undefined:
     if (relativeTo.zonedRelativeTo) {
         auto* zdt = relativeTo.zonedRelativeTo;
+        // Steps 27.a-e: compute relative endpoints (ToInternalDurationRecord + AddZonedDateTime).
+        auto endpoints = computeZonedRelativeEndpoints(globalObject, zdt, m_duration);
+        RETURN_IF_EXCEPTION(scope, { });
+        ASSERT(endpoints);
         auto& tz = zdt->timeZone();
-        auto startExact = zdt->exactTime();
 
-        auto endExactResult = TemporalCore::addZonedDateTime(startExact, tz, m_duration, TemporalOverflow::Constrain, zdt->calendarID());
-        if (!endExactResult) [[unlikely]] {
-            throwRangeError(globalObject, scope, endExactResult.error().message);
-            return { };
-        }
-        auto endExact = *endExactResult;
-        Int128 nsA = startExact.epochNanoseconds();
-        Int128 nsB = endExact.epochNanoseconds();
-
+        // Step 27 fast path: time-only output bypasses calendar diff.
         if (largestUnit > TemporalUnit::Day) {
-            auto zdtInternal = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), nsB - nsA);
+            auto zdtInternal = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), endpoints->nsB - endpoints->nsA);
             RETURN_IF_EXCEPTION(scope, { });
             zdtInternal = round(globalObject, zdtInternal, roundingIncrement, smallestUnit, roundingMode);
             RETURN_IF_EXCEPTION(scope, { });
@@ -955,13 +1068,15 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
             return *durResult;
         }
 
-        auto zdtDiffResult = TemporalCore::differenceZonedDateTimeWithRounding(startExact, endExact, tz, largestUnit, smallestUnit, roundingMode, static_cast<double>(roundingIncrement), zdt->calendarID());
+        // Step 27.f: internalDuration = ? DifferenceZonedDateTimeWithRounding(...).
+        auto zdtDiffResult = TemporalCore::differenceZonedDateTimeWithRounding(endpoints->startExact, endpoints->endExact, tz, largestUnit, smallestUnit, roundingMode, static_cast<double>(roundingIncrement), zdt->calendarID());
         if (!zdtDiffResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, zdtDiffResult.error());
             return { };
         }
-        // Step 27 sub-step: If TemporalUnitCategory(largestUnit) is ~date~, set largestUnit to ~hour~.
+        // Step 27.g: If TemporalUnitCategory(largestUnit) is ~date~, set largestUnit to ~hour~.
         TemporalUnit effectiveLargestUnit = (largestUnit <= TemporalUnit::Day) ? TemporalUnit::Hour : largestUnit;
+        // Step 27.h: Return ? TemporalDurationFromInternal(internalDuration, largestUnit).
         auto durResult = TemporalCore::temporalDurationFromInternal(*zdtDiffResult, effectiveLargestUnit);
         if (!durResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, durResult.error());
@@ -975,29 +1090,25 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         auto& plainDate = relativeTo.plainDate;
         ISO8601::PlainTime midnight;
 
-        // Step 28a: internalDuration = ToInternalDurationRecordWith24HourDays(duration).
+        // Step 28.a: internalDuration = ToInternalDurationRecordWith24HourDays(duration).
         auto internalDuration = toInternalDurationRecordWith24HourDays(globalObject, m_duration);
         RETURN_IF_EXCEPTION(scope, { });
 
-        // Step 28b-e: AddTime + CalendarDateAdd to get targetDate and targetTime.
-        auto intermediateDate = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, internalDuration.dateDuration(), TemporalOverflow::Constrain);
+        // Steps 28.b-e: AddTime + AdjustDateDurationRecord + CalendarDateAdd → {targetDate, targetTime}.
+        auto target = computePlainRelativeTarget(globalObject, relativeTo.calendarId, plainDate, internalDuration);
         RETURN_IF_EXCEPTION(scope, { });
+        ASSERT(target);
 
-        auto [overflowDays, subdayNs] = TemporalCore::splitTimeDuration(internalDuration.time());
-        ISO8601::Duration dayDuration(0LL, 0LL, 0LL, static_cast<int64_t>(overflowDays), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
-        auto targetDate = calendarAwareDateAdd(globalObject, relativeTo.calendarId, intermediateDate, dayDuration, TemporalOverflow::Constrain);
-        RETURN_IF_EXCEPTION(scope, { });
-        ISO8601::PlainTime targetTime = TemporalCore::plainTimeFromSubdayNs(subdayNs);
-
-        // Step 28h: internalDuration = ? DifferencePlainDateTimeWithRounding(isoDateTime, targetDateTime, ...).
-        auto diffResult = TemporalCore::differencePlainDateTimeWithRounding(plainDate, midnight, targetDate, targetTime,
+        // Steps 28.f-g: isoDateTime = (plainDate, midnight); targetDateTime = (targetDate, targetTime).
+        // Step 28.h: internalDuration = ? DifferencePlainDateTimeWithRounding(...).
+        auto diffResult = TemporalCore::differencePlainDateTimeWithRounding(plainDate, midnight, target->targetDate, target->targetTime,
             relativeTo.calendarId, largestUnit, smallestUnit, roundingMode, static_cast<double>(roundingIncrement));
         if (!diffResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, diffResult.error());
             return { };
         }
 
-        // Step 28i: Return ? TemporalDurationFromInternal(internalDuration, largestUnit).
+        // Step 28.i: Return ? TemporalDurationFromInternal(internalDuration, largestUnit).
         auto durResult = TemporalCore::temporalDurationFromInternal(*diffResult, largestUnit);
         if (!durResult) [[unlikely]] {
             throwTemporalError(globalObject, scope, durResult.error());
@@ -1006,7 +1117,7 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         return *durResult;
     }
 
-    // Step 29: If IsCalendarUnit(existingLargestUnit) or IsCalendarUnit(largestUnit), throw a RangeError.
+    // Step 29: If IsCalendarUnit(existingLargestUnit) or IsCalendarUnit(largestUnit), throw RangeError.
     if (years() || months() || weeks() || isCalendarUnit(largestUnit)) [[unlikely]] {
         throwRangeError(globalObject, scope, "Cannot round a duration of years, months, or weeks without a relativeTo option"_s);
         return { };
@@ -1036,6 +1147,8 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding done by caller.
+    // Steps 3-7: totalOf may be a String (treated as { unit }) or an options object.
     JSObject* options = nullptr;
     String unitString;
     if (optionsValue.isString()) {
@@ -1046,15 +1159,17 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
         RETURN_IF_EXCEPTION(scope, 0);
     }
 
-    // Parse relativeTo before unit — spec requires this ordering.
+    // Steps 8-10: relativeTo. Spec NOTE: "relativeTo" parsed before "unit" (alphabetical).
     RelativeToRecord relativeTo;
     if (options) {
         relativeTo = toRelativeTemporalObject(globalObject, options);
         RETURN_IF_EXCEPTION(scope, 0);
+        // Step 11: unit = ? GetTemporalUnitValuedOption(totalOf, "unit", unset).
         unitString = intlStringOption(globalObject, options, vm.propertyNames->unit, { }, { }, { });
         RETURN_IF_EXCEPTION(scope, 0);
     }
 
+    // Step 12: ValidateTemporalUnitValue(unit, ~datetime~).
     auto unitType = temporalUnitType(unitString);
     if (!unitType) [[unlikely]] {
         throwRangeError(globalObject, scope, "unit is an invalid Temporal unit"_s);
@@ -1064,108 +1179,45 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
 
     bool hasRelativeTo = relativeTo.zonedRelativeTo || relativeTo.hasPlainRelativeTo;
 
+    // Step 13: no relativeTo.
     if (!hasRelativeTo) {
+        // Step 13.a: reject calendar units.
         if (isCalendarUnit(unit) || years() || months() || weeks()) [[unlikely]] {
             throwRangeError(globalObject, scope, "Cannot total a duration of years, months, or weeks without a relativeTo option"_s);
             return 0;
         }
+        // Steps 13.b-c: ToInternalDurationRecordWith24HourDays + TotalTimeDuration.
         auto internalDuration = toInternalDurationRecordWith24HourDays(globalObject, m_duration);
         RETURN_IF_EXCEPTION(scope, 0);
         return TemporalCore::totalTimeDuration(internalDuration.time(), unit);
     }
 
+    // Step 14: zonedRelativeTo path → DifferenceZonedDateTimeWithTotal.
     if (relativeTo.zonedRelativeTo) {
-        auto* zdt = relativeTo.zonedRelativeTo;
-        auto& tz = zdt->timeZone();
-        auto startExact = zdt->exactTime();
-
-        auto endExactResult = TemporalCore::addZonedDateTime(startExact, tz, m_duration, TemporalOverflow::Constrain, zdt->calendarID());
-        if (!endExactResult) [[unlikely]] {
-            throwRangeError(globalObject, scope, endExactResult.error().message);
-            return 0;
-        }
-        auto endExact = *endExactResult;
-        Int128 nsA = startExact.epochNanoseconds();
-        Int128 nsB = endExact.epochNanoseconds();
-
-        // For sub-day time units: pure nanosecond arithmetic.
-        // (Day with timezone is irregular-length — falls through to calendar path.)
-        if (unit > TemporalUnit::Day)
-            return TemporalCore::totalTimeDuration(nsB - nsA, unit);
-
-        // Calendar units (Year/Month/Week/Day-with-TZ): full ZDT diff then nudge.
-        auto zdtDiffResult2 = TemporalCore::differenceZonedDateTimeWithRounding(startExact, endExact, tz, unit, unit, RoundingMode::Trunc, 1.0, zdt->calendarID());
-        if (!zdtDiffResult2) [[unlikely]] {
-            throwTemporalError(globalObject, scope, zdtDiffResult2.error());
-            return 0;
-        }
-        auto zdtDiff = *zdtDiffResult2;
-
-        ISO8601::PlainDate startDate;
-        ISO8601::PlainTime startTime;
-        auto offset1Result = TemporalCore::getOffsetNanosecondsFor(tz, startExact);
-        if (!offset1Result) [[unlikely]] {
-            throwRangeError(globalObject, scope, offset1Result.error().message);
-            return 0;
-        }
-        TemporalCore::exactTimeToLocalDateAndTime(startExact, *offset1Result, startDate, startTime);
-
-        int32_t sign = (nsB > nsA) ? 1 : (nsB < nsA) ? -1 : 1;
-        auto nudgedResult1 = TemporalCore::nudgeToCalendarUnit(sign, zdtDiff, nsA, nsB, startDate, startTime,
-            1.0, unit, RoundingMode::Trunc, &tz, relativeTo.zonedRelativeTo->calendarID());
-        if (!nudgedResult1) [[unlikely]] {
-            throwTemporalError(globalObject, scope, nudgedResult1.error());
-            return 0;
-        }
-        return nudgedResult1->total;
+        auto endpoints = computeZonedRelativeEndpoints(globalObject, relativeTo.zonedRelativeTo, m_duration);
+        RETURN_IF_EXCEPTION(scope, 0);
+        ASSERT(endpoints);
+        auto result = differenceZonedDateTimeWithTotal(globalObject, relativeTo.zonedRelativeTo, *endpoints, unit);
+        RETURN_IF_EXCEPTION(scope, 0);
+        ASSERT(result);
+        return *result;
     }
 
-    // PlainDate relativeTo path.
+    // Step 15: plainRelativeTo path → DifferencePlainDateTimeWithTotal.
     {
         auto& plainDate = relativeTo.plainDate;
-        ISO8601::PlainTime midnight;
-
+        // Step 15.a: ToInternalDurationRecordWith24HourDays.
         auto internalDuration = toInternalDurationRecordWith24HourDays(globalObject, m_duration);
         RETURN_IF_EXCEPTION(scope, 0);
-
-        auto intermediateDate = calendarAwareDateAdd(globalObject, relativeTo.calendarId, plainDate, internalDuration.dateDuration(), TemporalOverflow::Constrain);
+        // Steps 15.b-e: target {date, time}.
+        auto target = computePlainRelativeTarget(globalObject, relativeTo.calendarId, plainDate, internalDuration);
         RETURN_IF_EXCEPTION(scope, 0);
-
-        auto [overflowDays, subdayNs] = TemporalCore::splitTimeDuration(internalDuration.time());
-        ISO8601::Duration dayDuration(0LL, 0LL, 0LL, static_cast<int64_t>(overflowDays), 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0));
-        auto targetDate = calendarAwareDateAdd(globalObject, relativeTo.calendarId, intermediateDate, dayDuration, TemporalOverflow::Constrain);
+        ASSERT(target);
+        // Steps 15.f-h: DifferencePlainDateTimeWithTotal.
+        auto result = differencePlainDateTimeWithTotal(globalObject, relativeTo.calendarId, plainDate, *target, unit);
         RETURN_IF_EXCEPTION(scope, 0);
-        ISO8601::PlainTime targetTime = TemporalCore::plainTimeFromSubdayNs(subdayNs);
-
-        Int128 originEpochNs = TemporalCore::getUTCEpochNanoseconds(plainDate, midnight);
-        Int128 destEpochNs = TemporalCore::getUTCEpochNanoseconds(targetDate, targetTime);
-
-        // Spec: DifferencePlainDateTimeWithTotal early-return for zero duration,
-        // then ISODateTimeWithinLimits check on both endpoints.
-        if (originEpochNs == destEpochNs)
-            return 0;
-        bool dtOutOfRange2 = !ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 0, 0, 0, 0, 0, 0)
-            || !ISO8601::isDateTimeWithinLimits(targetDate.year(), targetDate.month(), targetDate.day(),
-                targetTime.hour(), targetTime.minute(), targetTime.second(),
-                targetTime.millisecond(), targetTime.microsecond(), targetTime.nanosecond());
-        if (dtOutOfRange2) [[unlikely]] {
-            throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
-            return 0;
-        }
-
-        if (unit >= TemporalUnit::Day)
-            return TemporalCore::totalTimeDuration(destEpochNs - originEpochNs, unit);
-
-        // Calendar units: diff then nudge.
-        auto diff = TemporalCore::diffISODateTime(plainDate, midnight, targetDate, targetTime, unit);
-        int32_t sign = (destEpochNs > originEpochNs) ? 1 : (destEpochNs < originEpochNs) ? -1 : 1;
-        auto nudgedResult2 = TemporalCore::nudgeToCalendarUnit(sign, diff, originEpochNs, destEpochNs,
-            plainDate, midnight, 1.0, unit, RoundingMode::Trunc, nullptr, relativeTo.calendarId);
-        if (!nudgedResult2) [[unlikely]] {
-            throwTemporalError(globalObject, scope, nudgedResult2.error());
-            return 0;
-        }
-        return nudgedResult2->total;
+        ASSERT(result);
+        return *result;
     }
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -71,10 +71,6 @@ public:
     String toString(JSGlobalObject*, JSValue options) const;
     String toString(JSGlobalObject* globalObject, std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const { return toString(globalObject, m_duration, precision); }
 
-    static ISO8601::InternalDuration toInternalDurationRecordWith24HourDays(JSGlobalObject*, ISO8601::Duration);
-
-    static ISO8601::InternalDuration round(JSGlobalObject*, ISO8601::InternalDuration, double increment, TemporalUnit, RoundingMode);
-    static std::optional<ISO8601::PlainDate> regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);
     static ISO8601::Duration toDateDurationRecordWithoutTime(JSGlobalObject*, const ISO8601::Duration&);
 private:
     TemporalDuration(VM&, Structure*, ISO8601::Duration&&);
@@ -84,6 +80,10 @@ private:
     static std::optional<ISO8601::Duration> parse(StringParsingBuffer<CharacterType>&);
 
     static String toString(JSGlobalObject*, const ISO8601::Duration&, std::tuple<Precision, unsigned> precision);
+
+    static ISO8601::InternalDuration round(JSGlobalObject*, ISO8601::InternalDuration, double increment, TemporalUnit, RoundingMode);
+
+    static ISO8601::InternalDuration toInternalDurationRecordWith24HourDays(JSGlobalObject*, ISO8601::Duration);
 
     ISO8601::Duration m_duration;
 };

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDayPrototype.cpp
@@ -28,6 +28,7 @@
 
 #include "CalendarFields.h"
 #include "CalendarICUBridge.h"
+#include "ISOArithmetic.h"
 #include "IntlDateTimeFormat.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
@@ -240,14 +241,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainMonthDayPrototypeFuncToPlainDate, (JSGloba
         RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(resolved->isoDate), resolved->calendarId)));
     }
 
-    auto plainDateOptional =
-        TemporalDuration::regulateISODate(itemYear.value(), thisMonth, thisDay, TemporalOverflow::Constrain);
-    if (!plainDateOptional) [[unlikely]] {
+    auto plainDateResult = TemporalCore::regulateISODate(itemYear.value(), thisMonth, thisDay, TemporalOverflow::Constrain);
+    if (!plainDateResult) [[unlikely]] {
         throwRangeError(globalObject, scope, "Temporal.PlainMonthDay.prototype.toPlainDate: date is invalid"_s);
         return { };
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDateOptional.value()), monthDay->calendarID())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(*plainDateResult), monthDay->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.valueof

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonthPrototype.cpp
@@ -29,6 +29,7 @@
 
 #include "CalendarFields.h"
 #include "CalendarICUBridge.h"
+#include "ISOArithmetic.h"
 #include "IntlDateTimeFormat.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
@@ -294,14 +295,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainYearMonthPrototypeFuncToPlainDate, (JSGlob
 
     auto thisYear = yearMonth->year();
     auto thisMonth = yearMonth->month();
-    auto plainDateOptional =
-        TemporalDuration::regulateISODate(thisYear, thisMonth, itemDay.value(), TemporalOverflow::Constrain);
-    if (!plainDateOptional) [[unlikely]] {
+    auto plainDateResult = TemporalCore::regulateISODate(thisYear, thisMonth, itemDay.value(), TemporalOverflow::Constrain);
+    if (!plainDateResult) [[unlikely]] {
         throwRangeError(globalObject, scope, "Temporal.PlainYearMonth.prototype.toPlainDate: date is invalid"_s);
         return { };
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(plainDateOptional.value()), yearMonth->calendarID())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(*plainDateResult), yearMonth->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.tostring


### PR DESCRIPTION
#### 002eefd45836878954c4e246011e83e85c10ee23
<pre>
[JSC][Temporal] Polish Temporal.Duration round and total spec alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=317877">https://bugs.webkit.org/show_bug.cgi?id=317877</a>
<a href="https://rdar.apple.com/180661221">rdar://180661221</a>

Reviewed by Yusuke Suzuki.

Extract the relativeTo endpoint computation (AddZonedDateTime,
AddTime + CalendarDateAdd) into computeZonedRelativeEndpoints
and computePlainRelativeTarget, and lift the inline blocks for
DifferenceZonedDateTimeWithTotal / DifferencePlainDateTimeWithTotal
into file-static functions named after their spec abstract ops.
Duration.prototype.round and Duration.prototype.total had parallel
implementations of the zoned and plain relativeTo paths; they now
share one code path and each call site labels its spec steps in
place.

Move toInternalDurationRecordWith24HourDays and the InternalDuration
overload of round to private — both are only used internally. Drop
TemporalDuration::regulateISODate; its only external callers
(PlainMonthDay/PlainYearMonth.prototype.toPlainDate) now call

TemporalCore::regulateISODate directly.
Canonical link: <a href="https://commits.webkit.org/315868@main">https://commits.webkit.org/315868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6143a05af87657874bfdba2bc8587dcf46f90257

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179657 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127995 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0028e93-47ea-417f-9980-12f77a626bf8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132770 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8f941ad-3ed5-46d8-8c13-107fe25e6b3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173242 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35942 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 9 pre-existing failure based on results-db; Uploaded test results") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113263 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4867d61c-4587-40ce-981a-8e563ca1bae3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28341 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1604 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182242 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31538 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35032 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37065 "Found 1 new test failure: http/tests/site-isolation/https-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141211 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43863 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44552 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108969 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36297 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116434 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/202962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43062 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7671 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42468 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42708 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->