### PR TITLE
REGRESSION(315650@main): Broke MiniBrowser WK2 window in CMake macOS 27 port (no NSRefreshControlHosting conformance found)

### DIFF
--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -55,6 +55,7 @@
 #import <WebKit/_WKInspector.h>
 #import <WebKit/_WKLinkIconParameters.h>
 #import <WebKit/_WKUserInitiatedAction.h>
+#import <objc/runtime.h>
 
 static void* keyValueObservingContext = &keyValueObservingContext;
 static const int testHeaderBannerHeight = 42;
@@ -171,11 +172,15 @@ static const int testFooterBannerHeight = 58;
 
     _zoomTextOnly = NO;
 
+    // FIXME: <webkit.org/b/317881> Remove this protocol check once the CMake port builds WKWebView+RefreshControl.swift.
 #if __MAC_OS_X_VERSION_MIN_REQUIRED >= 270000
-    _refreshController = [[NSRefreshController alloc] init];
-    _refreshController.target = self;
-    _refreshController.action = @selector(_refreshControllerActivated:);
-    _webView.refreshController = _refreshController;
+    Protocol *refreshControlHosting = NSProtocolFromString(@"NSRefreshControlHosting");
+    if (refreshControlHosting && [_webView conformsToProtocol:refreshControlHosting]) {
+        _refreshController = [[NSRefreshController alloc] init];
+        _refreshController.target = self;
+        _refreshController.action = @selector(_refreshControllerActivated:);
+        _webView.refreshController = _refreshController;
+    }
 #endif
 }
 


### PR DESCRIPTION
#### 425dd892bc84f29c6601f82f32ace002df93e1ae
<pre>
REGRESSION(315650@main): Broke MiniBrowser WK2 window in CMake macOS 27 port (no NSRefreshControlHosting conformance found)
<a href="https://bugs.webkit.org/show_bug.cgi?id=317880">https://bugs.webkit.org/show_bug.cgi?id=317880</a>
<a href="https://rdar.apple.com/180662875">rdar://180662875</a>

Reviewed by Pascoe, Sammy Gill, and Alex Christensen.

The CMake macOS 27 port does not currently build many Swift files, one
of which is WKWebView+RefreshControl.swift. As such, AppKit thinks
WKWebView does not have conformance to NSRefreshControlHosting, and as
such throws an exception during WK2BrowserWindowController launch.

In this patch, we work around the exception by gating the refresh
control install on the web view behind a protocol conformance check.

* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController awakeFromNib]):

Canonical link: <a href="https://commits.webkit.org/315851@main">https://commits.webkit.org/315851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/227f118bd4f0995a3597b8514c805be46e218d3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179659 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/127997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9df31332-12d4-4098-af39-6ca7673b15dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45452 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43840 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/127997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d59bcf76-1393-46a1-a4b9-b40f3092edba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173244 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f54057a-7422-442b-bb0b-eee2b513d2c9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28343 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182244 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43865 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141034 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44554 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108973 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25963 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36298 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43064 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7673 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42710 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42599 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->