### PR TITLE
[GFC] Extract hasStretchedBlockSize and stretchedBlockSize helpers in GridLayoutUtils

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -287,6 +287,35 @@ static LayoutUnit automaticMinimumBlockSize(const PlacedGridItem& gridItem, Layo
     return contentBasedMinimumSize();
 }
 
+bool hasStretchedBlockSize(const PlacedGridItem& placedGridItem)
+{
+    if (!placedGridItem.blockAxisSizes().preferredSize.isAuto())
+        return false;
+    if (placedGridItem.preferredAspectRatio() || placedGridItem.isReplacedElement())
+        return false;
+    auto& marginStart = placedGridItem.blockAxisSizes().marginStart;
+    auto& marginEnd = placedGridItem.blockAxisSizes().marginEnd;
+    return placedGridItem.blockAxisAlignment().position() == ItemPosition::Normal && !marginStart.isAuto() && !marginEnd.isAuto();
+}
+
+LayoutUnit stretchedBlockSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit rowsSize)
+{
+    ASSERT(hasStretchedBlockSize(placedGridItem));
+    auto& blockAxisSizes = placedGridItem.blockAxisSizes();
+    auto& usedZoom = placedGridItem.usedZoom();
+    auto marginStart = LayoutUnit { blockAxisSizes.marginStart.tryFixed()->resolveZoom(usedZoom) };
+    auto marginEnd = LayoutUnit { blockAxisSizes.marginEnd.tryFixed()->resolveZoom(usedZoom) };
+    auto stretchedSize = rowsSize - marginStart - marginEnd - borderAndPadding;
+
+    auto maximumSize = [&] {
+        auto& computedMaximumSize = blockAxisSizes.maximumSize;
+        if (computedMaximumSize.isNone())
+            return LayoutUnit::max();
+        return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
+    }();
+    return std::min(maximumSize, stretchedSize);
+}
+
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding,
     const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit rowsSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
 {
@@ -297,33 +326,20 @@ LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem, Layout
     if (preferredSize.isAuto()) {
         // Grid item calculations for automatic sizes in a given dimensions vary by their
         // self-alignment values:
-        auto alignmentPosition = placedGridItem.blockAxisAlignment().position();
-
+        //
         // normal:
         // If the grid item has no preferred aspect ratio, and no natural size in the relevant
         // axis (if it is a replaced element), the grid item is sized as for align-self: stretch.
         //
         // https://www.w3.org/TR/css-align-3/#propdef-align-self
         //
-        // When the box’s computed width/height (as appropriate to the axis) is auto and neither of
-        // its margins (in the appropriate axis) are auto, sets the box’s used size to the length
+        // When the box's computed width/height (as appropriate to the axis) is auto and neither of
+        // its margins (in the appropriate axis) are auto, sets the box's used size to the length
         // necessary to make its outer size as close to filling the alignment container as possible
         // while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
-        auto& marginStart = blockAxisSizes.marginStart;
-        auto& marginEnd = blockAxisSizes.marginEnd;
-        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement()
-            && !marginStart.isAuto() && !marginEnd.isAuto()) {
-            auto& usedZoom = placedGridItem.usedZoom();
-
+        if (hasStretchedBlockSize(placedGridItem)) {
             auto minimumSize = GridLayoutUtils::usedBlockMinimumSize(placedGridItem, trackSizingFunctions, borderAndPadding, rowsSize, formattingContext, inlineAxisConstraint);
-            auto maximumSize = [&blockAxisSizes, &usedZoom] {
-                auto& computedMaximumSize = blockAxisSizes.maximumSize;
-                if (computedMaximumSize.isNone())
-                    return LayoutUnit::max();
-                return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
-            };
-            auto stretchedBlockSize = rowsSize - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
-            return std::max(minimumSize, std::min(maximumSize(), stretchedBlockSize));
+            return std::max(minimumSize, stretchedBlockSize(placedGridItem, borderAndPadding, rowsSize));
         }
     }
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -47,6 +47,8 @@ LayoutUnit NODELETE totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize);
 
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, LayoutUnit columnsSize, const IntegrationUtils&);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, LayoutUnit rowsSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);
+bool hasStretchedBlockSize(const PlacedGridItem&);
+LayoutUnit stretchedBlockSize(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
 
 LayoutUnit usedInlineMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils&);
 LayoutUnit usedBlockMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);


### PR DESCRIPTION
#### abd75430aa54d1b777ea7e167343c51361d64aab
<pre>
[GFC] Extract hasStretchedBlockSize and stretchedBlockSize helpers in GridLayoutUtils
<a href="https://bugs.webkit.org/show_bug.cgi?id=317885">https://bugs.webkit.org/show_bug.cgi?id=317885</a>
<a href="https://rdar.apple.com/180664653">rdar://180664653</a>

Reviewed by Brandon Stewart.

Pull the block-axis stretch-fit computation out of usedBlockSizeForGridItem into
two standalone helpers. This is a behavior-preserving refactor that lets the
stretched block size be queried on its own, separately from the full
used-block-size logic.

hasStretchedBlockSize() captures the condition under which a grid item is sized
as align-self: stretch in the block axis (auto preferred size, normal alignment,
not replaced, no preferred aspect ratio, and non-auto margins). stretchedBlockSize()
computes the stretch-fit size exactly as the previous inline code did: the row
size minus margins and border/padding, clamped by the item&apos;s max size.
usedBlockSizeForGridItem() now calls these helpers instead of open-coding the
computation.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::hasStretchedBlockSize): Added.
(WebCore::Layout::GridLayoutUtils::stretchedBlockSize): Added.
(WebCore::Layout::GridLayoutUtils::usedBlockSizeForGridItem): Use the new helpers.
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:

Canonical link: <a href="https://commits.webkit.org/315914@main">https://commits.webkit.org/315914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4ba2fd31b2048732130815f89ff576a3bf6edf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128050 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b51a8a5d-b43d-4e8f-ba55-9cbc4b56a99d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132816 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9ebc9b8-0619-4b27-b272-43a0da1e551c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35994 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153245 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/321f9633-451e-4ced-9af7-7fadb8371c32) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28396 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182297 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141264 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43918 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38021 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44607 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109043 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36353 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116489 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43117 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7731 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42523 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42763 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->