### PR TITLE
Bump Xcode Project format to 26.3 and enable relevant features for MiniBrowser, SwiftBrowser, TestWebKitAPI, and WKTR projects

### DIFF
--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -3,15 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 110;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
 		DD403C872851B13F00D899FC /* MiniBrowser (Platform filters) */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = DD403C8A2851B13F00D899FC /* Build configuration list for PBXAggregateTarget "MiniBrowser (Platform filters)" */;
-			buildPhases = (
-			);
 			dependencies = (
 				DD403C8C2851B14300D899FC /* PBXTargetDependency */,
 			);
@@ -90,13 +88,11 @@
 /* Begin PBXFrameworksBuildPhase section */
 		8D11072E0486CEB800E47090 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				72945D0229B7F204006ACF75 /* QuartzCore.framework in Frameworks */,
 				5C9332AF24C1349C0036DECE /* SecurityInterface.framework in Frameworks */,
 				511AAEB72A8C1E77007ECBEE /* UserNotifications.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -205,8 +201,6 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			name = MiniBrowser;
 			productInstallPath = "$(HOME)/Applications";
 			productName = MiniBrowser;
@@ -233,13 +227,14 @@
 				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MiniBrowser" */;
-			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
 				en,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* MiniBrowser */;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 100;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -252,20 +247,17 @@
 /* Begin PBXResourcesBuildPhase section */
 		8D1107290486CEB800E47090 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				BC72B89611E57E0F001EB4EA /* BrowserWindow.xib in Resources */,
 				7CA379431AC381C10079DC37 /* ExtensionManagerWindowController.xib in Resources */,
 				BC72B89511E57E07001EB4EA /* MainMenu.xib in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8D11072C0486CEB800E47090 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				256AC3DA0F4B6AC300CF3369 /* AppDelegate.m in Sources */,
 				0FE643A1161FA8940059E3FF /* BrowserWindowController.m in Sources */,
@@ -277,7 +269,6 @@
 				0FE643A4161FAC660059E3FF /* WK1BrowserWindowController.m in Sources */,
 				BC329498116A941B008635D0 /* WK2BrowserWindowController.m in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -293,21 +284,21 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		C01FCF4B08A954540054247B /* Debug */ = {
+		C01FCF4B08A954540054247B /* Debug configuration for PBXNativeTarget "MiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BCA8CBDF11E578A000812FB7 /* MiniBrowser.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		C01FCF4C08A954540054247B /* Release */ = {
+		C01FCF4C08A954540054247B /* Release configuration for PBXNativeTarget "MiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BCA8CBDF11E578A000812FB7 /* MiniBrowser.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		C01FCF4F08A954540054247B /* Debug */ = {
+		C01FCF4F08A954540054247B /* Debug configuration for PBXProject "MiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BCA8CBDE11E578A000812FB7 /* DebugRelease.xcconfig */;
 			buildSettings = {
@@ -315,20 +306,20 @@
 			};
 			name = Debug;
 		};
-		C01FCF5008A954540054247B /* Release */ = {
+		C01FCF5008A954540054247B /* Release configuration for PBXProject "MiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BCA8CBDE11E578A000812FB7 /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		DD403C882851B13F00D899FC /* Debug */ = {
+		DD403C882851B13F00D899FC /* Debug configuration for PBXAggregateTarget "MiniBrowser (Platform filters)" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		DD403C892851B13F00D899FC /* Release */ = {
+		DD403C892851B13F00D899FC /* Release configuration for PBXAggregateTarget "MiniBrowser (Platform filters)" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
@@ -340,31 +331,29 @@
 		C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "MiniBrowser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C01FCF4B08A954540054247B /* Debug */,
-				C01FCF4C08A954540054247B /* Release */,
+				C01FCF4B08A954540054247B /* Debug configuration for PBXNativeTarget "MiniBrowser" */,
+				C01FCF4C08A954540054247B /* Release configuration for PBXNativeTarget "MiniBrowser" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MiniBrowser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C01FCF4F08A954540054247B /* Debug */,
-				C01FCF5008A954540054247B /* Release */,
+				C01FCF4F08A954540054247B /* Debug configuration for PBXProject "MiniBrowser" */,
+				C01FCF5008A954540054247B /* Release configuration for PBXProject "MiniBrowser" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		DD403C8A2851B13F00D899FC /* Build configuration list for PBXAggregateTarget "MiniBrowser (Platform filters)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD403C882851B13F00D899FC /* Debug */,
-				DD403C892851B13F00D899FC /* Release */,
+				DD403C882851B13F00D899FC /* Debug configuration for PBXAggregateTarget "MiniBrowser (Platform filters)" */,
+				DD403C892851B13F00D899FC /* Release configuration for PBXAggregateTarget "MiniBrowser (Platform filters)" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
 	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+	validationLevel = 1;
 }

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
@@ -3,15 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 110;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
 		DD2A1D052888D1CB00342472 /* MobileMiniBrowser (Platform filters) */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = DD2A1D082888D1CB00342472 /* Build configuration list for PBXAggregateTarget "MobileMiniBrowser (Platform filters)" */;
-			buildPhases = (
-			);
 			dependencies = (
 				DD2A1D0A2888D1D300342472 /* PBXTargetDependency */,
 			);
@@ -60,11 +58,14 @@
 			inputFiles = (
 				"$(SRCROOT)/../TestRunnerShared/Scripts/install-extensions-rule.sh",
 			);
-			isEditable = 1;
 			outputFiles = (
 				"$(BUILT_PRODUCTS_DIR)/$(EXTENSIONS_FOLDER_PATH)/$(INPUT_FILE_NAME)",
 			);
-			script = "echo \"source root $(SRCROOT)\"\n\"${SCRIPT_INPUT_FILE_0}\"\n";
+			script = (
+				"echo \"source root $(SRCROOT)\"",
+				"\"${SCRIPT_INPUT_FILE_0}\"",
+				"",
+			);
 		};
 /* End PBXBuildRule section */
 
@@ -95,27 +96,23 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		CD498B231D76341700681FA7 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolder = Frameworks;
 			files = (
 				CD498B431D76348000681FA7 /* MobileMiniBrowser.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E3EE46D92DF345E9009ED72B /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "$(EXTENSIONS_FOLDER_PATH)";
-			dstSubfolderSpec = 16;
+			dstSubfolder = Product;
 			files = (
 				E3EE46DB2DF3473D009ED72B /* GPUExtension.appex in CopyFiles */,
 				E3EE46DD2DF3475B009ED72B /* NetworkingExtension.appex in CopyFiles */,
 				E37DD4942FB4F8180069AF09 /* WebContentEnhancedSecurityExtension.appex in CopyFiles */,
 				E3EE46DF2DF34770009ED72B /* WebContentExtension.appex in CopyFiles */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -159,29 +156,23 @@
 /* Begin PBXFrameworksBuildPhase section */
 		CD1DAF8F1D709E3600017CF0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD498B421D76348000681FA7 /* MobileMiniBrowser.framework in Frameworks */,
 				DDC9E8CD2A91E0F400B015C1 /* UIKit.framework in Frameworks */,
 				4484520429424D840059B0FE /* WebKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD1DAFA81D709E3600017CF0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD498B371D76348000681FA7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				DDC9E8CC2A91DEDE00B015C1 /* UIKit.framework in Frameworks */,
 				DD403C5828500FE300D899FC /* WebKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -289,14 +280,12 @@
 /* Begin PBXHeadersBuildPhase section */
 		CD498B381D76348000681FA7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD498B501D763D7600681FA7 /* SceneDelegate.h in Headers */,
 				457D0F7A29088D9000AE5914 /* SettingsViewController.h in Headers */,
 				CD498B4E1D763D7600681FA7 /* TabViewController.h in Headers */,
 				CD498B4F1D763D7600681FA7 /* WebViewController.h in Headers */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
@@ -351,8 +340,6 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			name = MobileMiniBrowser.framework;
 			productName = MobileMiniBrowser;
 			productReference = CD498B3B1D76348000681FA7 /* MobileMiniBrowser.framework */;
@@ -384,7 +371,6 @@
 				};
 			};
 			buildConfigurationList = CD1DAF8D1D709E3600017CF0 /* Build configuration list for PBXProject "MobileMiniBrowser" */;
-			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -392,6 +378,8 @@
 				Base,
 			);
 			mainGroup = CD1DAF891D709E3600017CF0;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 100;
 			productRefGroup = CD1DAF931D709E3600017CF0 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -407,15 +395,12 @@
 /* Begin PBXResourcesBuildPhase section */
 		CD1DAF901D709E3600017CF0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD1DAFA51D709E3600017CF0 /* LaunchScreen.storyboard in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD1DAFA91D709E3600017CF0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CDC2792E2935418400151088 /* index.html in Resources */,
 				CDC2792A2935418400151088 /* looping.html in Resources */,
@@ -423,46 +408,37 @@
 				CDC2792C2935418400151088 /* test.mp4 in Resources */,
 				CDC2792B2935418400151088 /* test2s.mp4 in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD498B391D76348000681FA7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD498B521D763D8800681FA7 /* Assets.xcassets in Resources */,
 				CD498B511D763D7F00681FA7 /* Main.storyboard in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		CD1DAF8E1D709E3600017CF0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD1DAF971D709E3600017CF0 /* main.m in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD1DAFA71D709E3600017CF0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD1DAFB01D709E3600017CF0 /* MobileMiniBrowserUITests.m in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CD498B361D76348000681FA7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				CD498B4D1D763D7100681FA7 /* SceneDelegate.m in Sources */,
 				45BE567C2908C74600FD7A95 /* SettingsViewController.m in Sources */,
 				CD498B4B1D763D7100681FA7 /* TabViewController.m in Sources */,
 				CD498B4C1D763D7100681FA7 /* WebViewController.m in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -508,21 +484,21 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		CD1DAFB21D709E3600017CF0 /* Debug */ = {
+		CD1DAFB21D709E3600017CF0 /* Debug configuration for PBXProject "MobileMiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4DEEE31D78C6FF00625986 /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		CD1DAFB31D709E3600017CF0 /* Release */ = {
+		CD1DAFB31D709E3600017CF0 /* Release configuration for PBXProject "MobileMiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4DEEE31D78C6FF00625986 /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		CD1DAFB51D709E3600017CF0 /* Debug */ = {
+		CD1DAFB51D709E3600017CF0 /* Debug configuration for PBXNativeTarget "MobileMiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4DEEE41D78C6FF00625986 /* MobileMiniBrowser.xcconfig */;
 			buildSettings = {
@@ -538,7 +514,7 @@
 			};
 			name = Debug;
 		};
-		CD1DAFB61D709E3600017CF0 /* Release */ = {
+		CD1DAFB61D709E3600017CF0 /* Release configuration for PBXNativeTarget "MobileMiniBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4DEEE41D78C6FF00625986 /* MobileMiniBrowser.xcconfig */;
 			buildSettings = {
@@ -554,7 +530,7 @@
 			};
 			name = Release;
 		};
-		CD1DAFB81D709E3600017CF0 /* Debug */ = {
+		CD1DAFB81D709E3600017CF0 /* Debug configuration for PBXNativeTarget "MobileMiniBrowserUITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = MobileMiniBrowserUITests/Info.plist;
@@ -569,7 +545,7 @@
 			};
 			name = Debug;
 		};
-		CD1DAFB91D709E3600017CF0 /* Release */ = {
+		CD1DAFB91D709E3600017CF0 /* Release configuration for PBXNativeTarget "MobileMiniBrowserUITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = MobileMiniBrowserUITests/Info.plist;
@@ -584,7 +560,7 @@
 			};
 			name = Release;
 		};
-		CD498B451D76348000681FA7 /* Debug */ = {
+		CD498B451D76348000681FA7 /* Debug configuration for PBXNativeTarget "MobileMiniBrowser.framework" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4DEEE41D78C6FF00625986 /* MobileMiniBrowser.xcconfig */;
 			buildSettings = {
@@ -608,7 +584,7 @@
 			};
 			name = Debug;
 		};
-		CD498B461D76348000681FA7 /* Release */ = {
+		CD498B461D76348000681FA7 /* Release configuration for PBXNativeTarget "MobileMiniBrowser.framework" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4DEEE41D78C6FF00625986 /* MobileMiniBrowser.xcconfig */;
 			buildSettings = {
@@ -632,13 +608,13 @@
 			};
 			name = Release;
 		};
-		DD2A1D062888D1CB00342472 /* Debug */ = {
+		DD2A1D062888D1CB00342472 /* Debug configuration for PBXAggregateTarget "MobileMiniBrowser (Platform filters)" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		DD2A1D072888D1CB00342472 /* Release */ = {
+		DD2A1D072888D1CB00342472 /* Release configuration for PBXAggregateTarget "MobileMiniBrowser (Platform filters)" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
@@ -650,49 +626,45 @@
 		CD1DAF8D1D709E3600017CF0 /* Build configuration list for PBXProject "MobileMiniBrowser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CD1DAFB21D709E3600017CF0 /* Debug */,
-				CD1DAFB31D709E3600017CF0 /* Release */,
+				CD1DAFB21D709E3600017CF0 /* Debug configuration for PBXProject "MobileMiniBrowser" */,
+				CD1DAFB31D709E3600017CF0 /* Release configuration for PBXProject "MobileMiniBrowser" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		CD1DAFB41D709E3600017CF0 /* Build configuration list for PBXNativeTarget "MobileMiniBrowser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CD1DAFB51D709E3600017CF0 /* Debug */,
-				CD1DAFB61D709E3600017CF0 /* Release */,
+				CD1DAFB51D709E3600017CF0 /* Debug configuration for PBXNativeTarget "MobileMiniBrowser" */,
+				CD1DAFB61D709E3600017CF0 /* Release configuration for PBXNativeTarget "MobileMiniBrowser" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		CD1DAFB71D709E3600017CF0 /* Build configuration list for PBXNativeTarget "MobileMiniBrowserUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CD1DAFB81D709E3600017CF0 /* Debug */,
-				CD1DAFB91D709E3600017CF0 /* Release */,
+				CD1DAFB81D709E3600017CF0 /* Debug configuration for PBXNativeTarget "MobileMiniBrowserUITests" */,
+				CD1DAFB91D709E3600017CF0 /* Release configuration for PBXNativeTarget "MobileMiniBrowserUITests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		CD498B441D76348000681FA7 /* Build configuration list for PBXNativeTarget "MobileMiniBrowser.framework" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CD498B451D76348000681FA7 /* Debug */,
-				CD498B461D76348000681FA7 /* Release */,
+				CD498B451D76348000681FA7 /* Debug configuration for PBXNativeTarget "MobileMiniBrowser.framework" */,
+				CD498B461D76348000681FA7 /* Release configuration for PBXNativeTarget "MobileMiniBrowser.framework" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		DD2A1D082888D1CB00342472 /* Build configuration list for PBXAggregateTarget "MobileMiniBrowser (Platform filters)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD2A1D062888D1CB00342472 /* Debug */,
-				DD2A1D072888D1CB00342472 /* Release */,
+				DD2A1D062888D1CB00342472 /* Debug configuration for PBXAggregateTarget "MobileMiniBrowser (Platform filters)" */,
+				DD2A1D072888D1CB00342472 /* Release configuration for PBXAggregateTarget "MobileMiniBrowser (Platform filters)" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
 	rootObject = CD1DAF8A1D709E3600017CF0 /* Project object */;
+	validationLevel = 1;
 }

--- a/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
+++ b/Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 110;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -33,13 +33,11 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		07A4CEC52D092C0800764F5E /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolder = Frameworks;
 			files = (
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -77,12 +75,10 @@
 /* Begin PBXFrameworksBuildPhase section */
 		07A58BD12D0400B300CAB4ED /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				07A4CEC32D092C0800764F5E /* _WebKit_SwiftUI.framework in Frameworks */,
 				07A58C0E2D04DD4700CAB4ED /* WebKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -223,11 +219,7 @@
 			);
 			buildRules = (
 			);
-			dependencies = (
-			);
 			name = SwiftBrowser;
-			packageProductDependencies = (
-			);
 			productName = SwiftUIMiniBrowser;
 			productReference = 07A58BD42D0400B300CAB4ED /* SwiftBrowser.app */;
 			productType = "com.apple.product-type.application";
@@ -248,7 +240,6 @@
 				};
 			};
 			buildConfigurationList = 07A58BCF2D0400B300CAB4ED /* Build configuration list for PBXProject "SwiftBrowser" */;
-			compatibilityVersion = "Xcode 15.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -257,6 +248,7 @@
 			);
 			mainGroup = 07A58BCB2D0400B300CAB4ED;
 			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 100;
 			productRefGroup = 07A58BD52D0400B300CAB4ED /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -269,18 +261,15 @@
 /* Begin PBXResourcesBuildPhase section */
 		07A58BD22D0400B300CAB4ED /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				07A58BED2D04013100CAB4ED /* Assets.xcassets in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		07A58BD02D0400B300CAB4ED /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				07BAE3CE2E811F4400027836 /* _WKFeature+Extras.swift in Sources */,
 				07A58C482D05651C00CAB4ED /* AppStorageKeys.swift in Sources */,
@@ -301,33 +290,32 @@
 				07E88A892E777C61005A53CB /* WebContextMenu.swift in Sources */,
 				07E88A872E774C93005A53CB /* WebToolbarModifier.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		07A58BE12D0400B400CAB4ED /* Debug */ = {
+		07A58BE12D0400B400CAB4ED /* Debug configuration for PBXProject "SwiftBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07A58BF62D04056500CAB4ED /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		07A58BE22D0400B400CAB4ED /* Release */ = {
+		07A58BE22D0400B400CAB4ED /* Release configuration for PBXProject "SwiftBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07A58BF62D04056500CAB4ED /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		07A58BE42D0400B400CAB4ED /* Debug */ = {
+		07A58BE42D0400B400CAB4ED /* Debug configuration for PBXNativeTarget "SwiftBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07A58BF72D0405E200CAB4ED /* SwiftBrowser.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		07A58BE52D0400B400CAB4ED /* Release */ = {
+		07A58BE52D0400B400CAB4ED /* Release configuration for PBXNativeTarget "SwiftBrowser" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07A58BF72D0405E200CAB4ED /* SwiftBrowser.xcconfig */;
 			buildSettings = {
@@ -340,22 +328,21 @@
 		07A58BCF2D0400B300CAB4ED /* Build configuration list for PBXProject "SwiftBrowser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				07A58BE12D0400B400CAB4ED /* Debug */,
-				07A58BE22D0400B400CAB4ED /* Release */,
+				07A58BE12D0400B400CAB4ED /* Debug configuration for PBXProject "SwiftBrowser" */,
+				07A58BE22D0400B400CAB4ED /* Release configuration for PBXProject "SwiftBrowser" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		07A58BE32D0400B400CAB4ED /* Build configuration list for PBXNativeTarget "SwiftBrowser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				07A58BE42D0400B400CAB4ED /* Debug */,
-				07A58BE52D0400B400CAB4ED /* Release */,
+				07A58BE42D0400B400CAB4ED /* Debug configuration for PBXNativeTarget "SwiftBrowser" */,
+				07A58BE52D0400B400CAB4ED /* Release configuration for PBXNativeTarget "SwiftBrowser" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
 	rootObject = 07A58BCC2D0400B300CAB4ED /* Project object */;
+	validationLevel = 1;
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 90;
+	objectVersion = 110;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -2167,7 +2167,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 			);
-			preferredProjectObjectVersion = 90;
+			preferredProjectObjectVersion = 100;
 			projectDirPath = "";
 			projectReferences = (
 				{
@@ -2957,4 +2957,5 @@
 /* End XCConfigurationList section */
 	};
 	rootObject = 08FB7793FE84155DC02AAC07 /* Project object */;
+	validationLevel = 1;
 }

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 110;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -11,9 +11,7 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 5325BDDD21DFF4F500A0DEE1 /* Build configuration list for PBXAggregateTarget "Apply Configuration to XCFileLists" */;
 			buildPhases = (
-				5325BDDE21DFF4F800A0DEE1 /* ShellScript */,
-			);
-			dependencies = (
+				5325BDDE21DFF4F800A0DEE1 /* Run Sublaunch Script */,
 			);
 			name = "Apply Configuration to XCFileLists";
 			productName = "Apply Configuration to XCFileLists";
@@ -21,8 +19,6 @@
 		A115CCB41B9D769D00E89159 /* All */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = A115CCB51B9D769D00E89159 /* Build configuration list for PBXAggregateTarget "All" */;
-			buildPhases = (
-			);
 			dependencies = (
 				E3D8A94E2CC69CAF006B43E3 /* PBXTargetDependency */,
 				A115CCBC1B9D76C400E89159 /* PBXTargetDependency */,
@@ -38,15 +34,13 @@
 				DD453D922EC3A61700C1D6A8 /* Generate <wtf/Platform.h> args */,
 				BC952D8211F3BF78003398B4 /* Generate Derived Sources */,
 			);
-			dependencies = (
-			);
 			name = "Derived Sources";
 			productName = "Derived Sources";
 		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00E43E412D9781430060461A /* WebContentCaptivePortalExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = 00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		00E43E412D9781430060461A /* WebContentCaptivePortalExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = 00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0F18E6E51D6B9B9E0027E547 /* UIScriptContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E6DD1D6B9AAF0027E547 /* UIScriptContext.cpp */; };
 		0F18E6E61D6B9BA20027E547 /* UIScriptControllerShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E6DF1D6B9AAF0027E547 /* UIScriptControllerShared.cpp */; };
 		0F18E7181D6BC4560027E547 /* JSWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E7151D6BC4560027E547 /* JSWrapper.cpp */; };
@@ -170,9 +164,9 @@
 		E132AA3A17CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */; };
 		E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3B17CE776F00611DF0 /* WebKitTestRunnerEvent.mm */; };
 		E1C642C617CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1C642C417CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm */; };
-		E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC372C08EB01006DFE67 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC392C08F323006DFE67 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC372C08EB01006DFE67 /* GPUExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC392C08F323006DFE67 /* WebContentExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E3D8A94C2CC4B003006B43E3 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E17D422CC4447B0077C3AE /* main.cpp */; };
 		F4010B7E24DA205300A876E2 /* PoseAsClass.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B7C24DA204800A876E2 /* PoseAsClass.mm */; };
 		F415C22C27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h in Headers */ = {isa = PBXBuildFile; fileRef = F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */; };
@@ -195,11 +189,13 @@
 			inputFiles = (
 				"$(SRCROOT)/../TestRunnerShared/Scripts/install-extensions-rule.sh",
 			);
-			isEditable = 1;
 			outputFiles = (
 				"$(BUILT_PRODUCTS_DIR)/$(EXTENSIONS_FOLDER_PATH)/$(INPUT_FILE_NAME)",
 			);
-			script = "\"${SCRIPT_INPUT_FILE_0}\"\n";
+			script = (
+				"\"${SCRIPT_INPUT_FILE_0}\"",
+				"",
+			);
 		};
 /* End PBXBuildRule section */
 
@@ -265,20 +261,17 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		CEC209031D36E36A00261596 /* Copy Plug-Ins */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 13;
+			dstSubfolder = PlugIns;
 			files = (
 				2E34C90018B68808000067BB /* WebKitTestRunnerInjectedBundle.bundle in Copy Plug-Ins */,
 			);
 			name = "Copy Plug-Ins";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E372BC342C08E22D006DFE67 /* Embed Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
 			dstPath = "$(EXTENSIONS_FOLDER_PATH)";
-			dstSubfolderSpec = 16;
+			dstSubfolder = Product;
 			files = (
 				E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */,
 				E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */,
@@ -286,7 +279,6 @@
 				E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */,
 			);
 			name = "Embed Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -535,16 +527,13 @@
 /* Begin PBXFrameworksBuildPhase section */
 		2EE52CDD1890A9A80010ED21 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				D2D99AFC2AA27BA800000BBF /* Network.framework in Frameworks */,
 				57A0062F22976EF800AD08BD /* Security.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		8DD76F9B0486AA7600D96B5E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				51058AD51D678820009A538C /* libWebCoreTestSupport.dylib in Frameworks */,
 				D2D99AEE2A9EF3F500000BBF /* Network.framework in Frameworks */,
@@ -553,31 +542,24 @@
 				DD4671AE2A6B136200E49DBD /* WebCore.framework in Frameworks */,
 				51058AD61D678825009A538C /* WebKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A18510241B9ADE4800744AEB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BC25186011D15D54002EBC01 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				BC25194011D15D8B002EBC01 /* JavaScriptCore.framework in Frameworks */,
 				A664BC7613A5F3A9009A7B25 /* libWebCoreTestSupport.dylib in Frameworks */,
 				0F5169CC1445222D00E0A9D7 /* WebKit.framework in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E3D8A9412CC4AFB3006B43E3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -1109,7 +1091,6 @@
 /* Begin PBXHeadersBuildPhase section */
 		A18510251B9ADE4800744AEB /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2DB6187E1D7D58D400978D19 /* CoreGraphicsTestSPI.h in Headers */,
 				2DD4C49A1D6E7D3B0007379C /* EventSerializerMac.h in Headers */,
@@ -1121,7 +1102,6 @@
 				2D058E0B22E2EF6D00E4C145 /* UIScriptControllerMac.h in Headers */,
 				F474EE3D2B82B65100DE5F41 /* WKTextExtractionTestingHelpers.h in Headers */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
@@ -1241,7 +1221,6 @@
 				};
 			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "WebKitTestRunner" */;
-			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -1249,6 +1228,8 @@
 				Base,
 			);
 			mainGroup = 08FB7794FE84155DC02AAC07 /* WebKitTestRunner */;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 100;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1267,15 +1248,12 @@
 /* Begin PBXResourcesBuildPhase section */
 		2EE52CDE1890A9A80010ED21 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				0F4B08731D5BE88D00EC1B78 /* Launch.storyboard in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BC25185E11D15D54002EBC01 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				6510A78211EC643800410867 /* AHEM____.TTF in Resources */,
 				1CEA84DD203782ED00440D08 /* FakeHelvetica-ArmenianCharacter.ttf in Resources */,
@@ -1296,83 +1274,56 @@
 				6510A78B11EC643800410867 /* WebKitWeightWatcher800.ttf in Resources */,
 				6510A78C11EC643800410867 /* WebKitWeightWatcher900.ttf in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		5325BDDE21DFF4F800A0DEE1 /* Run Sublaunch Script */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
 			name = "Run Sublaunch Script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "eval \"${WK_SUBLAUNCH_SCRIPT_PARAMETERS[@]}\"\n";
+			shellScript = (
+				"eval \"${WK_SUBLAUNCH_SCRIPT_PARAMETERS[@]}\"",
+				"",
+			);
 		};
 		53A8193A21E52973000B93AB /* Check .xcfilelists */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"$(SRCROOT)/DerivedSources.make",
 			);
 			name = "Check .xcfilelists";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"$(TARGET_TEMP_DIR)/check-xcfilelists.timestamp",
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "Scripts/check-xcfilelists.sh && touch \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = (
+				"Scripts/check-xcfilelists.sh && touch \"${SCRIPT_OUTPUT_FILE_0}\"",
+				"",
+			);
 		};
 		BC952D8211F3BF78003398B4 /* Generate Derived Sources */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
 			inputFileListPaths = (
 				"$(SRCROOT)/DerivedSources-input.xcfilelist",
-			);
-			inputPaths = (
 			);
 			name = "Generate Derived Sources";
 			outputFileListPaths = (
 				"$(SRCROOT)/DerivedSources-output.xcfilelist",
 			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "Scripts/generate-derived-sources.sh\n";
+			shellScript = (
+				"Scripts/generate-derived-sources.sh",
+				"",
+			);
 		};
 		DD453D922EC3A61700C1D6A8 /* Generate <wtf/Platform.h> args */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
 			dependencyFile = "$(DERIVED_FILES_DIR)/generate-platform-args.d";
-			files = (
-			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"$(WTF_BUILD_SCRIPTS_DIR)/generate-platform-args",
 			);
 			name = "Generate <wtf/Platform.h> args";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitTestRunner/platform-enabled-swift-args.arm64.resp",
 				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitTestRunner/platform-enabled-swift-args.arm64_32.resp",
@@ -1381,16 +1332,20 @@
 				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitTestRunner/platform-enabled-swift-args.x86_64.resp",
 				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKitTestRunner/rdar150228472.swift",
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${ACTION}\" = installhdrs ]\nthen touch \"${DERIVED_FILES_DIR}/generate-platform-args.d\"\nelse \"${SCRIPT_INPUT_FILE_0}\"\nfi\n";
+			shellScript = (
+				"if [ \"${ACTION}\" = installhdrs ]",
+				"then touch \"${DERIVED_FILES_DIR}/generate-platform-args.d\"",
+				"else \"${SCRIPT_INPUT_FILE_0}\"",
+				"fi",
+				"",
+			);
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2EE52CDC1890A9A80010ED21 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2E749BF21891EBFA007FC175 /* EventSenderProxyIOS.mm in Sources */,
 				4430AE191F82C4FD0099915A /* GeneratedTouchesDebugWindow.mm in Sources */,
@@ -1400,11 +1355,9 @@
 				2E63ED921891ADAD002A7AFC /* TestControllerIOS.mm in Sources */,
 				F415C23527AF5B390028F505 /* UIPasteboardConsistencyEnforcer.mm in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		8DD76F990486AA7600D96B5E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				5670B8281386FCA5002EB355 /* EventSenderProxy.mm in Sources */,
 				334BF3B92D4E5BE7004AE4EA /* EventSenderProxyCocoa.mm in Sources */,
@@ -1418,11 +1371,9 @@
 				E1C642C617CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm in Sources */,
 				9376417A210D737200A3DAAE /* WebKitTestRunnerWindow.mm in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A18510231B9ADE4800744AEB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				F44A531721B899E200DBB99C /* ClassMethodSwizzler.mm in Sources */,
 				A185103A1B9AE0DA00744AEB /* CrashReporterInfo.mm in Sources */,
@@ -1461,11 +1412,9 @@
 				A18510441B9AE14A00744AEB /* WorkQueueManager.cpp in Sources */,
 				33558B2E2AF1C22B0041E63F /* WPTFunctions.cpp in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BC25185F11D15D54002EBC01 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				29210EDA144CC3EA00835BB6 /* AccessibilityCommonCocoa.mm in Sources */,
 				29210EB0144CACBD00835BB5 /* AccessibilityController.cpp in Sources */,
@@ -1507,15 +1456,12 @@
 				5664A49A14326384008881BE /* TextInputController.cpp in Sources */,
 				93C78823250C6C2E00C0AA24 /* WPTFunctions.cpp in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E3D8A9362CC4AFB3006B43E3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				E3D8A94C2CC4B003006B43E3 /* main.cpp in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -1563,7 +1509,7 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		1DEB927508733DD40010E9CD /* Debug */ = {
+		1DEB927508733DD40010E9CD /* Debug configuration for PBXNativeTarget "WebKitTestRunner" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
@@ -1574,7 +1520,7 @@
 			};
 			name = Debug;
 		};
-		1DEB927608733DD40010E9CD /* Release */ = {
+		1DEB927608733DD40010E9CD /* Release configuration for PBXNativeTarget "WebKitTestRunner" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
@@ -1585,21 +1531,21 @@
 			};
 			name = Release;
 		};
-		1DEB927908733DD40010E9CD /* Debug */ = {
+		1DEB927908733DD40010E9CD /* Debug configuration for PBXProject "WebKitTestRunner" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC793427118F7DAF005EA8E2 /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		1DEB927A08733DD40010E9CD /* Release */ = {
+		1DEB927A08733DD40010E9CD /* Release configuration for PBXProject "WebKitTestRunner" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC793427118F7DAF005EA8E2 /* DebugRelease.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		2EE52D091890A9A90010ED21 /* Debug */ = {
+		2EE52D091890A9A90010ED21 /* Debug configuration for PBXNativeTarget "WebKitTestRunnerApp" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510391B9ADFF800744AEB /* WebKitTestRunnerApp.xcconfig */;
 			buildSettings = {
@@ -1616,7 +1562,7 @@
 			};
 			name = Debug;
 		};
-		2EE52D0A1890A9A90010ED21 /* Release */ = {
+		2EE52D0A1890A9A90010ED21 /* Release configuration for PBXNativeTarget "WebKitTestRunnerApp" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510391B9ADFF800744AEB /* WebKitTestRunnerApp.xcconfig */;
 			buildSettings = {
@@ -1631,7 +1577,7 @@
 			};
 			name = Release;
 		};
-		2EE52D0B1890A9A90010ED21 /* Production */ = {
+		2EE52D0B1890A9A90010ED21 /* Production configuration for PBXNativeTarget "WebKitTestRunnerApp" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510391B9ADFF800744AEB /* WebKitTestRunnerApp.xcconfig */;
 			buildSettings = {
@@ -1646,7 +1592,7 @@
 			};
 			name = Production;
 		};
-		5325BDDA21DFF4F500A0DEE1 /* Debug */ = {
+		5325BDDA21DFF4F500A0DEE1 /* Debug configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
@@ -1655,7 +1601,7 @@
 			};
 			name = Debug;
 		};
-		5325BDDB21DFF4F500A0DEE1 /* Release */ = {
+		5325BDDB21DFF4F500A0DEE1 /* Release configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
@@ -1664,7 +1610,7 @@
 			};
 			name = Release;
 		};
-		5325BDDC21DFF4F500A0DEE1 /* Production */ = {
+		5325BDDC21DFF4F500A0DEE1 /* Production configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
@@ -1673,70 +1619,70 @@
 			};
 			name = Production;
 		};
-		A115CCB61B9D769D00E89159 /* Debug */ = {
+		A115CCB61B9D769D00E89159 /* Debug configuration for PBXAggregateTarget "All" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
 		};
-		A115CCB71B9D769D00E89159 /* Release */ = {
+		A115CCB71B9D769D00E89159 /* Release configuration for PBXAggregateTarget "All" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};
-		A115CCB81B9D769D00E89159 /* Production */ = {
+		A115CCB81B9D769D00E89159 /* Production configuration for PBXAggregateTarget "All" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Production;
 		};
-		A185102E1B9ADE4800744AEB /* Debug */ = {
+		A185102E1B9ADE4800744AEB /* Debug configuration for PBXNativeTarget "WebKitTestRunner (Library)" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC251A1811D16795002EBC01 /* WebKitTestRunnerLibrary.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		A185102F1B9ADE4800744AEB /* Release */ = {
+		A185102F1B9ADE4800744AEB /* Release configuration for PBXNativeTarget "WebKitTestRunner (Library)" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC251A1811D16795002EBC01 /* WebKitTestRunnerLibrary.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		A18510301B9ADE4800744AEB /* Production */ = {
+		A18510301B9ADE4800744AEB /* Production configuration for PBXNativeTarget "WebKitTestRunner (Library)" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC251A1811D16795002EBC01 /* WebKitTestRunnerLibrary.xcconfig */;
 			buildSettings = {
 			};
 			name = Production;
 		};
-		BC25186411D15D55002EBC01 /* Debug */ = {
+		BC25186411D15D55002EBC01 /* Debug configuration for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC25197111D15E61002EBC01 /* InjectedBundle.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		BC25186511D15D55002EBC01 /* Release */ = {
+		BC25186511D15D55002EBC01 /* Release configuration for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC25197111D15E61002EBC01 /* InjectedBundle.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		BC646D6D136A3A8700B35DED /* Production */ = {
+		BC646D6D136A3A8700B35DED /* Production configuration for PBXProject "WebKitTestRunner" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC793426118F7D3C005EA8E2 /* Base.xcconfig */;
 			buildSettings = {
 			};
 			name = Production;
 		};
-		BC646D6E136A3A8700B35DED /* Production */ = {
+		BC646D6E136A3A8700B35DED /* Production configuration for PBXNativeTarget "WebKitTestRunner" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
@@ -1747,49 +1693,49 @@
 			};
 			name = Production;
 		};
-		BC646D6F136A3A8700B35DED /* Production */ = {
+		BC646D6F136A3A8700B35DED /* Production configuration for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC25197111D15E61002EBC01 /* InjectedBundle.xcconfig */;
 			buildSettings = {
 			};
 			name = Production;
 		};
-		BC646D70136A3A8700B35DED /* Production */ = {
+		BC646D70136A3A8700B35DED /* Production configuration for PBXAggregateTarget "Derived Sources" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "Derived Sources";
 			};
 			name = Production;
 		};
-		BC952D7811F3BF5E003398B4 /* Debug */ = {
+		BC952D7811F3BF5E003398B4 /* Debug configuration for PBXAggregateTarget "Derived Sources" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "Derived Sources";
 			};
 			name = Debug;
 		};
-		BC952D7911F3BF5E003398B4 /* Release */ = {
+		BC952D7911F3BF5E003398B4 /* Release configuration for PBXAggregateTarget "Derived Sources" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				PRODUCT_NAME = "Derived Sources";
 			};
 			name = Release;
 		};
-		E3D8A9472CC4AFB3006B43E3 /* Debug */ = {
+		E3D8A9472CC4AFB3006B43E3 /* Debug configuration for PBXNativeTarget "WebKitEligibilityUtil" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		E3D8A9482CC4AFB3006B43E3 /* Release */ = {
+		E3D8A9482CC4AFB3006B43E3 /* Release configuration for PBXNativeTarget "WebKitEligibilityUtil" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		E3D8A9492CC4AFB3006B43E3 /* Production */ = {
+		E3D8A9492CC4AFB3006B43E3 /* Production configuration for PBXNativeTarget "WebKitEligibilityUtil" */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E3E17D472CC49D440077C3AE /* WebKitEligibilityUtil.xcconfig */;
 			buildSettings = {
@@ -1802,94 +1748,86 @@
 		1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "WebKitTestRunner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1DEB927508733DD40010E9CD /* Debug */,
-				1DEB927608733DD40010E9CD /* Release */,
-				BC646D6E136A3A8700B35DED /* Production */,
+				1DEB927508733DD40010E9CD /* Debug configuration for PBXNativeTarget "WebKitTestRunner" */,
+				1DEB927608733DD40010E9CD /* Release configuration for PBXNativeTarget "WebKitTestRunner" */,
+				BC646D6E136A3A8700B35DED /* Production configuration for PBXNativeTarget "WebKitTestRunner" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "WebKitTestRunner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1DEB927908733DD40010E9CD /* Debug */,
-				1DEB927A08733DD40010E9CD /* Release */,
-				BC646D6D136A3A8700B35DED /* Production */,
+				1DEB927908733DD40010E9CD /* Debug configuration for PBXProject "WebKitTestRunner" */,
+				1DEB927A08733DD40010E9CD /* Release configuration for PBXProject "WebKitTestRunner" */,
+				BC646D6D136A3A8700B35DED /* Production configuration for PBXProject "WebKitTestRunner" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		2EE52D0F1890A9A90010ED21 /* Build configuration list for PBXNativeTarget "WebKitTestRunnerApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2EE52D091890A9A90010ED21 /* Debug */,
-				2EE52D0A1890A9A90010ED21 /* Release */,
-				2EE52D0B1890A9A90010ED21 /* Production */,
+				2EE52D091890A9A90010ED21 /* Debug configuration for PBXNativeTarget "WebKitTestRunnerApp" */,
+				2EE52D0A1890A9A90010ED21 /* Release configuration for PBXNativeTarget "WebKitTestRunnerApp" */,
+				2EE52D0B1890A9A90010ED21 /* Production configuration for PBXNativeTarget "WebKitTestRunnerApp" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		5325BDDD21DFF4F500A0DEE1 /* Build configuration list for PBXAggregateTarget "Apply Configuration to XCFileLists" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5325BDDA21DFF4F500A0DEE1 /* Debug */,
-				5325BDDB21DFF4F500A0DEE1 /* Release */,
-				5325BDDC21DFF4F500A0DEE1 /* Production */,
+				5325BDDA21DFF4F500A0DEE1 /* Debug configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */,
+				5325BDDB21DFF4F500A0DEE1 /* Release configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */,
+				5325BDDC21DFF4F500A0DEE1 /* Production configuration for PBXAggregateTarget "Apply Configuration to XCFileLists" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		A115CCB51B9D769D00E89159 /* Build configuration list for PBXAggregateTarget "All" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A115CCB61B9D769D00E89159 /* Debug */,
-				A115CCB71B9D769D00E89159 /* Release */,
-				A115CCB81B9D769D00E89159 /* Production */,
+				A115CCB61B9D769D00E89159 /* Debug configuration for PBXAggregateTarget "All" */,
+				A115CCB71B9D769D00E89159 /* Release configuration for PBXAggregateTarget "All" */,
+				A115CCB81B9D769D00E89159 /* Production configuration for PBXAggregateTarget "All" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		A185102D1B9ADE4800744AEB /* Build configuration list for PBXNativeTarget "WebKitTestRunner (Library)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A185102E1B9ADE4800744AEB /* Debug */,
-				A185102F1B9ADE4800744AEB /* Release */,
-				A18510301B9ADE4800744AEB /* Production */,
+				A185102E1B9ADE4800744AEB /* Debug configuration for PBXNativeTarget "WebKitTestRunner (Library)" */,
+				A185102F1B9ADE4800744AEB /* Release configuration for PBXNativeTarget "WebKitTestRunner (Library)" */,
+				A18510301B9ADE4800744AEB /* Production configuration for PBXNativeTarget "WebKitTestRunner (Library)" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		BC25186611D15D55002EBC01 /* Build configuration list for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC25186411D15D55002EBC01 /* Debug */,
-				BC25186511D15D55002EBC01 /* Release */,
-				BC646D6F136A3A8700B35DED /* Production */,
+				BC25186411D15D55002EBC01 /* Debug configuration for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */,
+				BC25186511D15D55002EBC01 /* Release configuration for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */,
+				BC646D6F136A3A8700B35DED /* Production configuration for PBXNativeTarget "WebKitTestRunnerInjectedBundle" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		BC952D7D11F3BF6A003398B4 /* Build configuration list for PBXAggregateTarget "Derived Sources" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC952D7811F3BF5E003398B4 /* Debug */,
-				BC952D7911F3BF5E003398B4 /* Release */,
-				BC646D70136A3A8700B35DED /* Production */,
+				BC952D7811F3BF5E003398B4 /* Debug configuration for PBXAggregateTarget "Derived Sources" */,
+				BC952D7911F3BF5E003398B4 /* Release configuration for PBXAggregateTarget "Derived Sources" */,
+				BC646D70136A3A8700B35DED /* Production configuration for PBXAggregateTarget "Derived Sources" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 		E3D8A9462CC4AFB3006B43E3 /* Build configuration list for PBXNativeTarget "WebKitEligibilityUtil" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E3D8A9472CC4AFB3006B43E3 /* Debug */,
-				E3D8A9482CC4AFB3006B43E3 /* Release */,
-				E3D8A9492CC4AFB3006B43E3 /* Production */,
+				E3D8A9472CC4AFB3006B43E3 /* Debug configuration for PBXNativeTarget "WebKitEligibilityUtil" */,
+				E3D8A9482CC4AFB3006B43E3 /* Release configuration for PBXNativeTarget "WebKitEligibilityUtil" */,
+				E3D8A9492CC4AFB3006B43E3 /* Production configuration for PBXNativeTarget "WebKitEligibilityUtil" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;
 		};
 /* End XCConfigurationList section */
 	};
 	rootObject = 08FB7793FE84155DC02AAC07 /* Project object */;
+	validationLevel = 1;
 }


### PR DESCRIPTION
#### 17d6073c34b205221848c101216f9a4e2dbac7eb
<pre>
Bump Xcode Project format to 26.3 and enable relevant features for MiniBrowser, SwiftBrowser, TestWebKitAPI, and WKTR projects
<a href="https://bugs.webkit.org/show_bug.cgi?id=317887">https://bugs.webkit.org/show_bug.cgi?id=317887</a>
<a href="https://rdar.apple.com/180665204">rdar://180665204</a>

Reviewed by NOBODY (OOPS!).

Bump the Xcode Project Format version to 26.3 and enable
&quot;Encoding: Minimize Project References&quot; and &quot;Decoding: Strictly Validate&quot; features.

* Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj:
* Tools/SwiftBrowser/SwiftBrowser.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17d6073c34b205221848c101216f9a4e2dbac7eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170289 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44212 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37629 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128001 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dabbd518-7269-4744-988e-e8f37a3cdb62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172155 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45456 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43844 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132771 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93577 "1 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61209b97-e399-40de-816b-4efc0fb20be5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113271 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60476687-b63b-47c2-8ebd-e8143f7092b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34574 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32898 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28347 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182248 "Built successfully") | | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37071 "Found 1 new test failure: http/tests/site-isolation/https-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141218 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43869 "Failed to compile WebKit") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141038 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44558 "Failed to compile WebKit") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29580 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108977 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36306 "Passed tests") | | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43068 "Failed to compile WebKit") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7681 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42474 "Failed to compile WebKit") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42714 "Failed to compile WebKit") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42603 "Failed to compile WebKit") | | | | 
<!--EWS-Status-Bubble-End-->