### PR TITLE
[WebDriver][Tools] Ensure W3C executor multiprocessing uses the fork start method for python 3.14 compatibility

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py
@@ -25,7 +25,9 @@ import os
 import json
 import sys
 
-from multiprocessing import Process, Queue
+import multiprocessing as mp
+_mp_context = mp.get_context('fork')
+
 from webkitpy.common.system.filesystem import FileSystem
 from webkitpy.common.webkit_finder import WebKitFinder
 
@@ -138,8 +140,8 @@ class WebDriverW3CExecutor(WdspecExecutor):
 
         self._timeout = timeout
         self._expectations = expectations
-        self._test_queue = Queue()
-        self._result_queue = Queue()
+        self._test_queue = _mp_context.Queue()
+        self._result_queue = _mp_context.Queue()
 
     def setup(self):
         super(WebDriverW3CExecutor, self).setup(self.runner)
@@ -153,7 +155,7 @@ class WebDriverW3CExecutor(WdspecExecutor):
                 self.server_config,
                 self._timeout,
                 self._expectations)
-        self._process = Process(target=WebDriverW3CExecutor._runner, args=args)
+        self._process = _mp_context.Process(target=WebDriverW3CExecutor._runner, args=args)
         self._process.start()
 
     def teardown(self):


### PR DESCRIPTION
#### fe37b6ef75da27c08aa2dbae12c89bbe8d927eec
<pre>
[WebDriver][Tools] Ensure W3C executor multiprocessing uses the fork start method for python 3.14 compatibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=317863">https://bugs.webkit.org/show_bug.cgi?id=317863</a>

Reviewed by Carlos Alberto Lopez Perez.

Python 3.14 changed multiprocessing default start method from fork to
forkserver, where a server process is in charge of forking the new
processes out of it.

This method breaks the current WebDriver W3C executor, which assumes
that the spawned code will inherit the state of the parent, like
envvars, etc.

This commit reverts back to use the original &apos;fork&apos; method locally for
these workers.

Note that we still need the changes from bug317850 with the required
bumps for full 3.14 compatibility.

* Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py:
(WebDriverW3CExecutor.__init__):
(WebDriverW3CExecutor.setup):

Canonical link: <a href="https://commits.webkit.org/315885@main">https://commits.webkit.org/315885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aee05bb137f77c1f40fefb0af433b0400974fd1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113276 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169615 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28352 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182253 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141223 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43874 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37997 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108985 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36312 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43073 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7702 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42719 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->