### PR TITLE
[Scrolling] Partition ScrollingStateNode to support copy-on-write commits and avoid sending empty transactions

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,10 @@
 #include "GraphicsLayer.h"
 #include "Logging.h"
 #include "ScrollingStateTree.h"
+#include <wtf/DataRef.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -40,13 +44,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStateFixedNode);
 
 ScrollingStateFixedNode::ScrollingStateFixedNode(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, FixedPositionViewportConstraints&& constraints)
     : ScrollingStateNode(ScrollingNodeType::Fixed, nodeID, WTF::move(children), changedProperties, layerID)
-    , m_constraints(WTF::move(constraints))
 {
+    m_staticLayoutData.access().constraints = WTF::move(constraints);
 }
 
 ScrollingStateFixedNode::ScrollingStateFixedNode(const ScrollingStateFixedNode& node, ScrollingStateTree& adoptiveTree)
     : ScrollingStateNode(node, adoptiveTree)
-    , m_constraints(FixedPositionViewportConstraints(node.viewportConstraints()))
+    , m_staticLayoutData(node.m_staticLayoutData)
 {
 }
 
@@ -71,20 +75,29 @@ OptionSet<ScrollingStateNode::Property> ScrollingStateFixedNode::applicablePrope
     return properties;
 }
 
+bool ScrollingStateFixedNode::hasUnchangedGroupsAs(const ScrollingStateNode& other) const
+{
+    if (!ScrollingStateNode::hasUnchangedGroupsAs(other))
+        return false;
+    auto& otherFixed = downcast<ScrollingStateFixedNode>(other);
+    return m_staticLayoutData.ptr() == otherFixed.m_staticLayoutData.ptr();
+}
+
 void ScrollingStateFixedNode::updateConstraints(const FixedPositionViewportConstraints& constraints)
 {
-    if (m_constraints == constraints)
+    if (m_staticLayoutData->constraints == constraints)
         return;
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateFixedNode " << scrollingNodeID() << " updateConstraints with viewport rect " << constraints.viewportRectAtLastLayout() << " layer pos at last layout " << constraints.layerPositionAtLastLayout() << " offset from top " << (constraints.layerPositionAtLastLayout().y() - constraints.viewportRectAtLastLayout().y()));
 
-    m_constraints = constraints;
+    m_staticLayoutData.access().constraints = constraints;
     setPropertyChanged(Property::ViewportConstraints);
 }
 
 void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const LayoutRect& viewportRect, ScrollingLayerPositionAction action)
 {
-    auto position = m_constraints.viewportRelativeLayerPosition(viewportRect);
+    auto& constraints = m_staticLayoutData->constraints;
+    auto position = constraints.viewportRelativeLayerPosition(viewportRect);
     if (layer().representsGraphicsLayer()) {
         RefPtr graphicsLayer = static_cast<GraphicsLayer*>(layer());
         ASSERT(graphicsLayer);
@@ -93,7 +106,7 @@ void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const Layout
             return;
 
         LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateFixedNode " << scrollingNodeID() <<" reconcileLayerPositionForViewportRect " << action << " position of layer " << graphicsLayer->primaryLayerID() << " to " << position);
-        
+
         switch (action) {
         case ScrollingLayerPositionAction::Set:
             graphicsLayer->setPosition(position);
@@ -102,7 +115,7 @@ void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const Layout
         case ScrollingLayerPositionAction::SetApproximate:
             graphicsLayer->setApproximatePosition(position);
             break;
-        
+
         case ScrollingLayerPositionAction::Sync:
             graphicsLayer->syncPosition(position);
             break;
@@ -115,27 +128,29 @@ void ScrollingStateFixedNode::dumpProperties(TextStream& ts, OptionSet<Scrolling
     ts << "Fixed node"_s;
     ScrollingStateNode::dumpProperties(ts, behavior);
 
-    if (m_constraints.anchorEdges()) {
+    auto& constraints = m_staticLayoutData->constraints;
+
+    if (constraints.anchorEdges()) {
         TextStream::GroupScope scope(ts);
         ts << "anchor edges: "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeLeft))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeLeft))
             ts << "AnchorEdgeLeft "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeRight))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeRight))
             ts << "AnchorEdgeRight "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeTop))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeTop))
             ts << "AnchorEdgeTop"_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeBottom))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeBottom))
             ts << "AnchorEdgeBottom"_s;
     }
 
-    if (!m_constraints.alignmentOffset().isEmpty())
-        ts.dumpProperty("alignment offset"_s, m_constraints.alignmentOffset());
+    if (!constraints.alignmentOffset().isEmpty())
+        ts.dumpProperty("alignment offset"_s, constraints.alignmentOffset());
 
-    if (!m_constraints.viewportRectAtLastLayout().isEmpty())
-        ts.dumpProperty("viewport rect at last layout"_s, m_constraints.viewportRectAtLastLayout());
+    if (!constraints.viewportRectAtLastLayout().isEmpty())
+        ts.dumpProperty("viewport rect at last layout"_s, constraints.viewportRectAtLastLayout());
 
-    if (m_constraints.layerPositionAtLastLayout() != FloatPoint())
-        ts.dumpProperty("layer position at last layout"_s, m_constraints.layerPositionAtLastLayout());
+    if (constraints.layerPositionAtLastLayout() != FloatPoint())
+        ts.dumpProperty("layer position at last layout"_s, constraints.layerPositionAtLastLayout());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ public:
     virtual ~ScrollingStateFixedNode();
 
     WEBCORE_EXPORT void updateConstraints(const FixedPositionViewportConstraints&);
-    const FixedPositionViewportConstraints& viewportConstraints() const LIFETIME_BOUND { return m_constraints; }
+    const FixedPositionViewportConstraints& viewportConstraints() const LIFETIME_BOUND { return m_staticLayoutData->constraints; }
 
 private:
     WEBCORE_EXPORT ScrollingStateFixedNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, FixedPositionViewportConstraints&&);
@@ -57,8 +57,26 @@ private:
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
     OptionSet<ScrollingStateNode::Property> applicableProperties() const final;
+    bool hasUnchangedGroupsAs(const ScrollingStateNode&) const final;
 
-    FixedPositionViewportConstraints m_constraints;
+    // Layout-derived fixed-node state. CoW-shared via DataRef.
+    class StaticLayoutFixedState : public ThreadSafeRefCounted<StaticLayoutFixedState> {
+    public:
+        static Ref<StaticLayoutFixedState> create() { return adoptRef(*new StaticLayoutFixedState); }
+        Ref<StaticLayoutFixedState> copy() const { return adoptRef(*new StaticLayoutFixedState(*this)); }
+
+        FixedPositionViewportConstraints constraints;
+
+    private:
+        StaticLayoutFixedState() = default;
+        StaticLayoutFixedState(const StaticLayoutFixedState& other)
+            : ThreadSafeRefCounted<StaticLayoutFixedState>()
+            , constraints(other.constraints)
+        {
+        }
+    };
+
+    DataRef<StaticLayoutFixedState> m_staticLayoutData { StaticLayoutFixedState::create() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,15 @@
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
+
+// Assign to a copy-on-write group member (via DataRef::access) only when it differs, marking the
+// node dirty. Consolidates the otherwise-identical compare / access / setPropertyChanged setter bodies.
+#define SET_COW_PROPERTY(dataRef, member, newValue, property) do { \
+        if ((dataRef)->member != (newValue)) { \
+            (dataRef).access().member = (newValue); \
+            setPropertyChanged(property); \
+        } \
+    } while (0)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStateFrameScrollingNode);
 
@@ -126,31 +135,36 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     scrollbarWidth,
     useDarkAppearanceForScrollbars,
     WTF::move(keyboardScrollData))
-    , m_rootContentsLayer(rootContentsLayer)
-    , m_counterScrollingLayer(counterScrollingLayer)
-    , m_insetClipLayer(insetClipLayer)
-    , m_contentShadowLayer(contentShadowLayer)
-    , m_eventTrackingRegions(WTF::move(eventTrackingRegions))
-    , m_layoutViewport(layoutViewport)
-    , m_sizeForVisibleContent(sizeForVisibleContent)
-    , m_minLayoutViewportOrigin(minLayoutViewportOrigin)
-    , m_maxLayoutViewportOrigin(maxLayoutViewportOrigin)
-    , m_overrideVisualViewportSize(overrideVisualViewportSize)
-    , m_frameScaleFactor(frameScaleFactor)
-    , m_obscuredContentInsets(obscuredContentInsets)
-#if HAVE(NSREFRESHCONTROLLER)
-    , m_topScrollStretchForRefreshController(topScrollStretchForRefreshController)
-#endif
-    , m_headerHeight(headerHeight)
-    , m_footerHeight(footerHeight)
-    , m_behaviorForFixed(WTF::move(scrollBehaviorForFixedElements))
-
-    , m_visualViewportIsSmallerThanLayoutViewport(visualViewportIsSmallerThanLayoutViewport)
-    , m_asyncFrameOrOverflowScrollingEnabled(asyncFrameOrOverflowScrollingEnabled)
-    , m_wheelEventGesturesBecomeNonBlocking(wheelEventGesturesBecomeNonBlocking)
-    , m_scrollingPerformanceTestingEnabled(scrollingPerformanceTestingEnabled)
-    , m_overlayScrollbarsEnabled(overlayScrollbarsEnabled)
 {
+    SUPPRESS_UNCOUNTED_LOCAL auto& layout = m_staticLayoutData.access();
+    layout.eventTrackingRegions = WTF::move(eventTrackingRegions);
+    layout.layoutViewport = layoutViewport;
+    layout.sizeForVisibleContent = sizeForVisibleContent;
+    layout.minLayoutViewportOrigin = minLayoutViewportOrigin;
+    layout.maxLayoutViewportOrigin = maxLayoutViewportOrigin;
+
+    SUPPRESS_UNCOUNTED_LOCAL auto& config = m_staticConfigData.access();
+    config.rootContentsLayer = rootContentsLayer;
+    config.counterScrollingLayer = counterScrollingLayer;
+    config.insetClipLayer = insetClipLayer;
+    config.contentShadowLayer = contentShadowLayer;
+    config.overrideVisualViewportSize = overrideVisualViewportSize;
+    config.obscuredContentInsets = WTF::move(obscuredContentInsets);
+
+    m_headerHeight = headerHeight;
+    m_footerHeight = footerHeight;
+    m_behaviorForFixed = WTF::move(scrollBehaviorForFixedElements);
+    m_visualViewportIsSmallerThanLayoutViewport = visualViewportIsSmallerThanLayoutViewport;
+    m_asyncFrameOrOverflowScrollingEnabled = asyncFrameOrOverflowScrollingEnabled;
+    m_wheelEventGesturesBecomeNonBlocking = wheelEventGesturesBecomeNonBlocking;
+    m_scrollingPerformanceTestingEnabled = scrollingPerformanceTestingEnabled;
+    m_overlayScrollbarsEnabled = overlayScrollbarsEnabled;
+
+    m_dynamicState.frameScaleFactor = frameScaleFactor;
+#if HAVE(NSREFRESHCONTROLLER)
+    m_dynamicState.topScrollStretchForRefreshController = topScrollStretchForRefreshController;
+#endif
+
     ASSERT(isFrameScrollingNode());
 }
 
@@ -162,25 +176,17 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(ScrollingStat
 
 ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(const ScrollingStateFrameScrollingNode& stateNode, ScrollingStateTree& adoptiveTree)
     : ScrollingStateScrollingNode(stateNode, adoptiveTree)
-    , m_eventTrackingRegions(stateNode.eventTrackingRegions())
-    , m_layoutViewport(stateNode.layoutViewport())
-    , m_sizeForVisibleContent(stateNode.sizeForVisibleContent())
-    , m_minLayoutViewportOrigin(stateNode.minLayoutViewportOrigin())
-    , m_maxLayoutViewportOrigin(stateNode.maxLayoutViewportOrigin())
-    , m_overrideVisualViewportSize(stateNode.overrideVisualViewportSize())
-    , m_frameScaleFactor(stateNode.frameScaleFactor())
-    , m_obscuredContentInsets(stateNode.obscuredContentInsets())
-#if HAVE(NSREFRESHCONTROLLER)
-    , m_topScrollStretchForRefreshController(stateNode.topScrollStretchForRefreshController())
-#endif
-    , m_headerHeight(stateNode.headerHeight())
-    , m_footerHeight(stateNode.footerHeight())
-    , m_behaviorForFixed(stateNode.scrollBehaviorForFixedElements())
-    , m_visualViewportIsSmallerThanLayoutViewport(stateNode.visualViewportIsSmallerThanLayoutViewport())
-    , m_asyncFrameOrOverflowScrollingEnabled(stateNode.asyncFrameOrOverflowScrollingEnabled())
-    , m_wheelEventGesturesBecomeNonBlocking(stateNode.wheelEventGesturesBecomeNonBlocking())
-    , m_scrollingPerformanceTestingEnabled(stateNode.scrollingPerformanceTestingEnabled())
-    , m_overlayScrollbarsEnabled(stateNode.overlayScrollbarsEnabled())
+    , m_staticLayoutData(stateNode.m_staticLayoutData)
+    , m_staticConfigData(stateNode.m_staticConfigData)
+    , m_dynamicState(stateNode.m_dynamicState)
+    , m_headerHeight(stateNode.m_headerHeight)
+    , m_footerHeight(stateNode.m_footerHeight)
+    , m_behaviorForFixed(stateNode.m_behaviorForFixed)
+    , m_visualViewportIsSmallerThanLayoutViewport(stateNode.m_visualViewportIsSmallerThanLayoutViewport)
+    , m_asyncFrameOrOverflowScrollingEnabled(stateNode.m_asyncFrameOrOverflowScrollingEnabled)
+    , m_wheelEventGesturesBecomeNonBlocking(stateNode.m_wheelEventGesturesBecomeNonBlocking)
+    , m_scrollingPerformanceTestingEnabled(stateNode.m_scrollingPerformanceTestingEnabled)
+    , m_overlayScrollbarsEnabled(stateNode.m_overlayScrollbarsEnabled)
 {
     if (hasChangedProperty(Property::RootContentsLayer))
         setRootContentsLayer(stateNode.rootContentsLayer().toRepresentation(adoptiveTree.preferredLayerRepresentation()));
@@ -245,21 +251,17 @@ OptionSet<ScrollingStateNode::Property> ScrollingStateFrameScrollingNode::applic
 
 void ScrollingStateFrameScrollingNode::setFrameScaleFactor(float scaleFactor)
 {
-    if (m_frameScaleFactor == scaleFactor)
+    if (m_dynamicState.frameScaleFactor == scaleFactor)
         return;
 
-    m_frameScaleFactor = scaleFactor;
+    m_dynamicState.frameScaleFactor = scaleFactor;
 
     setPropertyChanged(Property::FrameScaleFactor);
 }
 
 void ScrollingStateFrameScrollingNode::setEventTrackingRegions(const EventTrackingRegions& eventTrackingRegions)
 {
-    if (m_eventTrackingRegions == eventTrackingRegions)
-        return;
-
-    m_eventTrackingRegions = eventTrackingRegions;
-    setPropertyChanged(Property::EventTrackingRegion);
+    SET_COW_PROPERTY(m_staticLayoutData, eventTrackingRegions, eventTrackingRegions, Property::EventTrackingRegion);
 }
 
 void ScrollingStateFrameScrollingNode::setScrollBehaviorForFixedElements(ScrollBehaviorForFixedElements behaviorForFixed)
@@ -273,47 +275,27 @@ void ScrollingStateFrameScrollingNode::setScrollBehaviorForFixedElements(ScrollB
 
 void ScrollingStateFrameScrollingNode::setLayoutViewport(const FloatRect& r)
 {
-    if (m_layoutViewport == r)
-        return;
-
-    m_layoutViewport = r;
-    setPropertyChanged(Property::LayoutViewport);
+    SET_COW_PROPERTY(m_staticLayoutData, layoutViewport, r, Property::LayoutViewport);
 }
 
 void ScrollingStateFrameScrollingNode::setSizeForVisibleContent(const FloatSize& size)
 {
-    if (m_sizeForVisibleContent == size)
-        return;
-
-    m_sizeForVisibleContent = size;
-    setPropertyChanged(Property::SizeForVisibleContent);
+    SET_COW_PROPERTY(m_staticLayoutData, sizeForVisibleContent, size, Property::SizeForVisibleContent);
 }
 
 void ScrollingStateFrameScrollingNode::setMinLayoutViewportOrigin(const FloatPoint& p)
 {
-    if (m_minLayoutViewportOrigin == p)
-        return;
-
-    m_minLayoutViewportOrigin = p;
-    setPropertyChanged(Property::MinLayoutViewportOrigin);
+    SET_COW_PROPERTY(m_staticLayoutData, minLayoutViewportOrigin, p, Property::MinLayoutViewportOrigin);
 }
 
 void ScrollingStateFrameScrollingNode::setMaxLayoutViewportOrigin(const FloatPoint& p)
 {
-    if (m_maxLayoutViewportOrigin == p)
-        return;
-
-    m_maxLayoutViewportOrigin = p;
-    setPropertyChanged(Property::MaxLayoutViewportOrigin);
+    SET_COW_PROPERTY(m_staticLayoutData, maxLayoutViewportOrigin, p, Property::MaxLayoutViewportOrigin);
 }
 
 void ScrollingStateFrameScrollingNode::setOverrideVisualViewportSize(std::optional<FloatSize> viewportSize)
 {
-    if (viewportSize == m_overrideVisualViewportSize)
-        return;
-
-    m_overrideVisualViewportSize = viewportSize;
-    setPropertyChanged(Property::OverrideVisualViewportSize);
+    SET_COW_PROPERTY(m_staticConfigData, overrideVisualViewportSize, viewportSize, Property::OverrideVisualViewportSize);
 }
 
 void ScrollingStateFrameScrollingNode::setHeaderHeight(int headerHeight)
@@ -336,21 +318,17 @@ void ScrollingStateFrameScrollingNode::setFooterHeight(int footerHeight)
 
 void ScrollingStateFrameScrollingNode::setObscuredContentInsets(const FloatBoxExtent& obscuredContentInsets)
 {
-    if (m_obscuredContentInsets == obscuredContentInsets)
-        return;
-
-    m_obscuredContentInsets = obscuredContentInsets;
-    setPropertyChanged(Property::ObscuredContentInsets);
+    SET_COW_PROPERTY(m_staticConfigData, obscuredContentInsets, obscuredContentInsets, Property::ObscuredContentInsets);
 }
 
 #if HAVE(NSREFRESHCONTROLLER)
 
 void ScrollingStateFrameScrollingNode::setTopScrollStretchForRefreshController(float topScrollStretchForRefreshController)
 {
-    if (m_topScrollStretchForRefreshController == topScrollStretchForRefreshController)
+    if (m_dynamicState.topScrollStretchForRefreshController == topScrollStretchForRefreshController)
         return;
 
-    m_topScrollStretchForRefreshController = topScrollStretchForRefreshController;
+    m_dynamicState.topScrollStretchForRefreshController = topScrollStretchForRefreshController;
     setPropertyChanged(Property::TopScrollStretchForRefreshController);
 }
 
@@ -358,63 +336,39 @@ void ScrollingStateFrameScrollingNode::setTopScrollStretchForRefreshController(f
 
 void ScrollingStateFrameScrollingNode::setRootContentsLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_rootContentsLayer)
-        return;
-
-    m_rootContentsLayer = layerRepresentation;
-    setPropertyChanged(Property::RootContentsLayer);
+    SET_COW_PROPERTY(m_staticConfigData, rootContentsLayer, layerRepresentation, Property::RootContentsLayer);
 }
 
 void ScrollingStateFrameScrollingNode::setCounterScrollingLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_counterScrollingLayer)
-        return;
-    
-    m_counterScrollingLayer = layerRepresentation;
-    setPropertyChanged(Property::CounterScrollingLayer);
+    SET_COW_PROPERTY(m_staticConfigData, counterScrollingLayer, layerRepresentation, Property::CounterScrollingLayer);
 }
 
 void ScrollingStateFrameScrollingNode::setInsetClipLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_insetClipLayer)
-        return;
-    
-    m_insetClipLayer = layerRepresentation;
-    setPropertyChanged(Property::InsetClipLayer);
+    SET_COW_PROPERTY(m_staticConfigData, insetClipLayer, layerRepresentation, Property::InsetClipLayer);
 }
 
 void ScrollingStateFrameScrollingNode::setContentShadowLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_contentShadowLayer)
-        return;
-    
-    m_contentShadowLayer = layerRepresentation;
-    setPropertyChanged(Property::ContentShadowLayer);
+    SET_COW_PROPERTY(m_staticConfigData, contentShadowLayer, layerRepresentation, Property::ContentShadowLayer);
 }
 
 void ScrollingStateFrameScrollingNode::setHeaderLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_headerLayer)
-        return;
-    
-    m_headerLayer = layerRepresentation;
-    setPropertyChanged(Property::HeaderLayer);
+    SET_COW_PROPERTY(m_staticConfigData, headerLayer, layerRepresentation, Property::HeaderLayer);
 }
 
 void ScrollingStateFrameScrollingNode::setFooterLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_footerLayer)
-        return;
-    
-    m_footerLayer = layerRepresentation;
-    setPropertyChanged(Property::FooterLayer);
+    SET_COW_PROPERTY(m_staticConfigData, footerLayer, layerRepresentation, Property::FooterLayer);
 }
 
 void ScrollingStateFrameScrollingNode::setVisualViewportIsSmallerThanLayoutViewport(bool visualViewportIsSmallerThanLayoutViewport)
 {
     if (visualViewportIsSmallerThanLayoutViewport == m_visualViewportIsSmallerThanLayoutViewport)
         return;
-    
+
     m_visualViewportIsSmallerThanLayoutViewport = visualViewportIsSmallerThanLayoutViewport;
     setPropertyChanged(Property::VisualViewportIsSmallerThanLayoutViewport);
 }
@@ -423,7 +377,7 @@ void ScrollingStateFrameScrollingNode::setAsyncFrameOrOverflowScrollingEnabled(b
 {
     if (enabled == m_asyncFrameOrOverflowScrollingEnabled)
         return;
-    
+
     m_asyncFrameOrOverflowScrollingEnabled = enabled;
     setPropertyChanged(Property::AsyncFrameOrOverflowScrollingEnabled);
 }
@@ -432,7 +386,7 @@ void ScrollingStateFrameScrollingNode::setWheelEventGesturesBecomeNonBlocking(bo
 {
     if (enabled == m_wheelEventGesturesBecomeNonBlocking)
         return;
-    
+
     m_wheelEventGesturesBecomeNonBlocking = enabled;
     setPropertyChanged(Property::WheelEventGesturesBecomeNonBlocking);
 }
@@ -441,7 +395,7 @@ void ScrollingStateFrameScrollingNode::setScrollingPerformanceTestingEnabled(boo
 {
     if (enabled == m_scrollingPerformanceTestingEnabled)
         return;
-    
+
     m_scrollingPerformanceTestingEnabled = enabled;
     setPropertyChanged(Property::ScrollingPerformanceTestingEnabled);
 }
@@ -450,6 +404,7 @@ void ScrollingStateFrameScrollingNode::setOverlayScrollbarsEnabled(bool enabled)
 {
     if (m_overlayScrollbarsEnabled == enabled)
         return;
+
     m_overlayScrollbarsEnabled = enabled;
     setPropertyChanged(Property::OverlayScrollbarsEnabled);
 }
@@ -459,66 +414,142 @@ bool ScrollingStateFrameScrollingNode::isMainFrame() const
     return nodeType() == ScrollingNodeType::MainFrame;
 }
 
+bool ScrollingStateFrameScrollingNode::hasUnchangedGroupsAs(const ScrollingStateNode& other) const
+{
+    if (!ScrollingStateScrollingNode::hasUnchangedGroupsAs(other))
+        return false;
+    auto& otherFrame = downcast<ScrollingStateFrameScrollingNode>(other);
+    if (m_staticLayoutData.ptr() != otherFrame.m_staticLayoutData.ptr())
+        return false;
+    if (m_staticConfigData.ptr() != otherFrame.m_staticConfigData.ptr())
+        return false;
+    if (m_dynamicState != otherFrame.m_dynamicState)
+        return false;
+    // Direct (non-CoW) members, compared for the same reason as in the base class.
+    if (m_headerHeight != otherFrame.m_headerHeight)
+        return false;
+    if (m_footerHeight != otherFrame.m_footerHeight)
+        return false;
+    if (m_behaviorForFixed != otherFrame.m_behaviorForFixed)
+        return false;
+    if (m_visualViewportIsSmallerThanLayoutViewport != otherFrame.m_visualViewportIsSmallerThanLayoutViewport)
+        return false;
+    if (m_asyncFrameOrOverflowScrollingEnabled != otherFrame.m_asyncFrameOrOverflowScrollingEnabled)
+        return false;
+    if (m_wheelEventGesturesBecomeNonBlocking != otherFrame.m_wheelEventGesturesBecomeNonBlocking)
+        return false;
+    if (m_scrollingPerformanceTestingEnabled != otherFrame.m_scrollingPerformanceTestingEnabled)
+        return false;
+    if (m_overlayScrollbarsEnabled != otherFrame.m_overlayScrollbarsEnabled)
+        return false;
+    return true;
+}
+
+void ScrollingStateFrameScrollingNode::clearLayerFieldsForUnchangedProperties()
+{
+    // First clear scrolling-node layers on the base class, then frame-only layers.
+    ScrollingStateScrollingNode::clearLayerFieldsForUnchangedProperties();
+
+    bool needsAccess = (!hasChangedProperty(Property::RootContentsLayer) && m_staticConfigData->rootContentsLayer)
+        || (!hasChangedProperty(Property::CounterScrollingLayer) && m_staticConfigData->counterScrollingLayer)
+        || (!hasChangedProperty(Property::InsetClipLayer) && m_staticConfigData->insetClipLayer)
+        || (!hasChangedProperty(Property::ContentShadowLayer) && m_staticConfigData->contentShadowLayer)
+        || (!hasChangedProperty(Property::HeaderLayer) && m_staticConfigData->headerLayer)
+        || (!hasChangedProperty(Property::FooterLayer) && m_staticConfigData->footerLayer);
+    if (!needsAccess)
+        return;
+
+    SUPPRESS_UNCOUNTED_LOCAL auto& config = m_staticConfigData.access();
+    if (!hasChangedProperty(Property::RootContentsLayer))
+        config.rootContentsLayer = { };
+    if (!hasChangedProperty(Property::CounterScrollingLayer))
+        config.counterScrollingLayer = { };
+    if (!hasChangedProperty(Property::InsetClipLayer))
+        config.insetClipLayer = { };
+    if (!hasChangedProperty(Property::ContentShadowLayer))
+        config.contentShadowLayer = { };
+    if (!hasChangedProperty(Property::HeaderLayer))
+        config.headerLayer = { };
+    if (!hasChangedProperty(Property::FooterLayer))
+        config.footerLayer = { };
+}
+
+#if ASSERT_ENABLED
+void ScrollingStateFrameScrollingNode::verifyClearedLayerFieldsForUnchangedProperties() const
+{
+    ScrollingStateScrollingNode::verifyClearedLayerFieldsForUnchangedProperties();
+    ASSERT(hasChangedProperty(Property::RootContentsLayer) || !m_staticConfigData->rootContentsLayer);
+    ASSERT(hasChangedProperty(Property::CounterScrollingLayer) || !m_staticConfigData->counterScrollingLayer);
+    ASSERT(hasChangedProperty(Property::InsetClipLayer) || !m_staticConfigData->insetClipLayer);
+    ASSERT(hasChangedProperty(Property::ContentShadowLayer) || !m_staticConfigData->contentShadowLayer);
+    ASSERT(hasChangedProperty(Property::HeaderLayer) || !m_staticConfigData->headerLayer);
+    ASSERT(hasChangedProperty(Property::FooterLayer) || !m_staticConfigData->footerLayer);
+}
+#endif
+
 void ScrollingStateFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ts << "Frame scrolling node"_s;
     
     ScrollingStateScrollingNode::dumpProperties(ts, behavior);
-    
+
+    SUPPRESS_UNCOUNTED_LOCAL auto& layout = m_staticLayoutData.get();
+    SUPPRESS_UNCOUNTED_LOCAL auto& config = m_staticConfigData.get();
+
     if (behavior & ScrollingStateTreeAsTextBehavior::IncludeLayerIDs) {
-        ts.dumpProperty("root contents layer ID"_s, m_rootContentsLayer.layerID());
-        if (m_counterScrollingLayer.layerID())
-            ts.dumpProperty("counter scrolling layer ID"_s, m_counterScrollingLayer.layerID());
-        if (m_insetClipLayer.layerID())
-            ts.dumpProperty("inset clip layer ID"_s, m_insetClipLayer.layerID());
-        if (m_contentShadowLayer.layerID())
-            ts.dumpProperty("content shadow layer ID"_s, m_contentShadowLayer.layerID());
-        if (m_headerLayer.layerID())
-            ts.dumpProperty("header layer ID"_s, m_headerLayer.layerID());
-        if (m_footerLayer.layerID())
-            ts.dumpProperty("footer layer ID"_s, m_footerLayer.layerID());
+        ts.dumpProperty("root contents layer ID"_s, config.rootContentsLayer.layerID());
+        if (config.counterScrollingLayer.layerID())
+            ts.dumpProperty("counter scrolling layer ID"_s, config.counterScrollingLayer.layerID());
+        if (config.insetClipLayer.layerID())
+            ts.dumpProperty("inset clip layer ID"_s, config.insetClipLayer.layerID());
+        if (config.contentShadowLayer.layerID())
+            ts.dumpProperty("content shadow layer ID"_s, config.contentShadowLayer.layerID());
+        if (config.headerLayer.layerID())
+            ts.dumpProperty("header layer ID"_s, config.headerLayer.layerID());
+        if (config.footerLayer.layerID())
+            ts.dumpProperty("footer layer ID"_s, config.footerLayer.layerID());
     }
 
-    if (m_frameScaleFactor != 1)
-        ts.dumpProperty("frame scale factor"_s, m_frameScaleFactor);
-    if (m_obscuredContentInsets.top())
-        ts.dumpProperty("top content inset"_s, m_obscuredContentInsets.top());
-    if (m_obscuredContentInsets.bottom())
-        ts.dumpProperty("bottom content inset"_s, m_obscuredContentInsets.bottom());
-    if (m_obscuredContentInsets.left())
-        ts.dumpProperty("left content inset"_s, m_obscuredContentInsets.left());
-    if (m_obscuredContentInsets.right())
-        ts.dumpProperty("right content inset"_s, m_obscuredContentInsets.right());
+    if (m_dynamicState.frameScaleFactor != 1)
+        ts.dumpProperty("frame scale factor"_s, m_dynamicState.frameScaleFactor);
+    if (config.obscuredContentInsets.top())
+        ts.dumpProperty("top content inset"_s, config.obscuredContentInsets.top());
+    if (config.obscuredContentInsets.bottom())
+        ts.dumpProperty("bottom content inset"_s, config.obscuredContentInsets.bottom());
+    if (config.obscuredContentInsets.left())
+        ts.dumpProperty("left content inset"_s, config.obscuredContentInsets.left());
+    if (config.obscuredContentInsets.right())
+        ts.dumpProperty("right content inset"_s, config.obscuredContentInsets.right());
 #if HAVE(NSREFRESHCONTROLLER)
-    if (m_topScrollStretchForRefreshController)
-        ts.dumpProperty("top scroll stretch for refresh controller"_s, m_topScrollStretchForRefreshController);
+    if (m_dynamicState.topScrollStretchForRefreshController)
+        ts.dumpProperty("top scroll stretch for refresh controller"_s, m_dynamicState.topScrollStretchForRefreshController);
 #endif
     if (m_headerHeight)
         ts.dumpProperty("header height"_s, m_headerHeight);
     if (m_footerHeight)
         ts.dumpProperty("footer height"_s, m_footerHeight);
-    
-    ts.dumpProperty("layout viewport"_s, m_layoutViewport);
 
-    if (m_layoutViewport.size() != m_sizeForVisibleContent)
-        ts.dumpProperty("size for visible content"_s, m_sizeForVisibleContent);
+    ts.dumpProperty("layout viewport"_s, layout.layoutViewport);
 
-    ts.dumpProperty("min layout viewport origin"_s, m_minLayoutViewportOrigin);
-    ts.dumpProperty("max layout viewport origin"_s, m_maxLayoutViewportOrigin);
-    
-    if (m_overrideVisualViewportSize)
-        ts.dumpProperty("override visual viewport size"_s, m_overrideVisualViewportSize.value());
+    if (layout.layoutViewport.size() != layout.sizeForVisibleContent)
+        ts.dumpProperty("size for visible content"_s, layout.sizeForVisibleContent);
 
-    if (!m_eventTrackingRegions.asynchronousDispatchRegion.isEmpty()) {
+    ts.dumpProperty("min layout viewport origin"_s, layout.minLayoutViewportOrigin);
+    ts.dumpProperty("max layout viewport origin"_s, layout.maxLayoutViewportOrigin);
+
+    if (config.overrideVisualViewportSize)
+        ts.dumpProperty("override visual viewport size"_s, config.overrideVisualViewportSize.value());
+
+    if (!layout.eventTrackingRegions.asynchronousDispatchRegion.isEmpty()) {
         TextStream::GroupScope scope(ts);
         ts << "asynchronous event dispatch region"_s;
-        for (auto rect : m_eventTrackingRegions.asynchronousDispatchRegion.rects()) {
+        for (auto rect : layout.eventTrackingRegions.asynchronousDispatchRegion.rects()) {
             ts << '\n';
             ts << indent << rect;
         }
     }
 
-    auto& synchronousDispatchRegionMap = m_eventTrackingRegions.eventSpecificSynchronousDispatchRegions;
+    auto& synchronousDispatchRegionMap = layout.eventTrackingRegions.eventSpecificSynchronousDispatchRegions;
     if (!synchronousDispatchRegionMap.isEmpty()) {
         auto eventRegionNames = copyToVector(synchronousDispatchRegionMap.keys());
         std::ranges::sort(eventRegionNames);
@@ -540,5 +571,7 @@ void ScrollingStateFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<
 }
 
 } // namespace WebCore
+
+#undef SET_COW_PROPERTY
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,28 +48,28 @@ public:
 
     virtual ~ScrollingStateFrameScrollingNode();
 
-    float frameScaleFactor() const { return m_frameScaleFactor; }
+    float frameScaleFactor() const { return m_dynamicState.frameScaleFactor; }
     WEBCORE_EXPORT void setFrameScaleFactor(float);
 
-    const EventTrackingRegions& eventTrackingRegions() const LIFETIME_BOUND { return m_eventTrackingRegions; }
+    const EventTrackingRegions& eventTrackingRegions() const LIFETIME_BOUND { return m_staticLayoutData->eventTrackingRegions; }
     WEBCORE_EXPORT void setEventTrackingRegions(const EventTrackingRegions&);
 
     ScrollBehaviorForFixedElements scrollBehaviorForFixedElements() const { return m_behaviorForFixed; }
     WEBCORE_EXPORT void setScrollBehaviorForFixedElements(ScrollBehaviorForFixedElements);
 
-    FloatRect layoutViewport() const { return m_layoutViewport; };
+    FloatRect layoutViewport() const { return m_staticLayoutData->layoutViewport; };
     WEBCORE_EXPORT void setLayoutViewport(const FloatRect&);
 
-    FloatSize sizeForVisibleContent() const { return m_sizeForVisibleContent; }
+    FloatSize sizeForVisibleContent() const { return m_staticLayoutData->sizeForVisibleContent; }
     WEBCORE_EXPORT void setSizeForVisibleContent(const FloatSize&);
 
-    FloatPoint minLayoutViewportOrigin() const { return m_minLayoutViewportOrigin; }
+    FloatPoint minLayoutViewportOrigin() const { return m_staticLayoutData->minLayoutViewportOrigin; }
     WEBCORE_EXPORT void setMinLayoutViewportOrigin(const FloatPoint&);
 
-    FloatPoint maxLayoutViewportOrigin() const { return m_maxLayoutViewportOrigin; }
+    FloatPoint maxLayoutViewportOrigin() const { return m_staticLayoutData->maxLayoutViewportOrigin; }
     WEBCORE_EXPORT void setMaxLayoutViewportOrigin(const FloatPoint&);
 
-    std::optional<FloatSize> overrideVisualViewportSize() const { return m_overrideVisualViewportSize; };
+    std::optional<FloatSize> overrideVisualViewportSize() const { return m_staticConfigData->overrideVisualViewportSize; };
     WEBCORE_EXPORT void setOverrideVisualViewportSize(std::optional<FloatSize>);
 
     int headerHeight() const { return m_headerHeight; }
@@ -78,39 +78,39 @@ public:
     int footerHeight() const { return m_footerHeight; }
     WEBCORE_EXPORT void setFooterHeight(int);
 
-    FloatBoxExtent obscuredContentInsets() const { return m_obscuredContentInsets; }
+    FloatBoxExtent obscuredContentInsets() const { return m_staticConfigData->obscuredContentInsets; }
     WEBCORE_EXPORT void setObscuredContentInsets(const FloatBoxExtent&);
 
     // The target offset for rubber band animations when refresh controller is present.
     // When non-zero, rubber banding will snap to this offset instead of the edge.
 #if HAVE(NSREFRESHCONTROLLER)
-    float topScrollStretchForRefreshController() const { return m_topScrollStretchForRefreshController; }
+    float topScrollStretchForRefreshController() const { return m_dynamicState.topScrollStretchForRefreshController; }
     WEBCORE_EXPORT void setTopScrollStretchForRefreshController(float);
 #endif
 
-    const LayerRepresentation& rootContentsLayer() const LIFETIME_BOUND { return m_rootContentsLayer; }
+    const LayerRepresentation& rootContentsLayer() const LIFETIME_BOUND { return m_staticConfigData->rootContentsLayer; }
     WEBCORE_EXPORT void setRootContentsLayer(const LayerRepresentation&);
 
     // This is a layer moved in the opposite direction to scrolling, for example for background-attachment:fixed
-    const LayerRepresentation& counterScrollingLayer() const LIFETIME_BOUND { return m_counterScrollingLayer; }
+    const LayerRepresentation& counterScrollingLayer() const LIFETIME_BOUND { return m_staticConfigData->counterScrollingLayer; }
     WEBCORE_EXPORT void setCounterScrollingLayer(const LayerRepresentation&);
 
     // This is a clipping layer that will scroll with the page for all y-delta scroll values between 0
     // and obscuredInset().top. Once the y-deltas get beyond the content inset point, this layer no longer
     // needs to move. If the obscuredInset().top is 0, this layer does not need to move at all. This is
     // only used on the Mac.
-    const LayerRepresentation& insetClipLayer() const LIFETIME_BOUND { return m_insetClipLayer; }
+    const LayerRepresentation& insetClipLayer() const LIFETIME_BOUND { return m_staticConfigData->insetClipLayer; }
     WEBCORE_EXPORT void setInsetClipLayer(const LayerRepresentation&);
 
-    const LayerRepresentation& contentShadowLayer() const LIFETIME_BOUND { return m_contentShadowLayer; }
+    const LayerRepresentation& contentShadowLayer() const LIFETIME_BOUND { return m_staticConfigData->contentShadowLayer; }
     WEBCORE_EXPORT void setContentShadowLayer(const LayerRepresentation&);
 
     // The header and footer layers scroll vertically with the page, they should remain fixed when scrolling horizontally.
-    const LayerRepresentation& headerLayer() const LIFETIME_BOUND { return m_headerLayer; }
+    const LayerRepresentation& headerLayer() const LIFETIME_BOUND { return m_staticConfigData->headerLayer; }
     WEBCORE_EXPORT void setHeaderLayer(const LayerRepresentation&);
 
     // The header and footer layers scroll vertically with the page, they should remain fixed when scrolling horizontally.
-    const LayerRepresentation& footerLayer() const LIFETIME_BOUND { return m_footerLayer; }
+    const LayerRepresentation& footerLayer() const LIFETIME_BOUND { return m_staticConfigData->footerLayer; }
     WEBCORE_EXPORT void setFooterLayer(const LayerRepresentation&);
 
     // True when the visual viewport is smaller than the layout viewport, indicating that panning should be possible.
@@ -132,6 +132,11 @@ public:
     WEBCORE_EXPORT bool NODELETE isMainFrame() const;
     
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+    bool hasUnchangedGroupsAs(const ScrollingStateNode&) const final;
+    void clearLayerFieldsForUnchangedProperties() final;
+#if ASSERT_ENABLED
+    void verifyClearedLayerFieldsForUnchangedProperties() const final;
+#endif
 
 private:
     WEBCORE_EXPORT ScrollingStateFrameScrollingNode(
@@ -197,26 +202,79 @@ private:
 
     OptionSet<ScrollingStateNode::Property> applicableProperties() const final;
 
-    LayerRepresentation m_rootContentsLayer;
-    LayerRepresentation m_counterScrollingLayer;
-    LayerRepresentation m_insetClipLayer;
-    LayerRepresentation m_contentShadowLayer;
-    LayerRepresentation m_headerLayer;
-    LayerRepresentation m_footerLayer;
-
-    EventTrackingRegions m_eventTrackingRegions;
-
-    FloatRect m_layoutViewport;
-    FloatSize m_sizeForVisibleContent;
-    FloatPoint m_minLayoutViewportOrigin;
-    FloatPoint m_maxLayoutViewportOrigin;
-    std::optional<FloatSize> m_overrideVisualViewportSize;
-
-    float m_frameScaleFactor { 1 };
-    FloatBoxExtent m_obscuredContentInsets;
+    // Per-frame mutable frame-scrolling state.
+    struct DynamicFrameState {
+        float frameScaleFactor { 1 };
 #if HAVE(NSREFRESHCONTROLLER)
-    float m_topScrollStretchForRefreshController { 0 };
+        float topScrollStretchForRefreshController { 0 };
 #endif
+
+        friend bool operator==(const DynamicFrameState&, const DynamicFrameState&) = default;
+    };
+
+    // Layout-derived frame-scrolling state. CoW-shared via DataRef.
+    class StaticLayoutFrameState : public ThreadSafeRefCounted<StaticLayoutFrameState> {
+    public:
+        static Ref<StaticLayoutFrameState> create() { return adoptRef(*new StaticLayoutFrameState); }
+        Ref<StaticLayoutFrameState> copy() const { return adoptRef(*new StaticLayoutFrameState(*this)); }
+
+        EventTrackingRegions eventTrackingRegions;
+        FloatRect layoutViewport;
+        FloatSize sizeForVisibleContent;
+        FloatPoint minLayoutViewportOrigin;
+        FloatPoint maxLayoutViewportOrigin;
+
+    private:
+        StaticLayoutFrameState() = default;
+        StaticLayoutFrameState(const StaticLayoutFrameState& other)
+            : ThreadSafeRefCounted<StaticLayoutFrameState>()
+            , eventTrackingRegions(other.eventTrackingRegions)
+            , layoutViewport(other.layoutViewport)
+            , sizeForVisibleContent(other.sizeForVisibleContent)
+            , minLayoutViewportOrigin(other.minLayoutViewportOrigin)
+            , maxLayoutViewportOrigin(other.maxLayoutViewportOrigin)
+        {
+        }
+    };
+
+    // Long-lived frame-scrolling configuration. CoW-shared via DataRef.
+    class StaticConfigurationFrameState : public ThreadSafeRefCounted<StaticConfigurationFrameState> {
+    public:
+        static Ref<StaticConfigurationFrameState> create() { return adoptRef(*new StaticConfigurationFrameState); }
+        Ref<StaticConfigurationFrameState> copy() const { return adoptRef(*new StaticConfigurationFrameState(*this)); }
+
+        LayerRepresentation rootContentsLayer;
+        LayerRepresentation counterScrollingLayer;
+        LayerRepresentation insetClipLayer;
+        LayerRepresentation contentShadowLayer;
+        LayerRepresentation headerLayer;
+        LayerRepresentation footerLayer;
+        std::optional<FloatSize> overrideVisualViewportSize;
+        FloatBoxExtent obscuredContentInsets;
+
+    private:
+        StaticConfigurationFrameState() = default;
+        StaticConfigurationFrameState(const StaticConfigurationFrameState& other)
+            : ThreadSafeRefCounted<StaticConfigurationFrameState>()
+            , rootContentsLayer(other.rootContentsLayer)
+            , counterScrollingLayer(other.counterScrollingLayer)
+            , insetClipLayer(other.insetClipLayer)
+            , contentShadowLayer(other.contentShadowLayer)
+            , headerLayer(other.headerLayer)
+            , footerLayer(other.footerLayer)
+            , overrideVisualViewportSize(other.overrideVisualViewportSize)
+            , obscuredContentInsets(other.obscuredContentInsets)
+        {
+        }
+    };
+
+    DataRef<StaticLayoutFrameState> m_staticLayoutData { StaticLayoutFrameState::create() };
+    DataRef<StaticConfigurationFrameState> m_staticConfigData { StaticConfigurationFrameState::create() };
+    DynamicFrameState m_dynamicState;
+
+    // Tiny PODs kept as direct members rather than inside the CoW group: each mutation
+    // would otherwise force a copy of the entire ~hundreds-of-bytes static-config group
+    // (containing six LayerRepresentation variants + several other large fields).
     int m_headerHeight { 0 };
     int m_footerHeight { 0 };
     ScrollBehaviorForFixedElements m_behaviorForFixed { ScrollBehaviorForFixedElements::StickToDocumentBounds };

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,6 +141,26 @@ Ref<ScrollingStateNode> ScrollingStateNode::cloneAndReset(ScrollingStateTree& ad
     cloneAndResetChildren(clone.get(), adoptiveTree);
 
     return clone;
+}
+
+bool ScrollingStateNode::hasUnchangedGroupsAs(const ScrollingStateNode& other) const
+{
+    // The only caller (ScrollingStateTree::commit) reaches `other` via
+    // m_lastCommittedTree->stateNodeForID(this->scrollingNodeID()), so node IDs match by
+    // construction. Node types are stable per ID — a type change destroys the node and
+    // re-creates it with a new ID (see ScrollingStateTree::createUnparentedNode). Both
+    // invariants are debug-asserted; the runtime returns true so subclass overrides can
+    // downcast `other` to their concrete type without an extra runtime check.
+    //
+    // m_layer is intentionally not part of this comparison. The clone path's
+    // toRepresentation translation is gated on Property::Layer, so a snapshot taken after
+    // properties are reset cannot faithfully reproduce m_layer. Layer changes propagate
+    // through Property::Layer in m_changedProperties (existing IPC path) and, for partitioned
+    // subclasses, through DataRef-shared static-config layer fields.
+    ASSERT(m_nodeID == other.m_nodeID);
+    ASSERT(m_nodeType == other.m_nodeType);
+    UNUSED_PARAM(other);
+    return true;
 }
 
 void ScrollingStateNode::cloneAndResetChildren(ScrollingStateNode& clone, ScrollingStateTree& adoptiveTree)

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -262,6 +262,16 @@ public:
     virtual Ref<ScrollingStateNode> clone(ScrollingStateTree& adoptiveTree) = 0;
     Ref<ScrollingStateNode> cloneAndReset(ScrollingStateTree& adoptiveTree);
     void cloneAndResetChildren(ScrollingStateNode&, ScrollingStateTree& adoptiveTree);
+
+    virtual bool hasUnchangedGroupsAs(const ScrollingStateNode& other) const;
+    virtual void clearLayerFieldsForUnchangedProperties() { }
+
+#if ASSERT_ENABLED
+    // Debug-only verification of the clearLayerFieldsForUnchangedProperties contract. Asserts
+    // that for every layer field in the node's copy-on-write static-config group, either the
+    // corresponding Property::XxxLayer bit is set on this clone or the field is empty.
+    virtual void verifyClearedLayerFieldsForUnchangedProperties() const { }
+#endif
     
     bool hasChangedProperties() const { return !m_changedProperties.isEmpty(); }
     bool hasChangedProperty(Property property) const { return m_changedProperties.contains(property); }

--- a/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,10 @@
 #include "GraphicsLayer.h"
 #include "Logging.h"
 #include "ScrollingStateTree.h"
+#include <wtf/DataRef.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -40,9 +44,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStatePositionedNode);
 
 ScrollingStatePositionedNode::ScrollingStatePositionedNode(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, Vector<ScrollingNodeID>&& relatedOverflowScrollingNodes, AbsolutePositionConstraints&& constraints)
     : ScrollingStateNode(ScrollingNodeType::Positioned, nodeID, WTF::move(children), changedProperties, layerID)
-    , m_relatedOverflowScrollingNodes(WTF::move(relatedOverflowScrollingNodes))
-    , m_constraints(WTF::move(constraints))
 {
+    SUPPRESS_UNCOUNTED_LOCAL auto& layout = m_staticLayoutData.access();
+    layout.relatedOverflowScrollingNodes = WTF::move(relatedOverflowScrollingNodes);
+    layout.constraints = WTF::move(constraints);
 }
 
 ScrollingStatePositionedNode::ScrollingStatePositionedNode(ScrollingStateTree& tree, ScrollingNodeID nodeID)
@@ -52,8 +57,7 @@ ScrollingStatePositionedNode::ScrollingStatePositionedNode(ScrollingStateTree& t
 
 ScrollingStatePositionedNode::ScrollingStatePositionedNode(const ScrollingStatePositionedNode& node, ScrollingStateTree& adoptiveTree)
     : ScrollingStateNode(node, adoptiveTree)
-    , m_relatedOverflowScrollingNodes(node.relatedOverflowScrollingNodes())
-    , m_constraints(node.layoutConstraints())
+    , m_staticLayoutData(node.m_staticLayoutData)
 {
 }
 
@@ -73,23 +77,31 @@ OptionSet<ScrollingStateNode::Property> ScrollingStatePositionedNode::applicable
     return properties;
 }
 
+bool ScrollingStatePositionedNode::hasUnchangedGroupsAs(const ScrollingStateNode& other) const
+{
+    if (!ScrollingStateNode::hasUnchangedGroupsAs(other))
+        return false;
+    auto& otherPositioned = downcast<ScrollingStatePositionedNode>(other);
+    return m_staticLayoutData.ptr() == otherPositioned.m_staticLayoutData.ptr();
+}
+
 void ScrollingStatePositionedNode::setRelatedOverflowScrollingNodes(Vector<ScrollingNodeID>&& nodes)
 {
-    if (nodes == m_relatedOverflowScrollingNodes)
+    if (nodes == m_staticLayoutData->relatedOverflowScrollingNodes)
         return;
 
-    m_relatedOverflowScrollingNodes = WTF::move(nodes);
+    m_staticLayoutData.access().relatedOverflowScrollingNodes = WTF::move(nodes);
     setPropertyChanged(Property::RelatedOverflowScrollingNodes);
 }
 
 void ScrollingStatePositionedNode::updateConstraints(const AbsolutePositionConstraints& constraints)
 {
-    if (m_constraints == constraints)
+    if (m_staticLayoutData->constraints == constraints)
         return;
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingStatePositionedNode " << scrollingNodeID() << " updateConstraints " << constraints);
 
-    m_constraints = constraints;
+    m_staticLayoutData.access().constraints = constraints;
     setPropertyChanged(Property::LayoutConstraintData);
 }
 
@@ -98,14 +110,15 @@ void ScrollingStatePositionedNode::dumpProperties(TextStream& ts, OptionSet<Scro
     ts << "Positioned node"_s;
     ScrollingStateNode::dumpProperties(ts, behavior);
 
-    ts.dumpProperty("layout constraints"_s, m_constraints);
-    ts.dumpProperty("related overflow nodes"_s, m_relatedOverflowScrollingNodes.size());
+    SUPPRESS_UNCOUNTED_LOCAL auto& layout = m_staticLayoutData.get();
+    ts.dumpProperty("layout constraints"_s, layout.constraints);
+    ts.dumpProperty("related overflow nodes"_s, layout.relatedOverflowScrollingNodes.size());
 
     if (behavior & ScrollingStateTreeAsTextBehavior::IncludeNodeIDs) {
-        if (!m_relatedOverflowScrollingNodes.isEmpty()) {
+        if (!layout.relatedOverflowScrollingNodes.isEmpty()) {
             TextStream::GroupScope scope(ts);
             ts << "overflow nodes"_s;
-            for (auto nodeID : m_relatedOverflowScrollingNodes)
+            for (auto nodeID : layout.relatedOverflowScrollingNodes)
                 ts << '\n' << indent << "nodeID "_s << nodeID;
         }
     }

--- a/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,11 +47,11 @@ public:
     virtual ~ScrollingStatePositionedNode();
 
     // These are the overflow scrolling nodes whose scroll position affects the layers in this node.
-    const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const LIFETIME_BOUND { return m_relatedOverflowScrollingNodes; }
+    const Vector<ScrollingNodeID>& relatedOverflowScrollingNodes() const LIFETIME_BOUND { return m_staticLayoutData->relatedOverflowScrollingNodes; }
     WEBCORE_EXPORT void setRelatedOverflowScrollingNodes(Vector<ScrollingNodeID>&&);
 
     WEBCORE_EXPORT void updateConstraints(const AbsolutePositionConstraints&);
-    const AbsolutePositionConstraints& layoutConstraints() const LIFETIME_BOUND { return m_constraints; }
+    const AbsolutePositionConstraints& layoutConstraints() const LIFETIME_BOUND { return m_staticLayoutData->constraints; }
 
 private:
     WEBCORE_EXPORT ScrollingStatePositionedNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, Vector<ScrollingNodeID>&&, AbsolutePositionConstraints&&);
@@ -60,9 +60,28 @@ private:
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
     OptionSet<ScrollingStateNode::Property> applicableProperties() const final;
+    bool hasUnchangedGroupsAs(const ScrollingStateNode&) const final;
 
-    Vector<ScrollingNodeID> m_relatedOverflowScrollingNodes;
-    AbsolutePositionConstraints m_constraints;
+    // Layout-derived positioned-node state. CoW-shared via DataRef.
+    class StaticLayoutPositionedState : public ThreadSafeRefCounted<StaticLayoutPositionedState> {
+    public:
+        static Ref<StaticLayoutPositionedState> create() { return adoptRef(*new StaticLayoutPositionedState); }
+        Ref<StaticLayoutPositionedState> copy() const { return adoptRef(*new StaticLayoutPositionedState(*this)); }
+
+        Vector<ScrollingNodeID> relatedOverflowScrollingNodes;
+        AbsolutePositionConstraints constraints;
+
+    private:
+        StaticLayoutPositionedState() = default;
+        StaticLayoutPositionedState(const StaticLayoutPositionedState& other)
+            : ThreadSafeRefCounted<StaticLayoutPositionedState>()
+            , relatedOverflowScrollingNodes(other.relatedOverflowScrollingNodes)
+            , constraints(other.constraints)
+        {
+        }
+    };
+
+    DataRef<StaticLayoutPositionedState> m_staticLayoutData { StaticLayoutPositionedState::create() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,10 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include "ScrollingStateTree.h"
+#include <wtf/DataRef.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -37,6 +41,15 @@
 #endif
 
 namespace WebCore {
+
+// Assign to a copy-on-write group member (via DataRef::access) only when it differs, marking the
+// node dirty. Consolidates the otherwise-identical compare / access / setPropertyChanged setter bodies.
+#define SET_COW_PROPERTY(dataRef, member, newValue, property) do { \
+        if ((dataRef)->member != (newValue)) { \
+            (dataRef).access().member = (newValue); \
+            setPropertyChanged(property); \
+        } \
+    } while (0)
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStateScrollingNode);
 
@@ -80,75 +93,79 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
     bool useDarkAppearanceForScrollbars,
     RequestedKeyboardScrollData&& keyboardScrollData
 ) : ScrollingStateNode(nodeType, nodeID, WTF::move(children), changedProperties, layerID)
-    , m_scrollableAreaSize(scrollableAreaSize)
-    , m_totalContentsSize(totalContentsSize)
-    , m_reachableContentsSize(reachableContentsSize)
-    , m_scrollPosition(scrollPosition)
-    , m_scrollOrigin(scrollOrigin)
-    , m_snapOffsetsInfo(WTF::move(snapOffsetsInfo))
-    , m_currentHorizontalSnapPointIndex(currentHorizontalSnapPointIndex)
-    , m_currentVerticalSnapPointIndex(currentVerticalSnapPointIndex)
-    , m_scrollContainerLayer(scrollContainerLayer)
-    , m_scrolledContentsLayer(scrolledContentsLayer)
-    , m_horizontalScrollbarLayer(horizontalScrollbarLayer)
-    , m_verticalScrollbarLayer(verticalScrollbarLayer)
-    , m_scrollbarHoverState(WTF::move(scrollbarHoverState))
-    , m_mouseLocationState(WTF::move(mouseLocationState))
-    , m_scrollbarEnabledState(WTF::move(scrollbarEnabledState))
-    , m_scrollbarColor(WTF::move(scrollbarColor))
-    , m_scrollableAreaParameters(WTF::move(scrollableAreaParameters))
     , m_requestedScrollData(WTF::move(requestedScrollData))
-    , m_keyboardScrollData(WTF::move(keyboardScrollData))
-#if ENABLE(SCROLLING_THREAD)
-    , m_synchronousScrollingReasons(synchronousScrollingReasons)
-#endif
-    , m_scrollbarLayoutDirection(scrollbarLayoutDirection)
-    , m_scrollbarWidth(scrollbarWidth)
-    , m_useDarkAppearanceForScrollbars(useDarkAppearanceForScrollbars)
-    , m_isMonitoringWheelEvents(isMonitoringWheelEvents)
-    , m_mouseIsOverContentArea(mouseIsOverContentArea)
 {
+    SUPPRESS_UNCOUNTED_LOCAL auto& layout = m_staticLayoutData.access();
+    layout.scrollableAreaSize = scrollableAreaSize;
+    layout.totalContentsSize = totalContentsSize;
+    layout.reachableContentsSize = reachableContentsSize;
+    layout.snapOffsetsInfo = WTF::move(snapOffsetsInfo);
+
+    SUPPRESS_UNCOUNTED_LOCAL auto& config = m_staticConfigData.access();
+    config.scrollOrigin = scrollOrigin;
+    config.scrollableAreaParameters = WTF::move(scrollableAreaParameters);
+    config.scrollbarColor = WTF::move(scrollbarColor);
+    config.scrollContainerLayer = scrollContainerLayer;
+    config.scrolledContentsLayer = scrolledContentsLayer;
+    config.horizontalScrollbarLayer = horizontalScrollbarLayer;
+    config.verticalScrollbarLayer = verticalScrollbarLayer;
+#if ENABLE(SCROLLING_THREAD)
+    config.synchronousScrollingReasons = synchronousScrollingReasons;
+#endif
+
+    m_scrollbarEnabledState = WTF::move(scrollbarEnabledState);
+    m_scrollbarLayoutDirection = scrollbarLayoutDirection;
+    m_scrollbarWidth = scrollbarWidth;
+    m_useDarkAppearanceForScrollbars = useDarkAppearanceForScrollbars;
+
+    m_dynamicState.scrollPosition = scrollPosition;
+    m_dynamicState.currentHorizontalSnapPointIndex = currentHorizontalSnapPointIndex;
+    m_dynamicState.currentVerticalSnapPointIndex = currentVerticalSnapPointIndex;
+    m_dynamicState.scrollbarHoverState = WTF::move(scrollbarHoverState);
+    m_dynamicState.mouseLocationState = WTF::move(mouseLocationState);
+    m_dynamicState.keyboardScrollData = WTF::move(keyboardScrollData);
+    m_dynamicState.isMonitoringWheelEvents = isMonitoringWheelEvents;
+    m_dynamicState.mouseIsOverContentArea = mouseIsOverContentArea;
+
     // scrollingNodeAdded will be called in attachAfterDeserialization.
 }
 
 ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScrollingNode& stateNode, ScrollingStateTree& adoptiveTree)
     : ScrollingStateNode(stateNode, adoptiveTree)
-    , m_scrollableAreaSize(stateNode.scrollableAreaSize())
-    , m_totalContentsSize(stateNode.totalContentsSize())
-    , m_reachableContentsSize(stateNode.reachableContentsSize())
-    , m_scrollPosition(stateNode.scrollPosition())
-    , m_scrollOrigin(stateNode.scrollOrigin())
-    , m_snapOffsetsInfo(stateNode.m_snapOffsetsInfo)
-    // m_currentHorizontalSnapPointIndex is not currently copied.
-    // m_currentVerticalSnapPointIndex is not currently copied.
+    , m_staticLayoutData(stateNode.m_staticLayoutData)
+    , m_staticConfigData(stateNode.m_staticConfigData)
+    , m_requestedScrollData(stateNode.requestedScrollData())
+    , m_scrollbarEnabledState(stateNode.m_scrollbarEnabledState)
+    , m_scrollbarLayoutDirection(stateNode.m_scrollbarLayoutDirection)
+    , m_scrollbarWidth(stateNode.m_scrollbarWidth)
+    , m_useDarkAppearanceForScrollbars(stateNode.m_useDarkAppearanceForScrollbars)
 #if PLATFORM(MAC) || USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    , m_scrollbarHoverState(stateNode.scrollbarHoverState())
-#endif
-#if PLATFORM(MAC)
-    , m_mouseLocationState(stateNode.mouseLocationState())
-#endif
-#if PLATFORM(MAC) || USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    , m_scrollbarEnabledState(stateNode.scrollbarEnabledState())
     , m_verticalScrollerImp(stateNode.verticalScrollerImp())
     , m_horizontalScrollerImp(stateNode.horizontalScrollerImp())
 #endif
-    , m_scrollbarColor(stateNode.scrollbarColor())
-    , m_scrollableAreaParameters(stateNode.scrollableAreaParameters())
-    , m_requestedScrollData(stateNode.requestedScrollData())
-    , m_keyboardScrollData(stateNode.keyboardScrollData())
-#if ENABLE(SCROLLING_THREAD)
-    , m_synchronousScrollingReasons(stateNode.synchronousScrollingReasons())
-#endif
-    , m_scrollbarLayoutDirection(stateNode.scrollbarLayoutDirection())
-    , m_scrollbarWidth(stateNode.scrollbarWidth())
-    , m_useDarkAppearanceForScrollbars(stateNode.useDarkAppearanceForScrollbars())
-    , m_isMonitoringWheelEvents(stateNode.isMonitoringWheelEvents())
-    , m_mouseIsOverContentArea(stateNode.mouseIsOverContentArea())
 #if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
     , m_scrollbarOpacity(stateNode.scrollbarOpacity())
 #endif
 {
     scrollingStateTree().scrollingNodeAdded();
+
+    // Copy dynamic state. The legacy IPC clone path elided snap-point indices from the
+    // copy ctor; we no longer do, because (a) the elision was redundant for IPC (the encoder
+    // gates serialization on Property::CurrentHorizontal/VerticalSnapOffsetIndex, not on the
+    // field value), and (b) elision in the m_lastCommittedTree snapshot caused nodes with a
+    // non-default snap index to be perpetually flagged dirty by hasUnchangedGroupsAs.
+    m_dynamicState.scrollPosition = stateNode.m_dynamicState.scrollPosition;
+    m_dynamicState.currentHorizontalSnapPointIndex = stateNode.m_dynamicState.currentHorizontalSnapPointIndex;
+    m_dynamicState.currentVerticalSnapPointIndex = stateNode.m_dynamicState.currentVerticalSnapPointIndex;
+#if PLATFORM(MAC) || USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
+    m_dynamicState.scrollbarHoverState = stateNode.m_dynamicState.scrollbarHoverState;
+#endif
+#if PLATFORM(MAC)
+    m_dynamicState.mouseLocationState = stateNode.m_dynamicState.mouseLocationState;
+#endif
+    m_dynamicState.keyboardScrollData = stateNode.m_dynamicState.keyboardScrollData;
+    m_dynamicState.isMonitoringWheelEvents = stateNode.m_dynamicState.isMonitoringWheelEvents;
+    m_dynamicState.mouseIsOverContentArea = stateNode.m_dynamicState.mouseIsOverContentArea;
 
     if (hasChangedProperty(Property::ScrollContainerLayer))
         setScrollContainerLayer(stateNode.scrollContainerLayer().toRepresentation(adoptiveTree.preferredLayerRepresentation()));
@@ -198,102 +215,141 @@ OptionSet<ScrollingStateNode::Property> ScrollingStateScrollingNode::applicableP
     return properties;
 }
 
-void ScrollingStateScrollingNode::setScrollableAreaSize(const FloatSize& size)
+bool ScrollingStateScrollingNode::hasUnchangedGroupsAs(const ScrollingStateNode& other) const
 {
-    if (m_scrollableAreaSize == size)
+    if (!ScrollingStateNode::hasUnchangedGroupsAs(other))
+        return false;
+    auto& otherScrolling = downcast<ScrollingStateScrollingNode>(other);
+    if (m_staticLayoutData.ptr() != otherScrolling.m_staticLayoutData.ptr())
+        return false;
+    if (m_staticConfigData.ptr() != otherScrolling.m_staticConfigData.ptr())
+        return false;
+    if (m_dynamicState != otherScrolling.m_dynamicState)
+        return false;
+    // Direct (non-CoW) members are mutated outside the groups above, so they must be
+    // compared here too, otherwise a node dirtied only through one of them is dropped
+    // from the dirty-node list.
+    if (m_requestedScrollData != otherScrolling.m_requestedScrollData)
+        return false;
+    if (m_scrollbarEnabledState != otherScrolling.m_scrollbarEnabledState)
+        return false;
+    if (m_scrollbarLayoutDirection != otherScrolling.m_scrollbarLayoutDirection)
+        return false;
+    if (m_scrollbarWidth != otherScrolling.m_scrollbarWidth)
+        return false;
+    if (m_useDarkAppearanceForScrollbars != otherScrolling.m_useDarkAppearanceForScrollbars)
+        return false;
+    return true;
+}
+
+void ScrollingStateScrollingNode::clearLayerFieldsForUnchangedProperties()
+{
+    // Match the pre-refactor direct-member default-empty behavior: any layer field whose
+    // Property bit is NOT set on the clone must be empty in the IPC payload. Without this,
+    // the in-process Coordinated Graphics scrolling-tree receiver dereferences the inherited
+    // (un-translated) layer as ScrollingPlatformLayer* and asserts on the variant type.
+    bool needsAccess = (!hasChangedProperty(Property::ScrollContainerLayer) && m_staticConfigData->scrollContainerLayer)
+        || (!hasChangedProperty(Property::ScrolledContentsLayer) && m_staticConfigData->scrolledContentsLayer)
+        || (!hasChangedProperty(Property::HorizontalScrollbarLayer) && m_staticConfigData->horizontalScrollbarLayer)
+        || (!hasChangedProperty(Property::VerticalScrollbarLayer) && m_staticConfigData->verticalScrollbarLayer);
+    if (!needsAccess)
         return;
 
-    m_scrollableAreaSize = size;
-    setPropertyChanged(Property::ScrollableAreaSize);
+    SUPPRESS_UNCOUNTED_LOCAL auto& config = m_staticConfigData.access();
+    if (!hasChangedProperty(Property::ScrollContainerLayer))
+        config.scrollContainerLayer = { };
+    if (!hasChangedProperty(Property::ScrolledContentsLayer))
+        config.scrolledContentsLayer = { };
+    if (!hasChangedProperty(Property::HorizontalScrollbarLayer))
+        config.horizontalScrollbarLayer = { };
+    if (!hasChangedProperty(Property::VerticalScrollbarLayer))
+        config.verticalScrollbarLayer = { };
+}
+
+#if ASSERT_ENABLED
+void ScrollingStateScrollingNode::verifyClearedLayerFieldsForUnchangedProperties() const
+{
+    ASSERT(hasChangedProperty(Property::ScrollContainerLayer) || !m_staticConfigData->scrollContainerLayer);
+    ASSERT(hasChangedProperty(Property::ScrolledContentsLayer) || !m_staticConfigData->scrolledContentsLayer);
+    ASSERT(hasChangedProperty(Property::HorizontalScrollbarLayer) || !m_staticConfigData->horizontalScrollbarLayer);
+    ASSERT(hasChangedProperty(Property::VerticalScrollbarLayer) || !m_staticConfigData->verticalScrollbarLayer);
+}
+#endif
+
+void ScrollingStateScrollingNode::setScrollableAreaSize(const FloatSize& size)
+{
+    SET_COW_PROPERTY(m_staticLayoutData, scrollableAreaSize, size, Property::ScrollableAreaSize);
 }
 
 void ScrollingStateScrollingNode::setTotalContentsSize(const FloatSize& totalContentsSize)
 {
-    if (m_totalContentsSize == totalContentsSize)
-        return;
-
-    m_totalContentsSize = totalContentsSize;
-    setPropertyChanged(Property::TotalContentsSize);
+    SET_COW_PROPERTY(m_staticLayoutData, totalContentsSize, totalContentsSize, Property::TotalContentsSize);
 }
 
 void ScrollingStateScrollingNode::setReachableContentsSize(const FloatSize& reachableContentsSize)
 {
-    if (m_reachableContentsSize == reachableContentsSize)
-        return;
-
-    m_reachableContentsSize = reachableContentsSize;
-    setPropertyChanged(Property::ReachableContentsSize);
+    SET_COW_PROPERTY(m_staticLayoutData, reachableContentsSize, reachableContentsSize, Property::ReachableContentsSize);
 }
 
 void ScrollingStateScrollingNode::setScrollPosition(const FloatPoint& scrollPosition)
 {
-    if (m_scrollPosition == scrollPosition)
+    if (m_dynamicState.scrollPosition == scrollPosition)
         return;
 
-    m_scrollPosition = scrollPosition;
+    m_dynamicState.scrollPosition = scrollPosition;
     setPropertyChanged(Property::ScrollPosition);
 }
 
 void ScrollingStateScrollingNode::setScrollOrigin(const IntPoint& scrollOrigin)
 {
-    if (m_scrollOrigin == scrollOrigin)
-        return;
-
-    m_scrollOrigin = scrollOrigin;
-    setPropertyChanged(Property::ScrollOrigin);
+    SET_COW_PROPERTY(m_staticConfigData, scrollOrigin, scrollOrigin, Property::ScrollOrigin);
 }
 
 void ScrollingStateScrollingNode::setSnapOffsetsInfo(const FloatScrollSnapOffsetsInfo& info)
 {
-    if (m_snapOffsetsInfo.isEqual(info))
+    if (m_staticLayoutData->snapOffsetsInfo.isEqual(info))
         return;
 
-    m_snapOffsetsInfo = info;
+    m_staticLayoutData.access().snapOffsetsInfo = info;
     setPropertyChanged(Property::SnapOffsetsInfo);
 }
 
 void ScrollingStateScrollingNode::setCurrentHorizontalSnapPointIndex(std::optional<unsigned> index)
 {
-    if (m_currentHorizontalSnapPointIndex == index)
+    if (m_dynamicState.currentHorizontalSnapPointIndex == index)
         return;
-    
-    m_currentHorizontalSnapPointIndex = index;
+
+    m_dynamicState.currentHorizontalSnapPointIndex = index;
     setPropertyChanged(Property::CurrentHorizontalSnapOffsetIndex);
 }
 
 void ScrollingStateScrollingNode::setCurrentVerticalSnapPointIndex(std::optional<unsigned> index)
 {
-    if (m_currentVerticalSnapPointIndex == index)
+    if (m_dynamicState.currentVerticalSnapPointIndex == index)
         return;
 
-    m_currentVerticalSnapPointIndex = index;
+    m_dynamicState.currentVerticalSnapPointIndex = index;
     setPropertyChanged(Property::CurrentVerticalSnapOffsetIndex);
 }
 
 void ScrollingStateScrollingNode::setScrollableAreaParameters(const ScrollableAreaParameters& parameters)
 {
-    if (m_scrollableAreaParameters == parameters)
-        return;
-
-    m_scrollableAreaParameters = parameters;
-    setPropertyChanged(Property::ScrollableAreaParams);
+    SET_COW_PROPERTY(m_staticConfigData, scrollableAreaParameters, parameters, Property::ScrollableAreaParams);
 }
 
 #if ENABLE(SCROLLING_THREAD)
 void ScrollingStateScrollingNode::setSynchronousScrollingReasons(OptionSet<SynchronousScrollingReason> reasons)
 {
-    if (m_synchronousScrollingReasons == reasons)
-        return;
-
-    m_synchronousScrollingReasons = reasons;
-    setPropertyChanged(Property::ReasonsForSynchronousScrolling);
+    SET_COW_PROPERTY(m_staticConfigData, synchronousScrollingReasons, reasons, Property::ReasonsForSynchronousScrolling);
 }
 #endif
 
 
 void ScrollingStateScrollingNode::setKeyboardScrollData(const RequestedKeyboardScrollData& scrollData)
 {
-    m_keyboardScrollData = scrollData;
+    // One-shot command, not durable state: never de-dupe, or a repeated identical command
+    // across commits is dropped and the scroll won't fire. Mirrors setRequestedScrollData.
+    m_dynamicState.keyboardScrollData = scrollData;
     setPropertyChanged(Property::KeyboardScrollData);
 }
 
@@ -456,46 +512,31 @@ bool ScrollingStateScrollingNode::hasScrollPositionRequest() const
 
 void ScrollingStateScrollingNode::setIsMonitoringWheelEvents(bool isMonitoringWheelEvents)
 {
-    if (isMonitoringWheelEvents == m_isMonitoringWheelEvents)
+    if (isMonitoringWheelEvents == m_dynamicState.isMonitoringWheelEvents)
         return;
 
-    m_isMonitoringWheelEvents = isMonitoringWheelEvents;
+    m_dynamicState.isMonitoringWheelEvents = isMonitoringWheelEvents;
     setPropertyChanged(Property::IsMonitoringWheelEvents);
 }
 
 void ScrollingStateScrollingNode::setScrollContainerLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_scrollContainerLayer)
-        return;
-
-    m_scrollContainerLayer = layerRepresentation;
-    setPropertyChanged(Property::ScrollContainerLayer);
+    SET_COW_PROPERTY(m_staticConfigData, scrollContainerLayer, layerRepresentation, Property::ScrollContainerLayer);
 }
 
 void ScrollingStateScrollingNode::setScrolledContentsLayer(const LayerRepresentation& layerRepresentation)
 {
-    if (layerRepresentation == m_scrolledContentsLayer)
-        return;
-
-    m_scrolledContentsLayer = layerRepresentation;
-    setPropertyChanged(Property::ScrolledContentsLayer);
+    SET_COW_PROPERTY(m_staticConfigData, scrolledContentsLayer, layerRepresentation, Property::ScrolledContentsLayer);
 }
 
 void ScrollingStateScrollingNode::setHorizontalScrollbarLayer(const LayerRepresentation& layer)
 {
-    if (layer == m_horizontalScrollbarLayer)
-        return;
-
-    m_horizontalScrollbarLayer = layer;
-    setPropertyChanged(Property::HorizontalScrollbarLayer);
+    SET_COW_PROPERTY(m_staticConfigData, horizontalScrollbarLayer, layer, Property::HorizontalScrollbarLayer);
 }
 
 void ScrollingStateScrollingNode::setVerticalScrollbarLayer(const LayerRepresentation& layer)
 {
-    if (layer == m_verticalScrollbarLayer)
-        return;
-    m_verticalScrollbarLayer = layer;
-    setPropertyChanged(Property::VerticalScrollbarLayer);
+    SET_COW_PROPERTY(m_staticConfigData, verticalScrollbarLayer, layer, Property::VerticalScrollbarLayer);
 }
 
 #if !PLATFORM(MAC) && !USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
@@ -506,55 +547,50 @@ void ScrollingStateScrollingNode::setScrollerImpsFromScrollbars(Scrollbar*, Scro
 
 void ScrollingStateScrollingNode::setMouseIsOverContentArea(bool flag)
 {
-    if (flag == m_mouseIsOverContentArea)
+    if (flag == m_dynamicState.mouseIsOverContentArea)
         return;
 
-    m_mouseIsOverContentArea = flag;
+    m_dynamicState.mouseIsOverContentArea = flag;
     setPropertyChanged(Property::ContentAreaHoverState);
 }
 
 void ScrollingStateScrollingNode::setMouseMovedInContentArea(const MouseLocationState& mouseLocationState)
 {
-    m_mouseLocationState = mouseLocationState;
+    if (m_dynamicState.mouseLocationState == mouseLocationState)
+        return;
+    m_dynamicState.mouseLocationState = mouseLocationState;
     setPropertyChanged(Property::MouseActivityState);
 }
-    
+
 void ScrollingStateScrollingNode::setScrollbarHoverState(ScrollbarHoverState hoverState)
 {
-    if (hoverState == m_scrollbarHoverState)
+    if (hoverState == m_dynamicState.scrollbarHoverState)
         return;
 
-    m_scrollbarHoverState = hoverState;
+    m_dynamicState.scrollbarHoverState = hoverState;
     setPropertyChanged(Property::ScrollbarHoverState);
 }
 
 void ScrollingStateScrollingNode::setScrollbarEnabledState(ScrollbarOrientation orientation, bool enabled)
 {
-    if ((orientation == ScrollbarOrientation::Horizontal ? m_scrollbarEnabledState.horizontalScrollbarIsEnabled : m_scrollbarEnabledState.verticalScrollbarIsEnabled) == enabled)
+    bool& field = (orientation == ScrollbarOrientation::Horizontal)
+        ? m_scrollbarEnabledState.horizontalScrollbarIsEnabled
+        : m_scrollbarEnabledState.verticalScrollbarIsEnabled;
+    if (field == enabled)
         return;
-
-    if (orientation == ScrollbarOrientation::Horizontal)
-        m_scrollbarEnabledState.horizontalScrollbarIsEnabled = enabled;
-    else
-        m_scrollbarEnabledState.verticalScrollbarIsEnabled = enabled;
-
+    field = enabled;
     setPropertyChanged(Property::ScrollbarEnabledState);
 }
 
 void ScrollingStateScrollingNode::setScrollbarColor(std::optional<ScrollbarColor> state)
 {
-    if (state == m_scrollbarColor)
-        return;
-
-    m_scrollbarColor = state;
-    setPropertyChanged(Property::ScrollbarColor);
+    SET_COW_PROPERTY(m_staticConfigData, scrollbarColor, state, Property::ScrollbarColor);
 }
 
 void ScrollingStateScrollingNode::setScrollbarLayoutDirection(UserInterfaceLayoutDirection scrollbarLayoutDirection)
 {
     if (scrollbarLayoutDirection == m_scrollbarLayoutDirection)
         return;
-
     m_scrollbarLayoutDirection = scrollbarLayoutDirection;
     setPropertyChanged(Property::ScrollbarLayoutDirection);
 }
@@ -588,30 +624,33 @@ void ScrollingStateScrollingNode::setScrollbarOpacity(float scrollbarOpacity)
 void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ScrollingStateNode::dumpProperties(ts, behavior);
-    
-    if (!m_scrollPosition.isZero()) {
+
+    SUPPRESS_UNCOUNTED_LOCAL auto& layout = m_staticLayoutData.get();
+    SUPPRESS_UNCOUNTED_LOCAL auto& config = m_staticConfigData.get();
+
+    if (!m_dynamicState.scrollPosition.isZero()) {
         TextStream::GroupScope scope(ts);
         ts << "scroll position "_s
-            << TextStream::FormatNumberRespectingIntegers(m_scrollPosition.x()) << " "
-            << TextStream::FormatNumberRespectingIntegers(m_scrollPosition.y());
+            << TextStream::FormatNumberRespectingIntegers(m_dynamicState.scrollPosition.x()) << " "
+            << TextStream::FormatNumberRespectingIntegers(m_dynamicState.scrollPosition.y());
     }
 
-    if (!m_scrollableAreaSize.isEmpty()) {
+    if (!layout.scrollableAreaSize.isEmpty()) {
         TextStream::GroupScope scope(ts);
         ts << "scrollable area size "_s
-            << TextStream::FormatNumberRespectingIntegers(m_scrollableAreaSize.width()) << " "
-            << TextStream::FormatNumberRespectingIntegers(m_scrollableAreaSize.height());
+            << TextStream::FormatNumberRespectingIntegers(layout.scrollableAreaSize.width()) << " "
+            << TextStream::FormatNumberRespectingIntegers(layout.scrollableAreaSize.height());
     }
 
-    if (!m_totalContentsSize.isEmpty()) {
+    if (!layout.totalContentsSize.isEmpty()) {
         TextStream::GroupScope scope(ts);
         ts << "contents size "_s
-            << TextStream::FormatNumberRespectingIntegers(m_totalContentsSize.width()) << " "
-            << TextStream::FormatNumberRespectingIntegers(m_totalContentsSize.height());
+            << TextStream::FormatNumberRespectingIntegers(layout.totalContentsSize.width()) << " "
+            << TextStream::FormatNumberRespectingIntegers(layout.totalContentsSize.height());
     }
 
-    if (m_reachableContentsSize != m_totalContentsSize)
-        ts.dumpProperty("reachable contents size"_s, m_reachableContentsSize);
+    if (layout.reachableContentsSize != layout.totalContentsSize)
+        ts.dumpProperty("reachable contents size"_s, layout.reachableContentsSize);
 
     auto dumpRequest = [&](const RequestedScrollData& request) {
         if (request.requestType == ScrollRequestType::PositionUpdate || request.requestType == ScrollRequestType::AnimatedPositionUpdate) {
@@ -648,42 +687,44 @@ void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<Scrol
     for (auto& request : m_requestedScrollData)
         dumpRequest(request);
 
-    if (!m_scrollOrigin.isZero())
-        ts.dumpProperty("scroll origin"_s, m_scrollOrigin);
+    if (!config.scrollOrigin.isZero())
+        ts.dumpProperty("scroll origin"_s, config.scrollOrigin);
 
-    if (m_snapOffsetsInfo.horizontalSnapOffsets.size())
-        ts.dumpProperty("horizontal snap offsets"_s, m_snapOffsetsInfo.horizontalSnapOffsets);
+    if (layout.snapOffsetsInfo.horizontalSnapOffsets.size())
+        ts.dumpProperty("horizontal snap offsets"_s, layout.snapOffsetsInfo.horizontalSnapOffsets);
 
-    if (m_snapOffsetsInfo.verticalSnapOffsets.size())
-        ts.dumpProperty("vertical snap offsets"_s, m_snapOffsetsInfo.verticalSnapOffsets);
+    if (layout.snapOffsetsInfo.verticalSnapOffsets.size())
+        ts.dumpProperty("vertical snap offsets"_s, layout.snapOffsetsInfo.verticalSnapOffsets);
 
-    if (m_currentHorizontalSnapPointIndex)
-        ts.dumpProperty("current horizontal snap point index"_s, m_currentHorizontalSnapPointIndex);
+    if (m_dynamicState.currentHorizontalSnapPointIndex)
+        ts.dumpProperty("current horizontal snap point index"_s, m_dynamicState.currentHorizontalSnapPointIndex);
 
-    if (m_currentVerticalSnapPointIndex)
-        ts.dumpProperty("current vertical snap point index"_s, m_currentVerticalSnapPointIndex);
+    if (m_dynamicState.currentVerticalSnapPointIndex)
+        ts.dumpProperty("current vertical snap point index"_s, m_dynamicState.currentVerticalSnapPointIndex);
 
-    ts.dumpProperty("scrollable area parameters"_s, m_scrollableAreaParameters);
+    ts.dumpProperty("scrollable area parameters"_s, config.scrollableAreaParameters);
 
 #if ENABLE(SCROLLING_THREAD)
-    if (!m_synchronousScrollingReasons.isEmpty())
-        ts.dumpProperty("Scrolling on main thread because:"_s, ScrollingCoordinator::synchronousScrollingReasonsAsText(m_synchronousScrollingReasons));
+    if (!config.synchronousScrollingReasons.isEmpty())
+        ts.dumpProperty("Scrolling on main thread because:"_s, ScrollingCoordinator::synchronousScrollingReasonsAsText(config.synchronousScrollingReasons));
 #endif
 
     if (m_useDarkAppearanceForScrollbars)
         ts.dumpProperty("uses dark appearance for scrollbars"_s, m_useDarkAppearanceForScrollbars);
 
-    if (m_isMonitoringWheelEvents)
-        ts.dumpProperty("expects wheel event test trigger"_s, m_isMonitoringWheelEvents);
+    if (m_dynamicState.isMonitoringWheelEvents)
+        ts.dumpProperty("expects wheel event test trigger"_s, m_dynamicState.isMonitoringWheelEvents);
 
     if (behavior & ScrollingStateTreeAsTextBehavior::IncludeLayerIDs) {
-        if (m_scrollContainerLayer.layerID())
-            ts.dumpProperty("scroll container layer"_s, m_scrollContainerLayer.layerID());
-        if (m_scrolledContentsLayer.layerID())
-            ts.dumpProperty("scrolled contents layer"_s, m_scrolledContentsLayer.layerID());
+        if (config.scrollContainerLayer.layerID())
+            ts.dumpProperty("scroll container layer"_s, config.scrollContainerLayer.layerID());
+        if (config.scrolledContentsLayer.layerID())
+            ts.dumpProperty("scrolled contents layer"_s, config.scrolledContentsLayer.layerID());
     }
 }
 
 } // namespace WebCore
+
+#undef SET_COW_PROPERTY
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2014-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollingCoordinator.h>
 #include <WebCore/ScrollingStateNode.h>
+#include <wtf/Forward.h>
 
 #if PLATFORM(COCOA)
 OBJC_CLASS NSScrollerImp;
@@ -60,11 +61,15 @@ struct ScrollbarHoverState {
 struct MouseLocationState {
     IntPoint locationInHorizontalScrollbar;
     IntPoint locationInVerticalScrollbar;
+
+    friend bool operator==(const MouseLocationState&, const MouseLocationState&) = default;
 };
 
 struct ScrollbarEnabledState {
     bool horizontalScrollbarIsEnabled { false };
     bool verticalScrollbarIsEnabled { false };
+
+    friend bool operator==(const ScrollbarEnabledState&, const ScrollbarEnabledState&) = default;
 };
 
 class ScrollingStateScrollingNode : public ScrollingStateNode {
@@ -72,40 +77,40 @@ class ScrollingStateScrollingNode : public ScrollingStateNode {
 public:
     virtual ~ScrollingStateScrollingNode();
 
-    const FloatSize& scrollableAreaSize() const LIFETIME_BOUND { return m_scrollableAreaSize; }
+    const FloatSize& scrollableAreaSize() const LIFETIME_BOUND { return m_staticLayoutData->scrollableAreaSize; }
     WEBCORE_EXPORT void setScrollableAreaSize(const FloatSize&);
 
-    const FloatSize& totalContentsSize() const LIFETIME_BOUND { return m_totalContentsSize; }
+    const FloatSize& totalContentsSize() const LIFETIME_BOUND { return m_staticLayoutData->totalContentsSize; }
     WEBCORE_EXPORT void setTotalContentsSize(const FloatSize&);
 
-    const FloatSize& reachableContentsSize() const LIFETIME_BOUND { return m_reachableContentsSize; }
+    const FloatSize& reachableContentsSize() const LIFETIME_BOUND { return m_staticLayoutData->reachableContentsSize; }
     WEBCORE_EXPORT void setReachableContentsSize(const FloatSize&);
 
-    const FloatPoint& scrollPosition() const LIFETIME_BOUND { return m_scrollPosition; }
+    const FloatPoint& scrollPosition() const LIFETIME_BOUND { return m_dynamicState.scrollPosition; }
     WEBCORE_EXPORT void setScrollPosition(const FloatPoint&);
 
-    const IntPoint& scrollOrigin() const LIFETIME_BOUND { return m_scrollOrigin; }
+    const IntPoint& scrollOrigin() const LIFETIME_BOUND { return m_staticConfigData->scrollOrigin; }
     WEBCORE_EXPORT void setScrollOrigin(const IntPoint&);
 
-    const FloatScrollSnapOffsetsInfo& snapOffsetsInfo() const LIFETIME_BOUND { return m_snapOffsetsInfo; }
+    const FloatScrollSnapOffsetsInfo& snapOffsetsInfo() const LIFETIME_BOUND { return m_staticLayoutData->snapOffsetsInfo; }
     WEBCORE_EXPORT void setSnapOffsetsInfo(const FloatScrollSnapOffsetsInfo& newOffsetsInfo);
 
-    std::optional<unsigned> currentHorizontalSnapPointIndex() const { return m_currentHorizontalSnapPointIndex; }
+    std::optional<unsigned> currentHorizontalSnapPointIndex() const { return m_dynamicState.currentHorizontalSnapPointIndex; }
     WEBCORE_EXPORT void setCurrentHorizontalSnapPointIndex(std::optional<unsigned>);
 
-    std::optional<unsigned> currentVerticalSnapPointIndex() const { return m_currentVerticalSnapPointIndex; }
+    std::optional<unsigned> currentVerticalSnapPointIndex() const { return m_dynamicState.currentVerticalSnapPointIndex; }
     WEBCORE_EXPORT void setCurrentVerticalSnapPointIndex(std::optional<unsigned>);
 
-    const ScrollableAreaParameters& scrollableAreaParameters() const LIFETIME_BOUND { return m_scrollableAreaParameters; }
+    const ScrollableAreaParameters& scrollableAreaParameters() const LIFETIME_BOUND { return m_staticConfigData->scrollableAreaParameters; }
     WEBCORE_EXPORT void setScrollableAreaParameters(const ScrollableAreaParameters& params);
 
 #if ENABLE(SCROLLING_THREAD)
-    OptionSet<SynchronousScrollingReason> synchronousScrollingReasons() const { return m_synchronousScrollingReasons; }
+    OptionSet<SynchronousScrollingReason> synchronousScrollingReasons() const { return m_staticConfigData->synchronousScrollingReasons; }
     WEBCORE_EXPORT void setSynchronousScrollingReasons(OptionSet<SynchronousScrollingReason>);
-    bool hasSynchronousScrollingReasons() const { return !m_synchronousScrollingReasons.isEmpty(); }
+    bool hasSynchronousScrollingReasons() const { return !m_staticConfigData->synchronousScrollingReasons.isEmpty(); }
 #endif
 
-    const RequestedKeyboardScrollData& keyboardScrollData() const LIFETIME_BOUND { return m_keyboardScrollData; }
+    const RequestedKeyboardScrollData& keyboardScrollData() const LIFETIME_BOUND { return m_dynamicState.keyboardScrollData; }
     WEBCORE_EXPORT void setKeyboardScrollData(const RequestedKeyboardScrollData&);
 
     const ScrollRequestData& requestedScrollData() const LIFETIME_BOUND { return m_requestedScrollData; }
@@ -114,20 +119,20 @@ public:
 
     WEBCORE_EXPORT bool NODELETE hasScrollPositionRequest() const;
 
-    bool isMonitoringWheelEvents() const { return m_isMonitoringWheelEvents; }
+    bool isMonitoringWheelEvents() const { return m_dynamicState.isMonitoringWheelEvents; }
     WEBCORE_EXPORT void setIsMonitoringWheelEvents(bool);
 
-    const LayerRepresentation& scrollContainerLayer() const LIFETIME_BOUND { return m_scrollContainerLayer; }
+    const LayerRepresentation& scrollContainerLayer() const LIFETIME_BOUND { return m_staticConfigData->scrollContainerLayer; }
     WEBCORE_EXPORT void setScrollContainerLayer(const LayerRepresentation&);
 
     // This is a layer with the contents that move.
-    const LayerRepresentation& scrolledContentsLayer() const LIFETIME_BOUND { return m_scrolledContentsLayer; }
+    const LayerRepresentation& scrolledContentsLayer() const LIFETIME_BOUND { return m_staticConfigData->scrolledContentsLayer; }
     WEBCORE_EXPORT void setScrolledContentsLayer(const LayerRepresentation&);
 
-    const LayerRepresentation& horizontalScrollbarLayer() const LIFETIME_BOUND { return m_horizontalScrollbarLayer; }
+    const LayerRepresentation& horizontalScrollbarLayer() const LIFETIME_BOUND { return m_staticConfigData->horizontalScrollbarLayer; }
     WEBCORE_EXPORT void setHorizontalScrollbarLayer(const LayerRepresentation&);
 
-    const LayerRepresentation& verticalScrollbarLayer() const LIFETIME_BOUND { return m_verticalScrollbarLayer; }
+    const LayerRepresentation& verticalScrollbarLayer() const LIFETIME_BOUND { return m_staticConfigData->verticalScrollbarLayer; }
     WEBCORE_EXPORT void setVerticalScrollbarLayer(const LayerRepresentation&);
 
 #if PLATFORM(MAC)
@@ -137,22 +142,22 @@ public:
     ScrollerImpAdwaita* verticalScrollerImp() const { return m_verticalScrollerImp; }
     ScrollerImpAdwaita* horizontalScrollerImp() const { return m_horizontalScrollerImp; }
 #endif
-    ScrollbarHoverState scrollbarHoverState() const { return m_scrollbarHoverState; }
+    ScrollbarHoverState scrollbarHoverState() const { return m_dynamicState.scrollbarHoverState; }
     WEBCORE_EXPORT void setScrollbarHoverState(ScrollbarHoverState);
 
     ScrollbarEnabledState scrollbarEnabledState() const { return m_scrollbarEnabledState; }
     WEBCORE_EXPORT void setScrollbarEnabledState(ScrollbarOrientation, bool);
 
-    const std::optional<ScrollbarColor>& scrollbarColor() const LIFETIME_BOUND { return m_scrollbarColor; }
+    const std::optional<ScrollbarColor>& scrollbarColor() const LIFETIME_BOUND { return m_staticConfigData->scrollbarColor; }
     WEBCORE_EXPORT void setScrollbarColor(std::optional<ScrollbarColor>);
 
     void setScrollerImpsFromScrollbars(Scrollbar* verticalScrollbar, Scrollbar* horizontalScrollbar);
 
     WEBCORE_EXPORT void setMouseIsOverContentArea(bool);
-    bool mouseIsOverContentArea() const { return m_mouseIsOverContentArea; }
+    bool mouseIsOverContentArea() const { return m_dynamicState.mouseIsOverContentArea; }
 
     WEBCORE_EXPORT void setMouseMovedInContentArea(const MouseLocationState&);
-    const MouseLocationState& mouseLocationState() const LIFETIME_BOUND { return m_mouseLocationState; }
+    const MouseLocationState& mouseLocationState() const LIFETIME_BOUND { return m_dynamicState.mouseLocationState; }
 
     WEBCORE_EXPORT void setScrollbarLayoutDirection(UserInterfaceLayoutDirection);
     UserInterfaceLayoutDirection scrollbarLayoutDirection() const { return m_scrollbarLayoutDirection; }
@@ -208,28 +213,96 @@ protected:
 
     OptionSet<Property> applicableProperties() const override;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+    bool hasUnchangedGroupsAs(const ScrollingStateNode&) const override;
+    void clearLayerFieldsForUnchangedProperties() override;
+#if ASSERT_ENABLED
+    void verifyClearedLayerFieldsForUnchangedProperties() const override;
+#endif
+
+    // Per-frame mutable scrolling state. Every commit is expected to differ in at least one field.
+    struct DynamicScrollState {
+        FloatPoint scrollPosition;
+        std::optional<unsigned> currentHorizontalSnapPointIndex;
+        std::optional<unsigned> currentVerticalSnapPointIndex;
+        ScrollbarHoverState scrollbarHoverState;
+        MouseLocationState mouseLocationState;
+        RequestedKeyboardScrollData keyboardScrollData;
+        bool isMonitoringWheelEvents { false };
+        bool mouseIsOverContentArea { false };
+
+        friend bool operator==(const DynamicScrollState&, const DynamicScrollState&) = default;
+    };
+
+    // Layout-derived scrolling state. Recomputed on layout, stable between scrolls.
+    class StaticLayoutScrollState : public ThreadSafeRefCounted<StaticLayoutScrollState> {
+    public:
+        static Ref<StaticLayoutScrollState> create() { return adoptRef(*new StaticLayoutScrollState); }
+        Ref<StaticLayoutScrollState> copy() const { return adoptRef(*new StaticLayoutScrollState(*this)); }
+
+        FloatSize scrollableAreaSize;
+        FloatSize totalContentsSize;
+        FloatSize reachableContentsSize;
+        FloatScrollSnapOffsetsInfo snapOffsetsInfo;
+
+    private:
+        StaticLayoutScrollState() = default;
+        StaticLayoutScrollState(const StaticLayoutScrollState& other)
+            : ThreadSafeRefCounted<StaticLayoutScrollState>()
+            , scrollableAreaSize(other.scrollableAreaSize)
+            , totalContentsSize(other.totalContentsSize)
+            , reachableContentsSize(other.reachableContentsSize)
+            , snapOffsetsInfo(other.snapOffsetsInfo)
+        {
+        }
+    };
+
+    // Long-lived scrolling configuration. Rarely changes.
+    class StaticConfigurationScrollState : public ThreadSafeRefCounted<StaticConfigurationScrollState> {
+    public:
+        static Ref<StaticConfigurationScrollState> create() { return adoptRef(*new StaticConfigurationScrollState); }
+        Ref<StaticConfigurationScrollState> copy() const { return adoptRef(*new StaticConfigurationScrollState(*this)); }
+
+        IntPoint scrollOrigin;
+        ScrollableAreaParameters scrollableAreaParameters;
+        std::optional<ScrollbarColor> scrollbarColor;
+        LayerRepresentation scrollContainerLayer;
+        LayerRepresentation scrolledContentsLayer;
+        LayerRepresentation horizontalScrollbarLayer;
+        LayerRepresentation verticalScrollbarLayer;
+#if ENABLE(SCROLLING_THREAD)
+        OptionSet<SynchronousScrollingReason> synchronousScrollingReasons;
+#endif
+
+    private:
+        StaticConfigurationScrollState() = default;
+        StaticConfigurationScrollState(const StaticConfigurationScrollState& other)
+            : ThreadSafeRefCounted<StaticConfigurationScrollState>()
+            , scrollOrigin(other.scrollOrigin)
+            , scrollableAreaParameters(other.scrollableAreaParameters)
+            , scrollbarColor(other.scrollbarColor)
+            , scrollContainerLayer(other.scrollContainerLayer)
+            , scrolledContentsLayer(other.scrolledContentsLayer)
+            , horizontalScrollbarLayer(other.horizontalScrollbarLayer)
+            , verticalScrollbarLayer(other.verticalScrollbarLayer)
+#if ENABLE(SCROLLING_THREAD)
+            , synchronousScrollingReasons(other.synchronousScrollingReasons)
+#endif
+        {
+        }
+    };
+
+    DataRef<StaticLayoutScrollState> m_staticLayoutData { StaticLayoutScrollState::create() };
+    DataRef<StaticConfigurationScrollState> m_staticConfigData { StaticConfigurationScrollState::create() };
+    DynamicScrollState m_dynamicState;
 
 private:
     void mergeOrAppendScrollRequest(RequestedScrollData&&);
 
-    FloatSize m_scrollableAreaSize;
-    FloatSize m_totalContentsSize;
-    FloatSize m_reachableContentsSize;
-    FloatPoint m_scrollPosition;
-    IntPoint m_scrollOrigin;
-
-    FloatScrollSnapOffsetsInfo m_snapOffsetsInfo;
-    std::optional<unsigned> m_currentHorizontalSnapPointIndex;
-    std::optional<unsigned> m_currentVerticalSnapPointIndex;
-
-    LayerRepresentation m_scrollContainerLayer;
-    LayerRepresentation m_scrolledContentsLayer;
-    LayerRepresentation m_horizontalScrollbarLayer;
-    LayerRepresentation m_verticalScrollbarLayer;
-    
-    ScrollbarHoverState m_scrollbarHoverState;
-    MouseLocationState m_mouseLocationState;
+    ScrollRequestData m_requestedScrollData;
     ScrollbarEnabledState m_scrollbarEnabledState;
+    UserInterfaceLayoutDirection m_scrollbarLayoutDirection { UserInterfaceLayoutDirection::LTR };
+    ScrollbarWidth m_scrollbarWidth { ScrollbarWidth::Auto };
+    bool m_useDarkAppearanceForScrollbars { false };
 
 #if PLATFORM(MAC)
     RetainPtr<NSScrollerImp> m_verticalScrollerImp;
@@ -239,19 +312,6 @@ private:
     RefPtr<ScrollerImpAdwaita> m_horizontalScrollerImp;
 #endif
 
-    std::optional<ScrollbarColor> m_scrollbarColor;
-    ScrollableAreaParameters m_scrollableAreaParameters;
-    ScrollRequestData m_requestedScrollData;
-    RequestedKeyboardScrollData m_keyboardScrollData;
-#if ENABLE(SCROLLING_THREAD)
-    OptionSet<SynchronousScrollingReason> m_synchronousScrollingReasons;
-#endif
-    UserInterfaceLayoutDirection m_scrollbarLayoutDirection { UserInterfaceLayoutDirection::LTR };
-    ScrollbarWidth m_scrollbarWidth { ScrollbarWidth::Auto };
-
-    bool m_useDarkAppearanceForScrollbars { false };
-    bool m_isMonitoringWheelEvents { false };
-    bool m_mouseIsOverContentArea { false };
 #if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
     float m_scrollbarOpacity { 1 };
 #endif

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,10 @@
 #include "ScrollingStateOverflowScrollingNode.h"
 #include "ScrollingStateTree.h"
 #include "ScrollingTree.h"
+#include <wtf/DataRef.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
@@ -45,9 +49,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollingStateStickyNode);
 
 ScrollingStateStickyNode::ScrollingStateStickyNode(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, StickyPositionViewportConstraints&& constraints, LayerRepresentation&& viewportAnchorLayer)
     : ScrollingStateNode(ScrollingNodeType::Sticky, nodeID, WTF::move(children), changedProperties, layerID)
-    , m_constraints(WTF::move(constraints))
-    , m_viewportAnchorLayer(WTF::move(viewportAnchorLayer))
 {
+    m_staticLayoutData.access().constraints = WTF::move(constraints);
+    m_staticConfigData.access().viewportAnchorLayer = WTF::move(viewportAnchorLayer);
 }
 
 ScrollingStateStickyNode::ScrollingStateStickyNode(ScrollingStateTree& tree, ScrollingNodeID nodeID)
@@ -57,7 +61,8 @@ ScrollingStateStickyNode::ScrollingStateStickyNode(ScrollingStateTree& tree, Scr
 
 ScrollingStateStickyNode::ScrollingStateStickyNode(const ScrollingStateStickyNode& node, ScrollingStateTree& adoptiveTree)
     : ScrollingStateNode(node, adoptiveTree)
-    , m_constraints(StickyPositionViewportConstraints(node.viewportConstraints()))
+    , m_staticLayoutData(node.m_staticLayoutData)
+    , m_staticConfigData(node.m_staticConfigData)
 {
     if (hasChangedProperty(Property::ViewportAnchorLayer))
         setViewportAnchorLayer(node.viewportAnchorLayer().toRepresentation(adoptiveTree.preferredLayerRepresentation()));
@@ -82,28 +87,54 @@ OptionSet<ScrollingStateNode::Property> ScrollingStateStickyNode::applicableProp
     return properties;
 }
 
+bool ScrollingStateStickyNode::hasUnchangedGroupsAs(const ScrollingStateNode& other) const
+{
+    if (!ScrollingStateNode::hasUnchangedGroupsAs(other))
+        return false;
+    auto& otherSticky = downcast<ScrollingStateStickyNode>(other);
+    if (m_staticLayoutData.ptr() != otherSticky.m_staticLayoutData.ptr())
+        return false;
+    if (m_staticConfigData.ptr() != otherSticky.m_staticConfigData.ptr())
+        return false;
+    return true;
+}
+
+void ScrollingStateStickyNode::clearLayerFieldsForUnchangedProperties()
+{
+    if (hasChangedProperty(Property::ViewportAnchorLayer) || !m_staticConfigData->viewportAnchorLayer)
+        return;
+    m_staticConfigData.access().viewportAnchorLayer = { };
+}
+
+#if ASSERT_ENABLED
+void ScrollingStateStickyNode::verifyClearedLayerFieldsForUnchangedProperties() const
+{
+    ASSERT(hasChangedProperty(Property::ViewportAnchorLayer) || !m_staticConfigData->viewportAnchorLayer);
+}
+#endif
 void ScrollingStateStickyNode::setViewportAnchorLayer(const LayerRepresentation& layer)
 {
-    if (layer == m_viewportAnchorLayer)
+    if (layer == m_staticConfigData->viewportAnchorLayer)
         return;
 
-    m_viewportAnchorLayer = layer;
+    m_staticConfigData.access().viewportAnchorLayer = layer;
     setPropertyChanged(Property::ViewportAnchorLayer);
 }
 
 void ScrollingStateStickyNode::updateConstraints(const StickyPositionViewportConstraints& constraints)
 {
-    if (m_constraints == constraints)
+    if (m_staticLayoutData->constraints == constraints)
         return;
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateStickyNode " << scrollingNodeID() << " updateConstraints with constraining rect " << constraints.constrainingRectAtLastLayout() << " sticky offset " << constraints.stickyOffsetAtLastLayout() << " layer pos at last layout " << constraints.layerPositionAtLastLayout());
 
-    m_constraints = constraints;
+    m_staticLayoutData.access().constraints = constraints;
     setPropertyChanged(Property::ViewportConstraints);
 }
 
 FloatPoint ScrollingStateStickyNode::computeAnchorLayerPosition(const LayoutRect& viewportRect) const
 {
+    auto& constraints = m_staticLayoutData->constraints;
     // This logic follows ScrollingTreeStickyNode::computeConstrainingRectAndAnchorLayerPosition().
     FloatSize offsetFromStickyAncestors;
     auto computeLayerPositionForScrollingNode = [&](ScrollingStateNode& scrollingStateNode) {
@@ -111,10 +142,10 @@ FloatPoint ScrollingStateStickyNode::computeAnchorLayerPosition(const LayoutRect
         if (is<ScrollingStateFrameScrollingNode>(scrollingStateNode))
             constrainingRect = viewportRect;
         else if (auto* overflowScrollingNode = dynamicDowncast<ScrollingStateOverflowScrollingNode>(scrollingStateNode))
-            constrainingRect = FloatRect(overflowScrollingNode->scrollPosition(), m_constraints.constrainingRectAtLastLayout().size());
+            constrainingRect = FloatRect(overflowScrollingNode->scrollPosition(), constraints.constrainingRectAtLastLayout().size());
 
         constrainingRect.move(offsetFromStickyAncestors);
-        return m_constraints.anchorLayerPositionForConstrainingRect(constrainingRect);
+        return constraints.anchorLayerPositionForConstrainingRect(constrainingRect);
     };
 
     for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
@@ -134,11 +165,11 @@ FloatPoint ScrollingStateStickyNode::computeAnchorLayerPosition(const LayoutRect
 
         if (is<ScrollingStateFixedNode>(*ancestor)) {
             // FIXME: Do we need scrolling tree nodes at all for nested cases?
-            return m_constraints.layerPositionAtLastLayout();
+            return constraints.layerPositionAtLastLayout();
         }
     }
     ASSERT_NOT_REACHED();
-    return m_constraints.layerPositionAtLastLayout();
+    return constraints.layerPositionAtLastLayout();
 }
 
 FloatPoint ScrollingStateStickyNode::computeClippingLayerPosition(const LayoutRect& viewportRect) const
@@ -148,7 +179,7 @@ FloatPoint ScrollingStateStickyNode::computeClippingLayerPosition(const LayoutRe
         return { };
     }
 
-    return m_constraints.viewportRelativeLayerPosition(viewportRect);
+    return m_staticLayoutData->constraints.viewportRelativeLayerPosition(viewportRect);
 }
 
 void ScrollingStateStickyNode::reconcileLayerPositionForViewportRect(const LayoutRect& viewportRect, ScrollingLayerPositionAction action)
@@ -161,7 +192,7 @@ void ScrollingStateStickyNode::reconcileLayerPositionForViewportRect(const Layou
         if (!layer)
             return;
 
-        LOG_WITH_STREAM(Compositing, stream << "ScrollingStateStickyNode " << scrollingNodeID() << " reconcileLayerPositionForViewportRect " << action << " position of layer " << layer->primaryLayerID() << " to " << position << " sticky offset " << m_constraints.stickyOffsetAtLastLayout());
+        LOG_WITH_STREAM(Compositing, stream << "ScrollingStateStickyNode " << scrollingNodeID() << " reconcileLayerPositionForViewportRect " << action << " position of layer " << layer->primaryLayerID() << " to " << position << " sticky offset " << m_staticLayoutData->constraints.stickyOffsetAtLastLayout());
 
         switch (action) {
         case ScrollingLayerPositionAction::Set:
@@ -189,12 +220,13 @@ void ScrollingStateStickyNode::reconcileLayerPositionForViewportRect(const Layou
 
 bool ScrollingStateStickyNode::hasViewportClippingLayer() const
 {
-    return m_viewportAnchorLayer && layer() != m_viewportAnchorLayer;
+    auto& anchor = m_staticConfigData->viewportAnchorLayer;
+    return anchor && layer() != anchor;
 }
 
 FloatSize ScrollingStateStickyNode::scrollDeltaSinceLastCommit(const LayoutRect& viewportRect) const
 {
-    return computeAnchorLayerPosition(viewportRect) - m_constraints.anchorLayerPositionAtLastLayout();
+    return computeAnchorLayerPosition(viewportRect) - m_staticLayoutData->constraints.anchorLayerPositionAtLastLayout();
 }
 
 void ScrollingStateStickyNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
@@ -202,37 +234,39 @@ void ScrollingStateStickyNode::dumpProperties(TextStream& ts, OptionSet<Scrollin
     ts << "Sticky node"_s;
     ScrollingStateNode::dumpProperties(ts, behavior);
 
-    if (m_constraints.anchorEdges()) {
+    auto& constraints = m_staticLayoutData->constraints;
+
+    if (constraints.anchorEdges()) {
         TextStream::GroupScope scope(ts);
         ts << "anchor edges: "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeLeft))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeLeft))
             ts << "AnchorEdgeLeft "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeRight))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeRight))
             ts << "AnchorEdgeRight "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeTop))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeTop))
             ts << "AnchorEdgeTop "_s;
-        if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeBottom))
+        if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeBottom))
             ts << "AnchorEdgeBottom"_s;
     }
 
-    if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeLeft))
-        ts.dumpProperty("left offset"_s, m_constraints.leftOffset());
-    if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeRight))
-        ts.dumpProperty("right offset"_s, m_constraints.rightOffset());
-    if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeTop))
-        ts.dumpProperty("top offset"_s, m_constraints.topOffset());
-    if (m_constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeBottom))
-        ts.dumpProperty("bottom offset"_s, m_constraints.bottomOffset());
+    if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeLeft))
+        ts.dumpProperty("left offset"_s, constraints.leftOffset());
+    if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeRight))
+        ts.dumpProperty("right offset"_s, constraints.rightOffset());
+    if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeTop))
+        ts.dumpProperty("top offset"_s, constraints.topOffset());
+    if (constraints.hasAnchorEdge(ViewportConstraints::AnchorEdgeBottom))
+        ts.dumpProperty("bottom offset"_s, constraints.bottomOffset());
 
-    ts.dumpProperty("containing block rect"_s, m_constraints.containingBlockRect());
+    ts.dumpProperty("containing block rect"_s, constraints.containingBlockRect());
 
-    ts.dumpProperty("sticky box rect"_s, m_constraints.stickyBoxRect());
+    ts.dumpProperty("sticky box rect"_s, constraints.stickyBoxRect());
 
-    ts.dumpProperty("constraining rect"_s, m_constraints.constrainingRectAtLastLayout());
+    ts.dumpProperty("constraining rect"_s, constraints.constrainingRectAtLastLayout());
 
-    ts.dumpProperty("sticky offset at last layout"_s, m_constraints.stickyOffsetAtLastLayout());
+    ts.dumpProperty("sticky offset at last layout"_s, constraints.stickyOffsetAtLastLayout());
 
-    ts.dumpProperty("layer position at last layout"_s, m_constraints.layerPositionAtLastLayout());
+    ts.dumpProperty("layer position at last layout"_s, constraints.layerPositionAtLastLayout());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,9 +46,9 @@ public:
     virtual ~ScrollingStateStickyNode();
 
     WEBCORE_EXPORT void updateConstraints(const StickyPositionViewportConstraints&);
-    const StickyPositionViewportConstraints& viewportConstraints() const LIFETIME_BOUND { return m_constraints; }
+    const StickyPositionViewportConstraints& viewportConstraints() const LIFETIME_BOUND { return m_staticLayoutData->constraints; }
 
-    const LayerRepresentation& viewportAnchorLayer() const LIFETIME_BOUND { return m_viewportAnchorLayer; }
+    const LayerRepresentation& viewportAnchorLayer() const LIFETIME_BOUND { return m_staticConfigData->viewportAnchorLayer; }
     WEBCORE_EXPORT void setViewportAnchorLayer(const LayerRepresentation&);
 
 private:
@@ -63,11 +63,50 @@ private:
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
     OptionSet<ScrollingStateNode::Property> applicableProperties() const final;
+    bool hasUnchangedGroupsAs(const ScrollingStateNode&) const final;
+    void clearLayerFieldsForUnchangedProperties() final;
+#if ASSERT_ENABLED
+    void verifyClearedLayerFieldsForUnchangedProperties() const final;
+#endif
 
     bool hasViewportClippingLayer() const;
 
-    StickyPositionViewportConstraints m_constraints;
-    LayerRepresentation m_viewportAnchorLayer;
+    // Layout-derived sticky-node state. CoW-shared via DataRef.
+    class StaticLayoutStickyState : public ThreadSafeRefCounted<StaticLayoutStickyState> {
+    public:
+        static Ref<StaticLayoutStickyState> create() { return adoptRef(*new StaticLayoutStickyState); }
+        Ref<StaticLayoutStickyState> copy() const { return adoptRef(*new StaticLayoutStickyState(*this)); }
+
+        StickyPositionViewportConstraints constraints;
+
+    private:
+        StaticLayoutStickyState() = default;
+        StaticLayoutStickyState(const StaticLayoutStickyState& other)
+            : ThreadSafeRefCounted<StaticLayoutStickyState>()
+            , constraints(other.constraints)
+        {
+        }
+    };
+
+    // Long-lived sticky-node configuration. CoW-shared via DataRef.
+    class StaticConfigurationStickyState : public ThreadSafeRefCounted<StaticConfigurationStickyState> {
+    public:
+        static Ref<StaticConfigurationStickyState> create() { return adoptRef(*new StaticConfigurationStickyState); }
+        Ref<StaticConfigurationStickyState> copy() const { return adoptRef(*new StaticConfigurationStickyState(*this)); }
+
+        LayerRepresentation viewportAnchorLayer;
+
+    private:
+        StaticConfigurationStickyState() = default;
+        StaticConfigurationStickyState(const StaticConfigurationStickyState& other)
+            : ThreadSafeRefCounted<StaticConfigurationStickyState>()
+            , viewportAnchorLayer(other.viewportAnchorLayer)
+        {
+        }
+    };
+
+    DataRef<StaticLayoutStickyState> m_staticLayoutData { StaticLayoutStickyState::create() };
+    DataRef<StaticConfigurationStickyState> m_staticConfigData { StaticConfigurationStickyState::create() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -334,6 +334,26 @@ void ScrollingStateTree::clear()
     m_unparentedNodes.clear();
 }
 
+// Walk the live tree once, building the next-commit snapshot AND accumulating dirty node IDs
+// (those whose static CoW groups differ from the previous snapshot, plus any newly-added node).
+// Coalesces the previous "compute dirty" + "build snapshot" passes into a single recursion.
+static Ref<ScrollingStateNode> buildSnapshotNodeAndCollectDirty(ScrollingStateNode& liveNode, ScrollingStateTree& snapshotTree, CheckedPtr<const ScrollingStateTree> previousSnapshot, Vector<ScrollingNodeID>& dirtyNodeIDs)
+{
+    if (previousSnapshot) {
+        if (auto previousNode = previousSnapshot->stateNodeForID(liveNode.scrollingNodeID())) {
+            if (!liveNode.hasUnchangedGroupsAs(*previousNode))
+                dirtyNodeIDs.append(liveNode.scrollingNodeID());
+        } else
+            dirtyNodeIDs.append(liveNode.scrollingNodeID());
+    } else
+        dirtyNodeIDs.append(liveNode.scrollingNodeID());
+
+    Ref snapshotClone = liveNode.clone(snapshotTree);
+    for (auto& child : liveNode.children())
+        snapshotClone->appendChild(buildSnapshotNodeAndCollectDirty(child.get(), snapshotTree, previousSnapshot, dirtyNodeIDs));
+    return snapshotClone;
+}
+
 std::unique_ptr<ScrollingStateTree> ScrollingStateTree::commit(LayerRepresentation::Type preferredLayerRepresentation)
 {
     ASSERT(isValid());
@@ -342,6 +362,21 @@ std::unique_ptr<ScrollingStateTree> ScrollingStateTree::commit(LayerRepresentati
         // We expect temporarily to have unparented nodes when committing when connecting across iframe boundaries, but unparented nodes should not stick around for a long time.
         LOG(ScrollingTree, "Committing with %u unparented nodes", m_unparentedNodes.size());
     }
+
+    // If no setter has mutated state since the last commit, and the root structure is unchanged, skip cloning the live tree.
+    if (m_lastCommittedTree && !m_hasChangedProperties && !m_hasNewRootStateNode) {
+        m_dirtyNodeIDsFromLastCommit.clear();
+        LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateTree " << this << " commit: empty transaction (nothing changed since last commit)");
+        // The UI process expects a non-nullptr result, so return an empty ScrollingStateTree with hasChangedProperties() == false so existing consumer-side guards correctly no-op the transaction.
+        auto emptyTree = makeUnique<ScrollingStateTree>();
+        emptyTree->setPreferredLayerRepresentation(preferredLayerRepresentation);
+        return emptyTree;
+    }
+
+    // Compute dirty nodes for diagnostic logging and external inspection (via
+    // dirtyNodeIDsFromLastCommit()) in the non-idle path. Folded into the snapshot-build
+    // traversal below so we visit each live node once for both purposes.
+    Vector<ScrollingNodeID> dirtyNodeIDs;
 
     // This function clones and resets the current state tree, but leaves the tree structure intact.
     auto treeStateClone = makeUnique<ScrollingStateTree>();
@@ -353,6 +388,38 @@ std::unique_ptr<ScrollingStateTree> ScrollingStateTree::commit(LayerRepresentati
     // Now the clone tree has changed properties, and the original tree does not.
     treeStateClone->m_hasChangedProperties = std::exchange(m_hasChangedProperties, false);
     treeStateClone->m_hasNewRootStateNode = std::exchange(m_hasNewRootStateNode, false);
+
+    // Clear inherited layer fields on the IPC clone whose Property::XxxLayer bit isn't set
+    // (so the in-process Coordinated Graphics scrolling-tree receiver sees an empty
+    // LayerRepresentation rather than the live tree's un-translated GraphicsLayerData), and
+    // verify the post-condition in debug builds — both done in a single IPC-clone traversal.
+    // Layer-clearing is performed only on the IPC clone, NOT on the snapshot below, so the
+    // snapshot's static-config DataRef stays shared with the live tree and hasUnchangedGroupsAs
+    // reports accurate dirty-node counts.
+    if (RefPtr clonedRoot = treeStateClone->m_rootStateNode) {
+        clonedRoot->traverse([&](ScrollingStateNode& cloneNode) {
+            cloneNode.clearLayerFieldsForUnchangedProperties();
+#if ASSERT_ENABLED
+            cloneNode.verifyClearedLayerFieldsForUnchangedProperties();
+#endif
+        });
+    }
+
+    // Take a separate snapshot for the next commit's group comparison, AND collect the dirty
+    // node IDs for this commit, in a single live-tree traversal. CoW makes the static groups
+    // Ref-bumps; the cost is dominated by per-node dynamic-state copies. Properties on the
+    // live tree were already reset by the cloneAndReset above, so no resetChangedProperties
+    // is needed here.
+    auto committedSnapshot = makeUnique<ScrollingStateTree>();
+    committedSnapshot->setPreferredLayerRepresentation(preferredLayerRepresentation);
+    if (RefPtr rootStateNode = m_rootStateNode) {
+        CheckedPtr<const ScrollingStateTree> previousSnapshot = m_lastCommittedTree.get();
+        committedSnapshot->setRootStateNode(downcast<ScrollingStateFrameScrollingNode>(buildSnapshotNodeAndCollectDirty(*rootStateNode, *committedSnapshot, previousSnapshot, dirtyNodeIDs)));
+    }
+
+    LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateTree " << this << " commit: " << dirtyNodeIDs.size() << " node(s) with changed CoW groups out of " << m_stateNodeMap.size());
+    m_dirtyNodeIDsFromLastCommit = WTF::move(dirtyNodeIDs);
+    m_lastCommittedTree = WTF::move(committedSnapshot);
 
     return treeStateClone;
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,6 +97,9 @@ public:
     FrameIdentifier rootFrameIdentifier() const { return *m_rootFrameIdentifier; }
     void setRootFrameIdentifier(std::optional<FrameIdentifier> frameID) { m_rootFrameIdentifier = frameID; }
 
+    // Diagnostic/testing accessor: node IDs whose copy-on-write groups changed during the most recent commit() call.
+    const Vector<ScrollingNodeID>& dirtyNodeIDsFromLastCommit() const LIFETIME_BOUND { return m_dirtyNodeIDsFromLastCommit; }
+
 private:
     ScrollingStateTree(bool hasNewRootStateNode, bool hasChangedProperties, RefPtr<ScrollingStateFrameScrollingNode>&&);
 
@@ -122,6 +125,17 @@ private:
     HashMap<ScrollingNodeID, Ref<ScrollingStateNode>> m_unparentedNodes;
 
     RefPtr<ScrollingStateFrameScrollingNode> m_rootStateNode;
+
+    // Snapshot of the most recently committed tree, used by commit() to detect which nodes' copy-on-write groups
+    // have changed since the last commit. Owned (separate clone from the unique_ptr returned to the caller).
+    // The static groups are shared by DataRef (a ref-count bump), so this duplicates only the per-node object
+    // plus dynamic/requested state (order of a few hundred bytes per node), not the whole tree. A second such
+    // clone is built on every non-idle commit — a deliberate tradeoff to power the dirty-node diagnostic.
+    std::unique_ptr<ScrollingStateTree> m_lastCommittedTree;
+
+    // Cached output of the dirty-node detection from the most recent commit().
+    Vector<ScrollingNodeID> m_dirtyNodeIDsFromLastCommit;
+
     unsigned m_scrollingNodeCount { 0 };
     LayerRepresentation::Type m_preferredLayerRepresentation { LayerRepresentation::GraphicsLayerRepresentation };
     bool m_hasChangedProperties { false };

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -248,6 +248,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp
+        Tests/WebCore/ScrollingStateTreeCommit.cpp
         Tests/WebCore/SecurityOrigin.cpp
         Tests/WebCore/ShareableBitmap.cpp
         Tests/WebCore/SharedBuffer.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 				"",
 				"",
 				"",
+				"",
 			);
 		};
 /* End PBXBuildRule section */
@@ -764,6 +765,7 @@
 				WebCore/RenderStyleChange.cpp,
 				WebCore/RTCRtpSFrameTransformerTests.cpp,
 				WebCore/SampleMap.cpp,
+				WebCore/ScrollingStateTreeCommit.cpp,
 				WebCore/SecurityOrigin.cpp,
 				WebCore/SerializedScriptValue.cpp,
 				WebCore/ServiceWorkerRoutines.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/ScrollingStateTreeCommit.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ScrollingStateTreeCommit.cpp
@@ -1,0 +1,715 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(ASYNC_SCROLLING)
+
+#include <WebCore/ScrollingConstraints.h>
+#include <WebCore/ScrollingCoordinatorTypes.h>
+#include <WebCore/ScrollingNodeID.h>
+#include <WebCore/ScrollingStateFixedNode.h>
+#include <WebCore/ScrollingStateFrameScrollingNode.h>
+#include <WebCore/ScrollingStateOverflowScrollProxyNode.h>
+#include <WebCore/ScrollingStateOverflowScrollingNode.h>
+#include <WebCore/ScrollingStatePositionedNode.h>
+#include <WebCore/ScrollingStateScrollingNode.h>
+#include <WebCore/ScrollingStateStickyNode.h>
+#include <WebCore/ScrollingStateTree.h>
+#include <wtf/Assertions.h>
+#include <wtf/MonotonicTime.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+namespace {
+
+// Builds a tree with a MainFrame root and the requested number of overflow children
+// directly under the root, returns the tree along with the IDs in insertion order
+// (root first).
+struct BuiltTree {
+    std::unique_ptr<ScrollingStateTree> tree;
+    Vector<ScrollingNodeID> nodeIDs;
+};
+
+BuiltTree buildTreeWithOverflowChildren(size_t childCount)
+{
+    auto tree = makeUnique<ScrollingStateTree>();
+    Vector<ScrollingNodeID> ids;
+
+    auto rootID = ScrollingNodeID::generate();
+    auto rootInserted = tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    EXPECT_TRUE(rootInserted.has_value());
+    ids.append(rootID);
+
+    for (size_t i = 0; i < childCount; ++i) {
+        auto childID = ScrollingNodeID::generate();
+        auto childInserted = tree->insertNode(ScrollingNodeType::Overflow, childID, rootID, i);
+        EXPECT_TRUE(childInserted.has_value());
+        ids.append(childID);
+    }
+
+    return { WTF::move(tree), WTF::move(ids) };
+}
+
+} // namespace
+
+TEST(ScrollingStateTreeCommit, FirstCommitMarksAllNodesDirty)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    auto commitResult = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    EXPECT_TRUE(commitResult);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(3u, dirty.size());
+}
+
+TEST(ScrollingStateTreeCommit, IdleCommitProducesNoDirtyNodes)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    // Second commit with no mutations between.
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(0u, dirty.size());
+}
+
+TEST(ScrollingStateTreeCommit, FirstCommitReturnsNonEmptyTransaction)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    auto firstCommit = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, firstCommit.get());
+    EXPECT_TRUE(firstCommit->hasChangedProperties());
+    EXPECT_TRUE(firstCommit->rootStateNode().get());
+}
+
+TEST(ScrollingStateTreeCommit, IdleCommitReturnsEmptyTransaction)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    auto firstCommit = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, firstCommit.get());
+
+    // Confirm empty-transaction short-circuit returns an empty tree with no changed properties.
+    auto secondCommit = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, secondCommit.get());
+    EXPECT_FALSE(secondCommit->hasChangedProperties());
+    EXPECT_FALSE(secondCommit->rootStateNode().get());
+}
+
+TEST(ScrollingStateTreeCommit, MutationProducesNonEmptyTransaction)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto targetID = built.nodeIDs[1];
+    RefPtr targetNode = tree.stateNodeForID(targetID);
+    auto* scrollingNode = dynamicDowncast<ScrollingStateScrollingNode>(targetNode.get());
+    ASSERT_NE(nullptr, scrollingNode);
+    scrollingNode->setScrollPosition(FloatPoint(10, 20));
+
+    auto secondCommit = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, secondCommit.get());
+    EXPECT_TRUE(secondCommit->hasChangedProperties());
+    EXPECT_TRUE(secondCommit->rootStateNode().get());
+}
+
+TEST(ScrollingStateTreeCommit, RepeatedNoOpCommitsAllShortCircuit)
+{
+    auto built = buildTreeWithOverflowChildren(3);
+    auto& tree = *built.tree;
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // After the first commit, every subsequent idle commit must short-circuit and return an
+    // empty (but non-null) tree.
+    for (unsigned i = 0; i < 5; ++i) {
+        auto idleCommit = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+        ASSERT_NE(nullptr, idleCommit.get());
+        EXPECT_FALSE(idleCommit->hasChangedProperties());
+        EXPECT_FALSE(idleCommit->rootStateNode().get());
+    }
+}
+
+TEST(ScrollingStateTreeCommit, ScrollPositionMutationMarksOnlyMutatedNodeDirty)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // Mutate the scroll position on the second overflow child only.
+    auto targetID = built.nodeIDs[2];
+    RefPtr targetNode = tree.stateNodeForID(targetID);
+    ASSERT_NE(nullptr, targetNode.get());
+    auto* scrollingNode = dynamicDowncast<ScrollingStateScrollingNode>(targetNode.get());
+    ASSERT_NE(nullptr, scrollingNode);
+    scrollingNode->setScrollPosition(FloatPoint(10, 20));
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(targetID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, StaticLayoutGroupMutationMarksOnlyMutatedNodeDirty)
+{
+    auto built = buildTreeWithOverflowChildren(2);
+    auto& tree = *built.tree;
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // Mutate scrollableAreaSize (StaticLayout group) on the first overflow child.
+    auto targetID = built.nodeIDs[1];
+    RefPtr targetNode = tree.stateNodeForID(targetID);
+    ASSERT_NE(nullptr, targetNode.get());
+    auto* scrollingNode = dynamicDowncast<ScrollingStateScrollingNode>(targetNode.get());
+    ASSERT_NE(nullptr, scrollingNode);
+    scrollingNode->setScrollableAreaSize(FloatSize(800, 600));
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(targetID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, RepeatedScrollPositionWritesWithSameValueAreNoOp)
+{
+    auto built = buildTreeWithOverflowChildren(1);
+    auto& tree = *built.tree;
+
+    auto targetID = built.nodeIDs[1];
+    RefPtr targetNode = tree.stateNodeForID(targetID);
+    auto* scrollingNode = dynamicDowncast<ScrollingStateScrollingNode>(targetNode.get());
+    ASSERT_NE(nullptr, scrollingNode);
+    scrollingNode->setScrollPosition(FloatPoint(50, 75));
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // Re-set to the same value; setter's equality short-circuit should make this a no-op.
+    scrollingNode->setScrollPosition(FloatPoint(50, 75));
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(0u, dirty.size());
+}
+
+TEST(ScrollingStateTreeCommit, NewlyAddedChildAppearsInDirtyList)
+{
+    auto built = buildTreeWithOverflowChildren(1);
+    auto& tree = *built.tree;
+    auto rootID = built.nodeIDs[0];
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto newChildID = ScrollingNodeID::generate();
+    auto inserted = tree.insertNode(ScrollingNodeType::Overflow, newChildID, rootID, notFound);
+    ASSERT_TRUE(inserted.has_value());
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    // The newly-added node has no committed counterpart and must appear dirty.
+    EXPECT_TRUE(dirty.contains(newChildID));
+    // Note: the parent's m_children vector changed, but children-list mutations live outside
+    // the CoW partition, so hasUnchangedGroupsAs does not flag the parent here. This is a
+    // documented gap for Patch 4; Patch 5 will combine this signal with Property::ChildNodes.
+}
+
+TEST(ScrollingStateTreeCommit, GroupSharingAcrossUnchangedNodes)
+{
+    auto built = buildTreeWithOverflowChildren(3);
+    auto& tree = *built.tree;
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // Mutate one child only; the other two children's StaticLayout/StaticConfig groups
+    // should still be Ref-shared with the committed snapshot, so they remain clean.
+    auto mutatedID = built.nodeIDs[2];
+    RefPtr mutatedNode = tree.stateNodeForID(mutatedID);
+    auto* scrollingNode = dynamicDowncast<ScrollingStateScrollingNode>(mutatedNode.get());
+    ASSERT_NE(nullptr, scrollingNode);
+    scrollingNode->setTotalContentsSize(FloatSize(2000, 4000));
+
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree.dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(mutatedID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, FixedNodeConstraintsMutationMarksDirty)
+{
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto fixedID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Fixed, fixedID, rootID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr fixedNodeBase = tree->stateNodeForID(fixedID);
+    auto* fixedNode = dynamicDowncast<ScrollingStateFixedNode>(fixedNodeBase.get());
+    ASSERT_NE(nullptr, fixedNode);
+    FixedPositionViewportConstraints newConstraints;
+    newConstraints.setViewportRectAtLastLayout(FloatRect(0, 0, 800, 600));
+    fixedNode->updateConstraints(newConstraints);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree->dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(fixedID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, PositionedNodeConstraintsMutationMarksDirty)
+{
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto positionedID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Positioned, positionedID, rootID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr positionedNodeBase = tree->stateNodeForID(positionedID);
+    auto* positionedNode = dynamicDowncast<ScrollingStatePositionedNode>(positionedNodeBase.get());
+    ASSERT_NE(nullptr, positionedNode);
+    AbsolutePositionConstraints newConstraints;
+    newConstraints.setLayerPositionAtLastLayout(FloatPoint(100, 200));
+    positionedNode->updateConstraints(newConstraints);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree->dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(positionedID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, StickyNodeConstraintsMutationMarksDirty)
+{
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto stickyID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Sticky, stickyID, rootID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr stickyNodeBase = tree->stateNodeForID(stickyID);
+    auto* stickyNode = dynamicDowncast<ScrollingStateStickyNode>(stickyNodeBase.get());
+    ASSERT_NE(nullptr, stickyNode);
+    StickyPositionViewportConstraints newConstraints;
+    newConstraints.setTopOffset(50);
+    stickyNode->updateConstraints(newConstraints);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree->dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(stickyID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, StickyNodeViewportAnchorLayerMutationMarksDirty)
+{
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto stickyID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Sticky, stickyID, rootID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr stickyNodeBase = tree->stateNodeForID(stickyID);
+    auto* stickyNode = dynamicDowncast<ScrollingStateStickyNode>(stickyNodeBase.get());
+    ASSERT_NE(nullptr, stickyNode);
+
+    // Mutate the viewport-anchor layer with a real (non-empty) identifier so the setter is a
+    // genuine change, exercising the dirty-detection wiring on the anchor-layer path this test names.
+    stickyNode->setViewportAnchorLayer(LayerRepresentation { PlatformLayerIdentifier::generate() });
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    auto& dirty = tree->dirtyNodeIDsFromLastCommit();
+    EXPECT_EQ(1u, dirty.size());
+    if (dirty.size() == 1u)
+        EXPECT_TRUE(stickyID == dirty[0]);
+}
+
+TEST(ScrollingStateTreeCommit, ReparentingChildProducesNonEmptyTransaction)
+{
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto firstParentID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Overflow, firstParentID, rootID, 0);
+    auto secondParentID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Overflow, secondParentID, rootID, 1);
+    auto childID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Overflow, childID, firstParentID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // Reparent child from firstParent to secondParent. The reparent path goes through
+    // unparentNode -> insertNode reattachment; Property::ChildNodes must fire on both parents
+    // so m_hasChangedProperties is set on the live tree, defeating the short-circuit.
+    tree->insertNode(ScrollingNodeType::Overflow, childID, secondParentID, 0);
+
+    auto secondCommit = tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, secondCommit.get());
+    EXPECT_TRUE(secondCommit->hasChangedProperties());
+    EXPECT_TRUE(secondCommit->rootStateNode().get());
+}
+
+TEST(ScrollingStateTreeCommit, NonPartitionedSubclassesCommitAndShortCircuit)
+{
+    // Tree containing a non-partitioned subclass (OverflowScrollProxyNode). Its
+    // hasUnchangedGroupsAs falls through to the base class default; this test asserts the
+    // tree-level commit & short-circuit gates still work correctly via m_hasChangedProperties.
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto overflowID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Overflow, overflowID, rootID, 0);
+    auto proxyID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::OverflowProxy, proxyID, rootID, 1);
+
+    // Wire the OverflowScrollProxy to its target Overflow node — ScrollingStateTree::isValid()
+    // (asserted at the top of commit()) rejects proxy nodes that don't reference a real
+    // overflow node in the tree's node map.
+    RefPtr proxyBase = tree->stateNodeForID(proxyID);
+    auto* proxyNode = dynamicDowncast<ScrollingStateOverflowScrollProxyNode>(proxyBase.get());
+    ASSERT_NE(nullptr, proxyNode);
+    proxyNode->setOverflowScrollingNode(overflowID);
+
+    auto firstCommit = tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, firstCommit.get());
+    EXPECT_TRUE(firstCommit->hasChangedProperties());
+    EXPECT_TRUE(firstCommit->rootStateNode().get());
+
+    // Idle: short-circuit must still fire even with a non-partitioned subclass in the tree.
+    auto idleCommit = tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, idleCommit.get());
+    EXPECT_FALSE(idleCommit->hasChangedProperties());
+    EXPECT_FALSE(idleCommit->rootStateNode().get());
+}
+
+TEST(ScrollingStateTreeCommit, RequestedScrollDataMergesAcrossSetCallsBetweenCommits)
+{
+    // RequestedScrollData is intentionally exempt from CoW partitioning (design doc §3.1).
+    // mergeOrAppendScrollRequest has stateful merge semantics: two DeltaUpdate calls between
+    // commits accumulate their FloatSize deltas. This test verifies both calls arrive at the
+    // committed IPC clone via the live tree's m_requestedScrollData.
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto overflowID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Overflow, overflowID, rootID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr overflowNodeBase = tree->stateNodeForID(overflowID);
+    auto* overflowNode = dynamicDowncast<ScrollingStateScrollingNode>(overflowNodeBase.get());
+    ASSERT_NE(nullptr, overflowNode);
+
+    RequestedScrollData firstRequest;
+    firstRequest.requestType = ScrollRequestType::DeltaUpdate;
+    firstRequest.scrollPositionOrDelta = FloatSize { 10.f, 0.f };
+    overflowNode->setRequestedScrollData(RequestedScrollData { firstRequest });
+
+    RequestedScrollData secondRequest;
+    secondRequest.requestType = ScrollRequestType::DeltaUpdate;
+    secondRequest.scrollPositionOrDelta = FloatSize { 0.f, 5.f };
+    overflowNode->setRequestedScrollData(RequestedScrollData { secondRequest });
+
+    // Both calls must be visible on the IPC clone — the second merged into the first via
+    // accumulateDelta, producing a single DeltaUpdate of (10, 5).
+    auto commit = tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, commit.get());
+    EXPECT_TRUE(commit->hasChangedProperties());
+
+    RefPtr clonedOverflow = commit->stateNodeForID(overflowID);
+    auto* clonedScrolling = dynamicDowncast<ScrollingStateScrollingNode>(clonedOverflow.get());
+    ASSERT_NE(nullptr, clonedScrolling);
+
+    auto& mergedData = clonedScrolling->requestedScrollData();
+    ASSERT_EQ(1u, mergedData.size());
+    EXPECT_EQ(ScrollRequestType::DeltaUpdate, mergedData[0].requestType);
+    auto mergedDelta = std::get<FloatSize>(mergedData[0].scrollPositionOrDelta);
+    EXPECT_FLOAT_EQ(10.f, mergedDelta.width());
+    EXPECT_FLOAT_EQ(5.f, mergedDelta.height());
+}
+
+TEST(ScrollingStateTreeCommit, EmptyTreeRoundTripsThroughDeserializationPath)
+{
+    // The short-circuit returns a non-null but otherwise empty ScrollingStateTree
+    // (m_rootStateNode == nullptr, hasChangedProperties() == false, hasNewRootStateNode() ==
+    // false). The receiver's deserialization path calls createAfterReconstruction +
+    // attachDeserializedNodes on the wire-decoded fields. This test asserts those calls are
+    // safe on the empty-tree shape we produce — guards the same surface a CVE-class null-deref
+    // was found on earlier in this patch.
+    auto tree = buildTreeWithOverflowChildren(2);
+    tree.tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    auto idleCommit = tree.tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, idleCommit.get());
+    EXPECT_FALSE(idleCommit->hasChangedProperties());
+    EXPECT_FALSE(idleCommit->hasNewRootStateNode());
+    EXPECT_EQ(nullptr, idleCommit->rootStateNode().get());
+
+    // Mirror the receiver's reconstruction: pass the producer's three observable fields back
+    // into createAfterReconstruction, then run attachDeserializedNodes — that's what
+    // RemoteScrollingCoordinatorTransaction does on the UI process side.
+    auto reconstructed = ScrollingStateTree::createAfterReconstruction(
+        idleCommit->hasNewRootStateNode(),
+        idleCommit->hasChangedProperties(),
+        nullptr);
+    ASSERT_TRUE(reconstructed.has_value());
+    EXPECT_FALSE(reconstructed->hasChangedProperties());
+    EXPECT_FALSE(reconstructed->hasNewRootStateNode());
+    EXPECT_EQ(nullptr, reconstructed->rootStateNode().get());
+
+    reconstructed->attachDeserializedNodes();
+    EXPECT_FALSE(reconstructed->hasChangedProperties());
+    EXPECT_EQ(nullptr, reconstructed->rootStateNode().get());
+}
+
+TEST(ScrollingStateTreeCommit, ScrollbarFadeAndHoverLoopShortCircuits)
+{
+    // Motivating Spotify case: scrollbar hover/fade animations mutate ContentAreaHoverState,
+    // MouseActivityState, and ScrollbarHoverState in tight loops. With per-setter equality
+    // short-circuits in place, a re-set of the same value MUST NOT flip m_hasChangedProperties
+    // and the next commit MUST short-circuit. Guards against future code paths that mark
+    // dirty without value-checking.
+    auto built = buildTreeWithOverflowChildren(1);
+    auto& tree = *built.tree;
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr overflowNodeBase = tree.stateNodeForID(built.nodeIDs[1]);
+    auto* overflowNode = dynamicDowncast<ScrollingStateScrollingNode>(overflowNodeBase.get());
+    ASSERT_NE(nullptr, overflowNode);
+
+    auto commitIsIdle = [&]() {
+        auto result = tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+        return result && !result->hasChangedProperties();
+    };
+
+    // Transition: mouse enters content area. Expected non-idle.
+    overflowNode->setMouseIsOverContentArea(true);
+    EXPECT_FALSE(commitIsIdle());
+
+    // Re-set same value. Expected idle (equality short-circuit in setter).
+    overflowNode->setMouseIsOverContentArea(true);
+    EXPECT_TRUE(commitIsIdle());
+
+    // Mouse motion: new location. Expected non-idle.
+    MouseLocationState locationA;
+    locationA.locationInHorizontalScrollbar = IntPoint { 10, 20 };
+    overflowNode->setMouseMovedInContentArea(locationA);
+    EXPECT_FALSE(commitIsIdle());
+
+    // Same location. Expected idle.
+    overflowNode->setMouseMovedInContentArea(locationA);
+    EXPECT_TRUE(commitIsIdle());
+
+    // Hover state change. Expected non-idle.
+    ScrollbarHoverState hoverA;
+#if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
+    hoverA.hoveredPartInVerticalScrollbar = ThumbPart;
+#else
+    hoverA.mouseIsOverVerticalScrollbar = true;
+#endif
+    overflowNode->setScrollbarHoverState(hoverA);
+    EXPECT_FALSE(commitIsIdle());
+
+    // Same hover state. Expected idle.
+    overflowNode->setScrollbarHoverState(hoverA);
+    EXPECT_TRUE(commitIsIdle());
+
+    // Tight loop of identity re-sets across all three fields. Every commit must short-circuit.
+    for (unsigned i = 0; i < 16; ++i) {
+        overflowNode->setMouseIsOverContentArea(true);
+        overflowNode->setMouseMovedInContentArea(locationA);
+        overflowNode->setScrollbarHoverState(hoverA);
+        EXPECT_TRUE(commitIsIdle());
+    }
+}
+
+TEST(ScrollingStateTreeCommit, TinyPODDirectMembersPropagateThroughCommit)
+{
+    // Regression test: 12 fields were moved out of StaticConfiguration{Scroll,Frame}State
+    // CoW groups into direct members of their respective node classes (to avoid forcing a
+    // whole-group copy on a single-byte mutation). These direct members are NOT auto-
+    // propagated by the DataRef share in the copy constructor — each must be explicitly
+    // copied. A missing copy silently sends default values to the UI process.
+    //
+    // This test catches that class of regression for both partitioned subclasses by
+    // mutating each direct member and asserting the IPC clone carries the value.
+    auto tree = makeUnique<ScrollingStateTree>();
+    auto rootID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::MainFrame, rootID, std::nullopt, 0);
+    auto overflowID = ScrollingNodeID::generate();
+    tree->insertNode(ScrollingNodeType::Overflow, overflowID, rootID, 0);
+
+    tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    RefPtr rootBase = tree->stateNodeForID(rootID);
+    auto* frameNode = dynamicDowncast<ScrollingStateFrameScrollingNode>(rootBase.get());
+    ASSERT_NE(nullptr, frameNode);
+
+    RefPtr overflowBase = tree->stateNodeForID(overflowID);
+    auto* scrollNode = dynamicDowncast<ScrollingStateScrollingNode>(overflowBase.get());
+    ASSERT_NE(nullptr, scrollNode);
+
+    // Scrolling-node direct members.
+    scrollNode->setUseDarkAppearanceForScrollbars(true);
+    scrollNode->setScrollbarWidth(ScrollbarWidth::Thin);
+    scrollNode->setScrollbarLayoutDirection(UserInterfaceLayoutDirection::RTL);
+    scrollNode->setScrollbarEnabledState(ScrollbarOrientation::Vertical, true);
+
+    // Frame-node direct members.
+    frameNode->setHeaderHeight(42);
+    frameNode->setFooterHeight(7);
+    frameNode->setScrollBehaviorForFixedElements(ScrollBehaviorForFixedElements::StickToViewportBounds);
+    frameNode->setVisualViewportIsSmallerThanLayoutViewport(true);
+    frameNode->setAsyncFrameOrOverflowScrollingEnabled(true);
+    frameNode->setWheelEventGesturesBecomeNonBlocking(true);
+    frameNode->setScrollingPerformanceTestingEnabled(true);
+    frameNode->setOverlayScrollbarsEnabled(true);
+
+    auto commit = tree->commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    ASSERT_NE(nullptr, commit.get());
+    EXPECT_TRUE(commit->hasChangedProperties());
+
+    RefPtr clonedScrollBase = commit->stateNodeForID(overflowID);
+    auto* clonedScroll = dynamicDowncast<ScrollingStateScrollingNode>(clonedScrollBase.get());
+    ASSERT_NE(nullptr, clonedScroll);
+    EXPECT_TRUE(clonedScroll->useDarkAppearanceForScrollbars());
+    EXPECT_EQ(ScrollbarWidth::Thin, clonedScroll->scrollbarWidth());
+    EXPECT_EQ(UserInterfaceLayoutDirection::RTL, clonedScroll->scrollbarLayoutDirection());
+    EXPECT_TRUE(clonedScroll->scrollbarEnabledState().verticalScrollbarIsEnabled);
+
+    RefPtr clonedFrameBase = commit->stateNodeForID(rootID);
+    auto* clonedFrame = dynamicDowncast<ScrollingStateFrameScrollingNode>(clonedFrameBase.get());
+    ASSERT_NE(nullptr, clonedFrame);
+    EXPECT_EQ(42, clonedFrame->headerHeight());
+    EXPECT_EQ(7, clonedFrame->footerHeight());
+    EXPECT_EQ(ScrollBehaviorForFixedElements::StickToViewportBounds, clonedFrame->scrollBehaviorForFixedElements());
+    EXPECT_TRUE(clonedFrame->visualViewportIsSmallerThanLayoutViewport());
+    EXPECT_TRUE(clonedFrame->asyncFrameOrOverflowScrollingEnabled());
+    EXPECT_TRUE(clonedFrame->wheelEventGesturesBecomeNonBlocking());
+    EXPECT_TRUE(clonedFrame->scrollingPerformanceTestingEnabled());
+    EXPECT_TRUE(clonedFrame->overlayScrollbarsEnabled());
+}
+
+
+#ifndef LOG_DISABLED
+// Benchmark — exercises commit() repeatedly on a Spotify-shaped tree (30 overflow children)
+// and reports per-commit cost for three scenarios:
+//   1. Idle commits: Patch 5's empty-transaction short-circuit fires every time.
+//   2. Forced slow path: we set m_hasChangedProperties to defeat the short-circuit, exercising
+//      the full clone path without any actual mutations (simulates pre-Patch-5 cost).
+//   3. Real scroll mutation: per-frame setScrollPosition + commit, the realistic non-idle case.
+// Output goes to the Scrolling log channel (enable it to see the numbers). Sanity assertions are loose so the test passes
+// across machines, but a large regression in the short-circuit path will trip them.
+TEST(DISABLED_ScrollingStateTreeCommit, BenchmarkCommitCost)
+{
+    constexpr unsigned childCount = 30;
+    constexpr unsigned iterations = 1000;
+
+    auto built = buildTreeWithOverflowChildren(childCount);
+    auto& tree = *built.tree;
+
+    // First commit establishes m_lastCommittedTree; subsequent idle commits can short-circuit.
+    tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+
+    // Scenario 1: idle commits — short-circuit fires.
+    auto idleStart = MonotonicTime::now();
+    for (unsigned i = 0; i < iterations; ++i)
+        tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    auto idleSeconds = MonotonicTime::now() - idleStart;
+
+    // Scenario 2: forced slow path — same tree, no actual mutation, but we defeat the
+    // short-circuit by setting m_hasChangedProperties. Approximates pre-Patch-5 commit cost.
+    auto forcedSlowStart = MonotonicTime::now();
+    for (unsigned i = 0; i < iterations; ++i) {
+        tree.setHasChangedProperties(true);
+        tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    }
+    auto forcedSlowSeconds = MonotonicTime::now() - forcedSlowStart;
+
+    // Scenario 3: realistic per-frame mutation (a scroll position update).
+    RefPtr rootNode = tree.stateNodeForID(built.nodeIDs[0]);
+    auto* rootScrolling = dynamicDowncast<ScrollingStateScrollingNode>(rootNode.get());
+    ASSERT_NE(nullptr, rootScrolling);
+    auto mutationStart = MonotonicTime::now();
+    for (unsigned i = 0; i < iterations; ++i) {
+        rootScrolling->setScrollPosition(FloatPoint(static_cast<float>(i), 0));
+        tree.commit(LayerRepresentation::PlatformLayerIDRepresentation);
+    }
+    auto mutationSeconds = MonotonicTime::now() - mutationStart;
+
+    double idleUsPerCommit = idleSeconds.microseconds() / static_cast<double>(iterations);
+    double forcedSlowUsPerCommit = forcedSlowSeconds.microseconds() / static_cast<double>(iterations);
+    double mutationUsPerCommit = mutationSeconds.microseconds() / static_cast<double>(iterations);
+    double speedupVsForcedSlow = forcedSlowSeconds.microseconds() / std::max(1.0, idleSeconds.microseconds());
+    double speedupVsMutation = mutationSeconds.microseconds() / std::max(1.0, idleSeconds.microseconds());
+
+    LOG(Scrolling, "[ScrollingStateTreeCommit Bench] %u children, %u iterations:", childCount, iterations);
+    LOG(Scrolling, "  Idle (short-circuit):       %8.2f us/commit", idleUsPerCommit);
+    LOG(Scrolling, "  Forced slow path:           %8.2f us/commit", forcedSlowUsPerCommit);
+    LOG(Scrolling, "  Real scroll mutation:       %8.2f us/commit", mutationUsPerCommit);
+    LOG(Scrolling, "  Speedup vs forced slow:     %8.2fx", speedupVsForcedSlow);
+    LOG(Scrolling, "  Speedup vs mutation:        %8.2fx", speedupVsMutation);
+
+    // Loose sanity assertions: the short-circuit path must be measurably faster than the
+    // paths that perform the full clone.
+    EXPECT_LT(idleSeconds, forcedSlowSeconds);
+    EXPECT_LT(idleSeconds, mutationSeconds);
+}
+#endif
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(ASYNC_SCROLLING)


### PR DESCRIPTION
#### 1fec1ab65af624c9c5e34b4ea9b4e5f61170429b
<pre>
[Scrolling] Partition ScrollingStateNode to support copy-on-write commits and avoid sending empty transactions
<a href="https://bugs.webkit.org/show_bug.cgi?id=317879">https://bugs.webkit.org/show_bug.cgi?id=317879</a>
<a href="https://rdar.apple.com/180662073">rdar://180662073</a>

Reviewed by NOBODY (OOPS!).

Refactor ScrollingStateNode and its subclasses to follow ComputedStyle&apos;s copy-on-write
data-partition pattern, and use the new structure to skip the per-commit clone entirely on
frames where no observable scrolling state has changed.

ScrollingStateTree::commit() previously deep-cloned the entire scrolling state tree on
every call, even when no setter had mutated state since the prior commit. On pages with
many overflow scrollers (e.g., the Spotify Web Player&apos;s queue panel), overlay-scrollbar
fade animations and similar idle-frame activity drove commits that did substantial
allocation + value-copy work to produce a transaction the receiver would no-op on.

This patch does the following:

1. Partition each ScrollingStateNode subclass&apos;s mutable state into three
   groups, matching the ComputedStyle pattern:
   - DynamicState: per-frame fields like scrollPosition. Value-typed.
   - StaticLayout: layout-derived fields like scrollableAreaSize.
     RefCounted, held via DataRef&lt;&gt;, shared by clones unless mutated.
   - StaticConfiguration: long-lived configuration like scrollbar
     appearance and layer references. Same DataRef&lt;&gt; sharing.

   Group setters use .access() to copy-on-write the group only when the new value
   differs from the existing one. Clone constructors share Refs by default. This means
   clones are cheap (mostly Ref bumps) and group equality between two trees is an O(1)
   Ref-pointer compare.

2. Maintain a m_lastCommittedTree snapshot owned by the live tree. In commit(), if
   m_hasChangedProperties is false and m_hasNewRootStateNode is false, skip both the IPC
   clone and the snapshot update and return an empty ScrollingStateTree (with hasChangedProperties
   set to false), which RemoteScrollingCoordinatorTransaction  already knows how to handle.

   m_hasChangedProperties is the authoritative signal. Every setter that successfully
   mutates a value calls setPropertyChanged(), which sets it. The copy-on-write partition&apos;s
   hasUnchangedGroupsAs() is used as a diagnostic signal (exposed via dirtyNodeIDsFromLastCommit()
   for testing) but does not gate the short-circuit, so false negatives in group
   comparison cannot accidentally drop a real update.

Microbenchmark (Tools/TestWebKitAPI/Tests/WebCore/ScrollingStateTreeCommit.cpp:
BenchmarkCommitCost), 30-overflow-child tree, 1000 iterations, Release
build, M-class machine:

  Idle commit (short-circuit fires):     ~0 μs/commit  (timer floor)
  Forced slow path (no short-circuit):   ~5.5 μs/commit
  Real scroll mutation:                  ~5.5 μs/commit
  Speedup vs forced slow path:           ~2000x

Note: Some non-partitioned subclasses remain and could be considered in the future (e.g.,
FrameHostingNode, OverflowScrollProxyNode, PluginHostingNode, PluginScrollingNode).

Tests: Tools/TestWebKitAPI/Tests/WebCore/ScrollingStateTreeCommit.cpp

* Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp:
(WebCore::ScrollingStateFixedNode::ScrollingStateFixedNode):
(WebCore::ScrollingStateFixedNode::hasUnchangedGroupsAs const):
(WebCore::ScrollingStateFixedNode::updateConstraints):
(WebCore::ScrollingStateFixedNode::reconcileLayerPositionForViewportRect):
(WebCore::ScrollingStateFixedNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateFixedNode.h:
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
(WebCore::ScrollingStateFrameScrollingNode::setFrameScaleFactor):
(WebCore::ScrollingStateFrameScrollingNode::setEventTrackingRegions):
(WebCore::ScrollingStateFrameScrollingNode::setLayoutViewport):
(WebCore::ScrollingStateFrameScrollingNode::setSizeForVisibleContent):
(WebCore::ScrollingStateFrameScrollingNode::setMinLayoutViewportOrigin):
(WebCore::ScrollingStateFrameScrollingNode::setMaxLayoutViewportOrigin):
(WebCore::ScrollingStateFrameScrollingNode::setOverrideVisualViewportSize):
(WebCore::ScrollingStateFrameScrollingNode::setObscuredContentInsets):
(WebCore::ScrollingStateFrameScrollingNode::setTopScrollStretchForRefreshController):
(WebCore::ScrollingStateFrameScrollingNode::setRootContentsLayer):
(WebCore::ScrollingStateFrameScrollingNode::setCounterScrollingLayer):
(WebCore::ScrollingStateFrameScrollingNode::setInsetClipLayer):
(WebCore::ScrollingStateFrameScrollingNode::setContentShadowLayer):
(WebCore::ScrollingStateFrameScrollingNode::setHeaderLayer):
(WebCore::ScrollingStateFrameScrollingNode::setFooterLayer):
(WebCore::ScrollingStateFrameScrollingNode::setVisualViewportIsSmallerThanLayoutViewport):
(WebCore::ScrollingStateFrameScrollingNode::setAsyncFrameOrOverflowScrollingEnabled):
(WebCore::ScrollingStateFrameScrollingNode::setWheelEventGesturesBecomeNonBlocking):
(WebCore::ScrollingStateFrameScrollingNode::setScrollingPerformanceTestingEnabled):
(WebCore::ScrollingStateFrameScrollingNode::setOverlayScrollbarsEnabled):
(WebCore::ScrollingStateFrameScrollingNode::hasUnchangedGroupsAs const):
(WebCore::ScrollingStateFrameScrollingNode::clearLayerFieldsForUnchangedProperties):
(WebCore::ScrollingStateFrameScrollingNode::verifyClearedLayerFieldsForUnchangedProperties const):
(WebCore::ScrollingStateFrameScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::hasUnchangedGroupsAs const):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::clearLayerFieldsForUnchangedProperties):
(WebCore::ScrollingStateNode::verifyClearedLayerFieldsForUnchangedProperties const):
* Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp:
(WebCore::ScrollingStatePositionedNode::ScrollingStatePositionedNode):
(WebCore::ScrollingStatePositionedNode::hasUnchangedGroupsAs const):
(WebCore::ScrollingStatePositionedNode::setRelatedOverflowScrollingNodes):
(WebCore::ScrollingStatePositionedNode::updateConstraints):
(WebCore::ScrollingStatePositionedNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStatePositionedNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::hasUnchangedGroupsAs const):
(WebCore::ScrollingStateScrollingNode::clearLayerFieldsForUnchangedProperties):
(WebCore::ScrollingStateScrollingNode::verifyClearedLayerFieldsForUnchangedProperties const):
(WebCore::ScrollingStateScrollingNode::setScrollableAreaSize):
(WebCore::ScrollingStateScrollingNode::setTotalContentsSize):
(WebCore::ScrollingStateScrollingNode::setReachableContentsSize):
(WebCore::ScrollingStateScrollingNode::setScrollPosition):
(WebCore::ScrollingStateScrollingNode::setScrollOrigin):
(WebCore::ScrollingStateScrollingNode::setSnapOffsetsInfo):
(WebCore::ScrollingStateScrollingNode::setCurrentHorizontalSnapPointIndex):
(WebCore::ScrollingStateScrollingNode::setCurrentVerticalSnapPointIndex):
(WebCore::ScrollingStateScrollingNode::setScrollableAreaParameters):
(WebCore::ScrollingStateScrollingNode::setSynchronousScrollingReasons):
(WebCore::ScrollingStateScrollingNode::setKeyboardScrollData):
(WebCore::ScrollingStateScrollingNode::setIsMonitoringWheelEvents):
(WebCore::ScrollingStateScrollingNode::setScrollContainerLayer):
(WebCore::ScrollingStateScrollingNode::setScrolledContentsLayer):
(WebCore::ScrollingStateScrollingNode::setHorizontalScrollbarLayer):
(WebCore::ScrollingStateScrollingNode::setVerticalScrollbarLayer):
(WebCore::ScrollingStateScrollingNode::setMouseIsOverContentArea):
(WebCore::ScrollingStateScrollingNode::setMouseMovedInContentArea):
(WebCore::ScrollingStateScrollingNode::setScrollbarHoverState):
(WebCore::ScrollingStateScrollingNode::setScrollbarEnabledState):
(WebCore::ScrollingStateScrollingNode::setScrollbarColor):
(WebCore::ScrollingStateScrollingNode::setScrollbarLayoutDirection):
(WebCore::ScrollingStateScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::currentHorizontalSnapPointIndex const):
(WebCore::ScrollingStateScrollingNode::currentVerticalSnapPointIndex const):
(WebCore::ScrollingStateScrollingNode::synchronousScrollingReasons const):
(WebCore::ScrollingStateScrollingNode::hasSynchronousScrollingReasons const):
(WebCore::ScrollingStateScrollingNode::isMonitoringWheelEvents const):
(WebCore::ScrollingStateScrollingNode::scrollbarHoverState const):
(WebCore::ScrollingStateScrollingNode::mouseIsOverContentArea const):
(WebCore::ScrollingStateScrollingNode::StaticLayoutScrollState::create):
(WebCore::ScrollingStateScrollingNode::StaticLayoutScrollState::copy const):
(WebCore::ScrollingStateScrollingNode::StaticLayoutScrollState::StaticLayoutScrollState):
(WebCore::ScrollingStateScrollingNode::StaticConfigurationScrollState::create):
(WebCore::ScrollingStateScrollingNode::StaticConfigurationScrollState::copy const):
(WebCore::ScrollingStateScrollingNode::StaticConfigurationScrollState::StaticConfigurationScrollState):
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp:
(WebCore::ScrollingStateStickyNode::ScrollingStateStickyNode):
(WebCore::ScrollingStateStickyNode::hasUnchangedGroupsAs const):
(WebCore::ScrollingStateStickyNode::clearLayerFieldsForUnchangedProperties):
(WebCore::ScrollingStateStickyNode::verifyClearedLayerFieldsForUnchangedProperties const):
(WebCore::ScrollingStateStickyNode::setViewportAnchorLayer):
(WebCore::ScrollingStateStickyNode::updateConstraints):
(WebCore::ScrollingStateStickyNode::computeAnchorLayerPosition const):
(WebCore::ScrollingStateStickyNode::computeClippingLayerPosition const):
(WebCore::ScrollingStateStickyNode::reconcileLayerPositionForViewportRect):
(WebCore::ScrollingStateStickyNode::hasViewportClippingLayer const):
(WebCore::ScrollingStateStickyNode::scrollDeltaSinceLastCommit const):
(WebCore::ScrollingStateStickyNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateStickyNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::buildSnapshotNodeAndCollectDirty):
(WebCore::ScrollingStateTree::commit):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/ScrollingStateTreeCommit.cpp: Added.
(TestWebKitAPI::WebCore::buildTreeWithOverflowChildren):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, FirstCommitMarksAllNodesDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, IdleCommitProducesNoDirtyNodes)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, FirstCommitReturnsNonEmptyTransaction)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, IdleCommitReturnsEmptyTransaction)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, MutationProducesNonEmptyTransaction)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, RepeatedNoOpCommitsAllShortCircuit)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, ScrollPositionMutationMarksOnlyMutatedNodeDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, StaticLayoutGroupMutationMarksOnlyMutatedNodeDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, RepeatedScrollPositionWritesWithSameValueAreNoOp)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, NewlyAddedChildAppearsInDirtyList)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, GroupSharingAcrossUnchangedNodes)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, FixedNodeConstraintsMutationMarksDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, PositionedNodeConstraintsMutationMarksDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, StickyNodeConstraintsMutationMarksDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, StickyNodeViewportAnchorLayerMutationMarksDirty)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, ReparentingChildProducesNonEmptyTransaction)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, NonPartitionedSubclassesCommitAndShortCircuit)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, RequestedScrollDataMergesAcrossSetCallsBetweenCommits)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, EmptyTreeRoundTripsThroughDeserializationPath)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, ScrollbarFadeAndHoverLoopShortCircuits)):
(TestWebKitAPI::TEST(ScrollingStateTreeCommit, TinyPODDirectMembersPropagateThroughCommit)):
(TestWebKitAPI::TEST(DISABLED_ScrollingStateTreeCommit, BenchmarkCommitCost)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fec1ab65af624c9c5e34b4ea9b4e5f61170429b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181804 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129908 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9688d4d-bb4e-40d3-b82c-49a9374b7061) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134047 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94571 "1 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4016f5e9-b18f-40ca-aa36-8c6be31f3d47) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114518 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d54c77ff-2eea-4d11-8d6c-b4a0f891802d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36107 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34383 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30409 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184339 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142820 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45942 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142701 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46620 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30954 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111347 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37755 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118371 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45137 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9056 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44769 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44596 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->