### PR TITLE
[Scroll anchoring] Focused-element priority candidate is never selected, and ignores the caret position

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focus-prioritized-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focus-prioritized-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor selection prioritized focused element. assert_equals: y coordinate expected 458 but got 3358
+PASS Anchor selection prioritized focused element.
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -31,7 +31,10 @@
 #include "DocumentQuirks.h"
 #include "Editing.h"
 #include "FloatRect.h"
+#include "FrameSelection.h"
 #include "LegacyRenderSVGModelObject.h"
+#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "Quirks.h"
@@ -298,16 +301,34 @@ void ScrollAnchoringController::notifyChildHadSuppressingStyleChange(RenderEleme
     scrollerBox->setScrollAnchoringSuppressionStyleChanged(true);
 }
 
-static CheckedPtr<RenderElement> priorityCandidateForElement(Element* element)
+static CheckedPtr<RenderElement> priorityCandidateForNode(Node* node)
 {
-    while (element) {
-        if (CheckedPtr renderer = element->renderer()) {
+    for (RefPtr ancestor = node; ancestor; ancestor = ancestor->parentElement()) {
+        if (CheckedPtr renderer = dynamicDowncast<RenderElement>(ancestor->renderer())) {
             if (!renderer->isAnonymousBlock() && (!renderer->isInline() || renderer->isAtomicInlineLevelBox()))
                 return renderer;
         }
-        SUPPRESS_UNCOUNTED_LOCAL element = element->parentElement();
     }
     return nullptr;
+}
+
+// The priority candidate is the element containing the selection's focus point when it lies within
+// the focused editable element; otherwise it is the focused element itself.
+static RefPtr<Node> editingPriorityCandidateNode(Document& document, Element& focusedElement)
+{
+    RefPtr frame = document.frame();
+    if (!frame)
+        return &focusedElement;
+
+    auto& selection = frame->selection().selection();
+    if (selection.isNone())
+        return &focusedElement;
+
+    RefPtr focusNode = selection.focus().containerNode();
+    if (focusNode && focusedElement.contains(*focusNode))
+        return focusNode;
+
+    return &focusedElement;
 }
 
 // https://drafts.csswg.org/css-scroll-anchoring/#anchor-priority-candidates
@@ -319,7 +340,8 @@ bool ScrollAnchoringController::findPriorityCandidate(Document& document)
 
     RefPtr focusedElement = document.focusedElement();
     if (focusedElement && isEditableNode(*focusedElement)) {
-        if (CheckedPtr candidate = priorityCandidateForElement(focusedElement)) {
+        RefPtr candidateNode = editingPriorityCandidateNode(document, *focusedElement);
+        if (CheckedPtr candidate = priorityCandidateForNode(candidateNode.get())) {
             auto status = examinePriorityCandidate(*candidate);
             if (isViableStatus(status)) {
                 m_anchorObject = *candidate;
@@ -364,7 +386,7 @@ AnchorSearchStatus ScrollAnchoringController::examinePriorityCandidate(RenderEle
     if (!ancestor)
         return AnchorSearchStatus::Exclude;
 
-    return examineAnchorCandidate(*ancestor);
+    return examineAnchorCandidate(renderer);
 }
 
 static bool NODELETE overflowAnchorProhibitsAnchoring(const RenderElement& object, const RenderBox& scrollingAncestor)


### PR DESCRIPTION
#### 7088cb4172d01aa5efd53b2d158a8dca80d23505
<pre>
[Scroll anchoring] Focused-element priority candidate is never selected, and ignores the caret position
<a href="https://bugs.webkit.org/show_bug.cgi?id=315384">https://bugs.webkit.org/show_bug.cgi?id=315384</a>
<a href="https://rdar.apple.com/178274820">rdar://178274820</a>

Reviewed by NOBODY (OOPS!).

Per <a href="https://drafts.csswg.org/css-scroll-anchoring/#anchor-priority-candidates">https://drafts.csswg.org/css-scroll-anchoring/#anchor-priority-candidates</a>,
a focused editable element (or the element containing the caret within it)
should be selected as the scroll anchor ahead of the normal in-viewport
candidate search. Two bugs prevented this from working:

1. examinePriorityCandidate() walks from the candidate up to the scroll
  container to validate that every ancestor is eligible (overflow-anchor is
  not none and the element moves with the scroller). After that loop it
  passed the climbed `ancestor` -- which is now the scroller box itself --
  to examineAnchorCandidate(). The scroller box is never a viable anchor, so
  isViableStatus() was always false and findPriorityCandidate() always
  returned false. Focused-element prioritization was effectively dead code,
  and selection silently fell through to the normal anchor search.

2. The priority candidate was derived from the focused element itself rather
  than from the caret. When the focused editing host is a large container and
  the caret sits deep inside it, the spec anchors on the element at the
  selection&apos;s focus point, not the host. Anchoring on the host keeps the
  host&apos;s start edge stable instead of the content next to the cursor.

Fix (1) by examining the original candidate once its ancestor chain has been
validated. Fix (2) by resolving the priority candidate from the selection&apos;s
focus position when it lies within the focused editable element, falling back
to the focused element when there is no such selection. priorityCandidateForElement()
is generalized to priorityCandidateForNode() so the resolved focus node (which
may be a text node) is handled.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/focus-prioritized-expected.txt: Progression
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::priorityCandidateForNode):
(WebCore::editingPriorityCandidateNode):
(WebCore::ScrollAnchoringController::findPriorityCandidate):
(WebCore::ScrollAnchoringController::examinePriorityCandidate const):
(WebCore::priorityCandidateForElement): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7088cb4172d01aa5efd53b2d158a8dca80d23505

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128012 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66ca679a-98b8-456c-ad3a-5035c0c9747e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132782 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93588 "1 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6b553c7-bab9-4368-b4f8-c821117ed2f1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113282 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c64db29-5098-4622-b16c-53793c9eeb10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32910 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28358 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145033 "Found 2 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PanelTwice, TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182259 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35049 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37156 "Found 1 new test failure: http/tests/site-isolation/https-load.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141229 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43880 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44569 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108992 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36316 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116451 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43079 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7691 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->