### PR TITLE
Preloaded module scripts are blocked under a strict-dynamic CSP

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module-expected.txt
@@ -1,0 +1,7 @@
+A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic` in the script-src directive.
+
+
+PASS Parser-inserted external module script that is also `modulepreload`ed is allowed with `strict-dynamic`.
+PASS Parser-inserted external module script with only a `<link rel=preload as=script>` is not allowed with `strict-dynamic`.
+PASS A `modulepreload` for a different URL does not allow a parser-inserted external module script with `strict-dynamic`.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+    <link rel="modulepreload" href="simpleSourcedModule.js?modulepreloaded-module">
+    <link rel="preload" as="script" href="simpleSourcedModule.js?preload-as-script">
+    <link rel="modulepreload" href="simpleSourcedModule.js?modulepreloaded-other">
+</head>
+
+<body>
+    <h1>A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'modulepreloaded-module') {
+                    t.done();
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?modulepreloaded-module')) {
+                    return;
+                }
+                assert_unreached('A modulepreloaded parser-inserted external module script is allowed with `strict-dynamic`.');
+            }));
+        }, 'Parser-inserted external module script that is also `modulepreload`ed is allowed with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?modulepreloaded-module"></script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'preload-as-script') {
+                    assert_unreached('A generic `<link rel=preload as=script>` must not allow a parser-inserted module script with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?preload-as-script')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+        }, 'Parser-inserted external module script with only a `<link rel=preload as=script>` is not allowed with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?preload-as-script"></script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'url-mismatch') {
+                    assert_unreached('A `modulepreload` for a different URL must not allow a parser-inserted module script with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (!violation.blockedURI.includes('simpleSourcedModule.js?url-mismatch')) {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src-elem');
+                t.done();
+            }));
+        }, 'A `modulepreload` for a different URL does not allow a parser-inserted external module script with `strict-dynamic`.');
+    </script>
+    <script type="module" src="simpleSourcedModule.js?url-mismatch"></script>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -36,6 +36,7 @@
 #include "DocumentInlines.h"
 #include "DocumentPage.h"
 #include "DocumentPrefetcher.h"
+#include "DocumentResourceLoader.h"
 #include "ElementInlines.h"
 #include "Event.h"
 #include "EventLoop.h"
@@ -53,6 +54,7 @@
 #include "LoadableScriptError.h"
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
+#include "MemoryCache.h"
 #include "ModuleFetchParameters.h"
 #include "PendingScript.h"
 #include "SVGElementTypeHelpers.h"
@@ -403,6 +405,17 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
     return false;
 }
 
+ParserInserted ScriptElement::effectiveParserInsertedForModule(Document& document, const URL& moduleURL) const
+{
+    // A parser-inserted module script that reuses a <link rel=modulepreload> is not a new parser-inserted load.
+    if (m_parserInserted == ParserInserted::No)
+        return ParserInserted::No;
+
+    RefPtr resource = protect(document.cachedResourceLoader())->cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(moduleURL));
+    bool reusesModulePreload = (resource && resource->isLinkModulePreload());
+    return reusesModulePreload ? ParserInserted::No : ParserInserted::Yes;
+}
+
 bool ScriptElement::requestModuleScript(const String& sourceText, const TextPosition& scriptStartPosition)
 {
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
@@ -436,7 +449,8 @@ bool ScriptElement::requestModuleScript(const String& sourceText, const TextPosi
         Ref script = LoadableModuleScript::create(LoadableModuleScript::IsInline::No, nonce, integrity, referrerPolicy(), fetchPriority(), crossOriginMode,
             scriptCharset(), element->localName(), element->isInUserAgentShadowTree());
 
-        if (!protect(document->contentSecurityPolicy())->allowScriptForStrictDynamic(moduleScriptRootURL, URL(), m_startPosition.m_line, nonce, String(integrity), String(), m_parserInserted))
+        auto effectiveParserInserted = effectiveParserInsertedForModule(document, moduleScriptRootURL);
+        if (!protect(document->contentSecurityPolicy())->allowScriptForStrictDynamic(moduleScriptRootURL, URL(), m_startPosition.m_line, nonce, String(integrity), String(), effectiveParserInserted))
             return false;
 
         m_loadableScript = script.copyRef();

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -128,6 +128,7 @@ private:
 
     bool requestClassicScript(const String& sourceURL);
     bool requestModuleScript(const String& sourceText, const TextPosition& scriptStartPosition);
+    ParserInserted effectiveParserInsertedForModule(Document&, const URL& moduleURL) const;
 
     void updateTaintedOriginFromSourceURL();
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -404,6 +404,8 @@ RefPtr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const LinkLoadPara
     linkRequest.setInitiatorType("link"_s);
     linkRequest.setIgnoreForRequestCount(true);
     linkRequest.setIsLinkPreload();
+    if (params.relAttribute.isLinkModulePreload)
+        linkRequest.setIsLinkModulePreload();
 
     RefPtr<CachedResource> cachedLinkResource;
     if (auto result = protect(document.cachedResourceLoader())->preload(type.value(), WTF::move(linkRequest)))

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -92,6 +92,7 @@ CachedResource::CachedResource(CachedResourceRequest&& request, Type type, PAL::
     , m_preloadResult(PreloadResult::PreloadNotReferenced)
     , m_status(Pending)
     , m_isLinkPreload(request.isLinkPreload())
+    , m_isLinkModulePreload(request.isLinkModulePreload())
     , m_hasUnknownEncoding(request.isLinkPreload())
     , m_ignoreForRequestCount(request.ignoreForRequestCount())
 {
@@ -116,6 +117,7 @@ CachedResource::CachedResource(const URL& url, Type type, PAL::SessionID session
     , m_preloadResult(PreloadResult::PreloadNotReferenced)
     , m_status(Cached)
     , m_isLinkPreload(false)
+    , m_isLinkModulePreload(false)
     , m_hasUnknownEncoding(false)
     , m_ignoreForRequestCount(false)
 {

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -267,6 +267,8 @@ public:
     void setIsPreloaded(bool isPreloaded) { m_isPreloaded = isPreloaded; }
     bool isLinkPreload() const { return m_isLinkPreload; }
     void setLinkPreload() { m_isLinkPreload = true; }
+    bool isLinkModulePreload() const { return m_isLinkModulePreload; }
+    void setLinkModulePreload() { m_isLinkModulePreload = true; }
     bool hasUnknownEncoding() { return m_hasUnknownEncoding; }
     void setHasUnknownEncoding(bool hasUnknownEncoding) { m_hasUnknownEncoding = hasUnknownEncoding; }
 
@@ -420,6 +422,7 @@ private:
     bool m_inCache : 1 { false };
     bool m_loading : 1 { false };
     bool m_isLinkPreload : 1;
+    bool m_isLinkModulePreload : 1;
     bool m_hasUnknownEncoding : 1;
     bool m_switchingClientsToRevalidatedResource : 1 { false };
     bool m_ignoreForRequestCount : 1;

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1277,6 +1277,8 @@ ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestResource(Cache
 
     if (resource && request.isLinkPreload() && !resource->isLinkPreload())
         resource->setLinkPreload();
+    if (resource && request.isLinkModulePreload() && !resource->isLinkModulePreload())
+        resource->setLinkModulePreload();
 
     Ref cookieJar = page->cookieJar();
 

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -99,6 +99,8 @@ public:
 #endif
     bool isLinkPreload() const { return m_isLinkPreload; }
     void setIsLinkPreload() { m_isLinkPreload = true; }
+    bool isLinkModulePreload() const { return m_isLinkModulePreload; }
+    void setIsLinkModulePreload() { m_isLinkModulePreload = true; }
 
     void setOrigin(Ref<SecurityOrigin>&& origin) { m_origin = WTF::move(origin); }
     RefPtr<SecurityOrigin> releaseOrigin() { return WTF::move(m_origin); }
@@ -126,6 +128,7 @@ private:
     RefPtr<SecurityOrigin> m_origin;
     String m_fragmentIdentifier;
     bool m_isLinkPreload { false };
+    bool m_isLinkModulePreload { false };
     bool m_ignoreForRequestCount { false };
 };
 


### PR DESCRIPTION
#### d74bc8454ad40a5e567fd619b4f2cfff37b93df5
<pre>
Preloaded module scripts are blocked under a strict-dynamic CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=317890">https://bugs.webkit.org/show_bug.cgi?id=317890</a>
<a href="https://rdar.apple.com/179684592">rdar://179684592</a>

Reviewed by Ryan Reno.

When a page uses a Content Security Policy with strict-dynamic and preloads a module script,
that script is blocked even though the policy should allow it.

Under strict-dynamic a script request is only blocked when its parser metadata is
&quot;parser-inserted&quot; (CSP3 spec 6.7.1.1), and a &lt;link rel=modulepreload&gt; fetches the module
as &quot;not-parser-inserted&quot; and stores it in the document&apos;s module map (HTML spec 4.6.8.12).
A later parser-inserted &lt;script type=module&gt; for the same URL reuses that entry and issues no
new request to check, so it must not be blocked.

Fix by treating the module script as non-parser-inserted using a dedicated isLinkModulePreload
flag that only a modulepreload sets.

Tests: imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-strict_dynamic_modulepreload_parser_inserted_module.html.headers: Added.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::effectiveParserInsertedForModule const):
(WebCore::ScriptElement::requestModuleScript):
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::CachedResource):
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::isLinkModulePreload const):
(WebCore::CachedResource::setLinkModulePreload):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
(WebCore::CachedResourceRequest::isLinkModulePreload const):
(WebCore::CachedResourceRequest::setIsLinkModulePreload):

Canonical link: <a href="https://commits.webkit.org/316290@main">https://commits.webkit.org/316290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aef879c5846c1b021419de1bdd1e5cf88cd8346

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129398 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133690 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37075 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114161 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35707 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29897 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183815 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36431 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142285 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38402 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46108 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110743 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37385 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44626 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8641 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44026 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->