### PR TITLE
[tvOS] Placards are incorrectly hidden when built-in media controls are not visible

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
@@ -103,6 +103,11 @@ class TVOSMediaControls extends MediaControls
             }
         }
 
+        if (!this.visible) {
+            this.children = children;
+            return;
+        }
+
         this.closeButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
         this.muteButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
         this.playPauseButton.scaleFactor = TVOSMediaControls.playPauseButtonScaleFactor;
@@ -145,6 +150,15 @@ class TVOSMediaControls extends MediaControls
 
         children.push(...[this.topLeftControlsBar, this.topRightControlsBar, this.bottomControlsBar, this.metadataContainer, this.overflowControlsBar]);
         this.children = children;
+    }
+
+    commitProperty(propertyName)
+    {
+        // We override the default behavior of the "visible" property, which usually means the node
+        // will not be displayed if false, but we want to allow placards (e.g. the fullscreen placard)
+        // to be visible, even when controls are supposed to be hidden.
+        if (propertyName !== "visible")
+            super.commitProperty(propertyName);
     }
 
     // Private


### PR DESCRIPTION
#### 41021df5293d8ea797499791db0f9237f766b68f
<pre>
[tvOS] Placards are incorrectly hidden when built-in media controls are not visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=317895">https://bugs.webkit.org/show_bug.cgi?id=317895</a>
<a href="https://rdar.apple.com/180673836">rdar://180673836</a>

Reviewed by Jer Noble.

Adopted the approach used in inline-media-controls and vision-media-controls to ensure that
placards remain visible even if other controls are hidden.

* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js:
(TVOSMediaControls.prototype.layout):
(TVOSMediaControls.prototype.commitProperty):

Canonical link: <a href="https://commits.webkit.org/315861@main">https://commits.webkit.org/315861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/955c9931a98f1c9dc67609a916d22006a2c4055d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44241 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37658 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128030 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1fc4cf8-511d-40ba-b8d4-646c9cabd014) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43873 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9360a39a-63ea-4bfe-ba2a-b6b0a554b134) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173277 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113295 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6fc7756-b36c-47fe-83ef-7e7f9b2ef981) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28376 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182277 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43898 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37972 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44587 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109013 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36332 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116469 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43097 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42503 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->