### PR TITLE
Reject capture-toggle actions in callAcitonHandler when the capture-toggle API is disabled

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -567,7 +567,6 @@ webkit.org/b/311501 imported/w3c/web-platform-tests/mediasession/media-session-a
 # Media Session tests: rdar://178443322
 imported/w3c/web-platform-tests/mediasession/idlharness.window.html [ Failure ]
 imported/w3c/web-platform-tests/mediasession/mediametadata.html [ Failure ]
-imported/w3c/web-platform-tests/mediasession/setactionhandler.html [ Pass ]
 imported/w3c/web-platform-tests/mediasession/setcameraactive.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mediasession/setmicrophoneactive.html [ Pass Failure ]
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -155,6 +155,30 @@ static std::optional<std::pair<PlatformMediaSession::RemoteControlCommandType, P
     return std::make_pair(command, argument);
 }
 
+#if ENABLE(MEDIA_STREAM)
+static std::optional<Exception> validateMediaSessionCaptureToggleAction(const Document& document, MediaSessionAction action, ASCIILiteral actionDescriptor)
+{
+    if (!document.settings().mediaSessionCaptureToggleAPIEnabled()
+        && (action == MediaSessionAction::Togglecamera
+            || action == MediaSessionAction::Togglemicrophone
+            || action == MediaSessionAction::Togglescreenshare
+            || action == MediaSessionAction::Voiceactivity))
+        return Exception { ExceptionCode::TypeError, makeString(actionDescriptor, " must be a value other than '"_s, convertEnumerationToString(action), "'"_s) };
+    return std::nullopt;
+}
+#endif
+
+static std::optional<Exception> validateMediaSessionExtendedAction(const Document& document, MediaSessionAction action, ASCIILiteral actionDescriptor)
+{
+    if (!document.settings().mediaSessionExtendedActionsEnabled()
+        && (action == MediaSessionAction::Hangup
+            || action == MediaSessionAction::Previousslide
+            || action == MediaSessionAction::Nextslide
+            || action == MediaSessionAction::Enterpictureinpicture))
+        return Exception { ExceptionCode::TypeError, makeString(actionDescriptor, " must be a value other than '"_s, convertEnumerationToString(action), "'"_s) };
+    return std::nullopt;
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSession);
 
 Ref<MediaSession> MediaSession::create(Navigator& navigator)
@@ -292,10 +316,12 @@ void MediaSession::setPlaybackState(MediaSessionPlaybackState state)
 
 ExceptionOr<void> MediaSession::setActionHandler(MediaSessionAction action, RefPtr<MediaSessionActionHandler>&& handler)
 {
-#if ENABLE(MEDIA_STREAM)
     RefPtr document = this->document();
-    if (document && !document->settings().mediaSessionCaptureToggleAPIEnabled() && (action == MediaSessionAction::Togglecamera || action == MediaSessionAction::Togglemicrophone || action == MediaSessionAction::Togglescreenshare || action == MediaSessionAction::Voiceactivity))
-        return Exception { ExceptionCode::TypeError, makeString("Argument 1 ('action') to MediaSession.setActionHandler must be a value other than '"_s, convertEnumerationToString(action), "'"_s) };
+#if ENABLE(MEDIA_STREAM)
+    if (document) {
+        if (auto exception = validateMediaSessionCaptureToggleAction(*document, action, "Argument 1 ('action') to MediaSession.setActionHandler"_s))
+            return WTF::move(*exception);
+    }
 
 #if PLATFORM(MAC) && !HAVE(VOICEACTIVITYDETECTION)
     if (document && action == MediaSessionAction::Voiceactivity)
@@ -306,8 +332,10 @@ ExceptionOr<void> MediaSession::setActionHandler(MediaSessionAction action, RefP
         document->setShouldListenToVoiceActivity(!!handler);
 #endif
 
-    if (RefPtr document = this->document(); document && !document->settings().mediaSessionExtendedActionsEnabled() && (action == MediaSessionAction::Hangup || action == MediaSessionAction::Previousslide || action == MediaSessionAction::Nextslide || action == MediaSessionAction::Enterpictureinpicture))
-        return Exception { ExceptionCode::TypeError, makeString("Argument 1 ('action') to MediaSession.setActionHandler must be a value other than '"_s, convertEnumerationToString(action), "'"_s) };
+    if (document) {
+        if (auto exception = validateMediaSessionExtendedAction(*document, action, "Argument 1 ('action') to MediaSession.setActionHandler"_s))
+            return WTF::move(*exception);
+    }
 
     RefPtr sessionManager = this->sessionManager();
     if (!sessionManager)
@@ -359,9 +387,17 @@ void MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    if (RefPtr document = this->document(); document && !document->settings().mediaSessionExtendedActionsEnabled() && (actionDetails.action == MediaSessionAction::Hangup || actionDetails.action == MediaSessionAction::Previousslide || actionDetails.action == MediaSessionAction::Nextslide || actionDetails.action == MediaSessionAction::Enterpictureinpicture)) {
-        promise.reject(ExceptionCode::TypeError);
-        return;
+    if (RefPtr document = this->document()) {
+#if ENABLE(MEDIA_STREAM)
+        if (auto exception = validateMediaSessionCaptureToggleAction(*document, actionDetails.action, "Member MediaSessionActionDetails.action"_s)) {
+            promise.reject(WTF::move(*exception));
+            return;
+        }
+#endif
+        if (auto exception = validateMediaSessionExtendedAction(*document, actionDetails.action, "Member MediaSessionActionDetails.action"_s)) {
+            promise.reject(WTF::move(*exception));
+            return;
+        }
     }
 
     if (!callActionHandler(actionDetails, TriggerGestureIndicator::No)) {


### PR DESCRIPTION
#### 4730e33aa5001c63c63d3685cc65ef50aaccf07b
<pre>
Reject capture-toggle actions in callAcitonHandler when the capture-toggle API is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=317894">https://bugs.webkit.org/show_bug.cgi?id=317894</a>
<a href="https://rdar.apple.com/180673845">rdar://180673845</a>

Reviewed by NOBODY (OOPS!).

  There&apos;s a misalignment between MediaSession.setActionHandler() and callActionHandler().
  setActionHandler() rejects capture-toggle and extended actions with a TypeError when the
  MediaSessionCaptureToggleAPI setting is disabled, but callActionHandler() only validates
  extended actions.  This patch makes callActionHandler() validates the capture-toggle
  actions as well if the API setting is diabled.

  The shared validation is factored into two file-local helpers,
  validateMediaSessionCaptureToggleAction() (gated on ENABLE(MEDIA_STREAM)) and
  validateMediaSessionExtendedAction(). The redundant
  setactionhandler.html [ Pass ] expectation is also removed.

* LayoutTests/TestExpectations:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::validateMediaSessionCaptureToggleAction):
(WebCore::validateMediaSessionExtendedAction):
(WebCore::MediaSession::setActionHandler):
(WebCore::MediaSession::callActionHandler):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4730e33aa5001c63c63d3685cc65ef50aaccf07b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132796 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93605 "14 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113296 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34601 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32935 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182278 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141244 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43899 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44588 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29608 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109014 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36333 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116470 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7709 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->