### PR TITLE
Focus-scroll paints an incorrect frame when scroll-anchoring adjusts scrollTop before the focus-scroll timer fires

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-to-focused-element-after-scroll-anchoring-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-to-focused-element-after-scroll-anchoring-expected.txt
@@ -1,0 +1,10 @@
+Focused-element scroll must commit before paint, even after scroll anchoring adjusts scrollTop. webkit.org/b/318168
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS scrollTopAfterFocus is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-to-focused-element-after-scroll-anchoring.html
+++ b/LayoutTests/fast/scrolling/scroll-to-focused-element-after-scroll-anchoring.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+#scroller { width: 360px; height: 600px; overflow-y: auto; border: 1px solid black; }
+.target { background: #ffe0a0; }
+</style>
+</head>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="scroller"></div>
+<script>
+description('Focused-element scroll must commit before paint, even after scroll anchoring adjusts scrollTop. webkit.org/b/318168');
+
+jsTestIsAsync = true;
+
+const scroller = document.getElementById('scroller');
+const nextRows = Array.from({length: 60}, (_, i) => `<div>Next ${i + 2}</div>`).join('');
+const headerRows = `
+  <h2>Header</h2>
+  <div>Subheader</div>
+  <div class="target" id="target" tabindex="0">Target</div>
+`;
+
+scroller.innerHTML = nextRows;
+
+requestAnimationFrame(() => {
+    scroller.scrollTop = 200; // Arm scroll anchoring
+    requestAnimationFrame(() => {
+        scroller.insertAdjacentHTML('afterbegin', headerRows);
+        document.getElementById('target').focus();
+
+        requestAnimationFrame(() => {
+            scrollTopAfterFocus = scroller.scrollTop;
+            shouldBe('scrollTopAfterFocus', '0');
+            scroller.remove(); // keep the scroller's filler rows out of the dumpAsText output
+            finishJSTest();
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/ManualTests/scroll-to-focused-element-after-scroll-anchoring-pretty.html
+++ b/ManualTests/scroll-to-focused-element-after-scroll-anchoring-pretty.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Spotify queue-panel "hop" repro (rdar://171019322)</title>
+<style>
+html, body {
+  margin: 0;
+  padding: 24px;
+  background: #121212;
+  color: #eee;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 14px;
+}
+
+h1 { margin: 0 0 16px 0; }
+
+#row { display: flex; gap: 24px; align-items: flex-start; }
+
+#text { max-width: 540px; }
+#text p { color: #aaa; line-height: 1.5; }
+
+button {
+  font: inherit;
+  background: #2d8c5c;
+  color: white;
+  border: 0;
+  border-radius: 20px;
+  padding: 10px 22px;
+  cursor: pointer;
+  margin-right: 8px;
+}
+button.secondary { background: #444; }
+
+#readout {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 13px;
+  color: #2dd87a;
+  margin: 12px 0;
+  white-space: pre;
+}
+
+/* The queue panel. Inner #queue-list is the scrollable; everything
+   inside it is subject to the browser's scroll-anchoring algorithm. */
+#panel {
+  width: 360px;
+  height: 600px;
+  background: #1a1a1a;
+  border-radius: 8px;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+#queue-list {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 8px;
+  /* explicit scroll-anchoring on; this is the default but we want it
+     unambiguous. */
+  overflow-anchor: auto;
+}
+
+.h-major {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0 0 8px 0;
+}
+
+.h-minor {
+  color: #999;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 16px 0 6px 0;
+  text-transform: uppercase;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.row:hover { background: rgba(255,255,255,0.05); }
+.row .art { width: 40px; height: 40px; background: #333; border-radius: 4px; flex-shrink: 0; }
+.row .title { color: #ddd; font-size: 14px; }
+.row .artist { color: #888; font-size: 12px; }
+
+.row.now-playing { background: rgba(45, 140, 92, 0.18); }
+.row.now-playing .title { color: #2dd87a; font-weight: 600; }
+.row.now-playing::before { content: "▶"; color: #2dd87a; font-size: 11px; margin-right: 4px; }
+
+a { text-decoration: none; color: inherit; outline: none; }
+a:focus { outline: 2px solid #5b9aff; outline-offset: -2px; }
+</style>
+</head>
+<body>
+
+<h1>Spotify queue-panel "hop" repro</h1>
+
+<div id="row">
+
+  <div id="text">
+    <p>
+      Press <b>Open Queue</b>. The flow:
+    </p>
+    <ol style="color:#aaa; line-height:1.5;">
+      <li>Mount the "Next from" section into the queue list. Visible content: "Next from: Rock Artist" at the top of the panel, scroll position = 0.</li>
+      <li>Wait one paint.</li>
+      <li>Prepend the "Queue" header, "Now playing" label, and the "Title 1" row above the existing content. The browser's scroll-anchoring algorithm shifts <code>scrollTop</code> automatically to keep the previously-visible content stable, so "Next from" stays at the top. Then <code>focus()</code> on the newly-inserted "Title 1" row.</li>
+    </ol>
+    <p>
+      <b>Unpatched Safari:</b> the <code>focus()</code> schedules a 0 s Timer for the focused-element scroll. The next paint happens before the Timer fires, so the list paints with "Next from" still at the top (anchored scrollTop). One Timer-fire later, scroll jumps to <code>scrollTop = 0</code> — "Now playing: Title 1" snaps into view at the top. <b>The hop.</b>
+    </p>
+    <p>
+      <b>Chrome:</b> focus-scroll commits before the paint that would have shown the anchored position, so the first paint shows Now Playing at the top.
+    </p>
+    <p>
+      <b>Patched Safari:</b> our rendering-update step runs the deferred focus-scroll inside the same rendering update as the content insertion, so paint commits at <code>scrollTop = 0</code> from the start.
+    </p>
+    <div>
+      <button id="openBtn">Open Queue</button>
+      <button class="secondary" id="resetBtn">Reset</button>
+    </div>
+    <div id="readout">state: idle</div>
+  </div>
+
+  <div id="panel">
+    <div id="queue-list"><!-- populated by JS --></div>
+  </div>
+
+</div>
+
+<script>
+const queueList = document.getElementById('queue-list');
+const readout = document.getElementById('readout');
+
+function setReadout(state) {
+  readout.textContent = `scrollTop: ${String(queueList.scrollTop).padEnd(4)} state: ${state}`;
+}
+
+queueList.addEventListener('scroll', () => setReadout('scrolling'), { passive: true });
+
+const nextFromHTML = `
+  <div class="h-minor">Next from: Rock Artist</div>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 2</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 3</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 4</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 5</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 6</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 7</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 8</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 9</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 10</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 11</div><div class="artist">Rock Artist</div></div></a>
+  <a class="row" href="#"><div class="art"></div><div><div class="title">Title 12</div><div class="artist">Rock Artist</div></div></a>
+`;
+
+const headerHTML = `
+  <h2 class="h-major">Queue</h2>
+  <div class="h-minor">Now playing</div>
+  <a class="row now-playing" id="nowPlaying" href="#" tabindex="0">
+    <div class="art"></div>
+    <div><div class="title">Title 1</div><div class="artist">Rock Artist</div></div>
+  </a>
+`;
+
+document.getElementById('openBtn').addEventListener('click', () => {
+  // STEP 1: Mount the "Next from" section only. scrollTop = 0.
+  // The first frame Spotify shows is exactly this state — "Next from"
+  // at the top of the queue, no Queue/Now playing headers yet.
+  queueList.innerHTML = nextFromHTML;
+  setReadout('mounted "Next from" only — waiting one paint');
+
+  // STEP 2: After the first paint commits with "Next from" at the
+  // top, prepend the upper sections. This is what triggers the hop.
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+
+    // Insert "Queue", "Now playing" label, and "Title 1"
+    // row at the top of the scrollable. Because this content is
+    // inserted ABOVE the current scroll position, the browser's
+    // scroll-anchoring algorithm shifts scrollTop by the height of
+    // the inserted content, keeping the previously-visible "Next
+    // from" section stable at the top of the viewport. The user
+    // continues to see "Next from" at the top.
+    queueList.insertAdjacentHTML('afterbegin', headerHTML);
+
+    // Now focus the newly-inserted "Title 1" row. This is
+    // currently scrolled out of view above the viewport (because
+    // scroll-anchoring moved scrollTop down). The browser is
+    // expected to scroll the queue list back up to bring it into
+    // view — which means scrollTop = 0 and Now Playing at the top.
+    //
+    //   Unpatched Safari: 0 s Timer schedules the focused-element
+    //   scroll. Timer fires next event loop iteration AFTER paint.
+    //   Paint N shows scrollTop = (anchor-adjusted value), "Next
+    //   from" still at top. Timer fires, scroll, Paint N+1 shows
+    //   scrollTop = 0 with Now Playing at top. HOP.
+    //
+    //   Chrome: focus-scroll runs synchronously / inside the same
+    //   rendering update, so Paint N shows scrollTop = 0 directly.
+    //
+    //   Patched Safari: the DrainScrollToFocusedElement rendering-
+    //   update step runs the deferred scroll before the next
+    //   paint, matching Chrome's behavior.
+    document.getElementById('nowPlaying').focus();
+    setReadout('prepended + focused — focus-scroll should fire');
+  }));
+});
+
+document.getElementById('resetBtn').addEventListener('click', () => {
+  queueList.innerHTML = '';
+  setReadout('idle');
+});
+
+setReadout('idle');
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * This library is free software; you can redistribute it and/or
@@ -2306,6 +2306,12 @@ void Page::updateRendering()
 
     runProcessingStep(RenderingUpdateStep::Animations, [] (Document& document) {
         document.updateAnimationsAndSendEvents();
+    });
+
+    // Commit any pending focus-induced scroll before paint, so it doesn't lose a race with something like scroll-anchoring mutating scrollTop first.
+    runProcessingStep(RenderingUpdateStep::DrainScrollToFocusedElement, [] (Document& document) {
+        if (RefPtr view = document.view())
+            view->scrollToFocusedElementImmediatelyIfNeeded();
     });
 
 #if ENABLE(FULLSCREEN_API)
@@ -5049,6 +5055,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
     case RenderingUpdateStep::PrepareCanvasesForDisplayOrFlush: ts << "PrepareCanvasesForDisplayOrFlush"_s; break;
     case RenderingUpdateStep::CaretAnimation: ts << "CaretAnimation"_s; break;
     case RenderingUpdateStep::FocusFixup: ts << "FocusFixup"_s; break;
+    case RenderingUpdateStep::DrainScrollToFocusedElement: ts << "DrainScrollToFocusedElement"_s; break;
     case RenderingUpdateStep::UpdateValidationMessagePositions: ts << "UpdateValidationMessagePositions"_s; break;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     case RenderingUpdateStep::AccessibilityRegionUpdate: ts << "AccessibilityRegionUpdate"_s; break;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * This library is free software; you can redistribute it and/or
@@ -314,6 +314,7 @@ enum class RenderingUpdateStep : uint32_t {
     PrepareCanvasesForDisplayOrFlush    = 1 << 21,
     CaretAnimation                      = 1 << 22,
     FocusFixup                          = 1 << 23,
+    DrainScrollToFocusedElement         = 1 << 24,
     UpdateValidationMessagePositions    = 1 << 25,
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     AccessibilityRegionUpdate           = 1 << 26,
@@ -344,6 +345,7 @@ constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
     RenderingUpdateStep::Scroll,
     RenderingUpdateStep::MediaQueryEvaluation,
     RenderingUpdateStep::Animations,
+    RenderingUpdateStep::DrainScrollToFocusedElement,
     RenderingUpdateStep::Fullscreen,
     RenderingUpdateStep::AnimationFrameCallbacks,
     RenderingUpdateStep::IntersectionObservations,


### PR DESCRIPTION
#### 034780ff08135fedfbc4739112fbb7dc7e304587
<pre>
Focus-scroll paints an incorrect frame when scroll-anchoring adjusts scrollTop before the focus-scroll timer fires
<a href="https://bugs.webkit.org/show_bug.cgi?id=318168">https://bugs.webkit.org/show_bug.cgi?id=318168</a>
&lt;<a href="https://rdar.apple.com/problem/180972768">rdar://problem/180972768</a>&gt;

Reviewed by NOBODY (OOPS!).

A focus-induced scroll scheduled by Element::focus() runs on a 0 second Timer that
fires in the next event-loop iteration, after the current rendering update has already
painted. If anything (such as scroll-anchoring) mutates scrollTop between the focus() call
and that Timer firing, the anchored scrollTop is painted for one frame before the Timer
fires and snaps the focused element into view. The result is a visible one-frame hop from
the anchored position back to the focused element.

This patch adds a new RenderingUpdateStep::DrainScrollToFocusedElement, run from
Page::updateRendering immediately after the Animations step. It calls
LocalFrameView::scrollToFocusedElementImmediatelyIfNeeded(), which commits any pending
focus-scroll synchronously within the same rendering update, before paint, eliminating the
intermediate frame. The 0 second Timer is retained as a fallback for callers that observe
scrollTop after a 0 ms setTimeout.

Test: fast/scrolling/scroll-to-focused-element-after-scroll-anchoring.html

* LayoutTests/fast/scrolling/scroll-to-focused-element-after-scroll-anchoring-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-to-focused-element-after-scroll-anchoring.html: Added.
* ManualTests/scroll-to-focused-element-after-scroll-anchoring-pretty.html: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/034780ff08135fedfbc4739112fbb7dc7e304587

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132479 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135858 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95873 "1 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116336 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36305 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32669 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186616 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144778 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144637 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48890 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114670 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39519 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120892 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47397 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11118 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46799 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->