### PR TITLE
[EWS] Add selective-retry force schedulers for archive builders

### DIFF
--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -27,7 +27,7 @@ import re
 
 from buildbot.scheduler import AnyBranchScheduler, Periodic, Dependent, Triggerable, Nightly
 from buildbot.schedulers.trysched import Try_Userpass
-from buildbot.schedulers.forcesched import ForceScheduler, StringParameter, FixedParameter, CodebaseParameter
+from buildbot.schedulers.forcesched import ChoiceStringParameter, CodebaseParameter, FixedParameter, ForceScheduler, StringParameter
 from buildbot.worker import Worker
 from buildbot.util import identifiers as buildbot_identifiers
 from buildbot.changes.filter import ChangeFilter
@@ -66,6 +66,11 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
     c['workers'] = [Worker(worker['name'], passwords.get(worker['name'], 'password'), max_builds=worker.get('max_builds', 1)) for worker in config['workers']]
     if is_test_mode_enabled:
         c['workers'].append(Worker('local-worker', 'password', max_builds=1))
+
+    builder_triggers_map = {
+        builder['name']: list(builder.get('triggers') or [])
+        for builder in config['builders']
+    }
 
     c['builders'] = []
     for builder in config['builders']:
@@ -112,7 +117,7 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
         name='try_build',
         buttonName='Try Build',
         reason=StringParameter(name='reason', default='Trying pull request', size=20),
-        builderNames=[str(builder['name']) for builder in config['builders']],
+        builderNames=[str(builder['name']) for builder in config['builders'] if not builder_triggers_map.get(builder['name'])],
         # Disable default enabled input fields: branch, repository, project, additional properties
         codebases=[CodebaseParameter('',
                    revision=FixedParameter(name='revision', default=''),
@@ -125,6 +130,35 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
     )
     if setup_force_schedulers is True:
         c['schedulers'].append(forceScheduler)
+
+    if setup_force_schedulers is True:
+        for builder_name, builder_triggers in builder_triggers_map.items():
+            if not builder_triggers:
+                continue
+            c['schedulers'].append(ForceScheduler(
+                name=f'force-retry-{builder_name}',
+                buttonName='Try Build',
+                reason=StringParameter(name='reason', default='Selective retry', size=40),
+                builderNames=[builder_name],
+                codebases=[CodebaseParameter('',
+                           revision=FixedParameter(name='revision', default=''),
+                           repository=FixedParameter(name='repository', default=''),
+                           project=FixedParameter(name='project', default=''),
+                           branch=FixedParameter(name='branch', default=''))],
+                properties=[
+                    StringParameter(name='pr_number', label='Pull Request number (not bug number)', regex=r'^[0-9]{5,6}$', required=True, maxsize=6),
+                    StringParameter(name='ews_revision', label='WebKit git hash to checkout before retrying (optional)', required=False, maxsize=40),
+                    ChoiceStringParameter(
+                        name='triggers',
+                        label='Downstream testers to trigger:',
+                        choices=builder_triggers,
+                        multiple=True,
+                        strict=True,
+                        default=builder_triggers,
+                        required=True,
+                    ),
+                ],
+            ))
 
 
 # Copied from https://github.com/buildbot/buildbot/blob/master/master/buildbot/util/async_sort.py

--- a/Tools/CISupport/ews-build/loadConfig_unittest.py
+++ b/Tools/CISupport/ews-build/loadConfig_unittest.py
@@ -50,6 +50,42 @@ class ConfigDotJSONTest(unittest.TestCase):
         cwd = os.path.dirname(os.path.abspath(__file__))
         loadConfig.loadBuilderConfig({}, is_test_mode_enabled=True, master_prefix_path=cwd)
 
+    def test_force_retry_schedulers(self):
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        c = {}
+        loadConfig.loadBuilderConfig(c, is_test_mode_enabled=True, master_prefix_path=cwd)
+
+        config = self.get_config()
+        builders_with_triggers = [b for b in config['builders'] if b.get('triggers')]
+        self.assertTrue(builders_with_triggers,
+                        'config.json has no builders with triggers; the force-retry registration is no longer exercised')
+
+        scheduler_by_name = {s.name: s for s in c['schedulers']}
+
+        for builder in builders_with_triggers:
+            scheduler_name = f'force-retry-{builder["name"]}'
+            self.assertIn(scheduler_name, scheduler_by_name,
+                          f'expected force-retry scheduler {scheduler_name!r} for builder with triggers')
+            scheduler = scheduler_by_name[scheduler_name]
+            self.assertEqual(scheduler.builderNames, [builder['name']])
+
+            triggers_param = next((p for p in scheduler._config_kwargs.get('properties', []) if p.name == 'triggers'), None)
+            self.assertIsNotNone(triggers_param, f'{scheduler_name} missing triggers parameter')
+            self.assertEqual(sorted(triggers_param.choices), sorted(builder['triggers']),
+                             f'{scheduler_name} choices drifted from config.json triggers')
+            self.assertEqual(sorted(triggers_param.default), sorted(builder['triggers']),
+                             f'{scheduler_name} default should be the full fan-out')
+            self.assertTrue(triggers_param.multiple)
+            self.assertTrue(triggers_param.required)
+            self.assertTrue(triggers_param.strict)
+
+        for builder in config['builders']:
+            if builder.get('triggers'):
+                continue
+            scheduler_name = f'force-retry-{builder["name"]}'
+            self.assertNotIn(scheduler_name, scheduler_by_name,
+                             f'unexpected force-retry scheduler for builder without triggers: {builder["name"]}')
+
     def test_tab_character(self):
         cwd = os.path.dirname(os.path.abspath(__file__))
         with open(os.path.join(cwd, 'config.json'), 'r') as config:


### PR DESCRIPTION
#### 39462e4e89b8bf125e13f8bc8bf868d34ccc7c70
<pre>
[EWS] Add selective-retry force schedulers for archive builders
<a href="https://bugs.webkit.org/show_bug.cgi?id=317898">https://bugs.webkit.org/show_bug.cgi?id=317898</a>
<a href="https://rdar.apple.com/problem/180677371">rdar://problem/180677371</a>

Reviewed by Aakash Jain.

Register one ForceScheduler per archive builder that exposes the builder&apos;s &quot;triggers&quot; array
as a multi-select ChoiceStringParameter. Buildbot admins can use this to retry a parent
archive build with a chosen subset of testers, instead of always re-triggering the full
set of configured triggerables.

The new schedulers ride on the existing &quot;triggers&quot; build property, so the choices are sourced
live from config.json, keeping it as the single source of truth. Archive builders are dropped
from the shared try_build scheduler so each builder page still shows exactly one &quot;Try Build&quot;
button.

* Tools/CISupport/ews-build/loadConfig.py: Filter archive builders out of try_build and
register a per-builder force-retry ForceScheduler for each of them, both gated on
setup_force_schedulers.
* Tools/CISupport/ews-build/loadConfig_unittest.py:
(ConfigDotJSONTest.test_force_retry_schedulers): Add unit test.

Canonical link: <a href="https://commits.webkit.org/317413@main">https://commits.webkit.org/317413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/435cf4743450e898692514387a397f26c79f5f81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49206 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/184859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/136412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177138 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/50498 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/184859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/136412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/50498 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/157212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/184859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/50498 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/48889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/184859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/50498 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/36705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33332 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/48889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187280 "") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/174701 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48873 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/187280 "") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49553 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/33327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/187280 "") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26639 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/40072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115432 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/48059 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/11678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47462 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47692 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/47519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->