### PR TITLE
Clarify the analyze-safer-cpp download prompt

### DIFF
--- a/Tools/Scripts/analyze-safer-cpp
+++ b/Tools/Scripts/analyze-safer-cpp
@@ -468,10 +468,10 @@ def resolve_analyzer_clang(args):
     if not sys.stdin.isatty():
         sys.exit('Pass --clang PATH, or --download-toolchain to fetch a swift.org snapshot.')
     try:
-        answer = input('Download the latest swift.org development snapshot (~1.5 GB)? [y/N] ')
+        answer = input('`analyze-safer-cpp` requires an up-to-date toolchain. Download the latest swift.org development snapshot (~1.5 GB)? [Y/n] ')
     except (EOFError, KeyboardInterrupt):
         answer = ''
-    if answer.strip().lower() in ('y', 'yes'):
+    if answer.strip().lower() in ('y', 'yes', ''):
         clang, display = download_swift_toolchain()
         print('Using analyzer: {} ({})'.format(clang, display), file=sys.stderr)
         return clang


### PR DESCRIPTION
#### 6e9465ba37080413fabdb24ace032a2a92a52690
<pre>
Clarify the analyze-safer-cpp download prompt
<a href="https://bugs.webkit.org/show_bug.cgi?id=317900">https://bugs.webkit.org/show_bug.cgi?id=317900</a>
<a href="https://rdar.apple.com/180679157">rdar://180679157</a>

Reviewed by Tim Nguyen, Kiet Ho, Tim Horton, and Elliott Williams.

Based on feedback by Karl Dubost.

* Tools/Scripts/analyze-safer-cpp: Explain why we need such a large
download, and make &apos;Yes&apos; the default since &apos;No&apos; will just exit the tool.

Canonical link: <a href="https://commits.webkit.org/316382@main">https://commits.webkit.org/316382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93b75d158c946f0dee2fc521f33ec54eeeeecb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128039 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8def03e-374d-4596-93ff-6fe5c9ccfe66) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132805 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93608 "13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ce46e12-5d8a-4778-a06e-5ec42ca13be5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153234 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113305 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62e7dbcc-46c8-44ec-a4f7-d1f037e6f162) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34607 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32942 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28385 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145075 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward, TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182286 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141253 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43907 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141073 "Found 1 new API test failure: WebKitGTK/TestBackForwardList:/webkit/BackForwardList/navigation (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44596 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109024 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26124 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36341 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43106 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7720 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42512 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->