### PR TITLE
[WebKit Process Model | All] WebContent-supplied origin forwarded to system service without UI-process re-derivation at 4 sites

### DIFF
--- a/LayoutTests/ipc/forged-geolocation-permission-frame-origin-expected.txt
+++ b/LayoutTests/ipc/forged-geolocation-permission-frame-origin-expected.txt
@@ -1,0 +1,1 @@
+Tests that a forged FrameInfoData::securityOrigin in RequestGeolocationPermissionForFrame is ignored by the UI process. Passes if it does not crash.

--- a/LayoutTests/ipc/forged-geolocation-permission-frame-origin.html
+++ b/LayoutTests/ipc/forged-geolocation-permission-frame-origin.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.setGeolocationPermission(true);
+}
+
+function finish()
+{
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function run()
+{
+    if (!window.IPC) {
+        finish();
+        return;
+    }
+
+    const msgName = IPC.messages.WebPageProxy_RequestGeolocationPermissionForFrame.name;
+    let replayed = false;
+    IPC.addOutgoingMessageListener("UI", function (desc) {
+        if (!desc || desc.name !== msgName || replayed || !desc.buffer)
+            return;
+        replayed = true;
+        // Replay the captured RequestGeolocationPermissionForFrame with the
+        // FrameInfoData::securityOrigin protocol bytes mutated. The UI process should
+        // re-derive the origin from WebFrameProxy::securityOrigin() and ignore the
+        // forged value, so this must not crash or terminate the WebContent process.
+        const mutated = new Uint8Array(new Uint8Array(desc.buffer));
+        const enc = new TextEncoder();
+        const realBytes = enc.encode("file");
+        const evilBytes = enc.encode("http");
+        outer: for (let i = 0; i + realBytes.length <= mutated.length; i++) {
+            for (let j = 0; j < realBytes.length; j++) {
+                if (mutated[i + j] !== realBytes[j])
+                    continue outer;
+            }
+            for (let j = 0; j < evilBytes.length; j++)
+                mutated[i + j] = evilBytes[j];
+            i += realBytes.length - 1;
+        }
+        IPC.sendMessage("UI", desc.destinationID, msgName, mutated.slice(16));
+        setTimeout(finish, 0);
+    });
+
+    navigator.geolocation.getCurrentPosition(function () { }, function () { });
+    setTimeout(finish, 2000);
+}
+</script>
+</head>
+<body onload="run()">
+<p>Tests that a forged FrameInfoData::securityOrigin in RequestGeolocationPermissionForFrame is ignored by the UI process. Passes if it does not crash.</p>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -473,9 +473,10 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         weakPage->addConsoleMessage(*sourceFrameID, MessageSource::Network, MessageLevel::Error, makeString("Can't handle MarketplaceKit link "_s, url.string(), " due to error: "_s, error));
     };
 
-    auto requester = action->data().requester;
-    if (!action->shouldOpenExternalSchemes() || !action->isProcessingUserGesture() || action->isRedirect() || !requester || requester->topOrigin->data().isNull()) {
-        RELEASE_LOG_ERROR(Loading, "NavigationState: can't handle MarketplaceKit navigation with shouldOpenExternalSchemes: %d, isProcessingUserGesture: %d, isRedirect: %d, requesterTopOriginIsNull: %d", action->shouldOpenExternalSchemes(), action->isProcessingUserGesture(), action->isRedirect(), !requester || requester->topOrigin->data().isNull());
+    RefPtr mainFrame = page.mainFrame();
+    auto topOrigin = mainFrame ? WebCore::SecurityOriginData::fromURL(mainFrame->url()) : WebCore::SecurityOriginData { };
+    if (!action->shouldOpenExternalSchemes() || !action->isProcessingUserGesture() || action->isRedirect() || topOrigin.isNull()) {
+        RELEASE_LOG_ERROR(Loading, "NavigationState: can't handle MarketplaceKit navigation with shouldOpenExternalSchemes: %d, isProcessingUserGesture: %d, isRedirect: %d, requesterTopOriginIsNull: %d", action->shouldOpenExternalSchemes(), action->isProcessingUserGesture(), action->isRedirect(), topOrigin.isNull());
 
         if (!action->isProcessingUserGesture())
             addConsoleError("must be activated via a user gesture"_s);
@@ -485,7 +486,7 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         return;
     }
 
-    RetainPtr requesterTopOriginURL = protect(requester->topOrigin)->toURL().createNSURL();
+    RetainPtr requesterTopOriginURL = topOrigin.toURL().createNSURL();
     RetainPtr url = action->request().url().createNSURL();
 
     if (!requesterTopOriginURL || !url) {

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -239,13 +239,13 @@ void SOAuthorizationSession::beginAuthorizationIfReady()
     }
 
     auto initiatorOrigin = emptyString();
-    if (RefPtr sourceOrigin = m_navigationAction->sourceFrame() ? m_navigationAction->sourceFrame()->securityOrigin().securityOrigin().ptr() : nullptr; sourceOrigin && !sourceOrigin->isOpaque())
-        initiatorOrigin = sourceOrigin->toString();
     String initiatingPath = emptyString();
-    if (m_page->mainFrame()) {
-        if (m_action == InitiatingAction::SubFrame)
-            initiatorOrigin = WebCore::SecurityOrigin::create(m_page->mainFrame()->url())->toString();
-        initiatingPath = m_page->mainFrame()->url().path().toString();
+    RefPtr page = m_page.get();
+    if (RefPtr mainFrame = page ? page->mainFrame() : nullptr) {
+        Ref mainFrameOrigin = WebCore::SecurityOrigin::create(mainFrame->url());
+        if (m_action == InitiatingAction::SubFrame || !mainFrameOrigin->isOpaque())
+            initiatorOrigin = mainFrameOrigin->toString();
+        initiatingPath = mainFrame->url().path().toString();
     }
 
     RetainPtr<NSDictionary> authorizationOptions = @{

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
@@ -47,9 +47,9 @@ void GeolocationPermissionRequestManagerProxy::invalidateRequests()
     m_pendingRequests.clear();
 }
 
-Ref<GeolocationPermissionRequestProxy> GeolocationPermissionRequestManagerProxy::createRequest(GeolocationIdentifier geolocationID, WebProcessProxy& process)
+Ref<GeolocationPermissionRequestProxy> GeolocationPermissionRequestManagerProxy::createRequest(GeolocationIdentifier geolocationID, WebProcessProxy& process, WebCore::RegistrableDomain&& registrableDomain)
 {
-    Ref request = GeolocationPermissionRequestProxy::create(*this, geolocationID, process);
+    Ref request = GeolocationPermissionRequestProxy::create(*this, geolocationID, process, WTF::move(registrableDomain));
     m_pendingRequests.add(geolocationID, request);
     return request;
 }
@@ -67,7 +67,7 @@ void GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDe
 #if ENABLE(GEOLOCATION)
     String authorizationToken = allowed ? createVersion4UUIDString() : String();
     if (!authorizationToken.isNull())
-        m_validAuthorizationTokens.add(authorizationToken);
+        m_validAuthorizationTokens.add(authorizationToken, it->value->registrableDomain());
     if (RefPtr process = it->value->process())
         process->send(Messages::WebPage::DidReceiveGeolocationPermissionDecision(geolocationID, authorizationToken), page->webPageIDInProcess(*process));
 #else
@@ -80,6 +80,16 @@ void GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDe
 bool GeolocationPermissionRequestManagerProxy::isValidAuthorizationToken(const String& authorizationToken) const
 {
     return !authorizationToken.isNull() && m_validAuthorizationTokens.contains(authorizationToken);
+}
+
+std::optional<WebCore::RegistrableDomain> GeolocationPermissionRequestManagerProxy::registrableDomainForAuthorizationToken(const String& authorizationToken) const
+{
+    if (authorizationToken.isNull())
+        return std::nullopt;
+    auto it = m_validAuthorizationTokens.find(authorizationToken);
+    if (it == m_validAuthorizationTokens.end())
+        return std::nullopt;
+    return it->value;
 }
 
 void GeolocationPermissionRequestManagerProxy::revokeAuthorizationToken(const String& authorizationToken)

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h
@@ -28,8 +28,8 @@
 
 #include "GeolocationIdentifier.h"
 #include "GeolocationPermissionRequestProxy.h"
+#include <WebCore/RegistrableDomain.h>
 #include <wtf/HashMap.h>
-#include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -48,17 +48,18 @@ public:
     void deref() const;
 
     // Create a request to be presented to the user.
-    Ref<GeolocationPermissionRequestProxy> createRequest(GeolocationIdentifier, WebProcessProxy&);
-    
+    Ref<GeolocationPermissionRequestProxy> createRequest(GeolocationIdentifier, WebProcessProxy&, WebCore::RegistrableDomain&&);
+
     // Called by GeolocationPermissionRequestProxy when a decision is made by the user.
     void didReceiveGeolocationPermissionDecision(GeolocationIdentifier, bool allow);
 
     bool isValidAuthorizationToken(const String&) const;
+    std::optional<WebCore::RegistrableDomain> registrableDomainForAuthorizationToken(const String&) const;
     void revokeAuthorizationToken(const String&);
 
 private:
     HashMap<GeolocationIdentifier, Ref<GeolocationPermissionRequestProxy>> m_pendingRequests;
-    HashSet<String> m_validAuthorizationTokens;
+    HashMap<String, WebCore::RegistrableDomain> m_validAuthorizationTokens;
     WeakRef<WebPageProxy> m_page;
 };
 

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.cpp
@@ -31,10 +31,11 @@
 
 namespace WebKit {
 
-GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy& manager, GeolocationIdentifier geolocationID, WebProcessProxy& process)
+GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy& manager, GeolocationIdentifier geolocationID, WebProcessProxy& process, WebCore::RegistrableDomain&& registrableDomain)
     : m_manager(manager)
     , m_geolocationID(geolocationID)
     , m_process(process)
+    , m_registrableDomain(WTF::move(registrableDomain))
 {
 }
 

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "GeolocationIdentifier.h"
+#include <WebCore/RegistrableDomain.h>
 #include <wtf/Function.h>
 #include <wtf/WeakPtr.h>
 
@@ -37,24 +38,26 @@ class WebProcessProxy;
 
 class GeolocationPermissionRequestProxy : public RefCounted<GeolocationPermissionRequestProxy> {
 public:
-    static Ref<GeolocationPermissionRequestProxy> create(GeolocationPermissionRequestManagerProxy& manager, GeolocationIdentifier geolocationID, WebProcessProxy& process)
+    static Ref<GeolocationPermissionRequestProxy> create(GeolocationPermissionRequestManagerProxy& manager, GeolocationIdentifier geolocationID, WebProcessProxy& process, WebCore::RegistrableDomain&& registrableDomain)
     {
-        return adoptRef(*new GeolocationPermissionRequestProxy(manager, geolocationID, process));
+        return adoptRef(*new GeolocationPermissionRequestProxy(manager, geolocationID, process, WTF::move(registrableDomain)));
     }
 
     void allow();
     void deny();
-    
+
     void NODELETE invalidate();
 
     WebProcessProxy* NODELETE process() const;
+    const WebCore::RegistrableDomain& registrableDomain() const LIFETIME_BOUND { return m_registrableDomain; }
 
 private:
-    GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy&, GeolocationIdentifier, WebProcessProxy&);
+    GeolocationPermissionRequestProxy(GeolocationPermissionRequestManagerProxy&, GeolocationIdentifier, WebProcessProxy&, WebCore::RegistrableDomain&&);
 
     WeakPtr<GeolocationPermissionRequestManagerProxy> m_manager;
     GeolocationIdentifier m_geolocationID;
     WeakPtr<WebProcessProxy> m_process;
+    WebCore::RegistrableDomain m_registrableDomain;
 };
 
 class GeolocationPermissionRequest : public API::ObjectImpl<API::Object::Type::GeolocationPermissionRequest> {

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -129,8 +129,9 @@ void WebGeolocationManagerProxy::startUpdatingWithProxy(WebProcessProxy& proxy, 
     RefPtr page = WebProcessProxy::webPage(pageProxyID);
     MESSAGE_CHECK(proxy.connection(), !!page);
 
-    auto isValidAuthorizationToken = protect(page->geolocationPermissionRequestManager())->isValidAuthorizationToken(authorizationToken);
-    MESSAGE_CHECK(proxy.connection(), isValidAuthorizationToken);
+    auto authorizedDomain = protect(page->geolocationPermissionRequestManager())->registrableDomainForAuthorizationToken(authorizationToken);
+    MESSAGE_CHECK(proxy.connection(), !!authorizedDomain);
+    MESSAGE_CHECK(proxy.connection(), authorizedDomain->isEmpty() || *authorizedDomain == registrableDomain);
 
     auto& perDomainData = *m_perDomainData.ensure(registrableDomain, [] {
         return makeUnique<PerDomainData>();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14207,11 +14207,24 @@ void WebPageProxy::makeStorageSpaceRequest(FrameIdentifier frameID, const String
 
 void WebPageProxy::requestGeolocationPermissionForFrame(IPC::Connection& connection, GeolocationIdentifier geolocationID, FrameInfoData&& frameInfo)
 {
-    RefPtr frame = WebFrameProxy::webFrame(frameInfo.frameID);
-    if (!frame)
-        return;
+    Ref process = WebProcessProxy::fromConnection(connection);
 
-    auto request = protect(internals().geolocationPermissionRequestManager)->createRequest(geolocationID, protect(frame->process()));
+    RefPtr frame = WebFrameProxy::webFrame(frameInfo.frameID);
+    MESSAGE_CHECK(process, frame);
+
+    if (!frame->url().host().isEmpty())
+        frameInfo.securityOrigin = frame->securityOrigin()->data();
+
+    // The registrable domain bound to the authorization token must likewise be derived UI-side
+    // when possible so that WebGeolocationManagerProxy::StartUpdating can validate the
+    // WebContent-supplied domain. An empty RegistrableDomain indicates the UI process could not
+    // authoritatively determine it; in that case StartUpdating skips the equality check and
+    // accepts the WebContent-supplied domain (pre-existing behavior for these edge cases).
+    WebCore::RegistrableDomain mainFrameDomain;
+    if (RefPtr mainFrame = m_mainFrame.get(); mainFrame && !mainFrame->url().host().isEmpty())
+        mainFrameDomain = WebCore::RegistrableDomain { mainFrame->url() };
+
+    auto request = protect(internals().geolocationPermissionRequestManager)->createRequest(geolocationID, protect(frame->process()), WTF::move(mainFrameDomain));
     Function<void(bool)> completionHandler = [request = WTF::move(request)](bool allowed) {
         if (allowed)
             request->allow();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PermissionsAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/PermissionsAPI.mm
@@ -27,13 +27,18 @@
 
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "TestURLSchemeHandler.h"
 #import <WebKit/WKContext.h>
+#import <WebKit/WKFrameInfo.h>
 #import <WebKit/WKGeolocationManager.h>
 #import <WebKit/WKGeolocationPosition.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKSecurityOrigin.h>
 #import <WebKit/WKSecurityOriginRef.h>
 #import <WebKit/WKString.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <wtf/text/StringBuilder.h>
 
 static bool permissionsDidReceiveMessage;
@@ -85,6 +90,30 @@ enum class GeolocationPermissionState {
     decisionHandler(requestGeolocationPermissionDelegateResult);
 }
 @end
+
+#if ENABLE(IPC_TESTING_API)
+
+static Vector<String> gObservedGeolocationOriginHosts;
+static bool gDidReceiveGeolocationRequestForForgeryTest;
+
+@interface ForgedOriginGeolocationDelegate : NSObject<WKUIDelegate>
+@end
+
+@implementation ForgedOriginGeolocationDelegate
+- (void)_webView:(WKWebView *)webView queryPermission:(NSString *)name forOrigin:(WKSecurityOrigin *)origin completionHandler:(void (^)(WKPermissionDecision))completionHandler
+{
+    completionHandler(WKPermissionDecisionPrompt);
+}
+
+- (void)_webView:(WKWebView *)webView requestGeolocationPermissionForFrame:(WKFrameInfo *)frame decisionHandler:(void (^)(BOOL))decisionHandler
+{
+    gObservedGeolocationOriginHosts.append(String(frame.securityOrigin.host));
+    gDidReceiveGeolocationRequestForForgeryTest = true;
+    decisionHandler(NO);
+}
+@end
+
+#endif // ENABLE(IPC_TESTING_API)
 
 
 namespace TestWebKitAPI {
@@ -294,5 +323,84 @@ TEST(PermissionsAPI, GeolocationPermissionDeniedPermanentlyAndGeolocationNotRequ
 {
     testPermissionsAPIForGeolocation(GeolocationPermissionState::DeniedPermanently, RequestGeolocationSincePageLoad::No, "prompt"_s);
 }
+
+#if ENABLE(IPC_TESTING_API)
+
+// A compromised WebContent process may forge FrameInfoData::securityOrigin in the
+// RequestGeolocationPermissionForFrame IPC. The origin presented to the UIDelegate must be
+// re-derived UI-side from WebFrameProxy::securityOrigin() rather than trusted from the message.
+TEST(PermissionsAPI, GeolocationFrameInfoOriginIgnoresWebProcessForgery)
+{
+    gObservedGeolocationOriginHosts = { };
+    gDidReceiveGeolocationRequestForForgeryTest = false;
+
+    RetainPtr pool = adoptNS([[WKProcessPool alloc] init]);
+    WKGeolocationProviderV1 providerCallback;
+    zeroBytes(providerCallback);
+    providerCallback.base.version = 1;
+    WKGeolocationManagerSetProvider(WKContextGetGeolocationManager((WKContextRef)pool.get()), &providerCallback.base);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = pool.get();
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    // Captures the raw bytes of the legitimate RequestGeolocationPermissionForFrame IPC,
+    // byte-replaces every occurrence of the page's real host with a same-length forged host,
+    // and replays the message.
+    static constexpr auto byteReplayHTML =
+    "<script>"
+    "if (window.IPC) {"
+    "    const msgName = IPC.messages.WebPageProxy_RequestGeolocationPermissionForFrame.name;"
+    "    const enc = new TextEncoder();"
+    "    const realBytes = enc.encode('localhost');"
+    "    const evilBytes = enc.encode('evil.host');"
+    "    let replayed = false;"
+    "    IPC.addOutgoingMessageListener('UI', function (desc) {"
+    "        if (!desc || desc.name !== msgName || replayed || !desc.buffer) return;"
+    "        replayed = true;"
+    "        const mutated = new Uint8Array(new Uint8Array(desc.buffer));"
+    "        outer: for (let i = 0; i + realBytes.length <= mutated.length; i++) {"
+    "            for (let j = 0; j < realBytes.length; j++) if (mutated[i+j] !== realBytes[j]) continue outer;"
+    "            for (let j = 0; j < evilBytes.length; j++) mutated[i+j] = evilBytes[j];"
+    "            i += realBytes.length - 1;"
+    "        }"
+    "        IPC.sendMessage('UI', desc.destinationID, msgName, mutated.slice(16));"
+    "    });"
+    "}"
+    "navigator.geolocation.getCurrentPosition(function(){}, function(){});"
+    "</script>"_s;
+
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:[NSData dataWithBytes:byteReplayHTML.characters() length:byteReplayHTML.length()]];
+        [task didFinish];
+    }];
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"wcptest"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[ForgedOriginGeolocationDelegate alloc] init]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"wcptest://localhost/"]]];
+
+    TestWebKitAPI::Util::run(&gDidReceiveGeolocationRequestForForgeryTest);
+    // Give the replayed message a chance to dispatch to the delegate.
+    TestWebKitAPI::Util::runFor(0.25_s);
+
+    EXPECT_GT(gObservedGeolocationOriginHosts.size(), 0u);
+    for (auto& host : gObservedGeolocationOriginHosts) {
+        EXPECT_WK_STREQ(host, "localhost"_s);
+        EXPECT_FALSE(host.contains("evil"_s));
+    }
+}
+
+#endif // ENABLE(IPC_TESTING_API)
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -33,11 +33,13 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "TestURLSchemeHandler.h"
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <pal/spi/cocoa/AuthKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
@@ -1599,6 +1601,93 @@ TEST(SOAuthorizationRedirect, AuthorizationOptionsAboutBlank)
     checkAuthorizationOptions(true, ""_s, 0);
     EXPECT_TRUE(policyForAppSSOPerformed);
 }
+
+#if ENABLE(IPC_TESTING_API)
+static Vector<String> gObservedInitiatorOrigins;
+static unsigned gExpectedAuthorizationCount = 0;
+
+static void overrideBeginAuthorizationWithURLAndRecordInitiatorOrigin(id, SEL, NSURL *, NSDictionary *, NSData *)
+{
+    gObservedInitiatorOrigins.append([gAuthorization authorizationOptions][SOAuthorizationOptionInitiatorOrigin]);
+    if (gObservedInitiatorOrigins.size() >= gExpectedAuthorizationCount)
+        authorizationPerformed = true;
+    dispatch_async(mainDispatchQueueSingleton(), ^{
+        [gDelegate authorizationDidNotHandle:gAuthorization];
+    });
+}
+
+// A compromised WebContent process may forge originatingFrameInfoData.securityOrigin in
+// DecidePolicyForNavigationActionAsync. The InitiatorOrigin forwarded to AppSSO must be derived
+// from UI-process-authoritative state (the page's committed main-frame URL), not from that field.
+TEST(SOAuthorizationRedirect, InitiatorOriginIgnoresWebProcessSuppliedSourceFrameOrigin)
+{
+    resetState();
+    gObservedInitiatorOrigins = { };
+    gExpectedAuthorizationCount = 2;
+
+    ClassMethodSwizzler swizzler0(PAL::getSOAuthorizationClassSingleton(), @selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURLCompletion));
+    ClassMethodSwizzler swizzler1(PAL::getSOAuthorizationClassSingleton(), @selector(canPerformAuthorizationWithURL:responseCode:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURL));
+    InstanceMethodSwizzler swizzler2(PAL::getSOAuthorizationClassSingleton(), @selector(setDelegate:), reinterpret_cast<IMP>(overrideSetDelegate));
+    InstanceMethodSwizzler swizzler3(PAL::getSOAuthorizationClassSingleton(), @selector(beginAuthorizationWithURL:httpHeaders:httpBody:), reinterpret_cast<IMP>(overrideBeginAuthorizationWithURLAndRecordInitiatorOrigin));
+    InstanceMethodSwizzler swizzler4(PAL::getSOAuthorizationClassSingleton(), @selector(cancelAuthorization), reinterpret_cast<IMP>(overrideCancelAuthorization));
+    InstanceMethodSwizzler swizzler5(PAL::getSOAuthorizationClassSingleton(), @selector(getAuthorizationHintsWithURL:responseCode:completion:), reinterpret_cast<IMP>(overrideGetAuthorizationHintsWithURL));
+
+    // Captures the raw bytes of the legitimate DecidePolicyForNavigationActionAsync IPC, byte-replaces
+    // every occurrence of the page's real host with a same-length forged host, and replays the message.
+    static constexpr auto byteReplayHTML =
+    "<script>"
+    "const msgName = IPC.messages.WebPageProxy_DecidePolicyForNavigationActionAsync.name;"
+    "const enc = new TextEncoder();"
+    "const realBytes = enc.encode('localhost');"
+    "const evilBytes = enc.encode('evil.host');"
+    "function replaceAll(u8, from, to) {"
+    "    outer: for (let i = 0; i + from.length <= u8.length; i++) {"
+    "        for (let j = 0; j < from.length; j++) if (u8[i+j] !== from[j]) continue outer;"
+    "        for (let j = 0; j < to.length; j++) u8[i+j] = to[j];"
+    "        i += from.length - 1;"
+    "    }"
+    "}"
+    "let replayed = false;"
+    "IPC.addOutgoingMessageListener('UI', function (desc) {"
+    "    if (!desc || desc.name !== msgName || replayed || !desc.buffer) return;"
+    "    replayed = true;"
+    "    const mutated = new Uint8Array(new Uint8Array(desc.buffer));"
+    "    replaceAll(mutated, realBytes, evilBytes);"
+    "    IPC.sendMessage('UI', desc.destinationID, msgName, mutated.slice(16));"
+    "});"
+    "location = 'http://www.example.com';"
+    "</script>"_s;
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:[NSData dataWithBytes:byteReplayHTML.characters() length:byteReplayHTML.length()]];
+        [task didFinish];
+    }];
+    [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"wcptest"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"wcptest://localhost/"]]];
+    Util::run(&authorizationPerformed);
+
+    EXPECT_EQ(gObservedInitiatorOrigins.size(), 2u);
+    for (auto& origin : gObservedInitiatorOrigins) {
+        EXPECT_WK_STREQ(origin, "wcptest://localhost"_s);
+        EXPECT_FALSE(origin.contains("evil.host"_s));
+    }
+}
+#endif // ENABLE(IPC_TESTING_API)
 
 TEST(SOAuthorizationRedirect, InterceptionDidNotHandleTwice)
 {


### PR DESCRIPTION
#### 5ca4d87ac78cbb8cbb0e7210d91835f8559fab24
<pre>
[WebKit Process Model | All] WebContent-supplied origin forwarded to system service without UI-process re-derivation at 4 sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=315534">https://bugs.webkit.org/show_bug.cgi?id=315534</a>
<a href="https://rdar.apple.com/176895464">rdar://176895464</a>

Reviewed by Sihui Liu.

Four UI-process IPC handlers accepted an origin/domain field from a
DispatchedFrom=WebContent message and forwarded it verbatim to a system
service as a per-site authorization key, without comparing it against
UI-process-authoritative state. A compromised WebContent process could
spoof the origin and have CoreLocation / AppSSO / MarketplaceKit / the
geolocation policy decider apply another site&apos;s permission decision.

This change re-derives each value from UI-process-authoritative state
(WebFrameProxy::url() / WebFrameProxy::securityOrigin() / the page&apos;s
committed main-frame URL) instead of trusting the IPC-supplied field:

- SOAuthorizationSession: derive InitiatorOrigin from
  m_page-&gt;mainFrame()-&gt;url() for all initiating actions, matching the
  existing SubFrame override and dropping the read of
  NavigationActionData::originatingFrameInfoData.securityOrigin.
- interceptMarketplaceKitNavigation: derive the referrer/top-origin URL
  from page.mainFrame()-&gt;url() instead of NavigationRequester::topOrigin.
- WebPageProxy::requestGeolocationPermissionForFrame: overwrite
  FrameInfoData::securityOrigin with WebFrameProxy::securityOrigin()
  (computed UI-side at commit time) before passing it to the embedder,
  and MESSAGE_CHECK that the frame resolves. The override is only
  applied when the frame&apos;s load URL carries a meaningful host, since
  some loads (e.g. webarchives loaded from a local file URL) commit a
  document whose origin is determined by content the UIProcess cannot
  inspect; in that case the WebContent-supplied origin is left in place.
- WebGeolocationManagerProxy::startUpdatingWithProxy: bind the
  RegistrableDomain (derived UI-side from the page&apos;s committed
  main-frame URL at permission-request time) to the authorization token,
  and MESSAGE_CHECK that the WebContent-supplied domain in StartUpdating
  matches the token&apos;s bound domain. When the UI-derived domain is empty
  (same webarchive / opaque-document case as above), the equality check
  is skipped and the WebContent-supplied domain is accepted, matching
  the pre-existing behavior for those edge cases.

Tests: ipc/forged-geolocation-permission-frame-origin.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm

* LayoutTests/ipc/forged-geolocation-permission-frame-origin-expected.txt: Added.
* LayoutTests/ipc/forged-geolocation-permission-frame-origin.html: Added.
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::interceptMarketplaceKitNavigation):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp:
(WebKit::GeolocationPermissionRequestManagerProxy::createRequest):
(WebKit::GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDecision):
(WebKit::GeolocationPermissionRequestManagerProxy::registrableDomainForAuthorizationToken const):
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.cpp:
(WebKit::GeolocationPermissionRequestProxy::GeolocationPermissionRequestProxy):
* Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h:
(WebKit::GeolocationPermissionRequestProxy::create):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::startUpdatingWithProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::overrideBeginAuthorizationWithURLAndRecordInitiatorOrigin):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InitiatorOriginIgnoresWebProcessSuppliedSourceFrameOrigin)):

Canonical link: <a href="https://commits.webkit.org/315884@main">https://commits.webkit.org/315884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b27770a9683b185306c05fa1cb3607591777213d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128046 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/722c9ec8-7ef4-48c6-85c6-9db14cb7bb82) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e24c8349-8b46-4a9f-b0fc-0bff91382c38) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113310 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5245e03-3b9a-4310-b24d-5075a22593c7) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28392 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182293 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141260 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141080 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37996 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44603 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109035 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36349 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116485 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43113 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7726 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42519 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42648 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->