### PR TITLE
[EWS] Improve git cleanup step

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6933,10 +6933,9 @@ class CleanGitRepo(steps.ShellSequence, ShellMixin):
             self.shell_command('git am --abort || {}'.format(self.shell_exit_0())),
             self.shell_command('git cherry-pick --abort || {}'.format(self.shell_exit_0())),
             ['git', 'clean', '-f', '-d'],  # Remove any left-over layout test results, added files, etc.
-            ['git', 'checkout', '--progress', '{}/{}'.format(self.git_remote, self.default_branch), '-f'],  # Checkout branch from specific remote
-            ['git', 'branch', '-D', self.default_branch],  # Delete any local cache of the specified branch
-            ['git', 'branch', self.default_branch],  # Create local instance of branch from remote, but don't track it
-            self.shell_command("git branch | grep -v ' {}$' | grep -v 'HEAD detached at' | xargs git branch -D || {}".format(self.default_branch, self.shell_exit_0())),
+            self.shell_command(f'git switch --progress -d --discard-changes {self.git_remote}/{self.default_branch} || git switch --progress -d --discard-changes {self.default_branch} || git switch --progress -d --discard-changes'),  # Detach to either origin/main or main or HEAD
+            self.shell_command(f"git for-each-ref --format='delete %(refname) %(objectname)' refs/heads | git update-ref --stdin || {self.shell_exit_0()}"),  # Delete all local branches
+            ['git', 'branch', '--no-track', self.default_branch],  # Create local instance of branch from HEAD, but don't track it
             self.shell_command("git remote | grep -v '{}$' | xargs -L 1 git remote rm || {}".format(self.git_remote, self.shell_exit_0())),
             ['git', 'prune'],
         ]:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6599,46 +6599,31 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
     def tearDown(self):
         return self.tear_down_test_build_step()
 
+    def default_remote_commands(self, branch='main', remote='origin', platform='unix', switch_exit=0):
+        shell = 'bash' if platform == 'win' else '/bin/bash'
+        exit_0 = 'exit 0' if platform == 'win' else 'true'
+        stale_files = ['gc.log', 'index.lock', 'packed-refs.lock', 'packed-refs.new', 'HEAD.lock', 'config.lock', 'FETCH_HEAD.lock']
+        if platform == 'win':
+            stale_commands = [ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', rf'del .git\{f} || {exit_0}'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout='') for f in stale_files]
+        else:
+            stale_commands = [ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f'rm -f .git/{f} || {exit_0}'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout='') for f in stale_files]
+        return [
+            *stale_commands,
+            ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f'git rebase --abort || {exit_0}'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f'git am --abort || {exit_0}'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f'git cherry-pick --abort || {exit_0}'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f'git switch --progress -d --discard-changes {remote}/{branch} || git switch --progress -d --discard-changes {branch} || git switch --progress -d --discard-changes'], workdir='wkdir', timeout=300, log_environ=False).exit(switch_exit).log('stdio', stdout='' if switch_exit else 'HEAD is now at 57015967fef9'),
+            ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f"git for-each-ref --format='delete %(refname) %(objectname)' refs/heads | git update-ref --stdin || {exit_0}"], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=['git', 'branch', '--no-track', branch], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=[shell, '--posix', '-o', 'pipefail', '-c', f"git remote | grep -v '{remote}$' | xargs -L 1 git remote rm || {exit_0}"], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0).log('stdio', stdout=''),
+        ]
+
     def test_success(self):
         self.setup_step(CleanGitRepo())
         self.setProperty('buildername', 'Style-EWS')
-
-        self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/index.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.new || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/config.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/FETCH_HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git am --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-        )
+        self.expectRemoteCommands(*self.default_remote_commands())
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
         return self.run_step()
 
@@ -6646,129 +6631,21 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setup_step(CleanGitRepo())
         self.setProperty('buildername', 'Win-Build-EWS')
         self.setProperty('platform', 'win')
-
-        self.expectRemoteCommands(
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\gc.log || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\index.lock || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\packed-refs.lock || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\packed-refs.new || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\HEAD.lock || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\config.lock || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', r'del .git\FETCH_HEAD.lock || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git am --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || exit 0'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || exit 0"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || exit 0"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-        )
+        self.expectRemoteCommands(*self.default_remote_commands(platform='win'))
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
         return self.run_step()
 
     def test_success_master(self):
         self.setup_step(CleanGitRepo(default_branch='master'))
         self.setProperty('buildername', 'Commit-Queue')
-
-        self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/index.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.new || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/config.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/FETCH_HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git am --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/master', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch master (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'master'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'master'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' master$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-        )
+        self.expectRemoteCommands(*self.default_remote_commands(branch='master'))
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
         return self.run_step()
 
     def test_failure(self):
         self.setup_step(CleanGitRepo())
         self.setProperty('buildername', 'Commit-Queue')
-
-        self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/index.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.new || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/config.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/FETCH_HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git am --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(128)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-        )
+        self.expectRemoteCommands(*self.default_remote_commands(switch_exit=128))
         self.expect_outcome(result=FAILURE, state_string='Encountered some issues during cleanup')
         return self.run_step()
 
@@ -6776,43 +6653,7 @@ class TestCleanGitRepo(BuildStepMixinAdditions, unittest.TestCase):
         self.setup_step(CleanGitRepo())
         self.setProperty('buildername', 'Commit-Queue')
         self.setProperty('basename', 'safari-612-branch')
-
-        self.expectRemoteCommands(
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/gc.log || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/index.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/packed-refs.new || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/config.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'rm -f .git/FETCH_HEAD.lock || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git rebase --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git am --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'git cherry-pick --abort || true'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'clean', '-f', '-d'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'checkout', '--progress', 'origin/main', '-f'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='You are in detached HEAD state.'),
-            ExpectShell(command=['git', 'branch', '-D', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout='Deleted branch main (was 57015967fef9).'),
-            ExpectShell(command=['git', 'branch', 'main'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout="Switched to a new branch 'main'"),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git branch | grep -v ' main$' | grep -v 'HEAD detached at' | xargs git branch -D || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', "git remote | grep -v 'origin$' | xargs -L 1 git remote rm || true"], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-            ExpectShell(command=['git', 'prune'], workdir='wkdir', timeout=300, log_environ=False).exit(0)
-            .log('stdio', stdout=''),
-        )
+        self.expectRemoteCommands(*self.default_remote_commands())
         self.expect_outcome(result=SUCCESS, state_string='Cleaned up git repository')
         return self.run_step()
 


### PR DESCRIPTION
#### a9a0033f28d17aee94c726676f2f8f927f6fd061
<pre>
[EWS] Improve git cleanup step
<a href="https://bugs.webkit.org/show_bug.cgi?id=310319">https://bugs.webkit.org/show_bug.cgi?id=310319</a>
<a href="https://rdar.apple.com/173458312">rdar://173458312</a>

Reviewed by Sam Sneddon.

Replace the porcelain `git branch | grep | xargs git branch -D` with
plumbing commands to fix two cascading failures: `git checkout origin/main`
failing when the remote tracking ref doesn&apos;t exist, and `git branch` output
including `*` which gets passed literally to `git branch -D`.

Use `git switch -d --discard-changes` to safely detach HEAD (falling back
to local main, then current HEAD if origin/main is missing), delete all
local branches with `git for-each-ref | git update-ref --stdin`, then
recreate the default branch with `git branch --no-track`.

* Tools/CISupport/ews-build/steps.py:
(CleanGitRepo.run): Replace checkout/branch-delete/grep pipeline with
git switch and git for-each-ref.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestCleanGitRepo.default_remote_commands): Extract shared command
expectations into a helper to reduce repetition.

Canonical link: <a href="https://commits.webkit.org/317584@main">https://commits.webkit.org/317584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc872fb30dcd7faf3d3022d740c7c2703d41aa57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135568 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95650 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37644 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36011 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32341 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186283 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144478 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/173683 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47883 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144335 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39232 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48562 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32478 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114098 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39240 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47068 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46471 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->