### PR TITLE
[Scripts] --print-expectations fails when no tests match

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -955,6 +955,8 @@ class Manager(object):
             aggregate_tests = aggregate_tests_to_run | aggregate_tests_to_skip
 
             self._printer.print_found(len(aggregate_tests), len(aggregate_tests_to_run), self._options.repeat_each, self._options.iterations)
+            if not aggregate_tests:
+                continue
             test_col_width = max(len(test.test_path) for test in aggregate_tests) + 1
 
             self._print_expectations_for_subset(device_type_list[0], test_col_width, tests_to_run_by_device[device_type_list[0]], aggregate_tests_to_skip)

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
@@ -141,3 +141,14 @@ passes/text.html                       ['PASS']
         # so if the output is not *exactly* as expected including whitespaces, this
         # could lead to unwanted effects, like blocking builds for a long time.
         self.assertEqual(get_printed_expectations(), out)
+
+    def test_print_expectations_no_tests_found(self):
+        # Passing a non-existent path should not raise ValueError from max() on an
+        # empty sequence; it should return 0 cleanly.
+        manager = self._get_manager()
+        manager._options.update(repeat_each=1, iterations=1)
+        device_type_list = manager._port.supported_device_types()
+        manager._create_port_for_driver = Mock(return_value=manager._port)
+        manager._collect_tests = Mock(return_value=({dt: [] for dt in device_type_list}, set()))
+        exit_code = manager.print_expectations(['this/file/does/not/exist.html'])
+        self.assertEqual(exit_code, 0)


### PR DESCRIPTION
#### e081edf2cd1304ad8c7b521f4def4ee87508e9ad
<pre>
[Scripts] --print-expectations fails when no tests match
<a href="https://bugs.webkit.org/show_bug.cgi?id=294566">https://bugs.webkit.org/show_bug.cgi?id=294566</a>
<a href="https://rdar.apple.com/153547585">rdar://153547585</a>

Reviewed by Sam Sneddon.

When --print-expectations is passed a path that matches no tests, _collect_tests
returns empty sets and aggregate_tests is empty. The call to max() over an empty
generator then raises ValueError. Guard against this by skipping to the next
driver iteration when no tests are found, matching the behavior of run() which
also short-circuits on an empty test set.

* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.print_expectations): Guard against ValueError when no tests are found.
* Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py:
(test_print_expectations_no_tests_found): Added test for the case when no tests
are found.

Canonical link: <a href="https://commits.webkit.org/316162@main">https://commits.webkit.org/316162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6afdc0c77386c5476c19215a403152025e065127

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132818 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93622 "13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113318 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/169661 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32955 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28398 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182299 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37120 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141267 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43920 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141087 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44609 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29630 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109048 "The change is no longer eligible for processing.") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/26064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36355 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43119 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7733 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42525 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->