### PR TITLE
[CMake] Copy test resources into TestWebKitAPIResources.bundle instead of symlinking

### DIFF
--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -429,7 +429,7 @@ function(_testwebkitapi_stage_resources source_root skip_pattern)
         get_filename_component(_dst_dir "${_dst}" DIRECTORY)
         file(MAKE_DIRECTORY "${_dst_dir}")
         add_custom_command(OUTPUT "${_dst}"
-            COMMAND ${CMAKE_COMMAND} -E create_symlink "${_src}" "${_dst}"
+            COMMAND ${CMAKE_COMMAND} -E copy "${_src}" "${_dst}"
             MAIN_DEPENDENCY "${_src}"
             VERBATIM
         )


### PR DESCRIPTION
#### a7a82ef808090ad3313aa07271e948bd41227bc1
<pre>
[CMake] Copy test resources into TestWebKitAPIResources.bundle instead of symlinking
<a href="https://bugs.webkit.org/show_bug.cgi?id=317902">https://bugs.webkit.org/show_bug.cgi?id=317902</a>
<a href="https://rdar.apple.com/180688173">rdar://180688173</a>

Reviewed by Per Arne Vollan.

Symlinks in TestWebKitAPIResources.bundle resolve to their canonical path in the source tree, which is outside
WEBKIT2_FRAMEWORK_DIR. The WebContent sandbox profile only allows file-issue-extension for subpaths of
WEBKIT2_FRAMEWORK_DIR, so the kernel denies the extension and file URL loads fail. Copying instead of symlinking keeps
the canonical path inside the build directory where the sandbox rule permits it.

This fixes API test failures like SiteIsolation.LocalIframeOpensBlobURLFromFileMainFrame and WKWebView.LoadTwoFiles
when running with a CMake-built TestWebKitAPI.

* Tools/TestWebKitAPI/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/315906@main">https://commits.webkit.org/315906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/122a2030865cc3c800f160d3d8ed72c9bb5313b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128054 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7530e89-fca3-4460-b371-48601ef70689) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76946928-24cf-44d3-a603-f934d4e294bd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113320 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f0ad5c8-b1d4-442d-b7f7-ff7e76218afb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28400 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182301 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37122 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141268 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43922 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141088 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38017 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44611 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109049 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36356 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43121 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7736 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->