### PR TITLE
[JSC] Enable RegExp atom fast path for unicode patterns

### DIFF
--- a/JSTests/microbenchmarks/global-atom-match-multi-chars-unicode-sets.js
+++ b/JSTests/microbenchmarks/global-atom-match-multi-chars-unicode-sets.js
@@ -1,0 +1,10 @@
+function test(str, regexp) {
+    str.match(regexp);
+}
+noInline(test);
+
+let str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+let regexp = /aaaaa/gv;
+for (let i = 0; i < 1e4; i++) {
+    test(str, regexp);
+}

--- a/JSTests/microbenchmarks/global-atom-match-multi-chars-unicode.js
+++ b/JSTests/microbenchmarks/global-atom-match-multi-chars-unicode.js
@@ -1,0 +1,10 @@
+function test(str, regexp) {
+    str.match(regexp);
+}
+noInline(test);
+
+let str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+let regexp = /aaaaa/gu;
+for (let i = 0; i < 1e4; i++) {
+    test(str, regexp);
+}

--- a/JSTests/microbenchmarks/global-atom-match-one-char-unicode.js
+++ b/JSTests/microbenchmarks/global-atom-match-one-char-unicode.js
@@ -1,0 +1,10 @@
+function test(str, regexp) {
+    str.match(regexp);
+}
+noInline(test);
+
+let str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+let regexp = /a/gu;
+for (let i = 0; i < 1e4; i++) {
+    test(str, regexp);
+}

--- a/JSTests/stress/regexp-unicode-atom-fast-path.js
+++ b/JSTests/stress/regexp-unicode-atom-fast-path.js
@@ -1,0 +1,136 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(JSON.stringify(actual), JSON.stringify(expected));
+}
+
+// Multi-char atom under unicode flag.
+{
+    let str = "ab cd ab cd ab";
+    shouldBeArray(str.match(/ab/gu), ["ab", "ab", "ab"]);
+    shouldBeArray(str.match(/ab/gv), ["ab", "ab", "ab"]);
+    shouldBe(str.replace(/ab/gu, "X"), "X cd X cd X");
+    shouldBeArray(str.split(/ab/u), ["", " cd ", " cd ", ""]);
+}
+
+// Single-char atom under unicode flag.
+{
+    let str = "aaa";
+    shouldBeArray(str.match(/a/gu), ["a", "a", "a"]);
+    shouldBe(str.search(/a/u), 0);
+    shouldBe("xyz".search(/a/u), -1);
+}
+
+// exec / test fast path.
+{
+    let re = /ab/u;
+    let m = re.exec("xxabyy");
+    shouldBe(m.index, 2);
+    shouldBe(m[0], "ab");
+    shouldBe(/ab/u.test("xxabyy"), true);
+    shouldBe(/ab/u.test("xxaayy"), false);
+}
+
+// 16-bit input with surrogate pairs: atom must not match inside a surrogate pair.
+{
+    // U+10000 is "𐀀". Atom "ab" must not be confused.
+    let str = "\u{10000}ab\u{10000}ab";
+    shouldBeArray(str.match(/ab/gu), ["ab", "ab"]);
+    shouldBe(str.replace(/ab/gu, ""), "\u{10000}\u{10000}");
+}
+
+// Non-BMP fixed string: must NOT take atom fast path (still correct via Yarr).
+{
+    let str = "\u{1F600}x\u{1F600}";
+    shouldBeArray(str.match(/\u{1F600}/gu), ["\u{1F600}", "\u{1F600}"]);
+}
+
+// Lone-surrogate pattern: must NOT take atom fast path under unicode.
+// In unicode mode, /\uD800/u does NOT match the lead surrogate of a paired surrogate.
+{
+    let paired = "𐀀"; // U+10000
+    shouldBe(/\uD800/u.test(paired), false);
+    shouldBe(/\uD800/u.test("\uD800x"), true);
+    shouldBe(paired.match(/\uD800/gu), null);
+}
+
+// Lone trail surrogate.
+{
+    let paired = "𐀀";
+    shouldBe(/\uDC00/u.test(paired), false);
+    shouldBe(/\uDC00/u.test("x\uDC00"), true);
+}
+
+// Non-unicode lone surrogate: still takes atom path (no surrogate-pair semantics).
+{
+    let paired = "𐀀";
+    shouldBe(/\uD800/.test(paired), true);
+    shouldBeArray(paired.match(/\uD800/g), ["\uD800"]);
+}
+
+// RegExp.$_ etc. should reflect the last match.
+{
+    "xxabyy".match(/ab/gu);
+    shouldBe(RegExp.lastMatch, "ab");
+    shouldBe(RegExp.leftContext, "xx");
+    shouldBe(RegExp.rightContext, "yy");
+}
+
+// 16-bit BMP atom (non-ASCII, non-surrogate).
+{
+    let str = "あいあい";
+    shouldBeArray(str.match(/あ/gu), ["あ", "あ"]);
+    shouldBeArray(str.match(/あい/gu), ["あい", "あい"]);
+}
+
+// Boundary BMP characters adjacent to surrogate range.
+{
+    shouldBeArray("퟿퟿".match(/퟿/gu), ["퟿", "퟿"]);
+    shouldBeArray("".match(//gu), ["", ""]);
+}
+
+// Input contains broken trail surrogate before atom.
+{
+    shouldBeArray("\uDC00ab".match(/ab/gu), ["ab"]);
+    shouldBe("\uDC00ab".search(/ab/u), 1);
+}
+
+// Mixed BMP-and-surrogate atom must NOT be extracted.
+{
+    shouldBeArray("a\uD800x".match(/a\uD800/gu), ["a\uD800"]);
+    shouldBe("a\u{10000}x".match(/a\uD800/gu), null);
+}
+
+// dotAll flag does not affect fixed-string atoms.
+{
+    shouldBeArray("a.b a.b".match(/a/gsu), ["a", "a"]);
+}
+
+// matchAll iterator.
+{
+    let indices = [];
+    for (let m of "ab-ab".matchAll(/ab/gu))
+        indices.push(m.index);
+    shouldBeArray(indices, [0, 3]);
+}
+
+// replace and replaceAll.
+{
+    shouldBe("ab-ab-ab".replace(/ab/gu, "X"), "X-X-X");
+    shouldBe("ab-ab-ab".replaceAll(/ab/gu, ""), "--");
+    shouldBe("ab-ab".replace(/ab/u, "X"), "X-ab");
+}
+
+// JIT tier-up consistency.
+{
+    function f(s) { return s.match(/ab/gu); }
+    noInline(f);
+    for (let i = 0; i < 10000; i++) {
+        let r = f("xxab--ab");
+        if (r.length !== 2 || r[0] !== "ab" || r[1] !== "ab")
+            throw new Error("JIT tier-up mismatch at " + i);
+    }
+}

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2387,8 +2387,6 @@ public:
             return;
         if (m_pattern.sticky())
             return;
-        if (m_pattern.eitherUnicode())
-            return;
         if (m_pattern.ignoreCase())
             return;
 
@@ -2414,6 +2412,8 @@ public:
                 if (term.inputPosition != index)
                     return false;
                 if (U16_LENGTH(term.patternCharacter) != 1)
+                    return false;
+                if (m_pattern.eitherUnicode() && U_IS_SURROGATE(term.patternCharacter))
                     return false;
                 if (term.m_matchDirection != MatchDirection::Forward)
                     return false;
@@ -2617,6 +2617,9 @@ public:
         };
 
         if (tryExtractAtom())
+            return;
+
+        if (m_pattern.eitherUnicode())
             return;
 
         if (tryExtractSpaces())


### PR DESCRIPTION
#### 3dfb0a4b80bec46492dede7339c6b72cbbba436e
<pre>
[JSC] Enable RegExp atom fast path for unicode patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=317903">https://bugs.webkit.org/show_bug.cgi?id=317903</a>

Reviewed by Yusuke Suzuki.

setupSpecificPattern() bails out early when the pattern has the /u or
/v flag, so a fixed-string pattern such as /ab/gu does not get its atom
extracted and hasValidAtom() stays false. This forces String#match,
String#split, String#replace and RegExp#exec/#test to call into Yarr
for every match instead of using the StringSearch / countMatchedCharacters
based fast paths in collectGlobalAtomMatches, stringSplitFast and
RegExp::matchInline.

Allow tryExtractAtom() to run for unicode patterns. The extracted atom
is restricted to non-surrogate BMP code units (U16_LENGTH == 1 and
!U_IS_SURROGATE), so a code-unit based StringSearch produces the same
matches as a unicode code-point based search: each atom character is a
single code point that can never overlap a surrogate pair in the input,
and the atom is non-empty so AdvanceStringIndex is never reached. V8
applies the same condition for its ATOM regexp type.

Keep the eitherUnicode() bail-out for the remaining SpecificPattern
kinds (leading/trailing spaces, newlines).

                                              Baseline                  Patched

global-atom-match-one-char-unicode          5.6361+-0.1098     ^      0.5202+-0.0725        ^ definitely 10.8351x faster
global-atom-match-multi-chars-unicode       1.6494+-0.0645     ^      0.8089+-0.0287        ^ definitely 2.0390x faster
global-atom-match-multi-chars-unicode-sets  1.6130+-0.0512     ^      0.8415+-0.0447        ^ definitely 1.9169x faster

Tests: JSTests/microbenchmarks/global-atom-match-multi-chars-unicode-sets.js
       JSTests/microbenchmarks/global-atom-match-multi-chars-unicode.js
       JSTests/microbenchmarks/global-atom-match-one-char-unicode.js
       JSTests/stress/regexp-unicode-atom-fast-path.js

* JSTests/microbenchmarks/global-atom-match-multi-chars-unicode-sets.js: Added.
(test):
* JSTests/microbenchmarks/global-atom-match-multi-chars-unicode.js: Added.
(test):
* JSTests/microbenchmarks/global-atom-match-one-char-unicode.js: Added.
(test):
* JSTests/stress/regexp-unicode-atom-fast-path.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBeArray.str.split):
(shouldBe.f):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::extractSpecificPattern):

Canonical link: <a href="https://commits.webkit.org/315965@main">https://commits.webkit.org/315965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c357103e8a4bc1bc2feb1a58982842bfe765189

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179717 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128055 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132821 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93625 "1 flakes 13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32958 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28401 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1667 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182302 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31598 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141269 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43923 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141089 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38052 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44612 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109050 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36357 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116494 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203022 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43122 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7737 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54394 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42528 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->