### PR TITLE
Only use ProcessStateMonitor on processes that are managed by RunningBoard

### DIFF
--- a/Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h
+++ b/Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h
@@ -32,6 +32,7 @@ DECLARE_SYSTEM_HEADER
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <RunningBoardServices/RunningBoardServices.h>
+#import <RunningBoardServices/RBSProcessHandle_Private.h>
 
 extern const NSTimeInterval RBSProcessTimeLimitationNone;
 
@@ -122,6 +123,7 @@ extern const NSTimeInterval RBSProcessTimeLimitationNone;
 + (RBSProcessHandle *)handleForIdentifier:(RBSProcessIdentifier *)identifier error:(NSError **)outError;
 + (RBSProcessHandle *)currentProcess;
 @property (nonatomic, readonly, assign) pid_t pid;
+@property (nonatomic, readonly, assign, getter=isManaged) BOOL managed;
 @property (nonatomic, readonly, strong) RBSProcessState *currentState;
 @property (nonatomic, readonly, strong) RBSProcessLimitations *activeLimitations;
 @property (nonatomic, readonly, strong, nullable) RBSProcessHandle *hostProcess;

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.h
@@ -39,10 +39,9 @@ namespace WebKit {
 class ProcessStateMonitor : public RefCountedAndCanMakeWeakPtr<ProcessStateMonitor> {
     WTF_MAKE_TZONE_ALLOCATED(ProcessStateMonitor);
 public:
-    static Ref<ProcessStateMonitor> create(Function<void(bool)>&& becomeSuspendedHandler)
-    {
-        return adoptRef(*new ProcessStateMonitor(WTF::move(becomeSuspendedHandler)));
-    }
+    // This may return nullptr if process tracking is not available (e.g. the current process is not
+    // managed by RunningBoard).
+    static RefPtr<ProcessStateMonitor> create(Function<void(bool)>&& becomeSuspendedHandler);
 
     ~ProcessStateMonitor();
     void processWillBeSuspendedImmediately();

--- a/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
+++ b/Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm
@@ -32,6 +32,7 @@
 #import "NetworkProcessMessages.h"
 #import "ProcessAssertion.h"
 #import "RunningBoardServicesSPI.h"
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -39,6 +40,16 @@ namespace WebKit {
 static constexpr double maxPrepareForSuspensionDelayInSecond = 15;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessStateMonitor);
+
+RefPtr<ProcessStateMonitor> ProcessStateMonitor::create(Function<void(bool)>&& becomeSuspendedHandler)
+{
+    // FIXME: this bundle ID check is a short term fix; it should eventually check
+    // -[RBSProcessHandle isManaged].
+    if (applicationBundleIdentifier() == "com.apple.textunderstandingd"_s)
+        return nullptr;
+
+    return adoptRef(*new ProcessStateMonitor(WTF::move(becomeSuspendedHandler)));
+}
 
 ProcessStateMonitor::ProcessStateMonitor(Function<void(bool)>&& becomeSuspendedHandler)
     : m_becomeSuspendedHandler(WTF::move(becomeSuspendedHandler))


### PR DESCRIPTION
#### 2a667bb936d24418a4a6def1f0fb90f23ed00186
<pre>
Only use ProcessStateMonitor on processes that are managed by RunningBoard
<a href="https://bugs.webkit.org/show_bug.cgi?id=317905">https://bugs.webkit.org/show_bug.cgi?id=317905</a>
<a href="https://rdar.apple.com/180159037">rdar://180159037</a>

Reviewed by Per Arne Vollan.

There are some daemons that use WebKit to load webpages, but which are not managed by
RunningBoard. This doesn&apos;t work with ProcessStateMonitor, which we install once processes are in the
background (which is basically all the time in daemons).

In particular, a process that is not managed by RunningBoard may still get RunningBoard state
updates. This causes `ProcessStateMonitor::checkRemainingRunTime()` to run. Then
`checkRemainingRunTime()` asks RunningBoard how much time the process has to run before it suspends
via `[[[RBSProcessHandle currentProcess] activeLimitations] runTime]`. For an unmanaged process,
this may return 0.

This then makes us think that the process is about to suspend immediately, which causes us to
invalidate all of the activities tracked by the process, which then causes all WebKit auxiliary
processes to suspend.

In this patch, we disable ProcessStateMonitor for one of the problematic daemons specifically
(textunderstandingd). This will be followed up by a patch that disables creation of the object for
any process that is unmanaged (the only reason we&apos;re not doing that in this patch is to mitigate
risk).

This works because The only client of `ProcessStateMonitor::create` already understands how to deal
with a null return value.

* Source/WebKit/Platform/spi/ios/RunningBoardServicesSPI.h:
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.h:
(WebKit::ProcessStateMonitor::create): Deleted.
* Source/WebKit/UIProcess/ios/ProcessStateMonitor.mm:
(WebKit::ProcessStateMonitor::create):

Canonical link: <a href="https://commits.webkit.org/315902@main">https://commits.webkit.org/315902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a1212d8acfc63478515a1d377ecb79d2ba4a64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170366 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0653f571-4947-4b8a-abaf-8e37ea80621f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132837 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d249ddd-fa0e-45a1-af15-709e79ac27e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/492590cd-edea-40ab-b4ee-93cddfc11c3b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28424 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182326 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43946 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38012 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44635 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29653 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109080 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36377 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116517 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43145 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7756 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42791 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->