### PR TITLE
[Swift in WebKit] Remove unused `CxxVectorIterator` type

### DIFF
--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -99,33 +99,6 @@ extension CxxRefVector {
     }
 }
 
-// Iterator for WTF::Vectors.
-// rdar://169297366 when fixed will conform WTF::Vector directly to Sequence.
-// We can't do that manually since this would require C++ interop types to be public
-struct CxxVectorIterator<Vec: CxxVector>: Sequence, IteratorProtocol {
-    typealias Element = Vec.Element
-    var vec: Vec
-    var pos: Int
-
-    init(vec: Vec) {
-        self.vec = vec
-        self.pos = 0
-    }
-
-    mutating func next() -> Vec.Element? {
-        if pos >= vec.size() {
-            return nil
-        }
-        // Safety: we'll make a copy of the referent
-        // before the vector goes out of scope. It's guaranteed
-        // to have a valid lifetime, be initialized, and be
-        // within the vector bounds.
-        let item = unsafe vec.__atUnsafe(pos)
-        pos += 1
-        return unsafe item.pointee
-    }
-}
-
 #endif // ENABLE_BACK_FORWARD_LIST_SWIFT
 
 #endif // compiler(>=6.2.3)


### PR DESCRIPTION
#### 75890f1de6b87ac31886327b0432f8362c84ffac
<pre>
[Swift in WebKit] Remove unused `CxxVectorIterator` type
<a href="https://bugs.webkit.org/show_bug.cgi?id=317906">https://bugs.webkit.org/show_bug.cgi?id=317906</a>
<a href="https://rdar.apple.com/180692182">rdar://180692182</a>

Reviewed by Adrian Taylor.

* Source/WebKit/UIProcess/StdlibExtras.swift:
(CxxVectorIterator.vec): Deleted.
(CxxVectorIterator.pos): Deleted.
(CxxVectorIterator.next): Deleted.

Canonical link: <a href="https://commits.webkit.org/315873@main">https://commits.webkit.org/315873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2a710ea6212f552bb27e6bd0ce194e02452e72d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128060 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b96cf450-d869-4882-a877-7bc05dc8f2a0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132825 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f10183d-d4c8-46b3-802d-fab85afed580) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173307 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113325 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3ca6fb5-d89e-482b-8f52-b550146bd6f9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28406 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182307 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35097 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141273 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43928 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141093 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37983 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44617 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109059 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36362 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116499 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43127 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7740 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42533 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42773 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->