### PR TITLE
[JSC] Handle `Object.isExtensible()` in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/object-is-extensible.js
+++ b/JSTests/microbenchmarks/object-is-extensible.js
@@ -1,0 +1,108 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function objectIsExtensiblePlain(o)
+{
+    return Object.isExtensible(o);
+}
+noInline(objectIsExtensiblePlain);
+
+(function() {
+    var o = {};
+    for (var i = 0; i < 1e6; ++i) {
+        if (objectIsExtensiblePlain(o) !== true)
+            throw new Error("bad result");
+    }
+})();
+
+function objectIsExtensibleNonExtensible(o)
+{
+    return Object.isExtensible(o);
+}
+noInline(objectIsExtensibleNonExtensible);
+
+(function() {
+    var o = Object.preventExtensions({});
+    for (var i = 0; i < 1e6; ++i) {
+        if (objectIsExtensibleNonExtensible(o) !== false)
+            throw new Error("bad result");
+    }
+})();
+
+function objectIsExtensibleSealedOrFrozen(o)
+{
+    return Object.isExtensible(o);
+}
+noInline(objectIsExtensibleSealedOrFrozen);
+
+(function() {
+    var sealed = Object.seal({ a: 1 });
+    var frozen = Object.freeze({ b: 2 });
+    for (var i = 0; i < 1e6; ++i) {
+        var o = (i % 2 === 0) ? sealed : frozen;
+        if (objectIsExtensibleSealedOrFrozen(o) !== false)
+            throw new Error("bad result");
+    }
+})();
+
+function objectIsExtensibleNotObject(v)
+{
+    return Object.isExtensible(v);
+}
+noInline(objectIsExtensibleNotObject);
+
+(function() {
+    for (var i = 0; i < 1e6; ++i) {
+        if (objectIsExtensibleNotObject(42) !== false)
+            throw new Error("bad result");
+        if (objectIsExtensibleNotObject("str") !== false)
+            throw new Error("bad result");
+        if (objectIsExtensibleNotObject(null) !== false)
+            throw new Error("bad result");
+    }
+})();
+
+function objectIsExtensibleProxy(o)
+{
+    return Object.isExtensible(o);
+}
+noInline(objectIsExtensibleProxy);
+
+(function() {
+    var target = {};
+    var proxy = new Proxy(target, {});
+    for (var i = 0; i < 1e5; ++i) {
+        if (objectIsExtensibleProxy(proxy) !== true)
+            throw new Error("bad result");
+    }
+    Object.preventExtensions(target);
+    for (var i = 0; i < 1e5; ++i) {
+        if (objectIsExtensibleProxy(proxy) !== false)
+            throw new Error("bad result");
+    }
+})();
+
+function objectIsExtensibleMixed(v)
+{
+    return Object.isExtensible(v);
+}
+noInline(objectIsExtensibleMixed);
+
+(function() {
+    var extensible = {};
+    var nonExtensible = Object.preventExtensions({});
+    for (var i = 0; i < 1e6; ++i) {
+        switch (i % 4) {
+        case 0:
+            objectIsExtensibleMixed(extensible);
+            break;
+        case 1:
+            objectIsExtensibleMixed(nonExtensible);
+            break;
+        case 2:
+            objectIsExtensibleMixed(7);
+            break;
+        case 3:
+            objectIsExtensibleMixed("hi");
+            break;
+        }
+    }
+})();

--- a/JSTests/stress/object-is-extensible-jstypes.js
+++ b/JSTests/stress/object-is-extensible-jstypes.js
@@ -1,0 +1,54 @@
+function assert(b) {
+    if (!b)
+        throw new Error("Bad assertion");
+}
+
+function testFast(o, expected) {
+    return Object.isExtensible(o);
+}
+noInline(testFast);
+
+function testGeneric(v, expected) {
+    return Object.isExtensible(v);
+}
+noInline(testGeneric);
+
+function makeArguments() {
+    return arguments;
+}
+
+var cases = [
+    { make: () => makeArguments(1, 2, 3), name: "DirectArguments" },
+    { make: () => (function() { "use strict"; return arguments; })(1, 2, 3), name: "ScopedArguments" },
+    { make: () => [1, 2, 3], name: "Array" },
+    { make: () => new ArrayBuffer(8), name: "ArrayBuffer" },
+    { make: () => new Int32Array(4), name: "Int32Array" },
+    { make: () => new Float64Array(4), name: "Float64Array" },
+    { make: () => new DataView(new ArrayBuffer(8)), name: "DataView" },
+    { make: () => /abc/, name: "RegExp" },
+    { make: () => new Date(), name: "Date" },
+];
+
+for (var testCase of cases) {
+    var extensible = testCase.make();
+    var nonExtensible = Object.preventExtensions(testCase.make());
+
+    for (var i = 0; i < 20000; ++i) {
+        assert(testFast(extensible) === true);
+        assert(testFast(nonExtensible) === false);
+        assert(testGeneric(extensible) === true);
+        assert(testGeneric(nonExtensible) === false);
+    }
+}
+
+// Mixed/polymorphic call sites, to also cover the megamorphic feedback case.
+(function() {
+    var extensibleObjs = cases.map(c => c.make());
+    var nonExtensibleObjs = cases.map(c => Object.preventExtensions(c.make()));
+
+    for (var i = 0; i < 20000; ++i) {
+        var idx = i % cases.length;
+        assert(testGeneric(extensibleObjs[idx]) === true);
+        assert(testGeneric(nonExtensibleObjs[idx]) === false);
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2110,6 +2110,34 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case ObjectIsExtensible: {
+        AbstractValue& child = forNode(node->child1());
+        if (!child.couldBeType(SpecObject)) {
+            didFoldClobberWorld();
+            setConstant(node, jsBoolean(false));
+            break;
+        }
+        if (!child.couldBeType(SpecProxyObject | SpecGlobalProxy)) {
+            didFoldClobberWorld();
+            if (child.m_structure.isFinite() && !child.m_structure.isClear()) {
+                bool allNonExtensible = true;
+                child.m_structure.forEach([&](RegisteredStructure structure) {
+                    if (structure->isStructureExtensible())
+                        allNonExtensible = false;
+                });
+                if (allNonExtensible) {
+                    setConstant(node, jsBoolean(false));
+                    break;
+                }
+            }
+            setNonCellTypeForNode(node, SpecBoolean);
+            break;
+        }
+        clobberWorld();
+        setNonCellTypeForNode(node, SpecBoolean);
+        break;
+    }
+
     case NumberIsNaN: {
         AbstractValue& child = forNode(node->child1());
         if (JSValue value = child.value()) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3964,6 +3964,15 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case ObjectIsExtensibleIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            setResult(addToGraph(ObjectIsExtensible, get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            return CallOptimizationResult::Inlined;
+        }
+
         case ObjectIsIntrinsic: {
             if (argumentCountIncludingThis < 3)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -870,6 +870,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case ObjectGetOwnPropertyNames:
     case ObjectGetOwnPropertySymbols:
     case ObjectToString:
+    case ObjectIsExtensible:
     case ReflectOwnKeys:
         clobberTop();
         return;

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1703,6 +1703,35 @@ private:
                 break;
             }
 
+            case ObjectIsExtensible: {
+                AbstractValue& child = m_state.forNode(node->child1());
+                if (!child.couldBeType(SpecObject)) {
+                    m_interpreter.execute(indexInBlock);
+                    alreadyHandled = true;
+                    m_insertionSet.insertCheck(m_graph, indexInBlock, node);
+                    m_graph.convertToConstant(node, jsBoolean(false));
+                    changed = true;
+                    break;
+                }
+                if (!child.couldBeType(SpecProxyObject | SpecGlobalProxy)
+                    && child.m_structure.isFinite() && !child.m_structure.isClear()) {
+                    bool allNonExtensible = true;
+                    child.m_structure.forEach([&](RegisteredStructure structure) {
+                        if (structure->isStructureExtensible())
+                            allNonExtensible = false;
+                    });
+                    if (allNonExtensible) {
+                        m_interpreter.execute(indexInBlock);
+                        alreadyHandled = true;
+                        m_insertionSet.insertCheck(m_graph, indexInBlock, node);
+                        m_graph.convertToConstant(node, jsBoolean(false));
+                        changed = true;
+                        break;
+                    }
+                }
+                break;
+            }
+
             case GetScope: {
                 if (JSValue base = m_state.forNode(node->child1()).m_value) {
                     if (JSFunction* function = dynamicDowncast<JSFunction>(base)) {

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -413,6 +413,7 @@ bool doesGC(Graph& graph, Node* node)
     case ObjectGetOwnPropertyNames:
     case ObjectGetOwnPropertySymbols:
     case ObjectToString:
+    case ObjectIsExtensible:
     case SymbolToString:
     case ReflectOwnKeys:
     case AllocatePropertyStorage:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2996,6 +2996,11 @@ private:
             break;
         }
 
+        case ObjectIsExtensible: {
+            fixEdge<UntypedUse>(node->child1());
+            break;
+        }
+
         case HasStructureWithFlags: {
             fixEdge<KnownCellUse>(node->child1());
             break;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -325,6 +325,7 @@ namespace JSC { namespace DFG {
     macro(ObjectGetOwnPropertyNames, NodeMustGenerate | NodeResultJS) \
     macro(ObjectGetOwnPropertySymbols, NodeMustGenerate | NodeResultJS) \
     macro(ObjectToString, NodeMustGenerate | NodeResultJS) \
+    macro(ObjectIsExtensible, NodeMustGenerate | NodeResultBoolean) \
     macro(ReflectOwnKeys, NodeMustGenerate | NodeResultJS) \
     macro(SymbolToString, NodeResultJS) \
     \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3221,6 +3221,19 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIsArray, size_t, (JSGlobalObject* globalO
     OPERATION_RETURN(scope, isArraySlow(globalObject, uncheckedDowncast<ProxyObject>(value.asCell())));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationObjectIsExtensible, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedValue))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue value = JSValue::decode(encodedValue);
+    ASSERT(value.isCell() && value.asCell()->isObject());
+    bool isExtensible = asObject(value.asCell())->isExtensible(globalObject);
+    OPERATION_RETURN(scope, isExtensible);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationTypeOfObject, JSCell*, (JSGlobalObject* globalObject, JSCell* object))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -288,6 +288,7 @@ JSC_DECLARE_JIT_OPERATION(operationTypeOfIsFunction, size_t, (JSGlobalObject*, J
 JSC_DECLARE_JIT_OPERATION(operationObjectIsCallable, size_t, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationIsConstructor, size_t, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationArrayIsArray, size_t, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationObjectIsExtensible, size_t, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationTypeOfObject, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorageWithInitialCapacity, Butterfly*, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorage, Butterfly*, (VM*, size_t newSize));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1319,6 +1319,7 @@ private:
         case IsConstructor:
         case IsCellWithType:
         case ArrayIsArray:
+        case ObjectIsExtensible:
         case HasStructureWithFlags:
         case MatchStructure: {
             setPrediction(SpecBoolean);

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -287,6 +287,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case IsConstructor:
     case IsCellWithType:
     case ArrayIsArray:
+    case ObjectIsExtensible:
     case HasStructureWithFlags:
     case TypeOf:
     case ToBoolean:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -4779,6 +4779,71 @@ void SpeculativeJIT::compileArrayIsArray(Node* node)
     unblessedBooleanResult(resultGPR, node);
 }
 
+void SpeculativeJIT::compileObjectIsExtensible(Node* node)
+{
+    if (node->child1().useKind() == ObjectUse) {
+        SpeculateCellOperand value(this, node->child1());
+        GPRTemporary result(this);
+#if USE(JSVALUE32_64)
+        GPRTemporary valueTag(this);
+        GPRReg valueTagGPR = valueTag.gpr();
+#endif
+
+        GPRReg valueGPR = value.gpr();
+        GPRReg resultGPR = result.gpr();
+
+        speculateObject(node->child1(), valueGPR);
+
+#if USE(JSVALUE32_64)
+        move(TrustedImm32(JSValue::CellTag), valueTagGPR);
+#endif
+        load8(Address(valueGPR, JSCell::typeInfoTypeOffset()), resultGPR);
+        sub32(TrustedImm32(ProxyObjectType), resultGPR);
+        static_assert(GlobalProxyType == ProxyObjectType + 1);
+        Jump isProxyLike = branch32(BelowOrEqual, resultGPR, TrustedImm32(GlobalProxyType - ProxyObjectType));
+
+        emitLoadStructure(vm(), valueGPR, resultGPR);
+        test32(Zero, Address(resultGPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_didPreventExtensionsBits), resultGPR);
+        Jump done = jump();
+
+#if USE(JSVALUE32_64)
+        addSlowPathGenerator(slowPathCall(isProxyLike, this, operationObjectIsExtensible, resultGPR, LinkableConstant::globalObject(*this, node), JSValueRegs(valueTagGPR, valueGPR)));
+#else
+        addSlowPathGenerator(slowPathCall(isProxyLike, this, operationObjectIsExtensible, resultGPR, LinkableConstant::globalObject(*this, node), JSValueRegs(valueGPR)));
+#endif
+
+        done.link(this);
+        unblessedBooleanResult(resultGPR, node);
+        return;
+    }
+
+    JSValueOperand value(this, node->child1());
+    GPRTemporary result(this);
+
+    JSValueRegs valueRegs = value.jsValueRegs();
+    GPRReg resultGPR = result.gpr();
+
+    Jump isNotCell = branchIfNotCell(valueRegs);
+
+    load8(Address(valueRegs.payloadGPR(), JSCell::typeInfoTypeOffset()), resultGPR);
+    Jump isNotObject = branch32(Below, resultGPR, TrustedImm32(ObjectType));
+    sub32(TrustedImm32(ProxyObjectType), resultGPR);
+    Jump isProxyLike = branch32(BelowOrEqual, resultGPR, TrustedImm32(GlobalProxyType - ProxyObjectType));
+
+    emitLoadStructure(vm(), valueRegs.payloadGPR(), resultGPR);
+    test32(Zero, Address(resultGPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_didPreventExtensionsBits), resultGPR);
+    Jump done = jump();
+
+    isNotCell.link(this);
+    isNotObject.link(this);
+    move(TrustedImm32(0), resultGPR);
+
+    addSlowPathGenerator(slowPathCall(isProxyLike, this, operationObjectIsExtensible, resultGPR, LinkableConstant::globalObject(*this, node), valueRegs));
+
+    done.link(this);
+    unblessedBooleanResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileHasStructureWithFlags(Node* node)
 {
     SpeculateCellOperand object(this, node->child1());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -661,6 +661,7 @@ public:
 
     void compileIsCellWithType(Node*);
     void compileArrayIsArray(Node*);
+    void compileObjectIsExtensible(Node*);
 
     void emitCall(Node*);
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3757,7 +3757,6 @@ void SpeculativeJIT::compile(Node* node)
     case ArithAbs:
         compileArithAbs(node);
         break;
-        
     case ArithMin:
     case ArithMax: {
         compileArithMinMax(node);
@@ -5896,6 +5895,11 @@ void SpeculativeJIT::compile(Node* node)
 
     case ArrayIsArray: {
         compileArrayIsArray(node);
+        break;
+    }
+
+    case ObjectIsExtensible: {
+        compileObjectIsExtensible(node);
         break;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -333,6 +333,7 @@ inline CapabilityLevel canCompile(DFG::Node* node)
     case IsCallable:
     case IsConstructor:
     case ArrayIsArray:
+    case ObjectIsExtensible:
     case CheckTypeInfoFlags:
     case HasStructureWithFlags:
     case OverridesHasInstance:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1667,6 +1667,9 @@ private:
         case ArrayIsArray:
             compileArrayIsArray();
             break;
+        case ObjectIsExtensible:
+            compileObjectIsExtensible();
+            break;
         case MapHash:
             compileMapHash();
             break;
@@ -16169,6 +16172,89 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(continuation, lastNext);
         setBoolean(m_out.phi(Int32, notCellResult, arrayResult, otherCellResult, slowResult));
+    }
+
+    void compileObjectIsExtensible()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        if (m_node->child1().useKind() == ObjectUse) {
+            LValue value = lowCell(m_node->child1());
+
+            LBasicBlock fastCase = m_out.newBlock();
+            LBasicBlock slowPathBlock = m_out.newBlock();
+            LBasicBlock continuation = m_out.newBlock();
+
+            LBasicBlock lastNext = m_out.insertNewBlocksBefore(fastCase);
+            LValue type = m_out.load8ZeroExt32(value, m_heaps.JSCell_typeInfoType);
+            static_assert(GlobalProxyType == ProxyObjectType + 1);
+            LValue typeBiased = m_out.sub(type, m_out.constInt32(ProxyObjectType));
+            m_out.branch(m_out.belowOrEqual(typeBiased, m_out.constInt32(GlobalProxyType - ProxyObjectType)),
+                rarely(slowPathBlock), usually(fastCase));
+
+            m_out.appendTo(fastCase, slowPathBlock);
+            LValue structure = loadStructure(value);
+            LValue structureFlags = m_out.load32(structure, m_heaps.Structure_bitField);
+            ValueFromBlock fastResult = m_out.anchor(m_out.testIsZero32(structureFlags, m_out.constInt32(Structure::s_didPreventExtensionsBits)));
+            m_out.jump(continuation);
+
+            m_out.appendTo(slowPathBlock, continuation);
+            VM& vm = this->vm();
+            LValue slowResultValue = lazySlowPath(
+                [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                    return createLazyCallGenerator(vm,
+                        operationObjectIsExtensible, locations[0].directGPR(),
+                        CCallHelpers::TrustedImmPtr(globalObject), locations[1].directGPR());
+                }, value);
+            ValueFromBlock slowResult = m_out.anchor(m_out.notNull(slowResultValue));
+            m_out.jump(continuation);
+
+            m_out.appendTo(continuation, lastNext);
+            setBoolean(m_out.phi(Int32, fastResult, slowResult));
+            return;
+        }
+
+        LValue value = lowJSValue(m_node->child1());
+
+        LBasicBlock isCellCase = m_out.newBlock();
+        LBasicBlock proxyCheckBlock = m_out.newBlock();
+        LBasicBlock fastCase = m_out.newBlock();
+        LBasicBlock slowPathBlock = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        ValueFromBlock notCellResult = m_out.anchor(m_out.booleanFalse);
+        m_out.branch(isCell(value, provenType(m_node->child1())), usually(isCellCase), rarely(continuation));
+
+        LBasicBlock lastNext = m_out.appendTo(isCellCase, proxyCheckBlock);
+        LValue type = m_out.load8ZeroExt32(value, m_heaps.JSCell_typeInfoType);
+        ValueFromBlock notObjectResult = m_out.anchor(m_out.booleanFalse);
+        m_out.branch(m_out.below(type, m_out.constInt32(ObjectType)),
+            rarely(continuation), usually(proxyCheckBlock));
+
+        m_out.appendTo(proxyCheckBlock, fastCase);
+        LValue typeBiased = m_out.sub(type, m_out.constInt32(ProxyObjectType));
+        m_out.branch(m_out.belowOrEqual(typeBiased, m_out.constInt32(GlobalProxyType - ProxyObjectType)),
+            rarely(slowPathBlock), usually(fastCase));
+
+        m_out.appendTo(fastCase, slowPathBlock);
+        LValue structure = loadStructure(value);
+        LValue structureFlags = m_out.load32(structure, m_heaps.Structure_bitField);
+        ValueFromBlock fastResult = m_out.anchor(m_out.testIsZero32(structureFlags, m_out.constInt32(Structure::s_didPreventExtensionsBits)));
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowPathBlock, continuation);
+        VM& vm = this->vm();
+        LValue slowResultValue = lazySlowPath(
+            [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                return createLazyCallGenerator(vm,
+                    operationObjectIsExtensible, locations[0].directGPR(),
+                    CCallHelpers::TrustedImmPtr(globalObject), locations[1].directGPR());
+            }, value);
+        ValueFromBlock slowResult = m_out.anchor(m_out.notNull(slowResultValue));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBoolean(m_out.phi(Int32, notCellResult, notObjectResult, fastResult, slowResult));
     }
 
     void compileIsObject()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -120,6 +120,7 @@ namespace JSC {
     macro(ObjectGetOwnPropertySymbolsIntrinsic) \
     macro(ObjectGetPrototypeOfIntrinsic) \
     macro(ObjectHasOwnIntrinsic) \
+    macro(ObjectIsExtensibleIntrinsic) \
     macro(ObjectIsIntrinsic) \
     macro(ObjectKeysIntrinsic) \
     macro(ObjectToStringIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -84,7 +84,6 @@ namespace JSC {
     macro(BooleanObjectType, SpecObjectOther) \
     macro(NumberObjectType, SpecObjectOther) \
     macro(ErrorInstanceType, SpecObjectOther) \
-    macro(GlobalProxyType, SpecGlobalProxy) \
     macro(DirectArgumentsType, SpecDirectArguments) \
     macro(ScopedArgumentsType, SpecScopedArguments) \
     macro(ClonedArgumentsType, SpecObjectOther) \
@@ -134,7 +133,10 @@ namespace JSC {
     macro(ShadowRealmType, SpecObjectOther) \
     macro(RegExpObjectType, SpecRegExpObject) \
     macro(JSDateType, SpecDateObject) \
+    /* Start proxy-like types */ \
     macro(ProxyObjectType, SpecProxyObject) \
+    macro(GlobalProxyType, SpecGlobalProxy) \
+    /* End proxy-like types. */ \
     macro(JSGeneratorType, SpecObjectOther) \
     macro(JSAsyncFunctionGeneratorType, SpecObjectOther) \
     macro(JSAsyncGeneratorType, SpecObjectOther) \

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -77,7 +77,7 @@ const ClassInfo ObjectConstructor::s_info = { "Function"_s, &InternalFunction::s
   preventExtensions         objectConstructorPreventExtensions          DontEnum|Function 1
   isSealed                  objectConstructorIsSealed                   DontEnum|Function 1
   isFrozen                  objectConstructorIsFrozen                   DontEnum|Function 1
-  isExtensible              objectConstructorIsExtensible               DontEnum|Function 1
+  isExtensible              objectConstructorIsExtensible               DontEnum|Function 1 ObjectIsExtensibleIntrinsic
   is                        objectConstructorIs                         DontEnum|Function 2 ObjectIsIntrinsic
   assign                    objectConstructorAssign                     DontEnum|Function 2 ObjectAssignIntrinsic
   values                    objectConstructorValues                     DontEnum|Function 1


### PR DESCRIPTION
#### b7abd22509550166eef1d3d4397c8cfe0eec0f52
<pre>
[JSC] Handle `Object.isExtensible()` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=317907">https://bugs.webkit.org/show_bug.cgi?id=317907</a>

Reviewed by NOBODY (OOPS!).

This patch adds `Object.isExtensible()` to DFG and FTL.

The changes improve performance compared to the non-intrinsic implementation.
Before these changes, the benchmark test took about 43 ms,
after the changes it takes 25 ms.

Test:
JSTests/microbenchmarks/object-is-extensible.js
JSTests/stress/object-is-extensible-jstypes.js

* JSTests/microbenchmarks/object-is-extensible.js: Added.
(objectIsExtensiblePlain):
(objectIsExtensibleNonExtensible):
(objectIsExtensibleSealedOrFrozen):
(objectIsExtensibleNotObject):
(objectIsExtensibleProxy):
(objectIsExtensibleMixed):
(i.switch):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7abd22509550166eef1d3d4397c8cfe0eec0f52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/187269 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/61103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197497 "Built successfully") | [⏳ 🛠 win](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/146256 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/190224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48688 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46571 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/8435 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/15266 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/159007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/46336 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8584 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/48443 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/51105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199519 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60737 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155908 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/61449 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155560 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49895 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133607 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/131110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59847 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/21325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/59274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/59384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->