### PR TITLE
Don't register MediaPlayerPrivateWebM / MediaPlayerPrivateMediaSourceAVFObjC for playback in the GPU process when MediaContainment is enabled

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -95,6 +95,10 @@
 #include "MediaPlayerPrivateMediaSourceAVFObjC.h"
 #endif
 
+#if ENABLE(MEDIA_SOURCE)
+#include "MockMediaPlayerMediaSource.h"
+#endif
+
 #if ENABLE(MEDIA_STREAM) && USE(AVFOUNDATION)
 #include "MediaPlayerPrivateMediaStreamAVFObjC.h"
 #endif
@@ -110,7 +114,6 @@
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-#include "MediaDeviceRouteController.h"
 #include "MediaPlayerPrivateWirelessPlayback.h"
 #endif
 
@@ -309,41 +312,40 @@ void RemoteMediaPlayerSupport::setRegisterRemotePlayerCallback(RegisterRemotePla
     registerRemotePlayerCallback() = WTF::move(callback);
 }
 
+bool RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable(MediaEngineRegistrar registrar, MediaPlayerEnums::MediaEngineIdentifier identifier, PlatformMediaDecodingType platformType)
+{
+    auto& callback = registerRemotePlayerCallback();
+    if (!callback)
+        return false;
+    callback(registrar, identifier, platformType);
+    return true;
+}
+
 static void buildMediaEnginesVector() WTF_REQUIRES_LOCK(mediaEngineVectorLock)
 {
     ASSERT(mediaEngineVectorLock.isLocked());
 
 #if USE(AVFOUNDATION)
-    auto& registerRemoteEngine = registerRemotePlayerCallback();
 #if ENABLE(MEDIA_SOURCE)
-    bool useMSERemoteRenderer = hasPlatformStrategies() && platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::AVFoundationMSE);
-    if (!useMSERemoteRenderer && registerRemoteEngine && platformStrategies()->mediaStrategy()->mockMediaSourceEnabled())
-        registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::MockMSE, PlatformMediaDecodingType::MediaSource);
+    // Mock mode disables AVFoundation, so this branch sits outside the
+    // isAVFoundationEnabled() gate. When MediaPlayerPrivateMediaSourceAVFObjC would run in
+    // the GPU process (i.e. MSE is not using a remote renderer), register MockMSE as a
+    // remote proxy so MockMSE runs in the same process as MSE and inherits the same
+    // registration policy.
+    if (hasPlatformStrategies()
+        && platformStrategies()->mediaStrategy()->mockMediaSourceEnabled()
+        && !platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::AVFoundationMSE))
+        RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::MockMSE, PlatformMediaDecodingType::MediaSource);
 #endif
 
     if (DeprecatedGlobalSettings::isAVFoundationEnabled()) {
-        if (registerRemoteEngine)
-            registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::AVFoundation, PlatformMediaDecodingType::FileOrHLS);
-        else
-            MediaPlayerPrivateAVFoundationObjC::registerMediaEngine(addMediaEngine);
-
+        MediaPlayerPrivateAVFoundationObjC::registerMediaEngine(addMediaEngine);
 #if ENABLE(MEDIA_SOURCE)
-        if (registerRemoteEngine && !useMSERemoteRenderer)
-            registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE, PlatformMediaDecodingType::MediaSource);
-        else
-            MediaPlayerPrivateMediaSourceAVFObjC::registerMediaEngine(addMediaEngine);
+        MediaPlayerPrivateMediaSourceAVFObjC::registerMediaEngine(addMediaEngine);
 #endif
-
 #if ENABLE(COCOA_WEBM_PLAYER)
-        bool useRemoteRenderer = hasPlatformStrategies() && platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::CocoaWebM);
-        if (!hasPlatformStrategies() || platformStrategies()->mediaStrategy()->enableWebMMediaPlayer()) {
-            if (registerRemoteEngine && !useRemoteRenderer)
-                registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::CocoaWebM, PlatformMediaDecodingType::MediaSource);
-            else
-                MediaPlayerPrivateWebM::registerMediaEngine(addMediaEngine);
-        }
+        MediaPlayerPrivateWebM::registerMediaEngine(addMediaEngine);
 #endif
-
 #if ENABLE(MEDIA_STREAM)
         MediaPlayerPrivateMediaStreamAVFObjC::registerMediaEngine(addMediaEngine);
 #endif
@@ -368,12 +370,7 @@ static void buildMediaEnginesVector() WTF_REQUIRES_LOCK(mediaEngineVectorLock)
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    if (!hasPlatformStrategies() || platformStrategies()->mediaStrategy()->wirelessPlaybackMediaPlayerEnabled()) {
-        if (registerRemoteEngine && !mockMediaDeviceRouteControllerEnabled())
-            registerRemoteEngine(addMediaEngine, MediaPlayerEnums::MediaEngineIdentifier::WirelessPlayback, PlatformMediaDecodingType::FileOrHLS);
-        else
-            MediaPlayerPrivateWirelessPlayback::registerMediaEngine(addMediaEngine);
-    }
+    MediaPlayerPrivateWirelessPlayback::registerMediaEngine(addMediaEngine);
 #endif
 
     haveMediaEnginesVector() = true;
@@ -412,17 +409,29 @@ MediaPlayerPrivateInterface* MediaPlayer::playerPrivate()
     return m_private.get();
 }
 
-
-const MediaPlayerFactory* MediaPlayer::mediaEngine(MediaPlayerEnums::MediaEngineIdentifier identifier)
+static bool engineScopeMatchesSelection(MediaPlayerScope engineScope, MediaPlayerScope selectionScope)
 {
+    if (selectionScope == MediaPlayerScope::Playback)
+        return engineScope == MediaPlayerScope::Playback;
+    ASSERT(selectionScope == MediaPlayerScope::Supports);
+    return true;
+}
+
+const MediaPlayerFactory* MediaPlayer::mediaEngine(const MediaPlayerEngineSelection& selection)
+{
+    if (!selection.identifier) {
+        RELEASE_LOG_ERROR(Media, "MediaPlayer::mediaEngine called without an engine identifier");
+        return nullptr;
+    }
     auto& engines = installedMediaEngines();
-    auto currentIndex = engines.findIf([identifier] (auto& engine) {
-        return engine->identifier() == identifier;
+    auto currentIndex = engines.findIf([&] (auto& engine) {
+        return engine->identifier() == *selection.identifier
+            && engineScopeMatchesSelection(engine->supportedScope(selection.mediaContainmentEnabled), selection.scope);
     });
 
     if (currentIndex == notFound) {
 #if PLATFORM(IOS_FAMILY_SIMULATOR)
-        ASSERT(identifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE);
+        ASSERT(selection.identifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE);
 #endif
         return nullptr;
     }
@@ -430,13 +439,13 @@ const MediaPlayerFactory* MediaPlayer::mediaEngine(MediaPlayerEnums::MediaEngine
     return engines[currentIndex].get();
 }
 
-static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const MediaEngineSupportParameters& parameters, const WeakHashSet<const MediaPlayerFactory>& attemptedEngines = { }, const MediaPlayerFactory* current = nullptr)
+static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const MediaEngineSupportParameters& parameters, const MediaPlayerEngineSelection& selection, const WeakHashSet<const MediaPlayerFactory>& attemptedEngines = { }, const MediaPlayerFactory* current = nullptr)
 {
     if (parameters.type.isEmpty() && parameters.platformType == PlatformMediaDecodingType::FileOrHLS)
         return nullptr;
 
     // 4.8.10.3 MIME types - In the absence of a specification to the contrary, the MIME type "application/octet-stream"
-    // when used with parameters, e.g. "application/octet-stream;codecs=theora", is a type that the user agent knows 
+    // when used with parameters, e.g. "application/octet-stream;codecs=theora", is a type that the user agent knows
     // it cannot render.
     if (parameters.type.containerType() == applicationOctetStream()) {
         if (!parameters.type.codecs().isEmpty())
@@ -446,6 +455,8 @@ static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const Media
     const MediaPlayerFactory* foundEngine = nullptr;
     MediaPlayer::SupportsType supported = MediaPlayer::SupportsType::IsNotSupported;
     for (auto& engine : installedMediaEngines()) {
+        if (!engineScopeMatchesSelection(engine->supportedScope(selection.mediaContainmentEnabled), selection.scope))
+            continue;
         if (current) {
             if (current == engine.get())
                 current = nullptr;
@@ -466,7 +477,7 @@ static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const Media
 CheckedPtr<const MediaPlayerFactory> MediaPlayer::nextMediaEngine(const MediaPlayerFactory* current)
 {
     if (m_activeEngineIdentifier) {
-        CheckedPtr engine = mediaEngine(m_activeEngineIdentifier.value());
+        CheckedPtr engine = mediaEngine({ .identifier = m_activeEngineIdentifier.value() });
         return current != engine ? engine : nullptr;
     }
 
@@ -624,14 +635,14 @@ CheckedPtr<const MediaPlayerFactory> MediaPlayer::nextBestMediaEngine(const Medi
         if (current)
             return nullptr;
 
-        CheckedPtr engine = mediaEngine(m_activeEngineIdentifier.value());
+        CheckedPtr engine = mediaEngine({ .identifier = m_activeEngineIdentifier.value() });
         if (engine && engine->supportsTypeAndCodecs(parameters) != SupportsType::IsNotSupported)
             return engine;
 
         return nullptr;
     }
 
-    return bestMediaEngineForSupportParameters(parameters, m_attemptedEngines, current);
+    return bestMediaEngineForSupportParameters(parameters, { .scope = MediaPlayerScope::Playback }, m_attemptedEngines, current);
 }
 
 void MediaPlayer::reloadAndResumePlaybackIfNeeded()
@@ -1270,9 +1281,9 @@ bool MediaPlayer::shouldGetNativeImageForCanvasDrawing() const
     return protect(m_private)->shouldGetNativeImageForCanvasDrawing();
 }
 
-MediaPlayer::SupportsType MediaPlayer::supportsType(const MediaEngineSupportParameters& parameters)
+MediaPlayer::SupportsType MediaPlayer::supportsType(const MediaEngineSupportParameters& parameters, const MediaPlayerEngineSelection& selection)
 {
-    // 4.8.10.3 MIME types - The canPlayType(type) method must return the empty string if type is a type that the 
+    // 4.8.10.3 MIME types - The canPlayType(type) method must return the empty string if type is a type that the
     // user agent knows it cannot render or is the type "application/octet-stream"
     AtomString containerType { parameters.type.containerType() };
     if (containerType == applicationOctetStream())
@@ -1281,7 +1292,7 @@ MediaPlayer::SupportsType MediaPlayer::supportsType(const MediaEngineSupportPara
     if (!startsWithLettersIgnoringASCIICase(containerType, "video/"_s) && !startsWithLettersIgnoringASCIICase(containerType, "audio/"_s) && !startsWithLettersIgnoringASCIICase(containerType, "application/"_s))
         return SupportsType::IsNotSupported;
 
-    CheckedPtr engine = bestMediaEngineForSupportParameters(parameters);
+    CheckedPtr engine = bestMediaEngineForSupportParameters(parameters, selection);
     if (!engine)
         return SupportsType::IsNotSupported;
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -129,6 +129,12 @@ struct MediaEngineSupportParameters {
 #endif
 };
 
+struct MediaPlayerEngineSelection {
+    std::optional<MediaPlayerEnums::MediaEngineIdentifier> identifier { };
+    MediaPlayerScope scope { MediaPlayerScope::Playback };
+    MediaContainmentEnabled mediaContainmentEnabled { MediaContainmentEnabled::No };
+};
+
 struct SeekTarget {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(SeekTarget);
     SeekTarget(const MediaTime& targetTime, const MediaTime& negativeThreshold, const MediaTime& positiveThreshold)
@@ -377,8 +383,8 @@ public:
 
     // Media engine support.
     using MediaPlayerEnums::SupportsType;
-    static const MediaPlayerFactory* mediaEngine(MediaPlayerEnums::MediaEngineIdentifier);
-    static SupportsType supportsType(const MediaEngineSupportParameters&);
+    static const MediaPlayerFactory* mediaEngine(const MediaPlayerEngineSelection& = { });
+    static SupportsType supportsType(const MediaEngineSupportParameters&, const MediaPlayerEngineSelection& = { });
     static void getSupportedTypes(HashSet<String>&);
     static bool isAvailable();
     static HashSet<SecurityOriginData> originsInMediaCache(const String& path);
@@ -929,6 +935,12 @@ public:
     virtual void clearMediaCache(const String&, WallTime) const { }
     virtual void clearMediaCacheForOrigins(const String&, const HashSet<SecurityOriginData>&) const { }
     virtual bool supportsKeySystem(const String& /* keySystem */, const String& /* mimeType */) const { return false; }
+
+    // Describes how this factory may be used. The `mediaContainmentEnabled` context
+    // mirrors the per-WebProcess preference of the same name; in the GPU process it's
+    // sourced from the calling connection. Default is Playback; subclasses override
+    // only if they need to answer differently for some contexts.
+    virtual MediaPlayerScope supportedScope(MediaContainmentEnabled = MediaContainmentEnabled::No) const { return MediaPlayerScope::Playback; }
 };
 
 using MediaEngineRegistrar = void(std::unique_ptr<MediaPlayerFactory>&&);
@@ -943,6 +955,12 @@ class RemoteMediaPlayerSupport {
 public:
     using RegisterRemotePlayerCallback = Function<void(MediaEngineRegistrar, MediaPlayerEnums::MediaEngineIdentifier, PlatformMediaDecodingType)>;
     WEBCORE_EXPORT static void setRegisterRemotePlayerCallback(RegisterRemotePlayerCallback&&);
+
+    // If a remote-player callback has been installed (i.e. this is the WebContent
+    // process and a GPU process is available), register a remote proxy factory for
+    // the given engine and return true. Otherwise return false and leave the
+    // caller to register a local factory.
+    WEBCORE_EXPORT static bool registerRemoteEngineIfAvailable(MediaEngineRegistrar, MediaPlayerEnums::MediaEngineIdentifier, PlatformMediaDecodingType);
 };
 
 inline String MediaPlayer::audioOutputDeviceId() const

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -182,6 +182,16 @@ enum class MediaPlaybackTargetType : uint8_t {
     Serialized = 1 << 3,
 };
 
+enum class MediaPlayerScope : uint8_t {
+    Playback,
+    Supports,
+};
+
+enum class MediaContainmentEnabled : bool {
+    No,
+    Yes,
+};
+
 } // namespace WebCore
 
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -30,8 +30,11 @@
 
 #include "Logging.h"
 #include "MediaDeviceRoute.h"
+#include "MediaDeviceRouteController.h"
 #include "MediaPlaybackTargetWirelessPlayback.h"
 #include "MediaSelectionOption.h"
+#include "MediaStrategy.h"
+#include "PlatformStrategies.h"
 #include <pal/avfoundation/MediaTimeAVFoundation.h>
 #include <wtf/BlockPtr.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -71,6 +74,10 @@ private:
 
 void MediaPlayerPrivateWirelessPlayback::registerMediaEngine(MediaEngineRegistrar registrar)
 {
+    if (hasPlatformStrategies() && !platformStrategies()->mediaStrategy()->wirelessPlaybackMediaPlayerEnabled())
+        return;
+    if (!mockMediaDeviceRouteControllerEnabled() && RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable(registrar, MediaPlayerEnums::MediaEngineIdentifier::WirelessPlayback, PlatformMediaDecodingType::FileOrHLS))
+        return;
     registrar(makeUnique<MediaPlayerFactoryWirelessPlayback>());
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -311,6 +311,8 @@ private:
 
 void MediaPlayerPrivateAVFoundationObjC::registerMediaEngine(MediaEngineRegistrar registrar)
 {
+    if (RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable(registrar, MediaPlayerEnums::MediaEngineIdentifier::AVFoundation, PlatformMediaDecodingType::FileOrHLS))
+        return;
     if (!isAvailable())
         return;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -171,10 +171,18 @@ private:
     {
         return MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndCodecs(parameters);
     }
+
+    MediaPlayerScope supportedScope(MediaContainmentEnabled mediaContainmentEnabled) const final
+    {
+        return !hasPlatformStrategies() && mediaContainmentEnabled == MediaContainmentEnabled::Yes ? MediaPlayerScope::Supports : MediaPlayerScope::Playback;
+    }
 };
 
 void MediaPlayerPrivateMediaSourceAVFObjC::registerMediaEngine(MediaEngineRegistrar registrar)
 {
+    bool useMSERemoteRenderer = hasPlatformStrategies() && platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::AVFoundationMSE);
+    if (!useMSERemoteRenderer && RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable(registrar, MediaPlayerEnums::MediaEngineIdentifier::AVFoundationMSE, PlatformMediaDecodingType::MediaSource))
+        return;
     if (!isAvailable())
         return;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -37,6 +37,7 @@
 #import "MediaStreamPrivate.h"
 #import "PixelBufferConformerCV.h"
 #import "PlatformDynamicRangeLimitCocoa.h"
+#import "PlatformStrategies.h"
 #import "VideoFrame.h"
 #import "VideoFrameMetadata.h"
 #import "VideoLayerManagerObjC.h"
@@ -213,7 +214,7 @@ private:
 
 void MediaPlayerPrivateMediaStreamAVFObjC::registerMediaEngine(MediaEngineRegistrar registrar)
 {
-    if (!isAvailable())
+    if (!isAvailable() || !hasPlatformStrategies())
         return;
 
     registrar(makeUnique<MediaPlayerFactoryMediaStreamAVFObjC>());

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1757,10 +1757,20 @@ private:
     {
         return MediaPlayerPrivateWebM::supportsType(parameters);
     }
+
+    MediaPlayerScope supportedScope(MediaContainmentEnabled mediaContainmentEnabled) const final
+    {
+        return !hasPlatformStrategies() && mediaContainmentEnabled == MediaContainmentEnabled::Yes ? MediaPlayerScope::Supports : MediaPlayerScope::Playback;
+    }
 };
 
 void MediaPlayerPrivateWebM::registerMediaEngine(MediaEngineRegistrar registrar)
 {
+    if (hasPlatformStrategies() && !platformStrategies()->mediaStrategy()->enableWebMMediaPlayer())
+        return;
+    bool useRemoteRenderer = hasPlatformStrategies() && platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::CocoaWebM);
+    if (!useRemoteRenderer && RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable(registrar, MediaPlayerEnums::MediaEngineIdentifier::CocoaWebM, PlatformMediaDecodingType::FileOrHLS))
+        return;
     if (!isAvailable())
         return;
 

--- a/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
@@ -77,7 +77,10 @@ static std::optional<PlatformMediaCapabilitiesInfo> computeMediaCapabilitiesInfo
             .allowedMediaCodecTypes = configuration.allowedMediaCodecTypes
         };
 
-        if (MediaPlayer::supportsType(parameters) != MediaPlayer::SupportsType::IsSupported)
+        MediaPlayerEngineSelection selection {
+            .scope = MediaPlayerScope::Supports,
+        };
+        if (MediaPlayer::supportsType(parameters, selection) != MediaPlayer::SupportsType::IsSupported)
             return std::nullopt;
 
         auto codecs = parameters.type.codecs();
@@ -164,7 +167,10 @@ static std::optional<PlatformMediaCapabilitiesInfo> computeMediaCapabilitiesInfo
         .allowedMediaCodecTypes = configuration.allowedMediaCodecTypes,
     };
 
-    if (MediaPlayer::supportsType(parameters) != MediaPlayer::SupportsType::IsSupported)
+    MediaPlayerEngineSelection audioSelection {
+        .scope = MediaPlayerScope::Supports,
+    };
+    if (MediaPlayer::supportsType(parameters, audioSelection) != MediaPlayer::SupportsType::IsSupported)
         return std::nullopt;
 
     info.supported = true;

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -635,7 +635,16 @@ void GPUConnectionToWebProcess::canDecodeExtendedType(PlatformMediaDecodingType 
         .platformType = platformType,
         .type = contentType,
     };
-    completionHandler(MediaPlayer::supportsType(parameters) != MediaPlayer::SupportsType::IsNotSupported);
+    auto containment = MediaContainmentEnabled::No;
+#if PLATFORM(COCOA)
+    if (sharedPreferencesForWebProcessValue().mediaContainmentEnabled)
+        containment = MediaContainmentEnabled::Yes;
+#endif
+    MediaPlayerEngineSelection selection {
+        .scope = MediaPlayerScope::Supports,
+        .mediaContainmentEnabled = containment,
+    };
+    completionHandler(MediaPlayer::supportsType(parameters, selection) != MediaPlayer::SupportsType::IsNotSupported);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -58,6 +58,24 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManagerProxy);
 
+CheckedPtr<const MediaPlayerFactory> RemoteMediaPlayerManagerProxy::playbackEngineForConnection(MediaPlayerEnums::MediaEngineIdentifier engineIdentifier) const
+{
+    auto connection = m_gpuConnectionToWebProcess.get();
+    auto containment = MediaContainmentEnabled::No;
+#if PLATFORM(COCOA)
+    if (connection && connection->sharedPreferencesForWebProcessValue().mediaContainmentEnabled)
+        containment = MediaContainmentEnabled::Yes;
+#else
+    UNUSED_PARAM(connection);
+#endif
+    MediaPlayerEngineSelection selection {
+        .identifier = engineIdentifier,
+        .scope = MediaPlayerScope::Playback,
+        .mediaContainmentEnabled = containment,
+    };
+    return MediaPlayer::mediaEngine(selection);
+}
+
 RemoteMediaPlayerManagerProxy::RemoteMediaPlayerManagerProxy(GPUConnectionToWebProcess& connection)
     : m_gpuConnectionToWebProcess(connection)
 #if !RELEASE_LOG_DISABLED
@@ -104,11 +122,7 @@ void RemoteMediaPlayerManagerProxy::createMediaPlayer(MediaPlayerIdentifier iden
     ASSERT(RunLoop::isMain());
     ASSERT(!m_proxies.contains(identifier));
 
-#if PLATFORM(COCOA)
-    MESSAGE_CHECK(!connection->sharedPreferencesForWebProcessValue().mediaContainmentEnabled
-        || engineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::AVFoundation
-        || engineIdentifier == MediaPlayerEnums::MediaEngineIdentifier::WirelessPlayback);
-#endif
+    MESSAGE_CHECK(playbackEngineForConnection(engineIdentifier));
 
     auto proxy = RemoteMediaPlayerProxy::create(*this, identifier, clientIdentifier, connection->connection(), engineIdentifier, WTF::move(proxyConfiguration), Ref { connection->videoFrameObjectHeap() }, connection->webProcessIdentity());
     m_proxies.add(identifier, WTF::move(proxy));
@@ -131,7 +145,7 @@ void RemoteMediaPlayerManagerProxy::deleteMediaPlayer(MediaPlayerIdentifier iden
 
 void RemoteMediaPlayerManagerProxy::getSupportedTypes(MediaPlayerEnums::MediaEngineIdentifier engineIdentifier, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
-    CheckedPtr engine = MediaPlayer::mediaEngine(engineIdentifier);
+    CheckedPtr engine = playbackEngineForConnection(engineIdentifier);
     if (!engine) {
         WTFLogAlways("Failed to find media engine.");
         completionHandler({ });
@@ -150,7 +164,7 @@ void RemoteMediaPlayerManagerProxy::getSupportedTypes(MediaPlayerEnums::MediaEng
 
 void RemoteMediaPlayerManagerProxy::supportsTypeAndCodecs(MediaPlayerEnums::MediaEngineIdentifier engineIdentifier, const MediaEngineSupportParameters&& parameters, CompletionHandler<void(MediaPlayer::SupportsType)>&& completionHandler)
 {
-    CheckedPtr engine = MediaPlayer::mediaEngine(engineIdentifier);
+    CheckedPtr engine = playbackEngineForConnection(engineIdentifier);
     if (!engine) {
         WTFLogAlways("Failed to find media engine.");
         completionHandler(MediaPlayer::SupportsType::IsNotSupported);
@@ -163,7 +177,7 @@ void RemoteMediaPlayerManagerProxy::supportsTypeAndCodecs(MediaPlayerEnums::Medi
 
 void RemoteMediaPlayerManagerProxy::supportsKeySystem(MediaPlayerEnums::MediaEngineIdentifier engineIdentifier, const String&& keySystem, const String&& mimeType, CompletionHandler<void(bool)>&& completionHandler)
 {
-    CheckedPtr engine = MediaPlayer::mediaEngine(engineIdentifier);
+    CheckedPtr engine = playbackEngineForConnection(engineIdentifier);
     if (!engine) {
         WTFLogAlways("Failed to find media engine.");
         return;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -109,6 +109,8 @@ private:
     void supportsTypeAndCodecs(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const WebCore::MediaEngineSupportParameters&&, CompletionHandler<void(WebCore::MediaPlayer::SupportsType)>&&);
     void supportsKeySystem(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String&&, const String&&, CompletionHandler<void(bool)>&&);
 
+    CheckedPtr<const WebCore::MediaPlayerFactory> playbackEngineForConnection(WebCore::MediaPlayerEnums::MediaEngineIdentifier) const;
+
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const { return "RemoteMediaPlayerManagerProxy"; }
     WTFLogChannel& NODELETE logChannel() const;


### PR DESCRIPTION
#### 514ac2547e6f001230587536baf3c5da4b060272
<pre>
Don&apos;t register MediaPlayerPrivateWebM / MediaPlayerPrivateMediaSourceAVFObjC for playback in the GPU process when MediaContainment is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=317846">https://bugs.webkit.org/show_bug.cgi?id=317846</a>
<a href="https://rdar.apple.com/180623633">rdar://180623633</a>

Reviewed by Youenn Fablet.

The registration policy lived in MediaPlayer::buildMediaEnginesVector with
a hand-written MESSAGE_CHECK allowlist in RemoteMediaPlayerManagerProxy::createMediaPlayer.
MediaPlayerPrivateWebM and MediaPlayerPrivateMediaSourceAVFObjC were
registered in every process where their code compiled, including the
GPU process; the MESSAGE_CHECK rejected attempts to instantiate them
in GPU when MediaContainment was on, but the canDecodeExtendedType IPC
had no way to express &quot;answer codec capability queries from GPU
without being instantiable.&quot; When MediaContainment is enabled, those
engines demux in the WebContent process and only the renderer should
live in GPU, so registering the full MediaPlayerPrivate in GPU was
both unnecessary and a defence-in-depth weak point.

This commit moves the decision of when and where a MediaPlayerFactory
is registered into each MediaPlayerPrivate&apos;s static registerMediaEngine
— the factory itself owns it. buildMediaEnginesVector becomes a flat
list of registerMediaEngine calls (still gated by USE/ENABLE compile
flags and the existing isAVFoundationEnabled / isGStreamerEnabled
runtime gates); each engine&apos;s static decides between installing the
local factory, delegating to a remote proxy via
RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable, or skipping.

MediaPlayerFactory gains a MediaPlayerScope supportedScope(MediaContainmentEnabled)
the describes how the MediaPlayerPrivate is to be used.
MediaPlayer::supportsType and MediaPlayer::mediaEngine take a
MediaPlayerEngineSelection { identifier, scope, mediaContainmentEnabled }
struct, and engines are filtered by scope. MediaPlayerFactoryWebM and
MediaPlayerFactoryMediaSourceAVFObjC override supportedScope to return
RemoteRenderingCapability in the GPU process when MediaContainmentEnabled
is Yes — they can answer canDecodeExtendedType IPCs from the WebContent
demuxer but are not lookup-able for Playback.

GPUConnectionToWebProcess::canDecodeExtendedType queries with
MediaPlayerScope::RemoteRenderingCapability and the connection&apos;s
MediaContainmentEnabled. RemoteMediaPlayerManagerProxy::{createMediaPlayer,
getSupportedTypes, supportsTypeAndCodecs, supportsKeySystem} all funnel
through a new playbackEngineForConnection helper that queries with
MediaPlayerScope::Playback and the connection&apos;s preference;
createMediaPlayer&apos;s old MESSAGE_CHECK allowlist is replaced by this
registry lookup, so a containment-enabled connection asking the GPU
to instantiate WebM or MSE AVF is rejected by the registry rather
than a hand-maintained list.

This is required to disable the use of MediaPlayerPrivateRemote (the
WebContent-side remote proxy) with the WebM and MediaSource AVF
players without breaking the WebContent-side demuxer&apos;s ability to
query the GPU for codec capabilities.

* Source/WebCore/platform/graphics/MediaPlayerEnums.h: Add
MediaPlayerScope and MediaContainmentEnabled.
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::buildMediaEnginesVector):
(WebCore::bestMediaEngineForSupportParameters):
(WebCore::MediaPlayer::mediaEngine):
(WebCore::MediaPlayer::supportsType):
(WebCore::RemoteMediaPlayerSupport::registerRemoteEngineIfAvailable):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.{h,mm}:
(WebCore::MediaPlayerFactoryWebM::supportedScope):
(WebCore::MediaPlayerPrivateWebM::registerMediaEngine):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.{h,mm}:
(WebCore::MediaPlayerFactoryMediaSourceAVFObjC::supportedScope):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::registerMediaEngine):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.{h,mm}:
(WebCore::MediaPlayerPrivateAVFoundationObjC::registerMediaEngine):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.{h,mm}:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::registerMediaEngine):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.{h,cpp}:
(WebCore::MediaPlayerPrivateWirelessPlayback::registerMediaEngine):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.{h,cpp}:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.{h,cpp}:
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.{h,cpp}:
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.{h,cpp}:
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.{h,cpp}:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::canDecodeExtendedType):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.{h,cpp}:
(WebKit::RemoteMediaPlayerManagerProxy::playbackEngineForConnection):
(WebKit::RemoteMediaPlayerManagerProxy::createMediaPlayer):
(WebKit::RemoteMediaPlayerManagerProxy::getSupportedTypes):
(WebKit::RemoteMediaPlayerManagerProxy::supportsTypeAndCodecs):
(WebKit::RemoteMediaPlayerManagerProxy::supportsKeySystem):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::setUseGPUProcess):

Canonical link: <a href="https://commits.webkit.org/315905@main">https://commits.webkit.org/315905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47a4c4a255b047f516d0bf886ace4f5ed4fa7d3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179787 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128124 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbca529b-60ea-45a2-ad81-06d12dfa6456) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132882 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3c93a8c-4971-4e1d-87ee-2f6d5e8eb0a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3535714-5e36-4273-bd3e-9488b3cc7556) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28470 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182372 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35161 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37188 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 344 new passes 23 flakes 6 failures; Uploaded test results; Ignored 4 pre-existing failure based on results-db") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141333 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43992 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38015 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44681 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109149 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36417 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116563 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43191 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7797 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->