### PR TITLE
[SaferCPP][WebXR] Use safer downcasts for WebGL layer backings

### DIFF
--- a/Source/WebCore/Modules/webxr/XRLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRLayerBacking.h
@@ -67,6 +67,8 @@ public:
 
     virtual void clearTexturesIfNeeded(const IntRect& viewport, std::optional<uint32_t> slice) { UNUSED_PARAM(viewport); UNUSED_PARAM(slice); }
 
+    virtual bool isWebGLBacking() const { return false; }
+
 private:
     PlatformXR::LayerHandle m_handle;
 };

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -263,7 +263,7 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTex
 
             // Layout / textureType differences (size, array length, texture target) are baked into the swapchain at construction time.
             Vector<RefPtr<WebGLOpaqueTexture>> textures;
-            auto& backing = static_cast<XRWebGLLayerBacking&>(layer.backing());
+            auto& backing = downcast<XRWebGLLayerBacking>(layer.backing());
             uint32_t textureCount = backing.requiresPerViewColorTextures() ? 2 : 1;
             for (uint32_t index = 0; index < textureCount; ++index) {
                 RefPtr currentColorTexture = backing.currentColorTexture(index);
@@ -294,7 +294,7 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTex
             ASSERT(depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat));
             ASSERT(layer.layout() != XRLayerLayout::Default);
 
-            auto& backing = static_cast<XRWebGLLayerBacking&>(layer.backing());
+            auto& backing = downcast<XRWebGLLayerBacking>(layer.backing());
             uint32_t textureCount = backing.requiresPerViewColorTextures() ? 2 : 1;
             for (uint32_t index = 0; index < textureCount; ++index) {
                 RefPtr currentDepthTexture = backing.currentDepthTexture(index);
@@ -446,7 +446,7 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTex
                 return Exception { ExceptionCode::InvalidStateError, "Cannot create a projection layer with a lost WebGL context"_s };
 
             Vector<RefPtr<WebGLOpaqueTexture>> textures;
-            auto& backing = static_cast<XRWebGLLayerBacking&>(layer.backing());
+            auto& backing = downcast<XRWebGLLayerBacking>(layer.backing());
             switch (layer.layout()) {
             case XRLayerLayout::Mono:
                 return Exception { ExceptionCode::NotSupportedError, "Mono layout not implemented."_s };
@@ -494,7 +494,7 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTex
             if (baseContext->isWebGL1() && !baseContext->extensionIsEnabled("WEBGL_depth_texture"_s))
                 return textures;
 
-            auto& depthBacking = static_cast<XRWebGLLayerBacking&>(layer.backing());
+            auto& depthBacking = downcast<XRWebGLLayerBacking>(layer.backing());
             switch (layer.layout()) {
             case XRLayerLayout::Mono:
                 return Exception { ExceptionCode::NotSupportedError, "Mono layout not implemented."_s };

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -87,6 +87,8 @@ public:
 
     void clearTexturesIfNeeded(const IntRect& viewport, std::optional<uint32_t> slice) final;
 
+    bool isWebGLBacking() const final { return true; }
+
 protected:
     XRWebGLLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength);
 
@@ -113,5 +115,9 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::XRWebGLLayerBacking)
+    static bool isType(const WebCore::XRLayerBacking& backing) { return backing.isWebGLBacking(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEBXR_LAYERS)


### PR DESCRIPTION
#### 34b6dd893e5eaf874599683d8fe1947125400f24
<pre>
[SaferCPP][WebXR] Use safer downcasts for WebGL layer backings
<a href="https://bugs.webkit.org/show_bug.cgi?id=317911">https://bugs.webkit.org/show_bug.cgi?id=317911</a>

Reviewed by Dan Glastonbury.

Use downcast&lt;&gt; instead of static_cast&lt;&gt; as recommended by the safer cpp
guidelines[1] as it validates the type at runtime.

No new tests required.

[1] <a href="https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#use-downcast-when-casting-to-a-subclass-type">https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#use-downcast-when-casting-to-a-subclass-type</a>

* Source/WebCore/Modules/webxr/XRLayerBacking.h:
(WebCore::XRLayerBacking::isWebGLBacking const):
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::allocateColorTexturesForLayer):
(WebCore::XRWebGLBinding::allocateDepthTexturesForLayer):
(WebCore::XRWebGLBinding::allocateColorTexturesForProjectionLayer):
(WebCore::XRWebGLBinding::allocateDepthTexturesForProjectionLayer):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/315877@main">https://commits.webkit.org/315877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c171363e46fafd6aa78e213ecbd87bf58c01495

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113342 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28428 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182330 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35119 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141293 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43950 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141113 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37988 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44639 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109090 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36378 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116521 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43149 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7758 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42555 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42795 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->