### PR TITLE
[Skia] Set maximum size for skia internal resources cache and textures used for glyph cache

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -117,6 +117,7 @@ public:
     void setSkiaGLContextForCurrentThread(std::unique_ptr<GLContext>&&);
     GrDirectContext* skiaGrContext() const;
     unsigned msaaSampleCount() const;
+    size_t maxSkiaResourceCacheBytes() const;
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -50,6 +50,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #include <wtf/NeverDestroyed.h>
+#include <wtf/RAMSize.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
@@ -229,6 +230,32 @@ static unsigned initializeMSAASampleCount(GrDirectContext* grContext)
     return sampleCount;
 }
 
+static constexpr size_t s_lowEndDeviceMemoryThresholdBytes = 2 * GB;
+static constexpr size_t s_highEndDeviceMemoryThresholdBytes = 4 * GB;
+
+static constexpr size_t s_lowEndDeviceGlyphCacheTextureMaximumBytes = 2 * MB;
+static constexpr size_t s_lowEndMaxResourceCacheBytes = 48 * MB;
+static constexpr size_t s_maxResourceCacheBytes = 80 * MB;
+
+static std::optional<size_t> glyphCacheTextureMaximumBytes()
+{
+    size_t memorySize = WTF::ramSize();
+    if (memorySize < s_lowEndDeviceMemoryThresholdBytes)
+        return s_lowEndDeviceGlyphCacheTextureMaximumBytes;
+    return std::nullopt;
+}
+
+static size_t initializeMaxResourceCacheBytes(GrDirectContext* grContext)
+{
+    size_t memorySize = WTF::ramSize();
+    if (memorySize < s_lowEndDeviceMemoryThresholdBytes)
+        grContext->setResourceCacheLimit(s_lowEndMaxResourceCacheBytes);
+    else if (memorySize < s_highEndDeviceMemoryThresholdBytes)
+        grContext->setResourceCacheLimit(s_maxResourceCacheBytes);
+    // Use GrDirectContext default (256MB) for high end devices.
+    return grContext->getResourceCacheLimit();
+}
+
 class SkiaGLContext : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SkiaGLContext> {
 public:
     static Ref<SkiaGLContext> create(PlatformDisplay& display)
@@ -268,6 +295,11 @@ public:
         return m_sampleCount;
     }
 
+    size_t maxResourceCacheBytes() const
+    {
+        return m_maxResourceCacheBytes;
+    }
+
 private:
     explicit SkiaGLContext(PlatformDisplay& display)
         : SkiaGLContext(GLContext::createOffscreen(display))
@@ -284,10 +316,14 @@ private:
         options.fAllowMSAAOnNewIntel = shouldAllowMSAAOnNewIntel();
         thread_local std::unique_ptr<SkExecutor> s_executor = SkExecutor::MakeFIFOThreadPool(2);
         options.fExecutor = s_executor.get();
+        if (auto bytes = glyphCacheTextureMaximumBytes())
+            options.fGlyphCacheTextureMaximumBytes = *bytes;
+
         if (auto grContext = GrDirectContexts::MakeGL(skiaGLInterface(), options)) {
             m_skiaGLContext = WTF::move(glContext);
             m_skiaGrContext = WTF::move(grContext);
             m_sampleCount = initializeMSAASampleCount(m_skiaGrContext.get());
+            m_maxResourceCacheBytes = initializeMaxResourceCacheBytes(m_skiaGrContext.get());
         }
     }
 
@@ -295,6 +331,7 @@ private:
     sk_sp<GrDirectContext> m_skiaGrContext WTF_GUARDED_BY_LOCK(m_lock);
     mutable Lock m_lock;
     unsigned m_sampleCount { 0 };
+    size_t m_maxResourceCacheBytes { 0 };
 };
 #endif
 
@@ -333,6 +370,11 @@ GrDirectContext* PlatformDisplay::skiaGrContext() const
 unsigned PlatformDisplay::msaaSampleCount() const
 {
     return s_skiaGLContext ? s_skiaGLContext->sampleCount() : 0;
+}
+
+size_t PlatformDisplay::maxSkiaResourceCacheBytes() const
+{
+    return s_skiaGLContext ? s_skiaGLContext->maxResourceCacheBytes() : 0;
 }
 
 void PlatformDisplay::clearSkiaGLContext()

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -162,7 +162,8 @@ Ref<CoordinatedTileBuffer> CoordinatedAcceleratedTileBuffer::create(const sk_sp<
     auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
     ASSERT(backendFormat.isValid());
     auto properties = FontRenderOptions::singleton().createSurfaceProps();
-    auto characterization = threadSafeGrContext->createCharacterization(0, imageInfo, backendFormat, 0, kTopLeft_GrSurfaceOrigin, properties, skgpu::Mipmapped::kNo);
+    auto maxResourceCacheBytes = PlatformDisplay::sharedDisplay().maxSkiaResourceCacheBytes();
+    auto characterization = threadSafeGrContext->createCharacterization(maxResourceCacheBytes, imageInfo, backendFormat, 0, kTopLeft_GrSurfaceOrigin, properties, skgpu::Mipmapped::kNo);
     return adoptRef(*new CoordinatedAcceleratedTileBuffer(WTF::move(characterization), flags));
 }
 


### PR DESCRIPTION
#### 3dd9c1955d735274837e980b0f75e066b4e49dce
<pre>
[Skia] Set maximum size for skia internal resources cache and textures used for glyph cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=317914">https://bugs.webkit.org/show_bug.cgi?id=317914</a>

Reviewed by Nikolas Zimmermann.

Now that deferred display list is enabled with the skia compositor, we
are using more internal skia resources, so it&apos;s important to set the
limits for skia internal caches depending the device.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::glyphCacheTextureMaximumBytes):
(WebCore::initializeMaxResourceCacheBytes):
(WebCore::SkiaGLContext::maxResourceCacheBytes const):
(WebCore::SkiaGLContext::SkiaGLContext):
(WebCore::PlatformDisplay::maxSkiaResourceCacheBytes const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedAcceleratedTileBuffer::create):

Canonical link: <a href="https://commits.webkit.org/315883@main">https://commits.webkit.org/315883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48740e440ee93dbab026f8d958fc4e48a49a34a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36030 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113350 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/32989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28437 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182339 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141301 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43959 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141121 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44648 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109105 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36388 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116530 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43158 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7768 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->