### PR TITLE
[GTK][WPE] Release skia resources on memory pressure

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -45,6 +45,10 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/ThreadSafeWeakHashSet.h>
 #endif
 
+namespace WTF {
+enum class Critical : bool;
+}
+
 namespace WebCore {
 
 class GLContext;
@@ -118,6 +122,7 @@ public:
     GrDirectContext* skiaGrContext() const;
     unsigned msaaSampleCount() const;
     size_t maxSkiaResourceCacheBytes() const;
+    void skiaReleaseUnusedResources(WTF::Critical);
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -49,6 +49,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #endif
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
+#include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RAMSize.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -300,6 +301,23 @@ public:
         return m_maxResourceCacheBytes;
     }
 
+    void releaseUnusedResources(WTF::Critical critical)
+    {
+        Locker locker { m_lock };
+        if (!m_skiaGLContext)
+            return;
+
+        GLContext::ScopedGLContextCurrent scopedCurrent(*m_skiaGLContext);
+        switch (critical) {
+        case Critical::No:
+            m_skiaGrContext->purgeUnlockedResources(GrPurgeResourceOptions::kScratchResourcesOnly);
+            break;
+        case Critical::Yes:
+            m_skiaGrContext->freeGpuResources();
+            break;
+        }
+    }
+
 private:
     explicit SkiaGLContext(PlatformDisplay& display)
         : SkiaGLContext(GLContext::createOffscreen(display))
@@ -375,6 +393,12 @@ unsigned PlatformDisplay::msaaSampleCount() const
 size_t PlatformDisplay::maxSkiaResourceCacheBytes() const
 {
     return s_skiaGLContext ? s_skiaGLContext->maxResourceCacheBytes() : 0;
+}
+
+void PlatformDisplay::skiaReleaseUnusedResources(WTF::Critical critical)
+{
+    if (s_skiaGLContext)
+        s_skiaGLContext->releaseUnusedResources(critical);
 }
 
 void PlatformDisplay::clearSkiaGLContext()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
@@ -174,6 +174,12 @@ void DrawingAreaCoordinatedGraphics::backgroundColorDidChange()
     m_renderer->backgroundColorDidChange();
 }
 
+void DrawingAreaCoordinatedGraphics::releaseMemory(WTF::Critical critical)
+{
+    if (m_renderer)
+        m_renderer->releaseMemory(critical);
+}
+
 void DrawingAreaCoordinatedGraphics::setDeviceScaleFactor(float deviceScaleFactor, CompletionHandler<void()>&& completionHandler)
 {
     Ref webPage = m_webPage;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
@@ -69,6 +69,8 @@ private:
     bool enterAcceleratedCompositingModeIfNeeded() override;
     void backgroundColorDidChange() override;
 
+    void releaseMemory(WTF::Critical) override;
+
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM) && (USE(GBM)|| OS(ANDROID))
     void preferredBufferFormatsDidChange() override;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
@@ -37,6 +37,10 @@ class Region;
 class RunLoopObserver;
 }
 
+namespace WTF {
+enum class Critical : bool;
+}
+
 namespace WebKit {
 struct RenderProcessInfo;
 
@@ -73,6 +77,8 @@ public:
     virtual void adjustTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) = 0;
     virtual void commitTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) = 0;
 #endif
+
+    virtual void releaseMemory(WTF::Critical) = 0;
 
     void setLayerTreeStateIsFrozen(bool);
     void updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -575,6 +575,12 @@ void LayerTreeHost::fillGLInformation(RenderProcessInfo&& info, CompletionHandle
     m_compositor->fillGLInformation(WTF::move(info), WTF::move(completionHandler));
 }
 
+void LayerTreeHost::releaseMemory(WTF::Critical critical)
+{
+    PlatformDisplay::sharedDisplay().skiaReleaseUnusedResources(critical);
+    m_compositor->releaseMemory(critical);
+}
+
 } // namespace WebKit
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -114,6 +114,7 @@ private:
     void resume() override;
     void sizeDidChange() override;
     void backgroundColorDidChange() override;
+    void releaseMemory(WTF::Critical) override;
     bool ensureDrawing() override;
     void fillGLInformation(RenderProcessInfo&&, CompletionHandler<void(RenderProcessInfo&&)>&&) override;
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -381,6 +381,12 @@ void NonCompositedFrameRenderer::fillGLInformation(RenderProcessInfo&& info, Com
     completionHandler(WTF::move(info));
 }
 
+void NonCompositedFrameRenderer::releaseMemory(WTF::Critical critical)
+{
+    if (m_context)
+        PlatformDisplay::sharedDisplay().skiaReleaseUnusedResources(critical);
+}
+
 } // namespace WebKit
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
@@ -78,6 +78,8 @@ private:
     void commitTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) override;
 #endif
 
+    void releaseMemory(WTF::Critical) override;
+
     const WeakRef<WebPage> m_webPage;
     Ref<AcceleratedSurface> m_surface;
     std::unique_ptr<WebCore::GLContext> m_context;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -766,6 +766,13 @@ void ThreadedCompositor::fillGLInformation(RenderProcessInfo&& info, CompletionH
     });
 }
 
+void ThreadedCompositor::releaseMemory(WTF::Critical critical)
+{
+    m_workQueue->dispatchSync([protectedThis = Ref { *this }, critical] {
+        PlatformDisplay::sharedDisplay().skiaReleaseUnusedResources(critical);
+    });
+}
+
 } // namespace WebKit
 
 #endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -55,6 +55,10 @@ class TextureMapper;
 class TransformationMatrix;
 }
 
+namespace WTF {
+enum class Critical : bool;
+}
+
 namespace WebKit {
 class AcceleratedSurface;
 class CoordinatedSceneState;
@@ -102,6 +106,8 @@ public:
 #endif
 
     void fillGLInformation(RenderProcessInfo&&, CompletionHandler<void(RenderProcessInfo&&)>&&);
+
+    void releaseMemory(WTF::Critical);
 
     sk_sp<GrContextThreadSafeProxy> threadSafeGrContext() const { return m_threadSafeGrContext; }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -49,6 +49,7 @@ class MachSendRight;
 namespace IPC {
 class Connection;
 class Decoder;
+enum class Critical : bool;
 }
 
 namespace WebCore {
@@ -171,7 +172,11 @@ public:
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     virtual void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) = 0;
     virtual bool enterAcceleratedCompositingModeIfNeeded() = 0;
-    virtual void backgroundColorDidChange() { };
+    virtual void backgroundColorDidChange() { }
+#endif
+
+#if USE(COORDINATED_GRAPHICS)
+    virtual void releaseMemory(WTF::Critical) { }
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM) && (USE(GBM) || OS(ANDROID))

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5527,11 +5527,16 @@ void WebPage::didCompleteRenderingFrame()
     protect(corePage())->didCompleteRenderingFrame();
 }
 
-void WebPage::releaseMemory(Critical)
+void WebPage::releaseMemory(Critical critical)
 {
 #if ENABLE(GPU_PROCESS)
     if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
         renderingBackend->releaseMemory();
+#endif
+
+#if USE(COORDINATED_GRAPHICS)
+    if (RefPtr drawingArea = m_drawingArea)
+        drawingArea->releaseMemory(critical);
 #endif
 
     m_foundTextRangeController->clearCachedRanges();


### PR DESCRIPTION
#### dab2d0719597c8ad3b131754d3bd9b4b9447d03b
<pre>
[GTK][WPE] Release skia resources on memory pressure
<a href="https://bugs.webkit.org/show_bug.cgi?id=317921">https://bugs.webkit.org/show_bug.cgi?id=317921</a>

Reviewed by Nikolas Zimmermann.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::SkiaGLContext::releaseUnusedResources):
(WebCore::PlatformDisplay::skiaReleaseUnusedResources):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::releaseMemory):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::releaseMemory):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::releaseMemory):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::releaseMemory):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::backgroundColorDidChange):
(WebKit::DrawingArea::releaseMemory):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::releaseMemory):

Canonical link: <a href="https://commits.webkit.org/315960@main">https://commits.webkit.org/315960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f09f12958cca108389eeda18490b35684edd20a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132863 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34666 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33002 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182352 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141315 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43972 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44661 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109120 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26003 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36401 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116543 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43171 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7780 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42577 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->