### PR TITLE
WebGL: Remove code related to externalImageTextureBindingPoint()

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -169,10 +169,8 @@ void WebXROpaqueFramebuffer::startFrame(PlatformXR::FrameData::LayerData& data)
 
     m_isForTesting = data.isForTesting;
 
-    auto [textureTarget, textureTargetBinding] = gl->externalImageTextureBindingPoint();
-
     ScopedWebGLRestoreFramebuffer restoreFramebuffer { m_context };
-    ScopedWebGLRestoreTexture restoreTexture { m_context, textureTarget };
+    ScopedWebGLRestoreTexture restoreTexture { m_context, GL::TEXTURE_2D };
     ScopedWebGLRestoreRenderbuffer restoreRenderBuffer { m_context };
 
     m_drawFramebuffer->setInsideWebXRRAF(true);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -377,11 +377,6 @@ GraphicsContextGL::GraphicsContextGL(GraphicsContextGLAttributes attrs)
 
 GraphicsContextGL::~GraphicsContextGL() = default;
 
-std::tuple<GCGLenum, GCGLenum> GraphicsContextGL::externalImageTextureBindingPoint()
-{
-    return std::make_tuple(GraphicsContextGL::TEXTURE_2D, GraphicsContextGL::TEXTURE_BINDING_2D);
-}
-
 unsigned GraphicsContextGL::computeBytesPerGroup(GCGLenum format, GCGLenum type)
 {
     unsigned componentsPerGroup = 0;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -732,10 +732,6 @@ public:
     // WebGL-specific.
     static constexpr GCGLenum MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x9247;
 
-    // Necessary desktop OpenGL constants.
-    static constexpr GCGLenum TEXTURE_RECTANGLE_ARB = 0x84F5;
-    static constexpr GCGLenum TEXTURE_BINDING_RECTANGLE_ARB = 0x84F6;
-
     // EXT_sRGB formats
     static constexpr GCGLenum SRGB_EXT = 0x8C40;
     static constexpr GCGLenum SRGB_ALPHA_EXT = 0x8C42;
@@ -1670,8 +1666,6 @@ public:
     virtual GCGLint uniformBufferOffsetAlignment() = 0;
     virtual GCGLint max3DTextureSize() = 0;
     virtual GCGLint maxArrayTextureLayers() = 0;
-
-    virtual std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint();
 
     virtual void reshape(int width, int height) = 0;
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -207,7 +207,7 @@ bool GraphicsContextGLANGLE::initialize()
         GL_Enable(GraphicsContextGL::PRIMITIVE_RESTART_FIXED_INDEX);
 
     // Create the texture that will be used for the framebuffer.
-    GLenum textureTarget = drawingBufferTextureTarget();
+    GLenum textureTarget = GL_TEXTURE_2D;
 
     GL_GenTextures(1, &m_texture);
     GL_BindTexture(textureTarget, m_texture);
@@ -319,30 +319,6 @@ bool GraphicsContextGLANGLE::platformInitializeExtensions()
 bool GraphicsContextGLANGLE::platformInitialize()
 {
     return true;
-}
-
-GCGLenum GraphicsContextGLANGLE::drawingBufferTextureTarget()
-{
-    auto [textureTarget, _] = externalImageTextureBindingPoint();
-    UNUSED_VARIABLE(_);
-    return textureTarget;
-}
-
-std::tuple<GCGLenum, GCGLenum> GraphicsContextGLANGLE::drawingBufferTextureBindingPoint()
-{
-    return externalImageTextureBindingPoint();
-}
-
-GCGLint GraphicsContextGLANGLE::EGLDrawingBufferTextureTargetForDrawingTarget(GCGLenum drawingTarget)
-{
-    switch (drawingTarget) {
-    case TEXTURE_2D:
-        return EGL_TEXTURE_2D;
-    case TEXTURE_RECTANGLE_ARB:
-        return EGL_TEXTURE_RECTANGLE_ANGLE;
-    }
-    ASSERT_WITH_MESSAGE(false, "Invalid drawing target");
-    return 0;
 }
 
 bool GraphicsContextGLANGLE::releaseThreadResources(ReleaseThreadResourceBehavior releaseBehavior)
@@ -491,10 +467,10 @@ bool GraphicsContextGLANGLE::reshapeFBOs(const IntSize& size)
         GL_BindTexture(GL_TEXTURE_2D, texture2DBinding);
         // Attach m_texture to m_preserveDrawingBufferFBO for later blitting.
         GL_BindFramebuffer(GL_FRAMEBUFFER, m_preserveDrawingBufferFBO);
-        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, drawingBufferTextureTarget(), m_texture, 0);
+        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
         GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     } else
-        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, drawingBufferTextureTarget(), m_texture, 0);
+        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
 
     attachDepthAndStencilBufferIfNeeded(m_internalDepthStencilFormat, width, height);
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -47,10 +47,6 @@ public:
     GCGLDisplay platformDisplay() const;
     GCGLConfig platformConfig() const;
 
-    GCGLenum drawingBufferTextureTarget();
-    std::tuple<GCGLenum, GCGLenum> drawingBufferTextureBindingPoint();
-    static GCGLint NODELETE EGLDrawingBufferTextureTargetForDrawingTarget(GCGLenum drawingTarget);
-
     enum class ReleaseThreadResourceBehavior {
         // Releases current context after GraphicsContextGLANGLE calls done in the thread.
         ReleaseCurrentContext,
@@ -444,8 +440,6 @@ protected:
     GCGLuint m_preserveDrawingBufferTexture { 0 };
     // Attaches m_texture when m_preserveDrawingBufferTexture is non-zero.
     GCGLuint m_preserveDrawingBufferFBO { 0 };
-    // Queried at display startup.
-    GCGLint m_drawingBufferTextureTarget { -1 };
     GCGLErrorCodeSet m_errors;
     bool m_isForWebGL2 { false };
     bool m_failNextStatusCheck { false };

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -81,8 +81,6 @@ public:
     ~GraphicsContextGLCocoa();
     IOSurface* NODELETE displayBufferSurface();
 
-    std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
-
     enum class PbufferAttachmentUsage { Read, Write, ReadWrite };
     // Returns a handle which, if non-null, must be released via the
     // detach call below.

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -196,21 +196,6 @@ IOSurface* GraphicsContextGLCocoa::displayBufferSurface()
     return displayBuffer().surface();
 }
 
-std::tuple<GCGLenum, GCGLenum> GraphicsContextGLCocoa::externalImageTextureBindingPoint()
-{
-    if (m_drawingBufferTextureTarget == -1)
-        EGL_GetConfigAttrib(platformDisplay(), platformConfig(), EGL_BIND_TO_TEXTURE_TARGET_ANGLE, &m_drawingBufferTextureTarget);
-
-    switch (m_drawingBufferTextureTarget) {
-    case EGL_TEXTURE_2D:
-        return std::make_tuple(TEXTURE_2D, TEXTURE_BINDING_2D);
-    case EGL_TEXTURE_RECTANGLE_ANGLE:
-        return std::make_tuple(TEXTURE_RECTANGLE_ARB, TEXTURE_BINDING_RECTANGLE_ARB);
-    }
-    ASSERT_WITH_MESSAGE(false, "Invalid enum returned from EGL_GetConfigAttrib");
-    return std::make_tuple(0, 0);
-}
-
 bool GraphicsContextGLCocoa::platformInitializeContext()
 {
     GraphicsContextGLAttributes attributes = contextAttributes();
@@ -356,7 +341,6 @@ GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
         EGL_DestroyContext(m_displayObj, m_contextObj);
     }
     ASSERT(currentContext != this);
-    m_drawingBufferTextureTarget = -1;
 }
 
 bool GraphicsContextGLANGLE::makeContextCurrent()
@@ -449,7 +433,7 @@ bool GraphicsContextGLCocoa::bindNextDrawingBuffer()
             EGL_WIDTH, size.width(),
             EGL_HEIGHT, size.height(),
             EGL_IOSURFACE_PLANE_ANGLE, 0,
-            EGL_TEXTURE_TARGET, EGLDrawingBufferTextureTargetForDrawingTarget(drawingBufferTextureTarget()),
+            EGL_TEXTURE_TARGET, EGL_TEXTURE_2D,
             EGL_TEXTURE_INTERNAL_FORMAT_ANGLE, usingAlpha ? GL_BGRA_EXT : GL_RGB,
             EGL_TEXTURE_FORMAT, EGL_TEXTURE_RGBA,
             EGL_TEXTURE_TYPE_ANGLE, GL_UNSIGNED_BYTE,
@@ -463,9 +447,8 @@ bool GraphicsContextGLCocoa::bindNextDrawingBuffer()
         buffer = IOSurfacePbuffer { WTF::move(surface), pbuffer };
     }
 
-    auto [textureTarget, textureBinding] = drawingBufferTextureBindingPoint();
-    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
-    GL_BindTexture(textureTarget, m_texture);
+    ScopedRestoreTextureBinding restoreBinding(TEXTURE_BINDING_2D, TEXTURE_2D);
+    GL_BindTexture(TEXTURE_2D, m_texture);
     if (!EGL_BindTexImage(m_displayObj, buffer.pbuffer(), EGL_BACK_BUFFER)) {
         EGL_DestroySurface(m_displayObj, buffer.pbuffer());
         buffer = { };
@@ -495,7 +478,7 @@ bool GraphicsContextGLANGLE::makeCurrent(GCGLDisplay display, GCGLContext contex
 
 void* GraphicsContextGLCocoa::createPbufferAndAttachIOSurface(GCGLenum target, PbufferAttachmentUsage usage, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLenum type, IOSurfaceRef surface, GCGLuint plane)
 {
-    if (target != GraphicsContextGLANGLE::drawingBufferTextureTarget()) {
+    if (target != GraphicsContextGL::TEXTURE_2D) {
         LOG(WebGL, "Unknown texture target %d.", static_cast<int>(target));
         return nullptr;
     }
@@ -764,15 +747,14 @@ RefPtr<PixelBuffer> GraphicsContextGLCocoa::readCompositedResults()
     // out of an IOSurface in such a way that drawing the NativeImage would be guaranteed leave
     // the IOSurface be unrefenced after the draw call finishes.
     ScopedTexture texture;
-    auto [textureTarget, textureBinding] = drawingBufferTextureBindingPoint();
-    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
-    GL_BindTexture(textureTarget, texture);
+    ScopedRestoreTextureBinding restoreBinding(TEXTURE_BINDING_2D, TEXTURE_2D);
+    GL_BindTexture(TEXTURE_2D, texture);
     if (!EGL_BindTexImage(m_displayObj, buffer.pbuffer(), EGL_BACK_BUFFER))
         return nullptr;
-    GL_TexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GL_TexParameteri(TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     ScopedFramebuffer fbo;
     ScopedRestoreReadFramebufferBinding fboBinding(m_isForWebGL2, m_state.boundReadFBO, fbo);
-    GL_FramebufferTexture2D(fboBinding.framebufferTarget(), GL_COLOR_ATTACHMENT0, textureTarget, texture, 0);
+    GL_FramebufferTexture2D(fboBinding.framebufferTarget(), GL_COLOR_ATTACHMENT0, TEXTURE_2D, texture, 0);
     ASSERT(GL_CheckFramebufferStatus(fboBinding.framebufferTarget()) == GL_FRAMEBUFFER_COMPLETE);
 
     auto result = readPixelsForPaintResults();

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
@@ -74,30 +74,6 @@ static constexpr auto s_yuvVertexShaderTexture2D {
     "}"_s
 };
 
-static constexpr auto s_yuvVertexShaderTextureRectangle {
-    "attribute vec2 a_position;"
-    "uniform vec2 u_yTextureSize;"
-    "uniform vec2 u_uvTextureSize;"
-    "uniform int u_flipY;"
-    "uniform int u_flipX;"
-    "uniform int u_swapXY;"
-    "varying vec2 v_yTextureCoordinate;"
-    "varying vec2 v_uvTextureCoordinate;"
-    "void main()"
-    "{"
-    "    gl_Position = vec4(a_position, 0, 1.0);"
-    "    vec2 normalizedPosition = a_position * .5 + .5;"
-    "    if (u_flipY == 1)"
-    "        normalizedPosition.y = 1.0 - normalizedPosition.y;"
-    "    if (u_flipX == 1)"
-    "        normalizedPosition.x = 1.0 - normalizedPosition.x;"
-    "    if (u_swapXY == 1)"
-    "        normalizedPosition.xy = normalizedPosition.yx;"
-    "    v_yTextureCoordinate = normalizedPosition * u_yTextureSize;"
-    "    v_uvTextureCoordinate = normalizedPosition * u_uvTextureSize;"
-    "}"_s
-};
-
 constexpr auto s_yuvFragmentShaderTexture2D {
     "precision mediump float;"
     "uniform sampler2D u_yTexture;"
@@ -110,23 +86,6 @@ constexpr auto s_yuvFragmentShaderTexture2D {
     "    vec4 yuv;"
     "    yuv.r = texture2D(u_yTexture, v_yTextureCoordinate).r;"
     "    yuv.gb = texture2D(u_uvTexture, v_uvTextureCoordinate).rg;"
-    "    yuv.a = 1.0;"
-    "    gl_FragColor = yuv * u_colorMatrix;"
-    "}"_s
-};
-
-static constexpr auto s_yuvFragmentShaderTextureRectangle {
-    "precision mediump float;"
-    "uniform sampler2DRect u_yTexture;"
-    "uniform sampler2DRect u_uvTexture;"
-    "uniform mat4 u_colorMatrix;"
-    "varying vec2 v_yTextureCoordinate;"
-    "varying vec2 v_uvTextureCoordinate;"
-    "void main()"
-    "{"
-    "    vec4 yuv;"
-    "    yuv.r = texture2DRect(u_yTexture, v_yTextureCoordinate).r;"
-    "    yuv.gb = texture2DRect(u_uvTexture, v_uvTextureCoordinate).rg;"
     "    yuv.a = 1.0;"
     "    gl_FragColor = yuv * u_colorMatrix;"
     "}"_s
@@ -495,17 +454,6 @@ GraphicsContextGLCVCocoa::GraphicsContextGLCVCocoa(GraphicsContextGLCocoa& owner
         EGL_DestroyContext(display, context);
     });
 
-    const bool useTexture2D = m_owner->drawingBufferTextureTarget() == GL_TEXTURE_2D;
-
-#if PLATFORM(MAC)
-    if (!useTexture2D) {
-        GL_RequestExtensionANGLE("GL_ANGLE_texture_rectangle");
-        GL_RequestExtensionANGLE("GL_EXT_texture_format_BGRA8888");
-        if (GL_GetError() != GL_NO_ERROR)
-            return;
-    }
-#endif
-
     GLint vertexShader = GL_CreateShader(GL_VERTEX_SHADER);
     GLint fragmentShader = GL_CreateShader(GL_FRAGMENT_SHADER);
     GLuint yuvProgram = GL_CreateProgram();
@@ -515,10 +463,10 @@ GraphicsContextGLCVCocoa::GraphicsContextGLCVCocoa(GraphicsContextGLCocoa& owner
         GL_DeleteProgram(yuvProgram);
     });
     // These are written so strlen might be compile-time.
-    GLint vsLength = useTexture2D ? s_yuvVertexShaderTexture2D.length() : s_yuvVertexShaderTextureRectangle.length();
-    GLint fsLength = useTexture2D ? s_yuvFragmentShaderTexture2D.length() : s_yuvFragmentShaderTextureRectangle.length();
-    const char* vertexShaderSource = useTexture2D ? s_yuvVertexShaderTexture2D : s_yuvVertexShaderTextureRectangle;
-    const char* fragmentShaderSource = useTexture2D ? s_yuvFragmentShaderTexture2D : s_yuvFragmentShaderTextureRectangle;
+    GLint vsLength = s_yuvVertexShaderTexture2D.length();
+    GLint fsLength = s_yuvFragmentShaderTexture2D.length();
+    const char* vertexShaderSource = s_yuvVertexShaderTexture2D;
+    const char* fragmentShaderSource = s_yuvFragmentShaderTexture2D;
 
     GL_ShaderSource(vertexShader, 1, &vertexShaderSource, &vsLength);
     GL_ShaderSource(fragmentShader, 1, &fragmentShaderSource, &fsLength);
@@ -697,20 +645,18 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     auto uvPlaneWidth = IOSurfaceGetWidthOfPlane(surface.get(), 1);
     auto uvPlaneHeight = IOSurfaceGetHeightOfPlane(surface.get(), 1);
 
-    GLenum videoTextureTarget = m_owner->drawingBufferTextureTarget();
-
     GLuint uvTexture = 0;
     GL_GenTextures(1, &uvTexture);
     auto uvTextureCleanup = makeScopeExit([uvTexture] {
         GL_DeleteTextures(1, &uvTexture);
     });
     GL_ActiveTexture(GL_TEXTURE1);
-    GL_BindTexture(videoTextureTarget, uvTexture);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    auto uvHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, videoTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RG, uvPlaneWidth, uvPlaneHeight, GL_UNSIGNED_BYTE, surface.get(), 1);
+    GL_BindTexture(GL_TEXTURE_2D, uvTexture);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    auto uvHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, GL_TEXTURE_2D, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RG, uvPlaneWidth, uvPlaneHeight, GL_UNSIGNED_BYTE, surface.get(), 1);
     if (!uvHandle)
         return false;
     auto uvHandleCleanup = makeScopeExit([display = m_display, uvHandle] {
@@ -723,12 +669,12 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
         GL_DeleteTextures(1, &yTexture);
     });
     GL_ActiveTexture(GL_TEXTURE0);
-    GL_BindTexture(videoTextureTarget, yTexture);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    auto yHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, videoTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RED, yPlaneWidth, yPlaneHeight, GL_UNSIGNED_BYTE, surface.get(), 0);
+    GL_BindTexture(GL_TEXTURE_2D, yTexture);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    auto yHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, GL_TEXTURE_2D, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RED, yPlaneWidth, yPlaneHeight, GL_UNSIGNED_BYTE, surface.get(), 0);
     if (!yHandle)
         return false;
     auto yHandleCleanup = makeScopeExit([display = m_display, yHandle] {

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -184,10 +184,9 @@ bool GraphicsContextGLTextureMapperGBM::bindNextDrawingBuffer()
         m_drawingBuffer = WTF::move(buffer);
     }
 
-    auto [textureTarget, textureBinding] = drawingBufferTextureBindingPoint();
-    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
-    GL_BindTexture(textureTarget, m_texture);
-    GL_EGLImageTargetTexture2DOES(textureTarget, m_drawingBuffer.image);
+    ScopedRestoreTextureBinding restoreBinding(TEXTURE_BINDING_2D, TEXTURE_2D);
+    GL_BindTexture(GL_TEXTURE_2D, m_texture);
+    GL_EGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_drawingBuffer.image);
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -346,7 +346,7 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
     m_layerContentsDisplayDelegate = PlatformLayerDisplayDelegate::create(m_texmapLayer.get());
 #endif
 
-    GLenum textureTarget = drawingBufferTextureTarget();
+    GLenum textureTarget = GL_TEXTURE_2D;
 #if USE(COORDINATED_GRAPHICS) && USE(LIBEPOXY)
     GL_BindTexture(textureTarget, m_texture);
     m_textureID = setupCurrentTexture();
@@ -380,11 +380,11 @@ void GraphicsContextGLTextureMapperANGLE::swapCompositorTexture()
         GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_preserveDrawingBufferTexture, 0);
         // Attach m_texture to m_preserveDrawingBufferFBO for later blitting.
         GL_BindFramebuffer(GL_FRAMEBUFFER, m_preserveDrawingBufferFBO);
-        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, drawingBufferTextureTarget(), m_texture, 0);
+        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
         GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
     } else {
         GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, drawingBufferTextureTarget(), m_texture, 0);
+        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
     }
 
     GL_Flush();
@@ -400,9 +400,9 @@ bool GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer()
     const int width = size.width();
     const int height = size.height();
     GLuint colorFormat = attrs.alpha ? GL_RGBA : GL_RGB;
-    auto [textureTarget, textureBinding] = drawingBufferTextureBindingPoint();
-    GLuint internalColorFormat = textureTarget == GL_TEXTURE_2D ? colorFormat : m_internalColorFormat;
-    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
+    GLenum textureTarget = GL_TEXTURE_2D;
+    GLuint internalColorFormat = colorFormat;
+    ScopedRestoreTextureBinding restoreBinding(TEXTURE_BINDING_2D, TEXTURE_2D);
 
     GL_BindTexture(textureTarget, m_compositorTexture);
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp
@@ -41,7 +41,7 @@ GCGLuint GraphicsContextGLTextureMapperANGLE::setupCurrentTexture()
     // when another call causes a texture state sync, which doesn't happen. So, we set the same
     // parmeters here using epoxy to make sure the texture is configured as expected by the
     // texture mapper.
-    GLenum textureTarget = drawingBufferTextureTarget();
+    GLenum textureTarget = GL_TEXTURE_2D;
     glTexParameteri(textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -131,13 +131,10 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
         auto contextAttributes = context->contextAttributes();
         auto knownActiveExtensions = context->knownActiveExtensions();
         auto requestableExtensions = context->requestableExtensions();
-        auto [externalImageTarget, externalImageBindingQuery] = context->externalImageTextureBindingPoint();
         RemoteGraphicsContextGLInitializationState initializationState {
             .attributes = context->contextAttributes(),
             .knownActiveExtensions = knownActiveExtensions.toRaw(),
             .requestableExtensions = requestableExtensions.toRaw(),
-            .externalImageTarget = externalImageTarget,
-            .externalImageBindingQuery = externalImageBindingQuery,
             .maxCombinedTextureImageUnits = context->maxCombinedTextureImageUnits(),
             .maxVertexAttribs = context->maxVertexAttribs(),
             .maxTextureSize = context->maxTextureSize(),

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
@@ -39,8 +39,6 @@ struct RemoteGraphicsContextGLInitializationState {
     WebCore::GraphicsContextGLAttributes attributes;
     uint64_t knownActiveExtensions { 0 }; // EnumSet<WebCore::GCGLExtension> when EnumSet serialization works.
     uint64_t requestableExtensions { 0 }; // EnumSet<WebCore::GCGLExtension> when EnumSet serialization works.
-    GCGLenum externalImageTarget { 0 };
-    GCGLenum externalImageBindingQuery { 0 };
     GCGLint maxCombinedTextureImageUnits { 0 };
     GCGLint maxVertexAttribs { 0 };
     GCGLint maxTextureSize { 0 };

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in
@@ -26,8 +26,6 @@ struct WebKit::RemoteGraphicsContextGLInitializationState {
     WebCore::GraphicsContextGLAttributes attributes;
     uint64_t knownActiveExtensions;
     uint64_t requestableExtensions;
-    GCGLenum externalImageTarget;
-    GCGLenum externalImageBindingQuery;
     GCGLint maxCombinedTextureImageUnits;
     GCGLint maxVertexAttribs;
     GCGLint maxTextureSize;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -152,8 +152,6 @@ void RemoteGraphicsContextGLProxy::initialize(const RemoteGraphicsContextGLIniti
     setContextAttributes(initializationState.attributes);
     m_knownActiveExtensions = EnumSet<GCGLExtension>::fromRaw(initializationState.knownActiveExtensions);
     m_requestableExtensions = EnumSet<GCGLExtension>::fromRaw(initializationState.requestableExtensions);
-    m_externalImageTarget = initializationState.externalImageTarget;
-    m_externalImageBindingQuery = initializationState.externalImageBindingQuery;
     m_maxCombinedTextureImageUnits = initializationState.maxCombinedTextureImageUnits;
     m_maxVertexAttribs = initializationState.maxVertexAttribs;
     m_maxTextureSize = initializationState.maxTextureSize;
@@ -166,14 +164,6 @@ void RemoteGraphicsContextGLProxy::initialize(const RemoteGraphicsContextGLIniti
     m_uniformBufferOffsetAlignment = initializationState.uniformBufferOffsetAlignment;
     m_max3DTextureSize = initializationState.max3DTextureSize;
     m_maxArrayTextureLayers = initializationState.maxArrayTextureLayers;
-}
-
-std::tuple<GCGLenum, GCGLenum> RemoteGraphicsContextGLProxy::externalImageTextureBindingPoint()
-{
-    if (isContextLost())
-        return std::make_tuple(0, 0);
-
-    return std::make_tuple(m_externalImageTarget, m_externalImageBindingQuery);
 }
 
 void RemoteGraphicsContextGLProxy::reshape(int width, int height)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -74,7 +74,6 @@ public:
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, const Vector<uint32_t>& indicesOfObjectsFailingDecoding) final { }
 
     // WebCore::GraphicsContextGL overrides.
-    std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
     void reshape(int width, int height) final;
     bool supportsExtension(WebCore::GCGLExtension) final;
     bool enableExtension(WebCore::GCGLExtension) final;
@@ -432,8 +431,6 @@ private:
 #if ENABLE(VIDEO)
     RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
 #endif
-    GCGLenum m_externalImageTarget { 0 };
-    GCGLenum m_externalImageBindingQuery { 0 };
     GCGLint m_maxCombinedTextureImageUnits { 0 };
     GCGLint m_maxVertexAttribs { 0 };
     GCGLint m_maxTextureSize { 0 };


### PR DESCRIPTION
#### 8621b50ea2a36f48674a00466106bffedd2c22c9
<pre>
WebGL: Remove code related to externalImageTextureBindingPoint()
<a href="https://bugs.webkit.org/show_bug.cgi?id=317923">https://bugs.webkit.org/show_bug.cgi?id=317923</a>
<a href="https://rdar.apple.com/180717046">rdar://180717046</a>

Reviewed by Mike Wyrzykowski.

The external image texture binding point was used to support
CGL where TEXTURE_RECTANGLEs were used. Currently ANGLE
uses just TEXTURE_2D binding points on all platforms,
so remove the code.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::externalImageTextureBindingPoint): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):
(WebCore::GraphicsContextGLANGLE::reshapeFBOs):
(WebCore::GraphicsContextGLANGLE::drawingBufferTextureTarget): Deleted.
(WebCore::GraphicsContextGLANGLE::drawingBufferTextureBindingPoint): Deleted.
(WebCore::GraphicsContextGLANGLE::EGLDrawingBufferTextureTargetForDrawingTarget): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLCocoa::bindNextDrawingBuffer):
(WebCore::GraphicsContextGLCocoa::createPbufferAndAttachIOSurface):
(WebCore::GraphicsContextGLCocoa::readCompositedResults):
(WebCore::GraphicsContextGLCocoa::externalImageTextureBindingPoint): Deleted.
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm:
(WebCore::GraphicsContextGLCVCocoa::GraphicsContextGLCVCocoa):
(WebCore::GraphicsContextGLCVCocoa::copyVideoSampleToTexture):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::bindNextDrawingBuffer):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitialize):
(WebCore::GraphicsContextGLTextureMapperANGLE::swapCompositorTexture):
(WebCore::GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsContextGLTextureMapperANGLECoordinated.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::setupCurrentTexture):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::initialize):
(WebKit::RemoteGraphicsContextGLProxy::externalImageTextureBindingPoint): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:

Canonical link: <a href="https://commits.webkit.org/316369@main">https://commits.webkit.org/316369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5fba9ea3d310f27c841f203bcb3ec60d3a7f4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128999 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9bbc25d-189f-4404-b140-7f23417bc920) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133549 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94207 "1 flakes 20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34f93075-7e9a-4185-ae29-00a290d7573d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114018 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6685f14c-aafd-4c80-aef6-a9a08ab5a52a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33654 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29394 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183303 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142045 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44916 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141864 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38471 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45606 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110310 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37102 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117396 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44116 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8399 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43520 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43762 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->