### PR TITLE
[iOS] The UI process should not have access to the temp and cache folder of the Networking process

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -547,6 +547,7 @@ void NetworkProcess::addStorageSession(PAL::SessionID sessionID, const WebsiteDa
     RetainPtr<CFHTTPCookieStorageRef> uiProcessCookieStorage;
     if (!sessionID.isEphemeral() && !parameters.uiProcessCookieStorageIdentifier.isEmpty()) {
         SandboxExtension::consumePermanently(parameters.cookieStoragePathExtensionHandle);
+        setSharedHTTPCookieStorage(parameters.uiProcessCookieStorageIdentifier);
         if (sessionID != PAL::SessionID::defaultSessionID())
             uiProcessCookieStorage = cookieStorageFromIdentifyingData(parameters.uiProcessCookieStorageIdentifier);
     }
@@ -584,15 +585,24 @@ void NetworkProcess::addWebsiteDataStore(WebsiteDataStoreParameters&& parameters
 #if PLATFORM(IOS_FAMILY)
     if (auto& handle = parameters.cookieStorageDirectoryExtensionHandle)
         SandboxExtension::consumePermanently(*handle);
+#if !USE(EXTENSIONKIT)
     if (auto& handle = parameters.containerCachesDirectoryExtensionHandle)
         SandboxExtension::consumePermanently(*handle);
+#endif
     if (auto& handle = parameters.parentBundleDirectoryExtensionHandle)
         SandboxExtension::consumePermanently(*handle);
+#if !USE(EXTENSIONKIT)
     if (auto& handle = parameters.tempDirectoryExtensionHandle)
-        grantAccessToContainerTempDirectory(*handle);
-    if (auto& handle = parameters.tempDirectoryRootExtensionHandle)
         SandboxExtension::consumePermanently(*handle);
 #endif
+    if (auto& handle = parameters.tempDirectoryRootExtensionHandle)
+        SandboxExtension::consumePermanently(*handle);
+#if ENABLE(LLVM_PROFILE_GENERATION)
+    WebKit::initializeLLVMProfiling();
+    WebCore::initializeLLVMProfiling();
+    JSC::initializeLLVMProfiling();
+#endif // ENABLE(LLVM_PROFILE_GENERATION)
+#endif // PLATFORM(IOS_FAMILY)
 
     addStorageSession(sessionID, parameters);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -593,9 +593,7 @@ private:
     void setNetworkProxySettings(PAL::SessionID, WebCore::CurlProxySettings&&);
 #endif
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     static void setSharedHTTPCookieStorage(const Vector<uint8_t>& identifier);
-#endif
 
     void terminateRemoteWorkerContextConnectionWhenPossible(RemoteWorkerType, PAL::SessionID, const WebCore::RegistrableDomain&, WebCore::ProcessIdentifier);
     void runningOrTerminatingServiceWorkerCountForTesting(PAL::SessionID, CompletionHandler<void(unsigned)>&&) const;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -224,13 +224,11 @@ void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<vo
     }).get());
 }
 
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 void NetworkProcess::setSharedHTTPCookieStorage(const Vector<uint8_t>& identifier)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
     [NSHTTPCookieStorage _setSharedHTTPCookieStorage:adoptNS([[NSHTTPCookieStorage alloc] _initWithCFHTTPCookieStorage:cookieStorageFromIdentifyingData(identifier).get()]).get()];
 }
-#endif
 
 void NetworkProcess::flushCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -147,6 +147,12 @@
 (allow file-read* (with message "Allowing read access to root")
     (literal "/"))
 
+#if USE(EXTENSIONKIT)
+(allow file-read* file-write*
+    (container-subpath "Library/Caches")
+    (container-subpath "tmp"))
+#endif // USE(EXTENSIONKIT)
+
 (allow mach-lookup
     (mach-lookup-allowed))
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -268,16 +268,6 @@ void AuxiliaryProcess::applyProcessCreationParameters(AuxiliaryProcessCreationPa
 #endif
 }
 
-void AuxiliaryProcess::grantAccessToContainerTempDirectory(const SandboxExtension::Handle& handle)
-{
-    SandboxExtension::consumePermanently(handle);
-#if ENABLE(LLVM_PROFILE_GENERATION) && PLATFORM(IOS_FAMILY)
-    WebKit::initializeLLVMProfiling();
-    WebCore::initializeLLVMProfiling();
-    JSC::initializeLLVMProfiling();
-#endif // ENABLE(LLVM_PROFILE_GENERATION) && PLATFORM(IOS_FAMILY)
-}
-
 #if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
 void AuxiliaryProcess::populateMobileGestaltCache(std::optional<SandboxExtension::Handle>&&)
 {

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -163,7 +163,6 @@ protected:
     static void openDirectoryCacheInvalidated(SandboxExtension::Handle&&);
 #endif
 
-    void grantAccessToContainerTempDirectory(const SandboxExtension::Handle&);
     void populateMobileGestaltCache(std::optional<SandboxExtension::Handle>&& mobileGestaltExtensionHandle);
 
 #if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS)

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -221,7 +221,11 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 #endif
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(WEBCONTENT_SERVICE_INITIALIZER));
             } else if (serviceName == networkingServiceName) {
+#if USE(EXTENSIONKIT)
+                setUserDirSuffix(WTF::move(uiProcessName));
+#else
                 setUserDirSuffix(networkingServiceName);
+#endif
                 entryPointFunctionName = CFSTR(STRINGIZE_VALUE_OF(NETWORK_SERVICE_INITIALIZER));
             } else if (serviceName == gpuServiceName) {
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/Shared/WebsiteDataStoreParameters.h
+++ b/Source/WebKit/Shared/WebsiteDataStoreParameters.h
@@ -41,9 +41,11 @@ struct WebsiteDataStoreParameters {
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<SandboxExtension::Handle> cookieStorageDirectoryExtensionHandle;
+#if !USE(EXTENSIONKIT)
     std::optional<SandboxExtension::Handle> containerCachesDirectoryExtensionHandle;
-    std::optional<SandboxExtension::Handle> parentBundleDirectoryExtensionHandle;
     std::optional<SandboxExtension::Handle> tempDirectoryExtensionHandle;
+#endif
+    std::optional<SandboxExtension::Handle> parentBundleDirectoryExtensionHandle;
     std::optional<SandboxExtension::Handle> tempDirectoryRootExtensionHandle;
 #endif
 };

--- a/Source/WebKit/Shared/WebsiteDataStoreParameters.serialization.in
+++ b/Source/WebKit/Shared/WebsiteDataStoreParameters.serialization.in
@@ -29,9 +29,11 @@ header: "WebsiteDataFetchOption.h"
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<WebKit::SandboxExtensionHandle> cookieStorageDirectoryExtensionHandle;
+#if !USE(EXTENSIONKIT)
     std::optional<WebKit::SandboxExtensionHandle> containerCachesDirectoryExtensionHandle;
-    std::optional<WebKit::SandboxExtensionHandle> parentBundleDirectoryExtensionHandle;
     std::optional<WebKit::SandboxExtensionHandle> tempDirectoryExtensionHandle;
+#endif
+    std::optional<WebKit::SandboxExtensionHandle> parentBundleDirectoryExtensionHandle;
     std::optional<WebKit::SandboxExtensionHandle> tempDirectoryRootExtensionHandle;
 #endif
 };

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -376,12 +376,7 @@ void ProcessLauncher::tryFinishLaunchingProcess(ASCIILiteral name, Function<void
         xpc_dictionary_set_value(bootstrapMessage.get(), "OverrideLanguages", languages.get());
     }
 
-#if PLATFORM(IOS_FAMILY)
-    bool isWebContentOrGPUExtension = false;
-#if USE(EXTENSIONKIT)
-    isWebContentOrGPUExtension = (m_launchOptions.processType == ProcessLauncher::ProcessType::Web) || (m_launchOptions.processType == ProcessLauncher::ProcessType::GPU);
-#endif
-    if (!isWebContentOrGPUExtension) {
+#if PLATFORM(IOS_FAMILY) && !USE(EXTENSIONKIT)
         // Clients that set these environment variables explicitly do not have the values automatically forwarded by libxpc.
         auto containerEnvironmentVariables = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         if (const char* environmentHOME = getenv("HOME"))
@@ -391,8 +386,7 @@ void ProcessLauncher::tryFinishLaunchingProcess(ASCIILiteral name, Function<void
         if (const char* environmentTMPDIR = getenv("TMPDIR"))
             xpc_dictionary_set_string(containerEnvironmentVariables.get(), "TMPDIR", environmentTMPDIR);
         xpc_dictionary_set_value(bootstrapMessage.get(), "ContainerEnvironmentVariables", containerEnvironmentVariables.get());
-    }
-#endif
+#endif // PLATFORM(IOS_FAMILY) && !USE(EXTENSIONKIT)
 
     CheckedPtr client = m_client;
     if (client) {

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -221,6 +221,12 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.manualPrevalentResource = WTF::move(resourceLoadStatisticsManualPrevalentResource);
 
     auto cookieFile = directories.cookieStorageFile;
+#if PLATFORM(IOS_FAMILY)
+    if (cookieFile.isEmpty())
+        cookieFile = FileSystem::pathByAppendingComponent(WebsiteDataStore::resolvedCookieStorageDirectory(), "Cookies.binarycookies"_s);
+
+#endif // PLATFORM(IOS_FAMILY)
+
     createHandleFromResolvedPathIfPossible(FileSystem::parentPath(cookieFile), parameters.cookieStoragePathExtensionHandle);
 
     if (m_uiProcessCookieStorageIdentifier.isEmpty()) {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2289,16 +2289,18 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
         createHandleFromResolvedPathIfPossible(resolvedCookieStorageDirectory(), cookieStorageDirectoryExtensionHandle);
         parameters.cookieStorageDirectoryExtensionHandle = WTF::move(cookieStorageDirectoryExtensionHandle);
 
+#if !USE(EXTENSIONKIT)
         SandboxExtension::Handle containerCachesDirectoryExtensionHandle;
         createHandleFromResolvedPathIfPossible(resolvedContainerCachesNetworkingDirectory(), containerCachesDirectoryExtensionHandle);
         parameters.containerCachesDirectoryExtensionHandle = WTF::move(containerCachesDirectoryExtensionHandle);
 
+        if (auto handleAndFilePath = SandboxExtension::createHandleForTemporaryFile(networkingServiceName, SandboxExtension::Type::ReadWrite))
+            parameters.tempDirectoryExtensionHandle = WTF::move(handleAndFilePath->first);
+#endif
         SandboxExtension::Handle parentBundleDirectoryExtensionHandle;
         createHandleFromResolvedPathIfPossible(parentBundleDirectory(), parentBundleDirectoryExtensionHandle, SandboxExtension::Type::ReadOnly);
         parameters.parentBundleDirectoryExtensionHandle = WTF::move(parentBundleDirectoryExtensionHandle);
 
-        if (auto handleAndFilePath = SandboxExtension::createHandleForTemporaryFile(networkingServiceName, SandboxExtension::Type::ReadWrite))
-            parameters.tempDirectoryExtensionHandle = WTF::move(handleAndFilePath->first);
         if (auto handleAndFilePath = SandboxExtension::createHandleForTemporaryFile(emptyString(), SandboxExtension::Type::ReadOnly))
             parameters.tempDirectoryRootExtensionHandle = WTF::move(handleAndFilePath->first);
     }


### PR DESCRIPTION
#### cfb81e19f78c7f31dcad617b367ae15535be47f4
<pre>
[iOS] The UI process should not have access to the temp and cache folder of the Networking process
<a href="https://bugs.webkit.org/show_bug.cgi?id=316124">https://bugs.webkit.org/show_bug.cgi?id=316124</a>
<a href="https://rdar.apple.com/178551436">rdar://178551436</a>

Reviewed by NOBODY (OOPS!).

To achieve this, we can move these directories to its container. We have previously done the same
for the WebContent and GPU process.

This patch also removes sandbox extensions to the cache and temp folder, which are not needed
anymore after moving these directories.

Additionally, the patch maintains the old location for the cookie file, so that no migration of
cookies are needed.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::addStorageSession):
(WebKit::NetworkProcess::addWebsiteDataStore):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::setSharedHTTPCookieStorage):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::grantAccessToContainerTempDirectory): Deleted.
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/Shared/WebsiteDataStoreParameters.h:
* Source/WebKit/Shared/WebsiteDataStoreParameters.serialization.in:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::tryFinishLaunchingProcess):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfb81e19f78c7f31dcad617b367ae15535be47f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170419 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44342 "Hash cfb81e19 for PR 67947 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128131 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c5106ac-0578-44e8-ae56-d70431a558d9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132889 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93688 "2 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b678d65-e312-47ac-8cf4-acead8979b74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36066 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155744 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113389 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef7e65ac-f7fe-4d87-91ef-e5810468a972) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34690 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35498 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28477 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145150 "Found 15 new API test failures: TestWebKitAPI._WKDownload.DownloadMonitorCancel, TestWebKitAPI.WKWebsiteDataStoreConfiguration.SameCustomPathForDifferentTypes, TestWebKitAPI.WebKit.WebsiteDataStoreCustomPathsWithoutPrewarming, TestWebKitAPI.TimeBasedEviction.ThrottledToConfiguredInterval, TestWebKitAPI.TimeBasedEviction.ServiceWorkerRegistrationsOnlyMode, TestWebKitAPI.WKWebsiteDataStore.RemoveSessionWithIdentifierFromNetworkProcess, TestWebKitAPI.ResourceLoadStatistics.EnableResourceLoadStatisticsAfterNetworkProcessCreation, TestWebKitAPI.TimeBasedEviction.PushSubscriptionOriginNotEvicted, TestWebKitAPI.WebKit.AlternativeServicesDefaultDirectoryCreation, TestWebKitAPI.TimeBasedEviction.DiskCacheAccessUpdatesTimestamp ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32716 "Found 60 new test failures: compositing/overflow/overflow-change-reposition-descendants.html fast/inline/blocks-in-inline-layout-with-margin-after.html http/tests/inspector/dom/cross-domain-inspected-node-access.html http/tests/inspector/dom/didFireEvent.html http/tests/inspector/gatherWebInspectorRTCLogs.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html http/tests/inspector/network/fetch-network-data.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182379 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35183 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37210 "Found 60 new test failures: accessibility/mac/input-replacevalue-userinfo.html http/tests/inspector/dom/cross-domain-inspected-node-access.html http/tests/inspector/gatherWebInspectorRTCLogs.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html http/tests/inspector/network/fetch-network-data.html http/tests/inspector/network/fetch-response-body.html http/tests/inspector/network/getSerializedCertificate.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141340 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43999 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141158 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44688 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29704 "Found 60 new test failures: css3/blending/blend-mode-body-child-background-color.html fast/css-grid-layout/grid-simplified-layout-positioned.html http/tests/inspector/dom/cross-domain-inspected-node-access.html http/tests/inspector/dom/didFireEvent.html http/tests/inspector/gatherWebInspectorRTCLogs.html http/tests/inspector/network/beacon-type.html http/tests/inspector/network/copy-as-curl.html http/tests/inspector/network/copy-as-fetch.html http/tests/inspector/network/eventsource-type.html http/tests/inspector/network/fetch-network-data.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109159 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36426 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116570 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43198 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7804 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42604 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->