### PR TITLE
BorderShape: Implement corner-shape path generation and painting

### DIFF
--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -30,13 +30,13 @@
 namespace WebCore {
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path&, const CornerInput[4])
+void borderContourPath(Path&, const RectCorners<CornerInput>&)
 {
     // TODO: implement superellipse contour path generation.
 }
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
-double oppositeCornerScaleFactor(const CornerInput[4])
+double oppositeCornerScaleFactor(const RectCorners<CornerInput>&)
 {
     // TODO: implement opposite-corner scale factor computation.
     return 1.0;

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.h
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include "RectCorners.h"
+
 namespace WebCore {
 
 class Path;
@@ -36,13 +38,13 @@ struct CornerInput {
     double curvature { 0 }; // superellipse parameter s
     double startInset { 0 };
     double endInset { 0 };
-    int orientation { 0 };
+    BoxCorner orientation { BoxCorner::TopRight };
 };
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path&, const CornerInput cornerRects[4]);
+void borderContourPath(Path&, const RectCorners<CornerInput>&);
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
-double oppositeCornerScaleFactor(const CornerInput cornerRects[4]);
+double oppositeCornerScaleFactor(const RectCorners<CornerInput>&);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -31,7 +31,9 @@
 #include "config.h"
 #include "BorderShape.h"
 
+#include "AffineTransform.h"
 #include "BorderData.h"
+#include "CornerShapeUtilities.h"
 #include "FloatRoundedRect.h"
 #include "GraphicsContext.h"
 #include "LayoutRect.h"
@@ -77,8 +79,8 @@ static RectCorners<float> cornerCurvaturesFromStyle(const Style::ComputedStyle& 
     return {
         static_cast<float>(border.topLeftCornerShape().superellipse->value),
         static_cast<float>(border.topRightCornerShape().superellipse->value),
-        static_cast<float>(border.bottomRightCornerShape().superellipse->value),
         static_cast<float>(border.bottomLeftCornerShape().superellipse->value),
+        static_cast<float>(border.bottomRightCornerShape().superellipse->value)
     };
 }
 
@@ -267,13 +269,58 @@ static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path
         path.addRect(roundedRect.rect());
 }
 
+static void buildCornerInputs(const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures,
+    double leftWidth, double topWidth, double rightWidth, double bottomWidth, RectCorners<CornerInput>& cornerRects)
+{
+    auto tr = outerSnapped.topRightCorner();
+    auto br = outerSnapped.bottomRightCorner();
+    auto bl = outerSnapped.bottomLeftCorner();
+    auto tl = outerSnapped.topLeftCorner();
+
+    cornerRects.topRight() = { tr.x(), tr.y(), tr.width(), tr.height(), cornerCurvatures.topRight(), topWidth, rightWidth, BoxCorner::TopRight };
+    cornerRects.bottomRight() = { br.x(), br.y(), br.width(), br.height(), cornerCurvatures.bottomRight(), rightWidth, bottomWidth, BoxCorner::BottomRight };
+    cornerRects.bottomLeft() = { bl.x(), bl.y(), bl.width(), bl.height(), cornerCurvatures.bottomLeft(), bottomWidth, leftWidth, BoxCorner::BottomLeft };
+    cornerRects.topLeft() = { tl.x(), tl.y(), tl.width(), tl.height(), cornerCurvatures.topLeft(), leftWidth, topWidth, BoxCorner::TopLeft };
+}
+
+static void buildScaledCornerInputs(const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures,
+    double leftWidth, double topWidth, double rightWidth, double bottomWidth, RectCorners<CornerInput>& cornerRects)
+{
+    // Measure unmodified outer corners
+    RectCorners<CornerInput> outerRects;
+    buildCornerInputs(outerSnapped, cornerCurvatures, 0, 0, 0, 0, outerRects);
+    double scale = oppositeCornerScaleFactor(outerRects);
+
+    // Build corners with border insets
+    buildCornerInputs(outerSnapped, cornerCurvatures, leftWidth, topWidth, rightWidth, bottomWidth, cornerRects);
+    if (scale >= 1.0)
+        return;
+
+    for (auto key : { BoxCorner::TopLeft, BoxCorner::TopRight, BoxCorner::BottomLeft, BoxCorner::BottomRight }) {
+        CornerInput& corner = cornerRects[key];
+        double scaledWidth = corner.width * scale;
+        double scaledHeight = corner.height * scale;
+
+        bool anchorRight = corner.orientation == BoxCorner::TopRight || corner.orientation == BoxCorner::BottomRight;
+        bool anchorBottom = corner.orientation == BoxCorner::BottomRight || corner.orientation == BoxCorner::BottomLeft;
+
+        // Push right/down to compensate for shrink
+        if (anchorRight)
+            corner.x += corner.width - scaledWidth;
+        if (anchorBottom)
+            corner.y += corner.height - scaledHeight;
+        corner.width = scaledWidth;
+        corner.height = scaledHeight;
+    }
+}
+
 bool BorderShape::hasNonRoundCornerShape() const
 {
     const auto& radii = m_borderRect.radii();
     return (m_cornerCurvatures.topLeft() != 1.0f && !radii.topLeft().isEmpty())
         || (m_cornerCurvatures.topRight() != 1.0f && !radii.topRight().isEmpty())
-        || (m_cornerCurvatures.bottomRight() != 1.0f && !radii.bottomRight().isEmpty())
-        || (m_cornerCurvatures.bottomLeft() != 1.0f && !radii.bottomLeft().isEmpty());
+        || (m_cornerCurvatures.bottomLeft() != 1.0f && !radii.bottomLeft().isEmpty())
+        || (m_cornerCurvatures.bottomRight() != 1.0f && !radii.bottomRight().isEmpty());
 }
 
 Path BorderShape::pathForOuterRoundedRect(const FloatRoundedRect& outerSnapped) const
@@ -291,17 +338,44 @@ Path BorderShape::pathForInnerRoundedRect(const FloatRoundedRect& innerSnapped) 
     return path;
 }
 
+static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures)
+{
+    RectCorners<CornerInput> cornerRects;
+    buildScaledCornerInputs(outerSnapped, cornerCurvatures, 0, 0, 0, 0, cornerRects);
+    borderContourPath(path, cornerRects);
+}
+
 Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped) const
 {
-    // TODO: implement corner-shape path generation using outerSnapped.
+    Path path;
+    addOuterCornerShapeToPath(path, outerSnapped, m_cornerCurvatures);
+    if (!path.isEmpty())
+        return path;
     return pathForOuterRoundedRect(outerSnapped);
+}
+
+static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures)
+{
+    auto outerRect = outerSnapped.rect();
+    auto innerRect = innerSnapped.rect();
+
+    double leftWidth = innerRect.x() - outerRect.x();
+    double topWidth = innerRect.y() - outerRect.y();
+    double rightWidth = outerRect.maxX() - innerRect.maxX();
+    double bottomWidth = outerRect.maxY() - innerRect.maxY();
+
+    RectCorners<CornerInput> cornerRects;
+    buildScaledCornerInputs(outerSnapped, cornerCurvatures, leftWidth, topWidth, rightWidth, bottomWidth, cornerRects);
+    borderContourPath(path, cornerRects);
 }
 
 Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped) const
 {
-    // TODO: implement corner-shape path generation using outerSnapped and innerSnapped.
-    UNUSED_PARAM(outerSnapped);
-    return pathForInnerRoundedRect(innerSnapped);
+    Path path;
+    addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures);
+    if (path.isEmpty())
+        return pathForInnerRoundedRect(innerSnapped);
+    return path;
 }
 
 Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
@@ -323,25 +397,43 @@ Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
 
 void BorderShape::addOuterShapeToPath(Path& path, float deviceScaleFactor) const
 {
-    if (hasNonRoundCornerShape()) {
-        // TODO: addOuterCornerShapeToPath(path, deviceScaleFactor);
-    }
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (hasNonRoundCornerShape()) {
+        Path cornerPath;
+        addOuterCornerShapeToPath(cornerPath, outerSnapped, m_cornerCurvatures);
+        if (!cornerPath.isEmpty()) {
+            path.addPath(cornerPath, AffineTransform());
+            return;
+        }
+    }
     addRoundedRectToPath(outerSnapped, path);
 }
 
 void BorderShape::addInnerShapeToPath(Path& path, float deviceScaleFactor) const
 {
-    if (hasNonRoundCornerShape()) {
-        // TODO: addInnerCornerShapeToPath(path, deviceScaleFactor);
-    }
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (hasNonRoundCornerShape()) {
+        Path cornerPath;
+        addInnerCornerShapeToPath(cornerPath, outerSnapped, innerSnapped, m_cornerCurvatures);
+        if (!cornerPath.isEmpty()) {
+            path.addPath(cornerPath, AffineTransform());
+            return;
+        }
+    }
     ASSERT(innerSnapped.isRenderable());
     addRoundedRectToPath(innerSnapped, path);
 }
 
 Path BorderShape::pathForBorderArea(float deviceScaleFactor) const
 {
+    if (hasNonRoundCornerShape()) {
+        Path path;
+        addOuterShapeToPath(path, deviceScaleFactor);
+        addInnerShapeToPath(path, deviceScaleFactor);
+        return path;
+    }
+
     auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
 
@@ -420,11 +512,13 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
 
 void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        // TODO: implement corner-shape fill.
+        context.setFillColor(color);
+        context.fillPath(pathForOuterCornerShape(outerSnapped));
+        return;
     }
 
-    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (outerSnapped.hasNonZeroRadii())
         context.fillRoundedRect(outerSnapped, color);
     else
@@ -433,11 +527,14 @@ void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, f
 
 void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
+    auto outerSnapped = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape()) {
-        // TODO: implement corner-shape fill.
+        context.setFillColor(color);
+        context.fillPath(pathForInnerCornerShape(outerSnapped, innerSnapped));
+        return;
     }
 
-    auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(innerSnapped.isRenderable());
     if (innerSnapped.hasNonZeroRadii())
         context.fillRoundedRect(innerSnapped, color);
@@ -450,7 +547,12 @@ void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const Lay
     auto outerSnapped = snapRectToDevicePixels(outerRect, deviceScaleFactor);
 
     if (hasNonRoundCornerShape()) {
-        // TODO: implement corner-shape fill.
+        Path path;
+        path.addRect(outerSnapped);
+        addInnerShapeToPath(path, deviceScaleFactor);
+        context.setFillColor(color);
+        context.fillPath(path);
+        return;
     }
 
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);


### PR DESCRIPTION
#### 842fe4de0fa5058b06babff939f609eb1ec7dbbb
<pre>
BorderShape: Implement corner-shape path generation and painting
<a href="https://bugs.webkit.org/show_bug.cgi?id=317933">https://bugs.webkit.org/show_bug.cgi?id=317933</a>
<a href="https://rdar.apple.com/180731272">rdar://180731272</a>

Reviewed by Simon Fraser.

This patch implements all the functions that contained stubs as well as two helpers,
buildCornerInputs and buildScaledCornerInputs, that translate a FloatRoundedRect
and per-corner curvature values into CornerInput structs for borderContourPath.
buildScaledCornerInputs additionally applies the oppositeCornerScaleFactor(still a stub)
shrink when adjacent corners overlap, repositioning each corner rect to keep it
anchored to the correct edge. The patch also fixes a pre-existing bug in
cornerCurvaturesFromStyle and hasNonRoundCornerShape where bottomLeft and
bottomRight were ordered incorrectly in the RectCorners initializer.

Passes existing tests

* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::borderContourPath):
(WebCore::oppositeCornerScaleFactor):
* Source/WebCore/platform/graphics/CornerShapeUtilities.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::cornerCurvaturesFromStyle):
(WebCore::buildCornerInputs):
(WebCore::buildScaledCornerInputs):
(WebCore::BorderShape::hasNonRoundCornerShape const):
(WebCore::addOuterCornerShapeToPath):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::addInnerCornerShapeToPath):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::BorderShape::addOuterShapeToPath const):
(WebCore::BorderShape::addInnerShapeToPath const):
(WebCore::BorderShape::pathForBorderArea const):
(WebCore::BorderShape::fillOuterShape const):
(WebCore::BorderShape::fillInnerShape const):
(WebCore::BorderShape::fillRectWithInnerHoleShape const):

Canonical link: <a href="https://commits.webkit.org/315941@main">https://commits.webkit.org/315941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea9f48f9894b9118bd0a407f266f93b640cdad83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128181 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132934 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113432 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28526 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182428 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141386 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44049 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38038 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44738 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109221 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36469 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116627 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43248 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7848 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->