### PR TITLE
[Site Isolation] iframe should lose storage access when navigation initiator is cross-site

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -60,7 +60,6 @@ webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-
 http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ Pass ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html [ Failure ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
-http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html [ Failure ]
 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Failure ]
 http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Failure ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Failure ]

--- a/Source/WebCore/platform/network/NetworkStorageSession.cpp
+++ b/Source/WebCore/platform/network/NetworkStorageSession.cpp
@@ -396,13 +396,10 @@ void NetworkStorageSession::grantStorageAccess(const RegistrableDomain& resource
     }
 }
 
-void NetworkStorageSession::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
+void NetworkStorageSession::removeStorageAccessForFrame(FrameIdentifier frameID)
 {
-    auto iteration = m_framesGrantedStorageAccess.find(pageID);
-    if (iteration == m_framesGrantedStorageAccess.end())
-        return;
-
-    iteration->value.remove(frameID);
+    for (auto& innerMap : m_framesGrantedStorageAccess.values())
+        innerMap.remove(frameID);
 }
 
 void NetworkStorageSession::clearPageSpecificDataForResourceLoadStatistics(PageIdentifier pageID)

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -269,7 +269,7 @@ public:
     WEBCORE_EXPORT bool hasStorageAccess(const RegistrableDomain& resourceDomain, const RegistrableDomain& firstPartyDomain, std::optional<FrameIdentifier>, std::optional<PageIdentifier>) const;
     WEBCORE_EXPORT Vector<String> getAllStorageAccessEntries() const;
     WEBCORE_EXPORT void grantStorageAccess(const RegistrableDomain& resourceDomain, const RegistrableDomain& firstPartyDomain, std::optional<FrameIdentifier>, PageIdentifier);
-    WEBCORE_EXPORT void removeStorageAccessForFrame(FrameIdentifier, PageIdentifier);
+    WEBCORE_EXPORT void removeStorageAccessForFrame(FrameIdentifier);
     WEBCORE_EXPORT void clearPageSpecificDataForResourceLoadStatistics(PageIdentifier);
     WEBCORE_EXPORT void removeAllStorageAccess();
     WEBCORE_EXPORT void NODELETE setCacheMaxAgeCapForPrevalentResources(Seconds);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1332,10 +1332,10 @@ void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
         storageSession->clearPageSpecificDataForResourceLoadStatistics(pageID);
 }
 
-void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID, PageIdentifier pageID)
+void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier frameID)
 {
     if (CheckedPtr storageSession = m_networkProcess->storageSession(m_sessionID))
-        storageSession->removeStorageAccessForFrame(frameID, pageID);
+        storageSession->removeStorageAccessForFrame(frameID);
 }
 
 void NetworkConnectionToWebProcess::logUserInteraction(RegistrableDomain&& domain)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -402,7 +402,7 @@ private:
 
     void clearPageSpecificData(WebCore::PageIdentifier);
 
-    void removeStorageAccessForFrame(WebCore::FrameIdentifier, WebCore::PageIdentifier);
+    void removeStorageAccessForFrame(WebCore::FrameIdentifier);
 
     void logUserInteraction(RegistrableDomain&&);
     void resourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics>&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -85,7 +85,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     ClearPageSpecificData(WebCore::PageIdentifier pageID);
 
-    [EnabledBy=StorageAccessAPIEnabled] RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);
+    [EnabledBy=StorageAccessAPIEnabled] RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID);
     LogUserInteraction(WebCore::RegistrableDomain domain)
     ResourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics> statistics) -> ()
     [EnabledBy=StorageAccessAPIEnabled] HasStorageAccess(WebCore::RegistrableDomain subFrameDomain, WebCore::RegistrableDomain topFrameDomain, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID) -> (bool hasStorageAccess)

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -95,6 +95,7 @@ struct LoadParameters {
     bool isHandledByAboutSchemeHandler { false };
     bool isHistoryItemNavigation { false };
     bool shouldConsiderEnhancedSecurityForInsecureResponse { false };
+    bool shouldRevokeFrameSpecificStorageAccess { false };
 
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion { 0 };

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -61,6 +61,7 @@ enum class WebCore::LockBackForwardList : bool;
     bool isHandledByAboutSchemeHandler;
     bool isHistoryItemNavigation;
     bool shouldConsiderEnhancedSecurityForInsecureResponse;
+    bool shouldRevokeFrameSpecificStorageAccess;
 
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> advancedPrivacyProtections;
     uint64_t requiredCookiesVersion;

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -69,6 +69,7 @@ struct NavigationActionData {
     WebCore::NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior { WebCore::NavigationUpgradeToHTTPSBehavior::BasedOnPolicy };
     bool isInitialFrameSrcLoad { false };
     bool isContentRuleListRedirect { false };
+    bool shouldRevokeFrameSpecificStorageAccess { false };
     String openedMainFrameName;
     std::optional<WebCore::BackForwardItemIdentifier> targetBackForwardItemIdentifier;
     std::optional<WebCore::BackForwardItemIdentifier> sourceBackForwardItemIdentifier;

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -40,6 +40,7 @@ struct WebKit::NavigationActionData {
     WebCore::NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior;
     bool isInitialFrameSrcLoad;
     bool isContentRuleListRedirect;
+    bool shouldRevokeFrameSpecificStorageAccess;
     String openedMainFrameName;
     std::optional<WebCore::BackForwardItemIdentifier> targetBackForwardItemIdentifier;
     std::optional<WebCore::BackForwardItemIdentifier> sourceBackForwardItemIdentifier;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5749,6 +5749,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             loadParameters.ownerPermissionsPolicy = navigation->ownerPermissionsPolicy();
             loadParameters.navigationUpgradeToHTTPSBehavior = navigationAction->data().navigationUpgradeToHTTPSBehavior;
             loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(loadParameters.request.url());
+            loadParameters.shouldRevokeFrameSpecificStorageAccess = navigationAction->data().shouldRevokeFrameSpecificStorageAccess;
             if (auto& action = navigation->lastNavigationAction())
                 loadParameters.requester = action->requester;
             if (navigation->currentRequestIsRedirect())

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -596,7 +596,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         && webFrame->frameLoaderClient()) {
         auto navigationUpgradeToHTTPSBehavior = frame ? frame->loader().navigationUpgradeToHTTPSBehavior() : NavigationUpgradeToHTTPSBehavior::BasedOnPolicy;
         // FIXME: Gather more parameters here like we have in WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction.
-        loadParameters.mainResourceNavigationDataForAnyFrame = webFrame->frameLoaderClient()->navigationActionData(resourceLoader.documentLoader()->triggeringAction(), request, { }, { }, { }, { }, { }, navigationUpgradeToHTTPSBehavior, { });
+        loadParameters.mainResourceNavigationDataForAnyFrame = webFrame->frameLoaderClient()->navigationActionData(resourceLoader.documentLoader()->triggeringAction(), request, { }, { }, { }, { }, { }, navigationUpgradeToHTTPSBehavior, { }, false /* shouldRevokeFrameSpecificStorageAccess */);
     }
     if (loadParameters.mainResourceNavigationDataForAnyFrame) {
         if (RefPtr documentLoader = resourceLoader.documentLoader()) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -411,6 +411,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         frame.loader().navigationUpgradeToHTTPSBehavior(),
         navigationAction.isInitialFrameSrcLoad(),
         navigationAction.isContentRuleListRedirect(),
+        false, /* shouldRevokeFrameSpecificStorageAccess */
         openedMainFrameName,
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -40,7 +40,9 @@
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HitTestResult.h>
 #include <WebCore/LocalFrameInlines.h>
+#include <WebCore/NavigationAction.h>
 #include <WebCore/PolicyChecker.h>
+#include <WebCore/Site.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -66,7 +68,17 @@ WebFrameLoaderClient::WebFrameLoaderClient(Ref<WebFrame>&& frame, ScopeExit<Func
 
 WebFrameLoaderClient::~WebFrameLoaderClient() = default;
 
-std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, SandboxFlags sandboxFlags) const
+bool WebFrameLoaderClient::initiatorIsCrossFrameAndCrossSite(const NavigationAction& navigationAction, FrameIdentifier targetFrameID, const Site& targetSite)
+{
+    auto requestor = navigationAction.requester();
+    if (!requestor || !requestor->frameID)
+        return false;
+    if (*requestor->frameID == targetFrameID)
+        return false;
+    return Site(requestor->url) != targetSite;
+}
+
+std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, SandboxFlags sandboxFlags, bool shouldRevokeFrameSpecificStorageAccess) const
 {
     RefPtr webPage = m_frame->page();
     if (!webPage) {
@@ -164,6 +176,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         navigationUpgradeToHTTPSBehavior,
         navigationAction.isInitialFrameSrcLoad(),
         navigationAction.isContentRuleListRedirect(),
+        shouldRevokeFrameSpecificStorageAccess,
         { },
         navigationAction.targetBackForwardItemIdentifier(),
         navigationAction.sourceBackForwardItemIdentifier(),
@@ -190,11 +203,11 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
     };
 }
 
-void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse, FormState*, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
+void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse, FormState*, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, bool shouldRevokeFrameSpecificStorageAccess, FramePolicyFunction&& function)
 {
     LOG(Loading, "WebProcess %i - dispatchDecidePolicyForNavigationAction to request url %s", getCurrentProcessID(), request.url().string().utf8().data());
 
-    auto navigationActionData = this->navigationActionData(navigationAction, request, redirectResponse, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags);
+    auto navigationActionData = this->navigationActionData(navigationAction, request, redirectResponse, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, shouldRevokeFrameSpecificStorageAccess);
     if (!navigationActionData)
         return function(PolicyAction::Ignore);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -49,6 +49,7 @@ class HitTestResult;
 class NavigationAction;
 class ResourceRequest;
 class ResourceResponse;
+class Site;
 using FramePolicyFunction = CompletionHandler<void(PolicyAction)>;
 
 struct FrameTreeSyncSerializationData;
@@ -64,7 +65,7 @@ class WebFrameLoaderClient {
 public:
     WebFrame& webFrame() const { return m_frame.get(); }
 
-    std::optional<NavigationActionData> navigationActionData(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags) const;
+    std::optional<NavigationActionData> navigationActionData(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags, bool shouldRevokeFrameSpecificStorageAccess) const;
 
     virtual void applyWebsitePolicies(WebsitePoliciesData&&) = 0;
 
@@ -72,10 +73,17 @@ public:
 
     ScopeExit<Function<void()>> takeFrameInvalidator() { return WTF::move(m_frameInvalidator); }
 
+    // Returns true if the navigation's initiator is a different frame than the
+    // target and is on a different site than the target's current site. Used by
+    // both WebLocalFrameLoaderClient and WebRemoteFrameClient to decide whether
+    // to drop frame-specific storage access on cross-frame, cross-site iframe
+    // navigation.
+    static bool initiatorIsCrossFrameAndCrossSite(const WebCore::NavigationAction&, WebCore::FrameIdentifier targetFrameID, const WebCore::Site& targetSite);
+
 protected:
     WebFrameLoaderClient(Ref<WebFrame>&&, ScopeExit<Function<void()>>&& frameInvalidator);
 
-    void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&);
+    void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String&, std::optional<WebCore::NavigationIdentifier>, std::optional<WebCore::HitTestResult>&&, bool, WebCore::NavigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, bool shouldRevokeFrameSpecificStorageAccess, WebCore::FramePolicyFunction&&);
     void updateSandboxFlags(WebCore::SandboxFlags);
     void updateReferrerPolicy(WebCore::ReferrerPolicy);
     void updateOpener(std::optional<WebCore::FrameIdentifier>);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -518,6 +518,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         localFrame->loader().navigationUpgradeToHTTPSBehavior(),
         false, /* isInitialFrameSrcLoad */
         false, /* isContentRuleListRedirect */
+        false, /* shouldRevokeFrameSpecificStorageAccess */
         { }, /* openedMainFrameName */
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */
@@ -1038,6 +1039,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         localFrame->loader().navigationUpgradeToHTTPSBehavior(),
         navigationAction.isInitialFrameSrcLoad(),
         navigationAction.isContentRuleListRedirect(),
+        false, /* shouldRevokeFrameSpecificStorageAccess */
         { }, /* openedMainFrameName */
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */
@@ -1086,18 +1088,16 @@ WebCore::AllowsContentJavaScript WebLocalFrameLoaderClient::allowsContentJavaScr
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse,
     FormState* formState, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<WebCore::HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, WebCore::SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {
-    if (auto requestor = navigationAction.requester(); requestor && requestor->frameID) {
-        // another frame initiated navigation
-        if (*requestor->frameID != m_frame->frameID() && Site(requestor->url) != Site(m_frame->url()))
+    if (initiatorIsCrossFrameAndCrossSite(navigationAction, m_frame->frameID(), Site(m_frame->url())))
+        removeStorageAccess();
+    else if (auto requestor = navigationAction.requester(); requestor && requestor->frameID && *requestor->frameID == m_frame->frameID()) {
+        // The frame navigated itself: drop storage access if the new URL is cross-origin
+        // and this isn't a continuation of a redirect chain.
+        if (redirectResponse.isNull() && !SecurityOrigin::create(m_frame->url())->isSameOriginAs(SecurityOrigin::create(request.url())))
             removeStorageAccess();
-        // this frame navigated itself
-        else if (*requestor->frameID == m_frame->frameID()) {
-            if (redirectResponse.isNull() && !SecurityOrigin::create(m_frame->url())->isSameOriginAs(SecurityOrigin::create(request.url())))
-                removeStorageAccess();
-        }
     }
 
-    WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, policyDecisionMode, WTF::move(function));
+    WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, policyDecisionMode, /*shouldRevokeFrameSpecificStorageAccess=*/false, WTF::move(function));
 }
 
 void WebLocalFrameLoaderClient::updateSandboxFlags(WebCore::SandboxFlags sandboxFlags)
@@ -2222,7 +2222,7 @@ void WebLocalFrameLoaderClient::removeStorageAccess()
 {
     if (m_frameSpecificStorageAccessIdentifier) {
         WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame(
-            m_frameSpecificStorageAccessIdentifier->frameID, m_frameSpecificStorageAccessIdentifier->pageID), 0);
+            m_frameSpecificStorageAccessIdentifier->frameID), 0);
         m_frameSpecificStorageAccessIdentifier = std::nullopt;
     }
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -27,6 +27,8 @@
 #include "WebRemoteFrameClient.h"
 
 #include "MessageSenderInlines.h"
+#include "NetworkConnectionToWebProcessMessages.h"
+#include "NetworkProcessConnection.h"
 #include "RemoteDisplayListRecorderProxy.h"
 #include "WebFrameProxyMessages.h"
 #include "WebMessagePortChannelProvider.h"
@@ -41,9 +43,12 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/HTMLFrameOwnerElement.h>
 #include <WebCore/HitTestResult.h>
+#include <WebCore/NavigationAction.h>
 #include <WebCore/NodeDocument.h>
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/RemoteFrame.h>
+#include <WebCore/SecurityOrigin.h>
+#include <WebCore/Site.h>
 #include <WebCore/UserGestureIndicator.h>
 
 namespace WebKit {
@@ -205,7 +210,20 @@ void WebRemoteFrameClient::unfocus()
 void WebRemoteFrameClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse,
     FormState* formState, const String& clientRedirectSourceForHistory, std::optional<WebCore::NavigationIdentifier> navigationID, std::optional<HitTestResult>&& hitTestResult, bool hasOpener, NavigationUpgradeToHTTPSBehavior navigationUpgradeToHTTPSBehavior, SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {
-    WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, policyDecisionMode, WTF::move(function));
+    // For the SI case where this iframe is in a different process from the navigation's initiator,
+    // revoke the iframe's frame-specific storage-access grant. The NetworkProcess-side clear is
+    // sent directly from this (the initiating) WebProcess. The storage permission in the iframe's
+    // process is cleared when WebPage::loadRequest is called. A flag to revoke storage access is
+    // passed in from here to NavigationActionData and forwarded to LoadParameters.
+    bool shouldRevokeFrameSpecificStorageAccess = false;
+    if (RefPtr coreFrame = m_frame->coreFrame()) {
+        if (RefPtr targetOrigin = coreFrame->frameDocumentSecurityOrigin())
+            shouldRevokeFrameSpecificStorageAccess = initiatorIsCrossFrameAndCrossSite(navigationAction, m_frame->frameID(), Site(targetOrigin->data()));
+    }
+    if (shouldRevokeFrameSpecificStorageAccess)
+        WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame(m_frame->frameID()), 0);
+
+    WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(navigationAction, request, redirectResponse, formState, clientRedirectSourceForHistory, navigationID, WTF::move(hitTestResult), hasOpener, navigationUpgradeToHTTPSBehavior, sandboxFlags, policyDecisionMode, shouldRevokeFrameSpecificStorageAccess, WTF::move(function));
 }
 
 void WebRemoteFrameClient::updateSandboxFlags(WebCore::SandboxFlags sandboxFlags)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2430,6 +2430,11 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
         return;
     }
 
+    if (loadParameters.shouldRevokeFrameSpecificStorageAccess) {
+        if (RefPtr client = frame->localFrameLoaderClient())
+            client->revokeFrameSpecificStorageAccess();
+    }
+
     setLastNavigationWasAppInitiated(loadParameters.request.isAppInitiated());
 
 #if ENABLE(APP_BOUND_DOMAINS)


### PR DESCRIPTION
#### 5b698a448e6aa27de6580deee945b31ba5fa8bdd
<pre>
[Site Isolation] iframe should lose storage access when navigation initiator is cross-site
<a href="https://bugs.webkit.org/show_bug.cgi?id=317934">https://bugs.webkit.org/show_bug.cgi?id=317934</a>
<a href="https://rdar.apple.com/180735236">rdar://180735236</a>

Reviewed by NOBODY (OOPS!).

When some other frame initiates navigation of a cross-origin iframe,
that iframe should lose storage access.

This is encapsulated by step 7 of
http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html

In step 7, some other frame initiates an iframe to navigate same-site
and expects that the iframe has lost storage access. Even though the
iframe is navigated same-site, since the navigation was initiated by a
different frame, the iframe being navigated should lose storage access.

This is described by the navigation algorithm of the Storage Access API
spec: <a href="https://privacycg.github.io/storage-access/#navigation">https://privacycg.github.io/storage-access/#navigation</a>

&gt; Set reserved client’s has storage access to sourceSnapshotParams’s has storage access if all of the following hold:
&gt;    1. sourceSnapshotParams’s environment id equals navigable’s active document’s relevant settings object’s id.
&gt;     ...

Condition #1 states that if the environment id of the navigation
initiator is different than the environment id of the target, then the
target should lose storage access.

WebKit already implemented this logic for the case when both the
initiator and target frames are in the same process in
WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction
after <a href="https://commits.webkit.org/298918@main.">https://commits.webkit.org/298918@main.</a>
WebKit&apos;s current logic checks both if the initiator is cross-frame AND
cross-site, while the spec is looser and removes storage access if the
initiator is only cross-frame. This patch doesn&apos;t aim to address this
discrepancy, but instead to bring other site isolation cases up to par
with the existing check.

However, with Site Isolation, when an initiator and target frames are
in different processes, the target frame doesn&apos;t lose storage access
when it should.

This patch mirrors the existing initiator check from
WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction
to WebRemoteFrameClient::dispatchDecidePolicyForNavigationAction.

When an iframe is being navigated by a cross-site initiator from a
different process, the iframe needs to have its storage access revoked.
Since we can&apos;t directly remove the iframe&apos;s storage access in the
initiator&apos;s process, we perform the following IPC:
1. The initiator sends
   Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame
   to the NetworkProcess.
2. The initiator passes along a new flag to revoke storage access
   in the iframe itself (to update m_frameSpecificStorageAccessIdentifier).
   This new flag is passed via
   Messages::WebPageProxy::DecidePolicyForNavigationActionAsync/Sync
   to the UIProcess and then forwarded to the iframe&apos;s WebProcess via
   WebPage::LoadRequest (new field in LoadParameters).

Since the initiating process is removing storage access of another frame
in the NetworkProcess, I removed the PageIdentifier parameter of the
Messages::NetworkConnectionToWebProcess::RemoveStorageAccessForFrame
message. I found that the initiator process has no way to find the
PageIdentifier of the frame which is in another process. So instead,
NetworkStorageSession::removeStorageAccessForFrame will just remove
storage access for any frame with a matching FrameIdentifier.

I also lifted the initiator check in
WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction into
its own helper function called
WebFrameLoaderClient::initiatorIsCrossFrameAndCrossSite so that both
the Local and Remote cases could share the same logic.

This patch fixes
http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html
with site isolation enabled.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/platform/network/NetworkStorageSession.cpp:
(WebCore::NetworkStorageSession::removeStorageAccessForFrame):
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::removeStorageAccessForFrame):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::initiatorIsCrossFrameAndCrossSite):
    Helper function to share the initiator check between the cases where
    the target frame is either local and remote.
(WebKit::WebFrameLoaderClient::navigationActionData const):
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
    Use helper function in local case of initiator check and update
    comment for the self-navigation check.
(WebKit::WebLocalFrameLoaderClient::removeStorageAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::dispatchDecidePolicyForNavigationAction):
    New initiator check when the initiator is in different process
    than the target frame.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b698a448e6aa27de6580deee945b31ba5fa8bdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181006 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129257 "Hash 5b698a44 for PR 67950 does not build (failure)") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133625 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129257 "Hash 5b698a44 for PR 67950 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114097 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33860 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29756 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183674 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36290 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38059 "Found 1 new test failure: media/media-source/media-source-real-scrub-then-play.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142282 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45287 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142173 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45967 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110601 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37308 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117655 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44485 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8552 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43944 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->