### PR TITLE
[GLIB] Add GRefPtrWrapper support to generate-serializers and generate GVariant IPC serialization

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -72,6 +72,7 @@ endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
+    Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/RenderProcessInfo.serialization.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -116,6 +116,7 @@ endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/AvailableInputDevices.serialization.in
+    Shared/glib/CoreIPCGVariant.serialization.in
     Shared/glib/DMABufBufferAttributes.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/RenderProcessInfo.serialization.in

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -189,6 +189,7 @@ class SerializedType(object):
         self.disableMissingMemberCheck = False
         self.debug_decoding_failure = False
         self.generic_wrapper = None
+        self.gref_type = None
         self.bundle = None
         if attributes is not None:
             for attribute in attributes.split(', '):
@@ -212,6 +213,9 @@ class SerializedType(object):
                         self.custom_secure_coding_class = value
                     elif key == 'Wrapper':
                         self.generic_wrapper = value
+                    elif key == 'GRefPtrWrapped':
+                        self.gref_type = value
+                        self.generic_wrapper = f'{self.namespace}::{self.name}'
                     else:
                         raise Exception(f'Invalid attribute ({key}={value}) found on struct: {self.namespace}::{self.name}')
                 else:
@@ -249,6 +253,8 @@ class SerializedType(object):
         return re.sub(r'\W+', '_', self.name)
 
     def namespace_and_name(self):
+        if self.gref_type is not None:
+            return f'GRefPtr<{self.gref_type}>'
         if self.cf_type is not None:
             return f'{self.cf_type}Ref'
         if self.namespace is None:
@@ -319,7 +325,7 @@ class SerializedType(object):
         return False
 
     def should_skip_forward_declare(self):
-        return self.nested or self.templates
+        return self.nested or self.templates or self.gref_type is not None
 
     def cpp_type_from_struct_or_class(self):
         if self.is_webkit_secure_coding_type():
@@ -1186,6 +1192,12 @@ def generate_one_impl(type, template_argument, serialized_types):
         else:
             result.append(f'void ArgumentCoder<{name_with_template}>::encode({encoder}& encoder, const {name_with_template}& {instanceArgName})')
         result.append('{')
+        if type.gref_type is not None:
+            result.append(f'    if (!{instanceArgName}) {{')
+            result.append('        encoder << false;')
+            result.append('        return;')
+            result.append('    }')
+            result.append('    encoder << true;')
         if type.generic_wrapper is not None:
             if type.rvalue:
                 result.append(f'    auto instance = {type.generic_wrapper}(WTF::move({instanceArgName}));')
@@ -1219,6 +1231,12 @@ def generate_one_impl(type, template_argument, serialized_types):
     else:
         result.append(f'std::optional<{name_with_template}> ArgumentCoder<{name_with_template}>::decode(Decoder& decoder)')
     result.append('{')
+    if type.gref_type is not None:
+        result.append('    auto isEngaged = decoder.decode<bool>();')
+        result.append('    if (!isEngaged) [[unlikely]]')
+        result.append('        return std::nullopt;')
+        result.append('    if (!*isEngaged)')
+        result.append(f'        return GRefPtr<{type.gref_type}> {{ }};')
     result = result + decode_type(type, serialized_types)
     if type.cf_type is None:
         if not type.members_are_subclasses:

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -188,6 +188,8 @@
     [Legacy] StructureParam WebCore::PixelBufferSourceView.bytes()
     [Legacy] StructureParam JSC::ArrayBufferContents.span()
 
+    [NeedsReview] StructureParam GRefPtr<GVariant>.data()
+
     [SecurityGatedReply] MessageParamReply WebPage.OpenPDFWithPreview data
     [SecurityGatedReply] MessageParamReply WebPage.SavePDF data
     [NotSentFromWebContent] MessageParam WebTransportSession.ReceiveDatagram datagram

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -31,6 +31,9 @@
 #if ENABLE(TEST_FEATURE)
 #include "CommonHeader.h"
 #endif
+#if USE(GLIB)
+#include "CoreIPCGFooBar.h"
+#endif
 #include "CustomEncoded.h"
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
@@ -1333,6 +1336,43 @@ std::optional<SkFooBar> ArgumentCoder<SkFooBar>::decode(Decoder& decoder)
         return std::nullopt;
     return {
         CoreIPCSkFooBar {
+            WTF::move(*foo),
+            WTF::move(*bar)
+        }
+    };
+}
+
+#endif
+
+#if USE(GLIB)
+void ArgumentCoder<GRefPtr<GFooBar>>::encode(Encoder& encoder, const GRefPtr<GFooBar>& passedInstance)
+{
+    if (!passedInstance) {
+        encoder << false;
+        return;
+    }
+    encoder << true;
+    auto instance = WebKit::CoreIPCGFooBar(passedInstance);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.foo())>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.bar())>, double>);
+
+    encoder << instance.foo();
+    encoder << instance.bar();
+}
+
+std::optional<GRefPtr<GFooBar>> ArgumentCoder<GRefPtr<GFooBar>>::decode(Decoder& decoder)
+{
+    auto isEngaged = decoder.decode<bool>();
+    if (!isEngaged) [[unlikely]]
+        return std::nullopt;
+    if (!*isEngaged)
+        return GRefPtr<GFooBar> { };
+    auto foo = decoder.decode<int>();
+    auto bar = decoder.decode<double>();
+    if (!decoder.isValid()) [[unlikely]]
+        return std::nullopt;
+    return {
+        WebKit::CoreIPCGFooBar {
             WTF::move(*foo),
             WTF::move(*bar)
         }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -35,6 +35,9 @@
 typedef struct CF_BRIDGED_TYPE(id) __SecTrust *SecTrustRef;
 #endif
 #endif
+#if USE(GLIB)
+#include <wtf/glib/GRefPtr.h>
+#endif
 
 namespace EnumNamespace {
 #if ENABLE(BOOL_ENUM)
@@ -134,6 +137,9 @@ class SkFooBar;
 
 #if USE(CFBAR)
 typedef struct __CFBar * CFBarRef;
+#endif
+#if USE(GLIB)
+typedef struct _GFooBar GFooBar;
 #endif
 namespace IPC { template<typename> class ObjectIdentifierReference; };
 namespace IPC { template<typename> class ObjectIdentifierWriteReference; };
@@ -367,6 +373,13 @@ template<> struct ArgumentCoder<SkFooBar> {
     static void encode(Encoder&, const SkFooBar&);
     static void encode(OtherEncoder&, const SkFooBar&);
     static std::optional<SkFooBar> decode(Decoder&);
+};
+#endif
+
+#if USE(GLIB)
+template<> struct ArgumentCoder<GRefPtr<GFooBar>> {
+    static void encode(Encoder&, const GRefPtr<GFooBar>&);
+    static std::optional<GRefPtr<GFooBar>> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -29,6 +29,9 @@
 #if ENABLE(TEST_FEATURE)
 #include "CommonHeader.h"
 #endif
+#if USE(GLIB)
+#include "CoreIPCGFooBar.h"
+#endif
 #include "CustomEncoded.h"
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
@@ -492,6 +495,18 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             },
         } },
 #endif // USE(SKIA)
+#if USE(GLIB)
+        { "GRefPtr<GFooBar>"_s, {
+            {
+                "int"_s,
+                "foo()"_s
+            },
+            {
+                "double"_s,
+                "bar()"_s
+            },
+        } },
+#endif // USE(GLIB)
         { "WebKit::RValueWithFunctionCalls"_s, {
             {
                 "SandboxExtensionHandle"_s,

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -290,6 +290,14 @@ additional_forward_declaration: typedef struct __CFBar * CFBarRef
 }
 #endif
 
+#if USE(GLIB)
+additional_forward_declaration: typedef struct _GFooBar GFooBar
+[GRefPtrWrapped=GFooBar] class WebKit::CoreIPCGFooBar {
+    int foo();
+    double bar();
+}
+#endif
+
 [RValue] class WebKit::RValueWithFunctionCalls {
     SandboxExtensionHandle callFunction()
 }

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -65,38 +65,6 @@ std::optional<GRefPtr<GByteArray>> ArgumentCoder<GRefPtr<GByteArray>>::decode(De
     return array;
 }
 
-void ArgumentCoder<GRefPtr<GVariant>>::encode(Encoder& encoder, const GRefPtr<GVariant>& variant)
-{
-    if (!variant) {
-        encoder << CString();
-        return;
-    }
-
-    encoder << CString(g_variant_get_type_string(variant.get()));
-    encoder << span(variant);
-}
-
-std::optional<GRefPtr<GVariant>> ArgumentCoder<GRefPtr<GVariant>>::decode(Decoder& decoder)
-{
-    auto variantTypeString = decoder.decode<CString>();
-    if (!variantTypeString) [[unlikely]]
-        return std::nullopt;
-
-    if (variantTypeString->isNull())
-        return GRefPtr<GVariant>();
-
-    if (!g_variant_type_string_is_valid(variantTypeString->data()))
-        return std::nullopt;
-
-    auto data = decoder.decode<std::span<const uint8_t>>();
-    if (!data) [[unlikely]]
-        return std::nullopt;
-
-    GUniquePtr<GVariantType> variantType(g_variant_type_new(variantTypeString->data()));
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(data->data(), data->size()));
-    return g_variant_new_from_bytes(variantType.get(), bytes.get(), FALSE);
-}
-
 void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, const GRefPtr<GTlsCertificate>& certificate)
 {
     if (!certificate) {

--- a/Source/WebKit/Shared/glib/CoreIPCGVariant.cpp
+++ b/Source/WebKit/Shared/glib/CoreIPCGVariant.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,35 +23,41 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "CoreIPCGVariant.h"
 
-#include "ArgumentCoders.h"
-#include <gio/gio.h>
-#include <wtf/glib/GRefPtr.h>
+#if USE(GLIB)
 
-typedef struct _GTlsCertificate GTlsCertificate;
-typedef struct _GUnixFDList GUnixFDList;
+#include <glib.h>
+#include <wtf/glib/GUniquePtr.h>
 
-namespace IPC {
+namespace WebKit {
 
-template<> struct ArgumentCoder<GRefPtr<GByteArray>> {
-    static void encode(Encoder&, const GRefPtr<GByteArray>&);
-    static std::optional<GRefPtr<GByteArray>> decode(Decoder&);
-};
+CoreIPCGVariant::CoreIPCGVariant(const GRefPtr<GVariant>& variant)
+    : m_typeString(g_variant_get_type_string(variant.get()))
+    , m_data(adoptGRef(g_variant_get_data_as_bytes(variant.get())))
+{
+}
 
-template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
-    static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
-    static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
-};
+CoreIPCGVariant::CoreIPCGVariant(CString&& typeString, std::span<const uint8_t> data)
+    : m_typeString(WTF::move(typeString))
+    , m_data(adoptGRef(g_bytes_new(data.data(), data.size())))
+{
+}
 
-template<> struct ArgumentCoder<GTlsCertificateFlags> {
-    static void encode(Encoder&, GTlsCertificateFlags);
-    static std::optional<GTlsCertificateFlags> decode(Decoder&);
-};
+std::span<const uint8_t> CoreIPCGVariant::data() const
+{
+    gsize size = 0;
+    const auto* data = static_cast<const uint8_t*>(g_bytes_get_data(m_data.get(), &size));
+    return unsafeMakeSpan(data, size);
+}
 
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
-};
+CoreIPCGVariant::operator GRefPtr<GVariant>() const
+{
+    GUniquePtr<GVariantType> type(g_variant_type_new(m_typeString.data()));
+    return g_variant_new_from_bytes(type.get(), m_data.get(), FALSE);
+}
 
-} // namespace IPC
+} // namespace WebKit
+
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGVariant.h
+++ b/Source/WebKit/Shared/glib/CoreIPCGVariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,33 +25,32 @@
 
 #pragma once
 
-#include "ArgumentCoders.h"
-#include <gio/gio.h>
+#if USE(GLIB)
+
+#include <span>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/text/CString.h>
 
-typedef struct _GTlsCertificate GTlsCertificate;
-typedef struct _GUnixFDList GUnixFDList;
+typedef struct _GVariant GVariant;
+typedef struct _GBytes GBytes;
 
-namespace IPC {
+namespace WebKit {
 
-template<> struct ArgumentCoder<GRefPtr<GByteArray>> {
-    static void encode(Encoder&, const GRefPtr<GByteArray>&);
-    static std::optional<GRefPtr<GByteArray>> decode(Decoder&);
+class CoreIPCGVariant {
+public:
+    explicit CoreIPCGVariant(const GRefPtr<GVariant>&);
+    CoreIPCGVariant(CString&&, std::span<const uint8_t>);
+
+    CString typeString() const { return m_typeString; }
+    std::span<const uint8_t> data() const;
+
+    operator GRefPtr<GVariant>() const;
+
+private:
+    CString m_typeString;
+    GRefPtr<GBytes> m_data;
 };
 
-template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
-    static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
-    static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
-};
+} // namespace WebKit
 
-template<> struct ArgumentCoder<GTlsCertificateFlags> {
-    static void encode(Encoder&, GTlsCertificateFlags);
-    static std::optional<GTlsCertificateFlags> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
-    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
-    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
-};
-
-} // namespace IPC
+#endif // USE(GLIB)

--- a/Source/WebKit/Shared/glib/CoreIPCGVariant.serialization.in
+++ b/Source/WebKit/Shared/glib/CoreIPCGVariant.serialization.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(GLIB)
+
+header: <glib.h>
+header: "CoreIPCGVariant.h"
+
+additional_forward_declaration: typedef struct _GVariant GVariant
+
+[GRefPtrWrapped=GVariant] class WebKit::CoreIPCGVariant {
+    [Validator='!typeString->isNull() && g_variant_type_string_is_valid(typeString->data())'] CString typeString();
+    std::span<const uint8_t> data();
+}
+
+#endif

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -83,6 +83,7 @@ Shared/API/glib/WebKitUserMessage.cpp @no-unify
 Shared/Extensions/gtk/WebExtensionUtilitiesGtk.cpp
 
 Shared/glib/ArgumentCodersGLib.cpp
+Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp
 Shared/glib/ProcessExecutablePathGLib.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -81,6 +81,7 @@ Shared/API/glib/WebKitURIResponse.cpp @no-unify
 Shared/API/glib/WebKitUserMessage.cpp @no-unify
 
 Shared/glib/ArgumentCodersGLib.cpp
+Shared/glib/CoreIPCGVariant.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/JavaScriptEvaluationResultGLib.cpp
 Shared/glib/ProcessExecutablePathGLib.cpp


### PR DESCRIPTION
#### ef90833ee0ee96d9983960f95bac5691316dd254
<pre>
[GLIB] Add GRefPtrWrapper support to generate-serializers and generate GVariant IPC serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=317939">https://bugs.webkit.org/show_bug.cgi?id=317939</a>

Reviewed by Michael Catanzaro.

This adds GRefPtrWrapper to generate-serializers.py, which can be used to
generate a serializer for a type that is wrapped by GRefPtr. The
coding for such a type passes first for generated code that takes care
of unwrapping/wrapping a GRefPtr.

Use this to generate the serialization for GVariant, which now uses
GRefPtrWrapper=GVariant and a CoreIPC wrapper.

Also add unit-test coverage for the new generator, which apparently
also had outdated generated files; regenerate to update those as well.
These generated files can be used during review to check the consistency
of the GRefPtrWrapper-generated code.

Covered by existing API tests (for WebProcessUserExtensions user
messages, for example, which test GVariant IPC).

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.namespace_and_name):
(SerializedType.should_skip_forward_declare):
(generate_header):
(generate_one_impl):
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GFooBar&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GFooBar&gt;&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:
* Source/WebKit/Shared/glib/CoreIPCGVariant.cpp: Copied from Source/WebKit/Shared/glib/ArgumentCodersGLib.h.
(WebKit::CoreIPCGVariant::CoreIPCGVariant):
(WebKit::CoreIPCGVariant::data const):
(WebKit::CoreIPCGVariant::operator GRefPtr&lt;GVariant&gt; const):
* Source/WebKit/Shared/glib/CoreIPCGVariant.h: Copied from Source/WebKit/Shared/glib/ArgumentCodersGLib.h.
(WebKit::CoreIPCGVariant::typeString const):
* Source/WebKit/Shared/glib/CoreIPCGVariant.serialization.in: Added.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/319460@main">https://commits.webkit.org/319460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f11a53a5052b1e39b392e125835ec4f7e5371150

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181526 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141678 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122118 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180850 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42315 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154452 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41961 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2910 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193677 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55142 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151085 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55829 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150793 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27570 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45370 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/128112 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123782 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54345 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53792 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->