### PR TITLE
snap points inside zero-sized elements don't work correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area-expected.txt
@@ -1,0 +1,5 @@
+
+PASS scrollTop = 600 snaps to the zero-height area at 600
+PASS scrollTop = 550 snaps to the zero-height area at 600
+PASS scrollTop = 650 snaps to the zero-height area at 600
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A zero-height snap area can be snapped to</title>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#snap-scope">
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#choosing">
+<meta name="assert" content="A snap area with zero extent along the scroll axis is still a valid snap target.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#scroller {
+  width: 300px;
+  height: 400px;
+  overflow: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+#scroller > div {
+  width: 100%;
+}
+
+.snap-start {
+  scroll-snap-align: start;
+}
+
+.block {
+  height: 400px;
+}
+
+.spacer {
+  height: 200px;
+}
+
+.marker {
+  height: 0;
+}
+</style>
+
+<div id="scroller">
+  <div class="snap-start block"></div>
+  <div class="spacer"></div>
+  <div class="snap-start marker"></div>
+  <div class="spacer"></div>
+  <div class="snap-start block"></div>
+</div>
+
+<script>
+const scroller = document.getElementById("scroller");
+
+[
+  [600, 600],  // exact: the empty area is itself a valid resting position
+  [550, 600],  // approaching from above: 600 is the nearest snap offset
+  [650, 600],  // approaching from below: 600 is the nearest snap offset
+].forEach(([destination, expected]) => {
+  test(() => {
+    scroller.scrollTo(0, 0);
+    assert_equals(scroller.scrollTop, 0, "reset to top");
+
+    scroller.scrollTop = destination;
+    assert_equals(scroller.scrollTop, expected);
+  }, `scrollTop = ${destination} snaps to the zero-height area at ${expected}`);
+});
+</script>

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -126,7 +126,7 @@ static bool NODELETE offsetHasVisibleSnapArea(const InfoType& info, const SnapOf
     for (auto index : snapOffset.snapAreaIndices) {
         const auto& snapArea = info.snapAreas[index];
         auto [otherAxisMin, otherAxisMax] = rangeForAxis<UnitType>(snapArea, otherAxis);
-        if ((snapOffsetOther.offset + viewportLengthInOtherAxis) > otherAxisMin && snapOffsetOther.offset < otherAxisMax)
+        if ((snapOffsetOther.offset + viewportLengthInOtherAxis) > otherAxisMin && snapOffsetOther.offset <= otherAxisMax)
             return true;
     }
     return false;
@@ -145,7 +145,7 @@ static size_t findCompatibleSnapArea(const InfoType& info, const SnapOffset<Unit
         auto [otherAxisMin, otherAxisMax] = rangeForAxis<UnitType>(snapArea, otherAxis);
         if (info.offsetsForAxis(otherAxis).isEmpty() && ((scrollDestinationInOtherAxis + viewportLengthInOtherAxis) < otherAxisMin || scrollDestinationInOtherAxis > otherAxisMax))
             return false;
-        return (snapOffset.offset + viewportLength) > axisMin && snapOffset.offset < axisMax;
+        return (snapOffset.offset + viewportLength) > axisMin && snapOffset.offset <= axisMax;
     });
 }
 


### PR DESCRIPTION
#### 04dc57e941dba51001a3cc34bc11e40bfd66f642
<pre>
snap points inside zero-sized elements don&apos;t work correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309717">https://bugs.webkit.org/show_bug.cgi?id=309717</a>
<a href="https://rdar.apple.com/172863699">rdar://172863699</a>

Reviewed by Abrar Rahman Protyasha.

In order for snapping to elements with zero size on the scroll axis to work, we need a `&lt;=` comparison
on the max edge.

Test: imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-to-zero-height-interior-area.html: Added.
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::offsetHasVisibleSnapArea):
(WebCore::findCompatibleSnapArea):

Canonical link: <a href="https://commits.webkit.org/315948@main">https://commits.webkit.org/315948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71028796dabd90d736beb1e61a817d17c941a212

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179824 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128160 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1847ad23-a588-4dce-a6b2-53243717bbe6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132913 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0167dcf1-33a6-4612-b349-3b8e34c9910a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113411 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb8afb76-861a-43c2-9226-139404d0ee2d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34713 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33054 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28505 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145174 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182407 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141372 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38041 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109200 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36450 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116606 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7841 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->