### PR TITLE
Convert if/else chain to switch in StyleRuleKeyframe::Key::writeToString

### DIFF
--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -40,20 +40,32 @@ namespace WebCore {
 
 void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
 {
-    if (rangeName == CSSValueContain)
+    switch (rangeName) {
+    case CSSValueContain:
         str.append("contain "_s);
-    else if (rangeName == CSSValueCover)
+        break;
+    case CSSValueCover:
         str.append("cover "_s);
-    else if (rangeName == CSSValueEntry)
+        break;
+    case CSSValueEntry:
         str.append("entry "_s);
-    else if (rangeName == CSSValueEntryCrossing)
+        break;
+    case CSSValueEntryCrossing:
         str.append("entry-crossing "_s);
-    else if (rangeName == CSSValueExit)
+        break;
+    case CSSValueExit:
         str.append("exit "_s);
-    else if (rangeName == CSSValueExitCrossing)
+        break;
+    case CSSValueExitCrossing:
         str.append("exit-crossing "_s);
-    else if (rangeName == CSSValueScroll)
+        break;
+    case CSSValueScroll:
         str.append("scroll "_s);
+        break;
+    default:
+        break;
+    }
+
     str.append(offset * 100, '%');
 }
 


### PR DESCRIPTION
#### 8c17b6f0079f0c164d7b2ae7025a892c080bae5c
<pre>
Convert if/else chain to switch in StyleRuleKeyframe::Key::writeToString
<a href="https://bugs.webkit.org/show_bug.cgi?id=317946">https://bugs.webkit.org/show_bug.cgi?id=317946</a>
<a href="https://rdar.apple.com/180744616">rdar://180744616</a>

Reviewed by NOBODY (OOPS!).

StyleRuleKeyframe::Key::writeToString compared rangeName against seven
CSSValueID keyword constants using a linear if/else chain. Convert it to
a switch statement for readability.
No behavior change: the default case preserves the previous fall-through
when rangeName matches none of the seven values.

* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::Key::writeToString const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c17b6f0079f0c164d7b2ae7025a892c080bae5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128200 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132948 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93739 "1 flakes 17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34746 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33087 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28545 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182447 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141400 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44068 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141217 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29761 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109248 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36480 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116646 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43267 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7863 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->