### PR TITLE
[AppKit Gestures] Follow-up to 315834@main to clean up the tests a bit

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -164,16 +164,7 @@ struct AppKitGesturesTests {
         arguments: [true, false]
     )
     func draggingSelectionToWindowEdgeAutoscrolls(dragPastEdge: Bool) async throws {
-        let lines = (0..<100)
-            .reversed()
-            .map { "<p id='line\($0)'>\($0) bottles of beer on the wall</p>" }
-            .joined(separator: "\n")
-
-        let html = """
-            <div id="text" style="font-size: 60px; margin: 0;">\(lines)</div>
-            """
-        try await page.load(html: html).wait()
-
+        try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
 
         let startViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "line97"))
@@ -189,10 +180,7 @@ struct AppKitGesturesTests {
 
         // Arbitrarily chosen to be close to the edge of the window.
         let dragEndYInWindow: CGFloat = dragPastEdge ? -20 : 20
-        let dragEnd = convertToCoreGraphicsScreenCoordinates(
-            pointInWindowCoordinates: CGPoint(x: window.frame.width / 2, y: dragEndYInWindow),
-            window: window
-        )
+        let dragEnd = screenBounds(ofPointInWindowCoordinates: CGPoint(x: window.frame.width / 2, y: dragEndYInWindow))
 
         await recap.play { composer in
             // Click-and-hold to begin a range selection, then drag to the bottom edge and hold.
@@ -223,7 +211,7 @@ struct AppKitGesturesTests {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
 
-        let startBounds = try await screenBounds(ofElementWithID: "line297")
+        let startBounds = try await screenBounds(ofElementWithID: "line97")
 
         // Recap requires this test to be ran within an app host.
         guard NSApp.isActive else {
@@ -240,7 +228,7 @@ struct AppKitGesturesTests {
         }
 
         // Just inside the bottom edge of the window (window coordinates have a bottom-left origin).
-        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 20)
+        let dragEnd = screenBounds(ofPointInWindowCoordinates: CGPoint(x: window.frame.width / 2, y: 20))
 
         await recap.play { composer in
             composer._wk_click(at: startBounds.center, for: .seconds(0.5))
@@ -274,7 +262,7 @@ struct AppKitGesturesTests {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
 
-        let startBounds = try await screenBounds(ofElementWithID: "line297")
+        let startBounds = try await screenBounds(ofElementWithID: "line97")
 
         // Recap requires this test to be ran within an app host.
         guard NSApp.isActive else {
@@ -285,7 +273,7 @@ struct AppKitGesturesTests {
         #expect(CGPoint(initialScrollPosition) == .zero)
 
         let contentHeight = try #require(window.contentViewController?.view.frame.height)
-        let midContent = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: contentHeight / 2)
+        let midContent = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: contentHeight / 2))
 
         await recap.play { composer in
             composer._wk_click(at: startBounds.center, for: .seconds(0.5))
@@ -306,14 +294,14 @@ struct AppKitGesturesTests {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
 
-        let startBounds = try await screenBounds(ofElementWithID: "line297")
+        let startBounds = try await screenBounds(ofElementWithID: "line97")
 
         // Recap requires this test to be ran within an app host.
         guard NSApp.isActive else {
             return
         }
 
-        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 20)
+        let dragEnd = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: 20))
 
         await recap.play { composer in
             composer._wk_click(at: startBounds.center, for: .seconds(0.5))
@@ -354,8 +342,8 @@ struct AppKitGesturesTests {
 
         // Begin a selection on the visible text at the window's center, then drag up to the top edge.
         let contentHeight = try #require(window.contentViewController?.view.frame.height)
-        let start = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: contentHeight / 2)
-        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: contentHeight - 20)
+        let start = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: contentHeight / 2))
+        let dragEnd = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: contentHeight - 20))
 
         await recap.play { composer in
             composer._wk_click(at: start, for: .seconds(0.5))
@@ -381,15 +369,12 @@ struct AppKitGesturesTests {
             return
         }
 
-        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
-        #expect(CGPoint(initialScrollPosition) == .zero)
-
         // Begin the selection inside the bottom edge band (~70pt from the bottom; the band is 100pt) and
         // drag only a short distance toward the edge - less than the ~50pt threshold. The selection
         // originates near the edge but the drag is too small to be a deliberate "scroll past the edge"
         // gesture, so the page must not autoscroll. (Pre-fix, being in the band alone started autoscroll.)
-        let start = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 70)
-        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 45)
+        let start = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: 70))
+        let dragEnd = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: 45))
 
         await recap.play { composer in
             composer._wk_click(at: start, for: .seconds(0.5))
@@ -417,13 +402,10 @@ struct AppKitGesturesTests {
             return
         }
 
-        let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
-        #expect(CGPoint(initialScrollPosition) == .zero)
-
         // Same near-edge origin as the short-drag test, but now drag well past the threshold (and past the
         // window edge) and hold, so the deliberate gesture engages autoscroll.
-        let start = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: 70)
-        let dragEnd = windowEdgePointInScreenCoordinates(x: window.frame.width / 2, y: -40)
+        let start = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: 70))
+        let dragEnd = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: -40))
 
         await recap.play { composer in
             composer._wk_click(at: start, for: .seconds(0.5))
@@ -479,7 +461,7 @@ struct AppKitGesturesTests {
     func clickingAndHoldingOnEmptyContentOpensContextMenu(contentEditable: Bool) async throws {
         try await loadHTML(contentEditable: contentEditable)
 
-        let middleOfWindow = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+        let middleOfWindow = screenBounds(ofPointInWindowCoordinates: window.frame.center)
 
         // Recap requires this test to be ran within an app host.
         guard NSApp.isActive else {
@@ -564,7 +546,7 @@ struct AppKitGesturesTests {
 
         await page.waitForNextPresentationUpdate()
 
-        let start = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+        let start = screenBounds(ofPointInWindowCoordinates: window.frame.center)
         let end = CGPoint(x: start.x, y: start.y + 200)
 
         await recap.play { composer in
@@ -623,10 +605,7 @@ struct AppKitGesturesTests {
             return
         }
 
-        let clickPoint = convertToCoreGraphicsScreenCoordinates(
-            pointInWindowCoordinates: .init(x: 100, y: 350),
-            window: window
-        )
+        let clickPoint = screenBounds(ofPointInWindowCoordinates: .init(x: 100, y: 350))
 
         await recap.play { composer in
             composer._wk_click(at: clickPoint, for: .seconds(0.1))
@@ -743,7 +722,7 @@ struct AppKitGesturesTests {
         let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
         #expect(CGPoint(initialScrollPosition) == .zero)
 
-        let start = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+        let start = screenBounds(ofPointInWindowCoordinates: window.frame.center)
         let end = CGPoint(x: start.x, y: start.y - 200)
 
         await recap.play { composer in
@@ -774,7 +753,7 @@ struct AppKitGesturesTests {
             return
         }
 
-        let center = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
         let scrollEnd = CGPoint(x: center.x, y: center.y - 200)
 
         // Begin a momentum scroll, then catch it before it settles.
@@ -1170,10 +1149,8 @@ extension AppKitGesturesTests {
         return screenCoordinates
     }
 
-    // Loads a tall column of identified lines (`line0` at the bottom, `line<count - 1>` at the top) so a
-    // selection drag has somewhere to autoscroll.
-    private func loadScrollableText(lineCount: Int = 300) async throws {
-        let lines = (0..<lineCount)
+    private func loadScrollableText() async throws {
+        let lines = (0..<100)
             .reversed()
             .map { "<p id='line\($0)'>\($0) bottles of beer on the wall</p>" }
             .joined(separator: "\n")
@@ -1189,8 +1166,8 @@ extension AppKitGesturesTests {
         return convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: viewportCoordinates, window: window)
     }
 
-    private func windowEdgePointInScreenCoordinates(x: CGFloat, y: CGFloat) -> CGPoint {
-        convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: CGPoint(x: x, y: y), window: window)
+    private func screenBounds(ofPointInWindowCoordinates point: NSPoint) -> NSPoint {
+        convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: point, window: window)
     }
 }
 


### PR DESCRIPTION
#### 01a618ae81f9e11543ad4588649b5e2a3db6ddd7
<pre>
[AppKit Gestures] Follow-up to 315834@main to clean up the tests a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=317947">https://bugs.webkit.org/show_bug.cgi?id=317947</a>
<a href="https://rdar.apple.com/180745459">rdar://180745459</a>

Reviewed by Abrar Rahman Protyasha.

I realized I didn&apos;t actually end up pushing these changes before merging 315834@main.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.draggingSelectionToWindowEdgeAutoscrolls(_:)):
(AppKitGesturesTests.holdingSelectionDragNearEdgeKeepsScrolling):
(AppKitGesturesTests.holdingSelectionDragMidContentDoesNotAutoscroll):
(AppKitGesturesTests.selectionAutoscrollStopsAfterGestureEnds):
(AppKitGesturesTests.draggingSelectionToTopEdgeScrollsUp):
(AppKitGesturesTests.selectionOriginatingNearEdgeWithShortDragDoesNotAutoscroll):
(AppKitGesturesTests.selectionOriginatingNearEdgeAutoscrollsAfterDraggingPastThreshold):
(AppKitGesturesTests.clickingAndHoldingOnEmptyContentOpensContextMenu(_:)):
(AppKitGesturesTests.scrollingDoesNotRemoveTextSelection):
(AppKitGesturesTests.tripleClickingInPDFSelectsLine):
(AppKitGesturesTests.scrollingChangesScrollPosition(_:)):
(AppKitGesturesTests.interruptingDeceleratingScrollDoesNotFollowLink):
(AppKitGesturesTests.loadScrollableText):
(AppKitGesturesTests.screenBounds(ofPointInWindowCoordinates:)):
(AppKitGesturesTests.loadScrollableText(_:)): Deleted.
(AppKitGesturesTests.windowEdgePointInScreenCoordinates(_:y:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/315919@main">https://commits.webkit.org/315919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/924cca458cf52f9c06d1cfe57d0b905ac5ba517e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128174 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/132927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/916def8d-4678-4d2e-a0a4-614cbb4ef7f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36105 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f6c0603-9438-4d6d-934f-32effc274a02) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28519 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182421 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44042 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141195 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44731 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109214 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25986 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36465 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43241 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42646 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->