### PR TITLE
AX: Coalesce repeated LayoutComplete notifications for the same object within the same runloop cycle

### DIFF
--- a/LayoutTests/accessibility/mac/layout-complete-notifications-coalesce-expected.txt
+++ b/LayoutTests/accessibility/mac/layout-complete-notifications-coalesce-expected.txt
@@ -1,0 +1,10 @@
+This test ensures that repeatedly forcing synchronous layout without returning to the run loop (as happens when JavaScript forces layout in a loop) does not accumulate one AXLayoutComplete notification per layout.
+
+
+
+PASS: layoutCompleteCount < 50 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/layout-complete-notifications-coalesce.html
+++ b/LayoutTests/accessibility/mac/layout-complete-notifications-coalesce.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<script>
+var output = "This test ensures that repeatedly forcing synchronous layout without returning to the run loop (as happens when JavaScript forces layout in a loop) does not accumulate one AXLayoutComplete notification per layout.\n\n\n\n";
+
+var layoutCompleteCount = 0;
+function notificationCallback(element, notification) {
+    if (notification == "AXLayoutComplete")
+        layoutCompleteCount++;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Build the root accessibility object so LayoutComplete notifications are actually posted.
+    accessibilityController.rootElement;
+    accessibilityController.addNotificationListener(notificationCallback);
+
+    var forcedLayoutCount = 1000;
+    setTimeout(async function() {
+        // Ignore any AXLayoutComplete from the initial page load.
+        layoutCompleteCount = 0;
+
+        // Force many synchronous layouts in a tight loop without yielding to the run loop, so the
+        // zero-delay notification-post timer never fires between layouts. Each forced layout posts an
+        // AXLayoutComplete for the same (root) object; without coalescing these would accumulate
+        // one-per-layout in m_notificationsToPost.
+        for (var i = 0; i < forcedLayoutCount; i++) {
+            document.body.appendChild(document.createElement("div"));
+            document.body.offsetHeight; // Force synchronous layout.
+        }
+
+        // Yield to the run loop so the notification-post timer fires and the pending notifications post.
+        await waitFor(() => layoutCompleteCount >= 1);
+
+        // With coalescing we expect roughly one AXLayoutComplete (per object) for the whole batch.
+        output += expect("layoutCompleteCount < 50", "true");
+
+        accessibilityController.removeNotificationListener(notificationCallback);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2003,6 +2003,9 @@ void AXObjectCache::notificationPostTimerFired()
     // In tests, posting notifications has a tendency to immediately queue up other notifications, which can lead to unexpected behavior
     // when the notification list is cleared at the end. Instead copy this list at the start.
     auto notifications = std::exchange(m_notificationsToPost, { });
+    // The pending-LayoutComplete coalescing set tracks entries in m_notificationsToPost, so clear it in
+    // lockstep with draining that vector. Any LayoutComplete posted during this flush belongs to the next batch.
+    m_pendingLayoutCompleteObjectIDs.clear();
 
     // Filter out the notifications that are not going to be posted to platform clients.
     Vector<std::pair<Ref<AccessibilityObject>, AXNotificationWithData>> notificationsToPost;
@@ -2057,6 +2060,27 @@ void AXObjectCache::setShouldRepostNotificationsForTests(bool value)
     gShouldRepostNotificationsForTests = value;
 }
 #endif
+
+void AXObjectCache::enqueueNotificationToPost(Ref<AccessibilityObject>&& object, AXNotificationWithData&& notification)
+{
+    // JavaScript can starve the zero-delay m_notificationPostTimer by forcing layout (or otherwise
+    // mutating the tree) in a loop without ever returning to the run loop, which would let
+    // m_notificationsToPost grow without bound. LayoutComplete notifications -- by far the most common
+    // offender -- are coalesced per object in postNotification() so that case can't trigger this issue.
+    // This cap is a backstop for every other notification type. If it is ever hit, that notification is
+    // being posted in an unbounded loop and needs its own coalescing strategy like LayoutComplete's, so
+    // assert to surface it while degrading gracefully (dropping the notification) in release rather than
+    // overflowing the Vector and crashing the WebContent process.
+    static constexpr size_t maxNotificationsToPost = 100000;
+    if (m_notificationsToPost.size() >= maxNotificationsToPost) [[unlikely]] {
+        AX_ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_notificationsToPost.append(std::make_pair(WTF::move(object), WTF::move(notification)));
+    if (!m_notificationPostTimer.isActive())
+        m_notificationPostTimer.startOneShot(0_s);
+}
 
 void AXObjectCache::postNotification(RenderObject* renderer, AXNotification notification, PostTarget postTarget)
 {
@@ -2125,9 +2149,14 @@ void AXObjectCache::postNotification(AccessibilityObject* object, Document* docu
         return;
 #endif
 
-    m_notificationsToPost.append(std::make_pair(axObject.releaseNonNull(), notification));
-    if (!m_notificationPostTimer.isActive())
-        m_notificationPostTimer.startOneShot(0_s);
+    if (notification == AXNotification::LayoutComplete) {
+        // To avoid needlessly accumulating large amounts of redundant layout-complete notifications,
+        // e.g. from JS that forces synchronous layout in a loop, coalesce them on a per-object basis.
+        if (!m_pendingLayoutCompleteObjectIDs.add(axObject->objectID()).isNewEntry)
+            return;
+    }
+
+    enqueueNotificationToPost(axObject.releaseNonNull(), notification);
 }
 
 void AXObjectCache::postNotification(AccessibilityObject& object, AXNotification notification)
@@ -2145,9 +2174,7 @@ void AXObjectCache::postNotification(AccessibilityObject& object, AXNotification
         return;
 #endif
 
-    m_notificationsToPost.append(std::make_pair(Ref { object }, dataNotification));
-    if (!m_notificationPostTimer.isActive())
-        m_notificationPostTimer.startOneShot(0_s);
+    enqueueNotificationToPost(Ref { object }, WTF::move(dataNotification));
 }
 
 void AXObjectCache::postARIANotifyNotification(Node& node, const String& announcement, const AriaNotifyOptions& options)
@@ -2183,17 +2210,13 @@ void AXObjectCache::postARIANotifyNotification(Node& node, const String& announc
         }
     }
 
-    m_notificationsToPost.append(std::make_pair(Ref { *object }, AXNotificationWithData(AXNotification::ARIANotify, AriaNotifyData { announcement, priority, interruptBehavior, object->languageIncludingAncestors() })));
-    if (!m_notificationPostTimer.isActive())
-        m_notificationPostTimer.startOneShot(0_s);
+    enqueueNotificationToPost(Ref { *object }, AXNotificationWithData(AXNotification::ARIANotify, AriaNotifyData { announcement, priority, interruptBehavior, object->languageIncludingAncestors() }));
 }
 
 #if PLATFORM(COCOA)
 void AXObjectCache::postLiveRegionNotification(AccessibilityObject& object, LiveRegionStatus status, const AttributedString& announcement)
 {
-    m_notificationsToPost.append(std::make_pair(Ref { object }, AXNotificationWithData(AXNotification::LiveRegionAnnouncement, LiveRegionAnnouncementData { announcement, status })));
-    if (!m_notificationPostTimer.isActive())
-        m_notificationPostTimer.startOneShot(0_s);
+    enqueueNotificationToPost(Ref { object }, AXNotificationWithData(AXNotification::LiveRegionAnnouncement, LiveRegionAnnouncementData { announcement, status }));
 }
 #endif
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -880,6 +880,7 @@ private:
     static AccessibilityObject* focusedImageMapUIElement(HTMLAreaElement&);
 
     void notificationPostTimerFired();
+    void enqueueNotificationToPost(Ref<AccessibilityObject>&&, AXNotificationWithData&&);
 
     void liveRegionChangedNotificationPostTimerFired();
 
@@ -1028,6 +1029,7 @@ private:
 
     Timer m_notificationPostTimer;
     Vector<std::pair<Ref<AccessibilityObject>, AXNotificationWithData>> m_notificationsToPost;
+    HashSet<AXID> m_pendingLayoutCompleteObjectIDs;
 
 #if PLATFORM(COCOA)
     Timer m_passwordNotificationTimer;


### PR DESCRIPTION
#### 88d4f079e156bef26125130bb5d852cd76ee887c
<pre>
AX: Coalesce repeated LayoutComplete notifications for the same object within the same runloop cycle
<a href="https://bugs.webkit.org/show_bug.cgi?id=317950">https://bugs.webkit.org/show_bug.cgi?id=317950</a>
<a href="https://rdar.apple.com/180704127">rdar://180704127</a>

Reviewed by Dominic Mazzoni.

AXObjectCache defers accessibility notifications in m_notificationsToPost and
flushes them from a zero-delay timer (m_notificationPostTimer) once control
returns to the run loop. When JavaScript forces synchronous layout in a loop
without yielding to the run loop -- for example by repeatedly reading a
layout-dependent property like clientWidth inside a MutationObserver callback --
the flush timer never fires, yet each completed layout still posts a
LayoutComplete notification via LocalFrameView::didLayout -&gt;
AXObjectCache::onLayoutComplete. These redundant, duplicate LayoutComplete
notifications accumulate in m_notificationsToPost without bound until the Vector
overflows and CrashOnOverflow deliberately terminates the WebContent process
(observed at ~23 million entries, ~1.66 GB).

Fix this two ways:

1. Coalesce LayoutComplete notifications. Every pending LayoutComplete for a
given object collapses to a single meaningful notification once flushed, so track
the objects that already have a pending LayoutComplete in a companion
HashSet&lt;AXID&gt; (m_pendingLayoutCompleteObjectIDs) and skip the append when one is
already queued. The set is cleared in lockstep with draining m_notificationsToPost
in notificationPostTimerFired. This eliminates the unbounded duplicate growth
while preserving existing notification semantics and ordering.

2. Add a hard-cap backstop. Route all appends to m_notificationsToPost through a
new enqueueNotificationToPost() helper that refuses to grow the queue past a fixed
maximum, asserting via AX_ASSERT_NOT_REACHED() and dropping the notification. With
the coalescing above, the cap is never reached for LayoutComplete; if it is ever
hit by another notification type, that is a signal the type is being posted in an
unbounded loop and needs its own coalescing strategy. The assert is debug-only, so
release builds degrade gracefully (dropping notifications) rather than overflowing
and crashing.

* LayoutTests/accessibility/mac/layout-complete-notifications-coalesce-expected.txt: Added.
* LayoutTests/accessibility/mac/layout-complete-notifications-coalesce.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::notificationPostTimerFired):
(WebCore::AXObjectCache::enqueueNotificationToPost):
(WebCore::AXObjectCache::postNotification):
(WebCore::AXObjectCache::postARIANotifyNotification):
(WebCore::AXObjectCache::postLiveRegionNotification):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/315950@main">https://commits.webkit.org/315950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/316de006f056fe056105bf8bcb88e1ecbd5f70b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128185 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5780f60-7a3b-4d79-90cf-3d5d3bd4fc36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132942 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/037424c6-bb76-4127-b2bf-e6f246cee1c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113440 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fe5495f-447d-4caf-8777-0854df08c7d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28530 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145198 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.NoPanelHidSuccess (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182432 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141389 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38044 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44742 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109225 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36473 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116631 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43252 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7852 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42657 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->