### PR TITLE
Separate GlobalPrivacyControlEnabled and user opt-in value

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3491,12 +3491,26 @@ GetUserMediaRequiresFocus:
     WebCore:
       default: true
 
-GlobalPrivacyControlEnabled:
+GlobalPrivacyControlFeatureEnabled:
   type: bool
   status: testable
   category: privacy
-  humanReadableName: "Global Privacy Control"
-  humanReadableDescription: "Enable Global Privacy Control (GPC) signal"
+  humanReadableName: "Global Privacy Control Feature"
+  humanReadableDescription: "Enable Global Privacy Control (GPC) Feature"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
+GlobalPrivacyControlStatus:
+  type: bool
+  status: developer
+  category: privacy
+  humanReadableName: "Global Privacy Control API"
+  humanReadableDescription: "Expose the status of Global Privacy Control (GPC) API (navigtor.gloabalPrivacyControl)"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
@@ -33,20 +33,20 @@
 
 namespace WebCore {
 
-bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(Navigator& navigator)
+bool NavigatorGlobalPrivacyControl::globalPrivacyControlStatus(Navigator& navigator)
 {
     auto* frame = navigator.frame();
     if (!frame)
         return false;
-    return frame->settings().globalPrivacyControlEnabled();
+    return frame->settings().globalPrivacyControlStatus();
 }
 
-bool NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled(WorkerNavigator& navigator)
+bool NavigatorGlobalPrivacyControl::globalPrivacyControlStatus(WorkerNavigator& navigator)
 {
     RefPtr scope = navigator.scriptExecutionContext();
     if (!scope)
         return false;
-    return scope->settingsValues().globalPrivacyControlEnabled;
+    return scope->settingsValues().globalPrivacyControlStatus;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.h
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.h
@@ -32,7 +32,7 @@ class WorkerNavigator;
 
 class NavigatorGlobalPrivacyControl {
 public:
-    static bool globalPrivacyControlEnabled(Navigator&);
-    static bool globalPrivacyControlEnabled(WorkerNavigator&);
+    static bool globalPrivacyControlStatus(Navigator&);
+    static bool globalPrivacyControlStatus(WorkerNavigator&);
 };
 }

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
@@ -24,8 +24,8 @@
  */
 
 // https://www.w3.org/TR/gpc/
-[                                                                                                                           
-    ImplementedBy=NavigatorGlobalPrivacyControl                                                                          
-] interface mixin NavigatorGlobalPrivacyControl {         
-    [ImplementedAs=globalPrivacyControlEnabled] readonly attribute boolean globalPrivacyControl;
+[
+    ImplementedBy=NavigatorGlobalPrivacyControl
+] interface mixin NavigatorGlobalPrivacyControl {
+    [ImplementedAs=globalPrivacyControlStatus] readonly attribute boolean globalPrivacyControl;
 };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -131,7 +131,7 @@ struct NetworkResourceLoadParameters {
 
     bool isInitiatorPrefetch { false };
     bool isInitiatedByDedicatedWorker { false };
-    bool globalPrivacyControlEnabled { false };
+    bool globalPrivacyControlStatus { false };
     bool shouldConsiderEnhancedSecurityForInsecureResponse { false };
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -110,7 +110,7 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
 
     bool isInitiatorPrefetch;
     bool isInitiatedByDedicatedWorker;
-    bool globalPrivacyControlEnabled;
+    bool globalPrivacyControlStatus;
     bool shouldConsiderEnhancedSecurityForInsecureResponse;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -463,7 +463,7 @@ void NetworkResourceLoader::startNetworkLoad(ResourceRequest&& request, FirstLoa
     if (networkSession->shouldSendPrivateTokenIPCForTesting())
         connectionToWebProcess().networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::DidAllowPrivateTokenUsageByThirdPartyForTesting(sessionID(), request.isPrivateTokenUsageByThirdPartyAllowed(), request.url()), 0);
 
-    if (m_parameters.globalPrivacyControlEnabled) {
+    if (m_parameters.globalPrivacyControlStatus) {
         auto requestOrigin = SecurityOrigin::create(request.url());
         if (requestOrigin->isPotentiallyTrustworthy())
             request.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::SecGPC, "1"_s);

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -202,8 +202,8 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         frame->settings().setTouchEventDOMAttributesEnabled(*overrideValue);
 #endif
 
-    if (auto overrideValue = websitePolicies.globalPrivacyControlEnabled)
-        frame->settings().setGlobalPrivacyControlEnabled(*overrideValue);
+    if (auto overrideValue = websitePolicies.globalPrivacyControlStatus)
+        frame->settings().setGlobalPrivacyControlStatus(*overrideValue);
 
     documentLoader.applyPoliciesToSettings();
 }

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -70,7 +70,7 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
-    std::optional<bool> globalPrivacyControlEnabled;
+    std::optional<bool> globalPrivacyControlStatus;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };
     WebsitePopUpPolicy popUpPolicy { WebsitePopUpPolicy::Default };
     WebsiteMetaViewportPolicy metaViewportPolicy { WebsiteMetaViewportPolicy::Default };

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -70,7 +70,7 @@ struct WebKit::WebsitePoliciesData {
 #if ENABLE(TOUCH_EVENTS)
     std::optional<bool> overrideTouchEventDOMAttributesEnabled;
 #endif
-    std::optional<bool> globalPrivacyControlEnabled;
+    std::optional<bool> globalPrivacyControlStatus;
     WebKit::WebsiteAutoplayPolicy autoplayPolicy;
     WebKit::WebsitePopUpPolicy popUpPolicy;
     WebKit::WebsiteMetaViewportPolicy metaViewportPolicy;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -138,8 +138,8 @@ public:
     bool allowPrivacyProxy() const { return m_data.allowPrivacyProxy; }
     void setAllowPrivacyProxy(bool allow) { m_data.allowPrivacyProxy = allow; }
 
-    std::optional<bool> globalPrivacyControlEnabled() const { return m_data.globalPrivacyControlEnabled; }
-    void setGlobalPrivacyControlEnabled(std::optional<bool> enabled) { m_data.globalPrivacyControlEnabled = enabled; }
+    std::optional<bool> globalPrivacyControlStatus() const { return m_data.globalPrivacyControlStatus; }
+    void setGlobalPrivacyControlStatus(std::optional<bool> enabled) { m_data.globalPrivacyControlStatus = enabled; }
 
     WebCore::HTTPSByDefaultMode httpsByDefaultMode() const { return m_data.httpsByDefaultMode; }
     void setHTTPSByDefault(WebCore::HTTPSByDefaultMode mode) { m_data.httpsByDefaultMode = mode; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -62,7 +62,7 @@ extension WKWebpagePreferences {
 
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
-        self.globalPrivacyControlEnabled = wrapped.isGlobalPrivacyControlEnabled
+        self.globalPrivacyControlStatus = wrapped.globalPrivacyControlStatus
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -145,6 +145,6 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  @discussion The default value is NO. When enabled, both navigator.globalPrivacyControl and the
  Sec-GPC: 1 request header are active for the main frame, its subframes, and their subresources.
  */
-@property (nonatomic) BOOL globalPrivacyControlEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic) BOOL globalPrivacyControlStatus WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -555,14 +555,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     return _websitePolicies->allowPrivacyProxy();
 }
 
-- (void)setGlobalPrivacyControlEnabled:(BOOL)enabled
+- (void)setGlobalPrivacyControlStatus:(BOOL)enabled
 {
-    _websitePolicies->setGlobalPrivacyControlEnabled(enabled);
+    _websitePolicies->setGlobalPrivacyControlStatus(enabled);
 }
 
-- (BOOL)globalPrivacyControlEnabled
+- (BOOL)globalPrivacyControlStatus
 {
-    return protect(*_websitePolicies)->globalPrivacyControlEnabled().value_or(false);
+    return protect(*_websitePolicies)->globalPrivacyControlStatus().value_or(false);
 }
 
 - (_WKWebsiteColorSchemePreference)_colorSchemePreference

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -148,7 +148,7 @@ extension WebPage {
         @available(TBA, *)
         @available(watchOS, unavailable)
         @available(tvOS, unavailable)
-        public var isGlobalPrivacyControlEnabled: Bool = false
+        public var globalPrivacyControlStatus: Bool = false
     }
 }
 
@@ -209,7 +209,7 @@ extension WebPage.NavigationPreferences {
 
         self.alternateRequest = wrapped.alternateRequest
         self.overrideReferrer = wrapped.overrideReferrer
-        self.isGlobalPrivacyControlEnabled = wrapped.globalPrivacyControlEnabled
+        self.globalPrivacyControlStatus = wrapped.globalPrivacyControlStatus
     }
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -402,7 +402,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
         parameters.mayBlockNetworkRequest = (!isMainFrameNavigation && document->settings().scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled()) ?
             std::optional { WebProcess::singleton().shouldBlockRequest(parameters.request.url(), protect(document->topOrigin())) } : std::nullopt;
-        parameters.globalPrivacyControlEnabled = document->settings().globalPrivacyControlEnabled();
+        parameters.globalPrivacyControlStatus = document->settings().globalPrivacyControlStatus();
     }
 
     if (RefPtr page = frame->page()) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
@@ -2290,7 +2290,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPI)
 
     __block BOOL nextNavigationGPC = YES;
     navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        [preferences setGlobalPrivacyControlEnabled:nextNavigationGPC];
+        [preferences setGlobalPrivacyControlStatus:nextNavigationGPC];
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView setNavigationDelegate:navigationDelegate.get()];
@@ -2341,7 +2341,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlRequestHeader)
     webView.get().navigationDelegate = delegate.get();
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
-        [preferences setGlobalPrivacyControlEnabled:YES];
+        [preferences setGlobalPrivacyControlStatus:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView loadRequest:server.requestWithLocalhost("/main"_s)];
@@ -2366,7 +2366,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlNavigatorAPIInSubframe)
     RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)
-            [preferences setGlobalPrivacyControlEnabled:YES];
+            [preferences setGlobalPrivacyControlStatus:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView setNavigationDelegate:delegate.get()];
@@ -2413,7 +2413,7 @@ TEST(WebpagePreferences, GlobalPrivacyControlRequestHeaderInSubframe)
 
     delegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^completionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
         if (action.targetFrame.mainFrame)
-            [preferences setGlobalPrivacyControlEnabled:YES];
+            [preferences setGlobalPrivacyControlStatus:YES];
         completionHandler(WKNavigationActionPolicyAllow, preferences);
     };
     [webView loadRequest:server.requestWithLocalhost("/main"_s)];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -100,10 +100,10 @@ struct WebPageTests {
     }
 
     @Test(arguments: [true, false])
-    func globalPrivacyControlEnabledForNavigation(enabled: Bool) async throws {
+    func globalPrivacyControlStatusForNavigation(enabled: Bool) async throws {
         let decider = TestNavigationDecider()
         decider.preferencesMutation = { preferences in
-            preferences.isGlobalPrivacyControlEnabled = enabled
+            preferences.globalPrivacyControlStatus = enabled
         }
 
         let page = WebPage(navigationDecider: decider)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1432,7 +1432,8 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetMinimumFontSize(preferences, 0);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
-        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlEnabled").get());
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlStatus").get());
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlFeatureEnabled").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyMockContentFilterIPC(), toWK("AllowTestOnlyMockContentFilterIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyOriginAccessAllowListIPC(), toWK("AllowTestOnlyOriginAccessAllowListIPC").get());
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1349,12 +1349,12 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "GetGlobalPrivacyControl")) {
-        bool value = WKPreferencesGetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), toWK("GlobalPrivacyControlEnabled").get());
+        bool value = WKPreferencesGetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), toWK("GlobalPrivacyControlStatus").get());
         return adoptWK(WKBooleanCreate(value)).leakRef();
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetGlobalPrivacyControl")) {
-        WKPreferencesSetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), booleanValue(messageBody), toWK("GlobalPrivacyControlEnabled").get());
+        WKPreferencesSetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), booleanValue(messageBody), toWK("GlobalPrivacyControlStatus").get());
         return nullptr;
     }
 


### PR DESCRIPTION
#### 1e8b30a2cf343c004a68b6d0994ad261f318dc5c
<pre>
Separate GlobalPrivacyControlEnabled and user opt-in value
<a href="https://bugs.webkit.org/show_bug.cgi?id=317959">https://bugs.webkit.org/show_bug.cgi?id=317959</a>
<a href="https://rdar.apple.com/179490783">rdar://179490783</a>

Reviewed by Matthew Finkel.

Global Privacy Control API returns the feature’s current state (enabled/disabled).
This fix define another feature for the user&apos;s opt-in choice and it differents it
from the overall feature’s status.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp:
(WebCore::NavigatorGlobalPrivacyControl::globalPrivacyControlStatus):
(WebCore::NavigatorGlobalPrivacyControl::globalPrivacyControlEnabled): Deleted.
* Source/WebCore/page/NavigatorGlobalPrivacyControl.h:
* Source/WebCore/page/NavigatorGlobalPrivacyControl.idl:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startNetworkLoad):
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences setGlobalPrivacyControlStatus:]):
(-[WKWebpagePreferences globalPrivacyControlStatus]):
(-[WKWebpagePreferences setGlobalPrivacyControlEnabled:]): Deleted.
(-[WKWebpagePreferences globalPrivacyControlEnabled]): Deleted.
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
(globalPrivacyControlStatus):
(isGlobalPrivacyControlEnabled): Deleted.
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebsitePolicies.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.globalPrivacyControlStatusForNavigation(_:)):
(WebPageTests.globalPrivacyControlEnabledForNavigation(_:)): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/315959@main">https://commits.webkit.org/315959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/734792760a1178d183f4b00941a37613a1007099

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179888 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c050c2f-de4c-48d4-854e-85f0375c2c24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132969 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7332f41d-780a-4812-9e20-db7904dcfa4c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113466 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a1086dc-5c82-4cbc-90d7-0492125e982a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33112 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28569 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1816 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182471 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31766 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141422 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44092 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38049 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44781 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109285 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36505 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116670 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203190 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43291 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7888 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54413 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42696 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42827 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->