### PR TITLE
[WGSL] shader,validation,types,pointer:access_mode:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/types/pointer-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/types/pointer-expected.txt
@@ -37,34 +37,8 @@ PASS :access_mode:aspace="private";access="read_write";comma=""
 PASS :access_mode:aspace="private";access="read_write";comma=","
 PASS :access_mode:aspace="storage";access="read";comma=""
 PASS :access_mode:aspace="storage";access="read";comma=","
-FAIL :access_mode:aspace="storage";access="write";comma="" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    alias T = ptr<storage, u32, write>;
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:680:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
-FAIL :access_mode:aspace="storage";access="write";comma="," assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    alias T = ptr<storage, u32, write,>;
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:680:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :access_mode:aspace="storage";access="write";comma=""
+PASS :access_mode:aspace="storage";access="write";comma=","
 PASS :access_mode:aspace="storage";access="read_write";comma=""
 PASS :access_mode:aspace="storage";access="read_write";comma=","
 PASS :access_mode:aspace="uniform";access="read";comma=""

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -321,6 +321,9 @@ Result<void> TypeChecker::declareBuiltins()
                     TYPE_ERROR(type.arguments()[2].span(), "only pointers in <storage> address space may specify an access mode"_s);
 
                 UNWRAP_ASSIGN(accessMode, this->accessMode(type.arguments()[2]));
+
+                if (accessMode == AccessMode::Write) [[unlikely]]
+                    TYPE_ERROR(type.arguments()[2].span(), "access mode 'write' is not valid for the <storage> address space"_s);
             } else {
                 switch (addressSpace) {
                 case AddressSpace::Function:

--- a/Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm
@@ -643,6 +643,9 @@ TEST(WGSLTypeCheckingTests, PointerAsConstant)
 TEST(WGSLTypeCheckingTests, PointerAccessMode)
 {
     expectTypeError("fn f1(x: ptr<function, i32, read>) { }"_s, "only pointers in <storage> address space may specify an access mode"_s);
+    expectTypeError("alias T = ptr<storage, u32, write>;"_s, "access mode 'write' is not valid for the <storage> address space"_s);
+    expectNoError("alias T = ptr<storage, u32, read>;"_s);
+    expectNoError("alias T = ptr<storage, u32, read_write>;"_s);
 }
 
 TEST(WGSLTypeCheckingTests, Redeclaration)


### PR DESCRIPTION
#### dbb0c0cd1d45afda1de7c1485b6e118c34086d2d
<pre>
[WGSL] shader,validation,types,pointer:access_mode:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=317960">https://bugs.webkit.org/show_bug.cgi?id=317960</a>
<a href="https://rdar.apple.com/180753798">rdar://180753798</a>

Reviewed by Mike Wyrzykowski.

The &lt;storage&gt; address space only supports the read and read_write access modes, so a
pointer type such as ptr&lt;storage, u32, write&gt; must be rejected. The pointer type
constructor parsed the access mode but did not reject write; reject it there, matching
the validation already applied to variable declarations.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/types/pointer-expected.txt:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::declareBuiltins):
* Tools/TestWebKitAPI/Tests/WGSL/TypeCheckingTests.mm:
(TestWGSLAPI::TEST(WGSLTypeCheckingTests, PointerAccessMode)):

Canonical link: <a href="https://commits.webkit.org/316029@main">https://commits.webkit.org/316029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e702dfae648a58ca8b7cdd7a4127c06b17adb6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128204 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/491f3d04-dda8-415e-b973-4a2978abf70f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132951 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93743 "16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ce7a9ce-c710-4778-9fc2-d302c9cdf702) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113449 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbb71388-680d-40f2-92f4-67b58ca9563e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34749 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33091 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182451 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37269 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141402 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44072 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38109 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29762 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109252 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36483 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116650 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43271 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7864 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42676 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42917 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42807 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->