### PR TITLE
[WebGPU] shader,validation,expression,call,builtin,textureSampleLevel:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias-expected.txt
@@ -484,47 +484,7 @@ PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="abstract-flo
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="f32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="f16"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cabstract-int%3E"
-FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstract-int%3E" assert_unreached:
-  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=-9) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleBias(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(-9, -9, -9));
-      return vec4f(0);
-    }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: value=-9) INFO: subcase ran
-  - (in subcase: value=-8) INFO: subcase ran
-  - (in subcase: value=0) INFO: subcase ran
-  - (in subcase: value=7) INFO: subcase ran
-  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=8) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleBias(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(8, 8, 8));
-      return vec4f(0);
-    }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: value=8) INFO: subcase ran
- Reached unreachable code
+PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstract-int%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cabstract-int%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cabstract-float%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cf32%3E"
@@ -537,47 +497,7 @@ PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cf32%3
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cf16%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="i32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Ci32%3E"
-FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3E" assert_unreached:
-  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=-9) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleBias(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(i32(-9), i32(-9), i32(-9)));
-      return vec4f(0);
-    }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: value=-9) INFO: subcase ran
-  - (in subcase: value=-8) INFO: subcase ran
-  - (in subcase: value=0) INFO: subcase ran
-  - (in subcase: value=7) INFO: subcase ran
-  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=8) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleBias(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(i32(8), i32(8), i32(8)));
-      return vec4f(0);
-    }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: value=8) INFO: subcase ran
- Reached unreachable code
+PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Ci32%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="u32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cu32%3E"
@@ -590,54 +510,8 @@ PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType=
 PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType="u"
 PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType="l"
 PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="c"
-FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="u" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @group(0) @binding(2) var<uniform> u: vec3<i32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      const c = 1;
-      let l = vec3(i32(0), i32(0), i32(0));
-      let v = textureSampleBias(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3<i32>(u));
-      return vec4f(0);
-    }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:680:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
-FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="l" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @group(0) @binding(2) var<uniform> u: vec3<i32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      const c = 1;
-      let l = vec3(i32(0), i32(0), i32(0));
-      let v = textureSampleBias(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3<i32>(l));
-      return vec4f(0);
-    }
-
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:680:31
-    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
- Reached unreachable code
+PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="u"
+PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="l"
 PASS :only_in_fragment:textureType="texture_2d%3Cf32%3E";entryPoint="none";offset=false
 PASS :only_in_fragment:textureType="texture_2d%3Cf32%3E";entryPoint="none";offset=true
 PASS :only_in_fragment:textureType="texture_2d%3Cf32%3E";entryPoint="fragment";offset=false

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel-expected.txt
@@ -179,25 +179,7 @@ PASS :return_type:returnType="vec4%3Cabstract-float%3E";textureType="texture_dep
 PASS :return_type:returnType="vec4%3Cabstract-float%3E";textureType="texture_depth_2d_array"
 PASS :return_type:returnType="vec4%3Cabstract-float%3E";textureType="texture_depth_cube"
 PASS :return_type:returnType="vec4%3Cabstract-float%3E";textureType="texture_depth_cube_array"
-FAIL :return_type:returnType="vec4%3Cf32%3E";textureType="texture_1d%3Cf32%3E" assert_unreached:
-  - (in subcase: offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:22: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v: vec4<f32> = textureSampleLevel(t, s, 0.0f, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:21: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :return_type:returnType="vec4%3Cf32%3E";textureType="texture_1d%3Cf32%3E"
 PASS :return_type:returnType="vec4%3Cf32%3E";textureType="texture_2d%3Cf32%3E"
 PASS :return_type:returnType="vec4%3Cf32%3E";textureType="texture_2d_array%3Cf32%3E"
 PASS :return_type:returnType="vec4%3Cf32%3E";textureType="texture_3d%3Cf32%3E"
@@ -301,147 +283,9 @@ PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="bool"
 PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="vec2%3Cbool%3E"
 PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="vec3%3Cbool%3E"
 PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="vec4%3Cbool%3E"
-FAIL :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="abstract-int" assert_unreached:
-  - (in subcase: value=-1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractInt>, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, -1, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=-1;offset=false) INFO: subcase ran
-  - (in subcase: value=0;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractInt>, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=0;offset=false) INFO: subcase ran
-  - (in subcase: value=1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractInt>, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 1, 0);
-      return vec4f(0);
-    }
-
-      at (elided: only 2 shown)
-  - (in subcase: value=1;offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractInt>, <AbstractInt>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="abstract-float" assert_unreached:
-  - (in subcase: value=-1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractFloat>, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, -1.0, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=-1;offset=false) INFO: subcase ran
-  - (in subcase: value=0;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractFloat>, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=0;offset=false) INFO: subcase ran
-  - (in subcase: value=1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractFloat>, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 1.0, 0);
-      return vec4f(0);
-    }
-
-      at (elided: only 2 shown)
-  - (in subcase: value=1;offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, <AbstractFloat>, <AbstractInt>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="f32" assert_unreached:
-  - (in subcase: value=-1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, -1.0f, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=-1;offset=false) INFO: subcase ran
-  - (in subcase: value=0;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=0;offset=false) INFO: subcase ran
-  - (in subcase: value=1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 1.0f, 0);
-      return vec4f(0);
-    }
-
-      at (elided: only 2 shown)
-  - (in subcase: value=1;offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="abstract-int"
+PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="abstract-float"
+PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="f32"
 PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="f16"
 PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="vec2%3Cabstract-int%3E"
 PASS :coords_argument:textureType="texture_1d%3Cf32%3E";coordType="vec3%3Cabstract-int%3E"
@@ -831,147 +675,9 @@ PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="bool"
 PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="vec2%3Cbool%3E"
 PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="vec3%3Cbool%3E"
 PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="vec4%3Cbool%3E"
-FAIL :level_argument:textureType="texture_1d%3Cf32%3E";levelType="abstract-int" assert_unreached:
-  - (in subcase: value=-1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, -1);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=-1;offset=false) INFO: subcase ran
-  - (in subcase: value=0;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=0;offset=false) INFO: subcase ran
-  - (in subcase: value=1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 1);
-      return vec4f(0);
-    }
-
-      at (elided: only 2 shown)
-  - (in subcase: value=1;offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :level_argument:textureType="texture_1d%3Cf32%3E";levelType="abstract-float" assert_unreached:
-  - (in subcase: value=-1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractFloat>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, -1.0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=-1;offset=false) INFO: subcase ran
-  - (in subcase: value=0;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractFloat>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 0.0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=0;offset=false) INFO: subcase ran
-  - (in subcase: value=1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractFloat>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 1.0);
-      return vec4f(0);
-    }
-
-      at (elided: only 2 shown)
-  - (in subcase: value=1;offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractFloat>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :level_argument:textureType="texture_1d%3Cf32%3E";levelType="f32" assert_unreached:
-  - (in subcase: value=-1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, f32)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, -1.0f);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=-1;offset=false) INFO: subcase ran
-  - (in subcase: value=0;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, f32)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 0.0f);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: value=0;offset=false) INFO: subcase ran
-  - (in subcase: value=1;offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, f32)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 1.0f);
-      return vec4f(0);
-    }
-
-      at (elided: only 2 shown)
-  - (in subcase: value=1;offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, f32)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="abstract-int"
+PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="abstract-float"
+PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="f32"
 PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="f16"
 PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="vec2%3Cabstract-int%3E"
 PASS :level_argument:textureType="texture_1d%3Cf32%3E";levelType="vec3%3Cabstract-int%3E"
@@ -1310,45 +1016,7 @@ PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="abstract-flo
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="f32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="f16"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cabstract-int%3E"
-FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstract-int%3E" assert_unreached:
-  - (in subcase: value=-9) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(-9, -9, -9));
-      return vec4f(0);
-    }
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.js:290:24
-  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=-9) INFO: subcase ran
-  - (in subcase: value=-8) INFO: subcase ran
-  - (in subcase: value=0) INFO: subcase ran
-  - (in subcase: value=7) INFO: subcase ran
-  - (in subcase: value=8) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(8, 8, 8));
-      return vec4f(0);
-    }
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.js:290:24
-  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=8) INFO: subcase ran
- Reached unreachable code
+PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstract-int%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cabstract-int%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cabstract-float%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cf32%3E"
@@ -1361,45 +1029,7 @@ PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cf32%3
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cf16%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="i32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Ci32%3E"
-FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3E" assert_unreached:
-  - (in subcase: value=-9) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(i32(-9), i32(-9), i32(-9)));
-      return vec4f(0);
-    }
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.js:290:24
-  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=-9) INFO: subcase ran
-  - (in subcase: value=-8) INFO: subcase ran
-  - (in subcase: value=0) INFO: subcase ran
-  - (in subcase: value=7) INFO: subcase ran
-  - (in subcase: value=8) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3(i32(8), i32(8), i32(8)));
-      return vec4f(0);
-    }
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.js:290:24
-  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: value=8) INFO: subcase ran
- Reached unreachable code
+PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Ci32%3E"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="u32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cu32%3E"
@@ -1468,87 +1098,15 @@ PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType=
 PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType="u"
 PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType="l"
 PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="c"
-FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="u" assert_unreached:
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @group(0) @binding(2) var<uniform> u: vec3<i32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      const c = 1;
-      let l = vec3(i32(0), i32(0), i32(0));
-      let v = textureSampleLevel(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3<i32>(u));
-      return vec4f(0);
-    }
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.js:328:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
- Reached unreachable code
-FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="l" assert_unreached:
-  - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_3d<f32>;
-    @group(0) @binding(2) var<uniform> u: vec3<i32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      const c = 1;
-      let l = vec3(i32(0), i32(0), i32(0));
-      let v = textureSampleLevel(t, s, vec3(0.0f, 0.0f, 0.0f), 0, vec3<i32>(l));
-      return vec4f(0);
-    }
-
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.js:328:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
- Reached unreachable code
+PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="u"
+PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="l"
 PASS :offset_argument,non_const:textureType="texture_depth_2d";varType="c"
 PASS :offset_argument,non_const:textureType="texture_depth_2d";varType="u"
 PASS :offset_argument,non_const:textureType="texture_depth_2d";varType="l"
 PASS :offset_argument,non_const:textureType="texture_depth_2d_array";varType="c"
 PASS :offset_argument,non_const:textureType="texture_depth_2d_array";varType="u"
 PASS :offset_argument,non_const:textureType="texture_depth_2d_array";varType="l"
-FAIL :texture_type:testTextureType="texture_1d%3Cf32%3E" assert_unreached:
-  - (in subcase: textureType="texture_1d<f32>";offset=false) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    5:11: error: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-
-    ---- shader ----
-
-    @group(0) @binding(0) var s: sampler;
-    @group(0) @binding(1) var t: texture_1d<f32>;
-    @fragment fn fs() -> @location(0) vec4f {
-      let v = textureSampleLevel(t, s, 0.0f, 0);
-      return vec4f(0);
-    }
-
-      at (elided: below max severity)
-  - (in subcase: textureType="texture_1d<f32>";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_2d<f32>";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_2d<f32>";offset=true) INFO: subcase ran
-  - (in subcase: textureType="texture_2d_array<f32>";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_2d_array<f32>";offset=true) INFO: subcase ran
-  - (in subcase: textureType="texture_3d<f32>";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_3d<f32>";offset=true) INFO: subcase ran
-  - (in subcase: textureType="texture_cube<f32>";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_cube_array<f32>";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_depth_2d";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_depth_2d";offset=true) INFO: subcase ran
-  - (in subcase: textureType="texture_depth_2d_array";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_depth_2d_array";offset=true) INFO: subcase ran
-  - (in subcase: textureType="texture_depth_cube";offset=false) INFO: subcase ran
-  - (in subcase: textureType="texture_depth_cube_array";offset=false) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    5:10: no matching overload for initializer textureSampleLevel(ref<handle, texture_1d<f32>, read>, ref<handle, sampler, read>, f32, <AbstractInt>)
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :texture_type:testTextureType="texture_1d%3Cf32%3E"
 PASS :texture_type:testTextureType="texture_1d%3Cu32%3E"
 PASS :texture_type:testTextureType="texture_2d%3Cf32%3E"
 PASS :texture_type:testTextureType="texture_2d%3Cu32%3E"

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1452,7 +1452,6 @@ http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/extractBits.h
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/insertBits.html [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSample.html [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleGrad.html [ Skip ]
-http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.html [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/parse/shadow_builtins.html [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/barriers.html  [ Skip ]
 http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/mix.html [ Skip ]

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1618,7 +1618,7 @@ Result<void> TypeChecker::visit(AST::CallExpression& call)
 
                 auto& lastArg = call.arguments().last();
                 auto* vectorType = std::get_if<Types::Vector>(lastArg.inferredType());
-                if (!vectorType || vectorType->size != 2 || vectorType->element != m_types.i32Type())
+                if (!vectorType || (vectorType->size != 2 && vectorType->size != 3) || vectorType->element != m_types.i32Type())
                     return { };
 
                 auto& maybeConstant = lastArg.constantValue();
@@ -1626,7 +1626,7 @@ Result<void> TypeChecker::visit(AST::CallExpression& call)
                     TYPE_ERROR(lastArg.span(), "the offset argument must be a const-expression"_s);
 
                 auto& vector = std::get<ConstantVector>(*maybeConstant);
-                for (unsigned i = 0; i < 2; ++i) {
+                for (unsigned i = 0; i < vectorType->size; ++i) {
                     auto& i32 = std::get<int32_t>(vector.elements[i]);
                     if (i32 < -8 || i32 > 7) [[unlikely]]
                         TYPE_ERROR(lastArg.span(), "each component of the offset argument must be at least -8 and at most 7. offset component "_s, String::number(i), " is "_s, String::number(i32));


### PR DESCRIPTION
#### 3bbcb976cc66a3dbefccff6de95b8d628d0baeea
<pre>
[WebGPU] shader,validation,expression,call,builtin,textureSampleLevel:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=317958">https://bugs.webkit.org/show_bug.cgi?id=317958</a>
<a href="https://rdar.apple.com/180753294">rdar://180753294</a>

Reviewed by NOBODY (OOPS!).

We were missing the validation for the vec3 offset for texture3d.
The patch also fixes shader,validation,expression,call,builtin,textureSampleBias:*

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleLevel-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bbcb976cc66a3dbefccff6de95b8d628d0baeea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/090d2bfe-3053-4b2e-8d6d-2a41e79dc15f) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1e98799-5d90-483b-9885-d5771402ad21) 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0e7e43a-068f-4771-9b73-3024947ae53f) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->