### PR TITLE
[Site Isolation][Debug] Fix TestWebKitAPI.SiteIsolation.DrawAfterNavigateToDomainAgain

### DIFF
--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -205,9 +205,13 @@ void SuspendedPageProxy::teardown()
     allSuspendedPages().remove(*this);
 
     if (RefPtr page = m_page.get()) {
-        if (hasSuspensionStarted()) {
+        if (hasSuspensionStarted() && m_suspendedFrameItemID) {
             m_browsingContextGroup->forEachRemotePage(*page, [suspendedPage = Ref { *this }](auto& remotePage) {
-                protect(remotePage.siteIsolatedProcess())->removeSuspendedPageProxy(suspendedPage);
+                Ref process = remotePage.siteIsolatedProcess();
+                // Mirror the suspendSubframeProcesses() filter: only processes that received addSuspendedPageProxy() need the matching remove.
+                if (!suspendedPage->hasSubframeInProcess(process->coreProcessIdentifier()))
+                    return;
+                process->removeSuspendedPageProxy(suspendedPage);
             });
         }
         if (m_suspensionState != SuspensionState::Resumed)


### PR DESCRIPTION
#### 7223c62c181adfde7ae62a19d8ff5b4b5907ccc3
<pre>
[Site Isolation][Debug] Fix TestWebKitAPI.SiteIsolation.DrawAfterNavigateToDomainAgain
<a href="https://bugs.webkit.org/show_bug.cgi?id=317965">https://bugs.webkit.org/show_bug.cgi?id=317965</a>
<a href="https://rdar.apple.com/180757482">rdar://180757482</a>

Reviewed by Basuke Suzuki.

When site isolation is on but the back/forward cache is not actually in use, SuspendedPageProxy can still be created
with a null m_suspendedFrameItemID (e.g. to delay tearing down the old page and avoid a white flash during navigation)
In this case suspendSubframeProcesses() is never called, so subframe processes never receive addSuspendedPageProxy().
However, teardown() unconditionally iterated over all remote pages in the BrowsingContextGroup and called
removeSuspendedPageProxy() on each of their processes, hitting assertion m_suspendedPages.contains(suspendedPage).

Fix by guarding the loop with m_suspendedFrameItemID: if it is not set, suspendSubframeProcesses() was never called and
there is nothing to clean up in subframe processes. Within the loop, mirror the hasSubframeInProcess() filter from
suspendSubframeProcesses() so that only processes that actually received addSuspendedPageProxy() get the matching
removeSuspendedPageProxy().

* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::teardown):

Canonical link: <a href="https://commits.webkit.org/316025@main">https://commits.webkit.org/316025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/916e9b01c75ff03fdffcd16a6d4f7080765bbcb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128427 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/355083a3-f351-4f13-9684-16538ef85634) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133137 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc51efff-742a-4a41-af38-17b8314b5c9d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/759ef2bd-7be2-4d70-a402-201773ee43a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28772 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145421 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.NoPanelHidSuccess, TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent, TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182675 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37465 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141597 "Found 1 new test failure: fast/flexbox/002.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44295 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38103 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29965 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109647 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36686 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116873 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43495 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8067 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43140 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->