### PR TITLE
[JSC][Temporal] Polish Temporal.PlainTime: spec alignment and helper rename

### DIFF
--- a/JSTests/stress/temporal-plain-time-since-operand-swap.js
+++ b/JSTests/stress/temporal-plain-time-since-operand-swap.js
@@ -1,0 +1,42 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+
+const earlier = new Temporal.PlainTime(8, 22, 36, 123, 456, 789);
+const later = new Temporal.PlainTime(12, 39, 40, 987, 654, 289);
+
+// Each row: [roundingMode, smallestUnit, expectedHours(later.since(earlier)), expectedHours(earlier.since(later))]
+// Values verified against the test262 corpus and against V8 (which delegates to temporal_rs).
+// Hours are chosen because the +4.28h / -4.28h difference produces distinct integer hours
+// under every asymmetric mode.
+const cases = [
+    ["ceil", "hour", 5, -4],
+    ["floor", "hour", 4, -5],
+    ["expand", "hour", 5, -5],
+    ["trunc", "hour", 4, -4],
+    ["halfCeil", "hour", 4, -4],
+    ["halfFloor", "hour", 4, -4],
+    ["halfExpand", "hour", 4, -4],
+    ["halfTrunc", "hour", 4, -4],
+    ["halfEven", "hour", 4, -4],
+];
+
+for (const [roundingMode, smallestUnit, posHours, negHours] of cases) {
+    const pos = later.since(earlier, { roundingMode, smallestUnit });
+    const neg = earlier.since(later, { roundingMode, smallestUnit });
+    shouldBe(pos.hours, posHours, `later.since(earlier) ${roundingMode}/${smallestUnit} hours`);
+    shouldBe(neg.hours, negHours, `earlier.since(later) ${roundingMode}/${smallestUnit} hours`);
+    // The sign must match the wall-clock direction.
+    if (posHours !== 0) shouldBe(pos.sign, 1, `later.since(earlier) ${roundingMode} positive sign`);
+    if (negHours !== 0) shouldBe(neg.sign, -1, `earlier.since(later) ${roundingMode} negative sign`);
+}
+
+// Sanity check: until() and since() differ only in sign for symmetric modes.
+for (const mode of ["halfExpand", "halfEven", "trunc", "expand"]) {
+    const u = later.until(earlier, { roundingMode: mode, smallestUnit: "hour" });
+    const s = later.since(earlier, { roundingMode: mode, smallestUnit: "hour" });
+    shouldBe(u.hours, -s.hours, `until/since hours symmetry under ${mode}`);
+}

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -93,7 +93,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* g
     auto plainDate = TemporalPlainDate::toPlainDate(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto plainTime = TemporalPlainTime::toPlainTime(globalObject, duration);
+    auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), WTF::move(plainTime)));

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -167,7 +167,7 @@ static EncodedJSValue addDurationToPlainDateTime(JSGlobalObject* globalObject, T
 
     // Steps 5-6: ToInternalDurationRecordWith24HourDays + AddTime(dateTime.[[Time]], duration).
     auto balancedTimeDuration = TemporalPlainTime::addTime(plainDateTime->plainTime(), duration);
-    auto plainTime = TemporalPlainTime::toPlainTime(globalObject, balancedTimeDuration);
+    auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, balancedTimeDuration);
     RETURN_IF_EXCEPTION(scope, { });
 
     TemporalOverflow overflow = toTemporalOverflow(globalObject, options);

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.cpp
@@ -61,9 +61,9 @@ TemporalPlainTime::TemporalPlainTime(VM& vm, Structure* structure, ISO8601::Plai
 {
 }
 
-
 // https://tc39.es/proposal-temporal/#sec-temporal-isvalidtime
-ISO8601::PlainTime TemporalPlainTime::toPlainTime(JSGlobalObject* globalObject, const ISO8601::Duration& duration)
+// https://tc39.es/proposal-temporal/#sec-temporal-createtimerecord
+ISO8601::PlainTime TemporalPlainTime::validateAndCreateTimeRecord(JSGlobalObject* globalObject, const ISO8601::Duration& duration)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -74,30 +74,37 @@ ISO8601::PlainTime TemporalPlainTime::toPlainTime(JSGlobalObject* globalObject, 
     double millisecond = duration.milliseconds();
     double microsecond = static_cast<double>(duration.microseconds());
     double nanosecond = static_cast<double>(duration.nanoseconds());
+    // Step 1: If hour < 0 or hour > 23, return false.
     if (!(hour >= 0 && hour <= 23)) [[unlikely]] {
         throwRangeError(globalObject, scope, "hour is out of range"_s);
         return { };
     }
+    // Step 2: If minute < 0 or minute > 59, return false.
     if (!(minute >= 0 && minute <= 59)) [[unlikely]] {
         throwRangeError(globalObject, scope, "minute is out of range"_s);
         return { };
     }
+    // Step 3: If second < 0 or second > 59, return false.
     if (!(second >= 0 && second <= 59)) [[unlikely]] {
         throwRangeError(globalObject, scope, "second is out of range"_s);
         return { };
     }
+    // Step 4: If millisecond < 0 or millisecond > 999, return false.
     if (!(millisecond >= 0 && millisecond <= 999)) [[unlikely]] {
         throwRangeError(globalObject, scope, "millisecond is out of range"_s);
         return { };
     }
+    // Step 5: If microsecond < 0 or microsecond > 999, return false.
     if (!(microsecond >= 0 && microsecond <= 999)) [[unlikely]] {
         throwRangeError(globalObject, scope, "microsecond is out of range"_s);
         return { };
     }
+    // Step 6: If nanosecond < 0 or nanosecond > 999, return false.
     if (!(nanosecond >= 0 && nanosecond <= 999)) [[unlikely]] {
         throwRangeError(globalObject, scope, "nanosecond is out of range"_s);
         return { };
     }
+    // Step 7: Return true. (Materialize the Time Record from the validated fields.)
     return ISO8601::PlainTime {
         static_cast<unsigned>(hour),
         static_cast<unsigned>(minute),
@@ -108,24 +115,25 @@ ISO8601::PlainTime TemporalPlainTime::toPlainTime(JSGlobalObject* globalObject, 
     };
 }
 
-// CreateTemporalPlainTime ( years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds [ , newTarget ] )
-// https://tc39.es/proposal-temporal/#sec-temporal-createtemporalplainTime
+// CreateTemporalTime ( time [ , newTarget ] )
+// https://tc39.es/proposal-temporal/#sec-temporal-createtemporaltime
 TemporalPlainTime* TemporalPlainTime::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::Duration&& duration)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto plainTime = toPlainTime(globalObject, duration);
+    // IsValidTime + materialize the Time Record.
+    auto plainTime = validateAndCreateTimeRecord(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Steps 1-4: OrdinaryCreateFromConstructor + set [[Time]].
     return TemporalPlainTime::create(vm, structure, WTF::move(plainTime));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-balancetime
 static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128 second, Int128 millisecond, Int128 microsecond, Int128 nanosecond)
 {
-    // https://github.com/tc39/proposal-temporal/issues/1804
-    // Use non-negative modulo operation.
+    // Steps 1-2: microsecond += floor(nanosecond/1000); nanosecond %= 1000.
     microsecond += nanosecond / 1000;
     nanosecond = nanosecond % 1000;
     if (nanosecond < 0) {
@@ -133,6 +141,7 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         nanosecond += 1000;
     }
 
+    // Steps 3-4: millisecond += floor(microsecond/1000); microsecond %= 1000.
     millisecond += microsecond / 1000;
     microsecond = microsecond % 1000;
     if (microsecond < 0) {
@@ -140,6 +149,7 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         microsecond += 1000;
     }
 
+    // Steps 5-6: second += floor(millisecond/1000); millisecond %= 1000.
     second += millisecond / 1000;
     millisecond = millisecond % 1000;
     if (millisecond < 0) {
@@ -147,6 +157,7 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         millisecond += 1000;
     }
 
+    // Steps 7-8: minute += floor(second/60); second %= 60.
     minute += second / 60;
     second = second % 60;
     if (second < 0) {
@@ -154,6 +165,7 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         second += 60;
     }
 
+    // Steps 9-10: hour += floor(minute/60); minute %= 60.
     hour += minute / 60;
     minute = minute % 60;
     if (minute < 0) {
@@ -161,6 +173,7 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         minute += 60;
     }
 
+    // Steps 11-12: deltaDays = floor(hour/24); hour %= 24.
     Int128 days = hour / 24;
     hour = hour % 24;
     if (hour < 0) {
@@ -168,9 +181,13 @@ static ISO8601::Duration NODELETE balanceTime(Int128 hour, Int128 minute, Int128
         hour += 24;
     }
 
+    // Step 13: Return CreateTimeRecord(h, m, s, ms, us, ns, deltaDays). deltaDays is packed into [[Days]].
     return ISO8601::Duration(0, 0, 0, static_cast<int64_t>(days), static_cast<int64_t>(hour), static_cast<int64_t>(minute), static_cast<int64_t>(second), static_cast<int64_t>(millisecond), Int128(microsecond), Int128(nanosecond));
 }
 
+// RoundTime ( time, increment, unit, roundingMode ) — JSC uses fractional-double quantities;
+// spec uses ns-integer math. Equivalent for PlainTime's bounded field range. dayLengthNs lets
+// ZonedDateTime supply a non-standard day length.
 // https://tc39.es/proposal-temporal/#sec-temporal-roundtime
 ISO8601::Duration TemporalPlainTime::roundTime(ISO8601::PlainTime plainTime, double increment, TemporalUnit unit, RoundingMode roundingMode, std::optional<double> dayLengthNs)
 {
@@ -181,42 +198,50 @@ ISO8601::Duration TemporalPlainTime::roundTime(ISO8601::PlainTime plainTime, dou
     double quantity = 0;
     switch (unit) {
     case TemporalUnit::Day: {
+        // Steps 1, 9: quantity = whole-time-as-ns / dayLength; return CreateTimeRecord(...result).
         double length = dayLengthNs.value_or(8.64 * 1e13);
         quantity = (((((plainTime.hour() * 60.0 + plainTime.minute()) * 60.0 + plainTime.second()) * 1000.0 + plainTime.millisecond()) * 1000.0 + plainTime.microsecond()) * 1000.0 + plainTime.nanosecond()) / length;
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
+        ASSERT(std::isfinite(result) && result >= static_cast<double>(INT64_MIN) && result <= static_cast<double>(INT64_MAX));
         return ISO8601::Duration(0, 0, 0, static_cast<int64_t>(result), 0, 0, 0, 0, Int128(0), Int128(0));
     }
     case TemporalUnit::Hour: {
+        // Steps 1, 10: quantity = fractional hours; return BalanceTime(result, 0, ...).
         quantity = (fractionalSecond(plainTime) / 60.0 + plainTime.minute()) / 60.0 + plainTime.hour();
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(result), 0, 0, 0, 0, 0);
     }
     case TemporalUnit::Minute: {
+        // Steps 2, 11: quantity = fractional minutes; return BalanceTime(hour, result, ...).
         quantity = fractionalSecond(plainTime) / 60.0 + plainTime.minute();
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(result), 0, 0, 0, 0);
     }
     case TemporalUnit::Second: {
+        // Steps 3, 12: quantity = fractional seconds; return BalanceTime(..., result, ...).
         quantity = fractionalSecond(plainTime);
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(result), 0, 0, 0);
     }
     case TemporalUnit::Millisecond: {
+        // Steps 4, 13: quantity = fractional ms; return BalanceTime(..., result, ...).
         quantity = plainTime.millisecond() + plainTime.microsecond() * 1e-3 + plainTime.nanosecond() * 1e-6;
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(plainTime.second()), static_cast<Int128>(result), 0, 0);
     }
     case TemporalUnit::Microsecond: {
+        // Steps 5, 14: quantity = fractional µs; return BalanceTime(..., result, ...).
         quantity = plainTime.microsecond() + plainTime.nanosecond() * 1e-3;
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
         return balanceTime(static_cast<Int128>(plainTime.hour()), static_cast<Int128>(plainTime.minute()), static_cast<Int128>(plainTime.second()), static_cast<Int128>(plainTime.millisecond()), static_cast<Int128>(result), 0);
     }
     case TemporalUnit::Nanosecond: {
+        // Steps 6, 16: quantity = ns; return BalanceTime(..., result).
         quantity = plainTime.nanosecond();
         auto result = TemporalCore::roundNumberToIncrementDouble(quantity, increment, roundingMode);
         ASSERT(std::isfinite(result));
@@ -236,9 +261,12 @@ ISO8601::PlainTime TemporalPlainTime::round(JSGlobalObject* globalObject, JSValu
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding done by the caller. Step 3: roundTo === undefined check also done by caller.
+
     JSObject* options = nullptr;
     std::optional<TemporalUnit> smallest;
     if (optionsValue.isString()) {
+        // Steps 4.a-c: treat string roundTo as { smallestUnit: <string> }; decode unit directly.
         auto string = optionsValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
 
@@ -248,35 +276,44 @@ ISO8601::PlainTime TemporalPlainTime::round(JSGlobalObject* globalObject, JSValu
             return { };
         }
 
+        // Step 10 (string path): ValidateTemporalUnitValue(smallestUnit, ~time~) — reject date units.
         if (smallest.value() <= TemporalUnit::Day) [[unlikely]] {
             throwRangeError(globalObject, scope, "smallestUnit is a disallowed unit"_s);
             return { };
         }
     } else {
+        // Step 5: roundTo = ? GetOptionsObject(roundTo).
         options = intlGetOptionsObject(globalObject, optionsValue);
         RETURN_IF_EXCEPTION(scope, { });
     }
 
+    // Step 6 NOTE: alphabetical — roundingIncrement, roundingMode, smallestUnit.
+    // Step 7: roundingIncrement = ? GetRoundingIncrementOption(roundTo).
     auto roundingIncrement = temporalRoundingIncrement(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
+    // Step 8: roundingMode = ? GetRoundingModeOption(roundTo, ~half-expand~).
     auto roundingMode = temporalRoundingMode(globalObject, options, RoundingMode::HalfExpand);
     RETURN_IF_EXCEPTION(scope, { });
     if (!smallest) {
+        // Step 9: smallestUnit = ? GetTemporalUnitValuedOption(roundTo, "smallestUnit", ~required~).
         auto smallestMaybeAuto = temporalUnitValued(globalObject, options, vm.propertyNames->smallestUnit, TemporalUnitDefault::Required);
         RETURN_IF_EXCEPTION(scope, { });
+        // Step 10 (object path): ValidateTemporalUnitValue(smallestUnit, ~time~).
         validateTemporalUnitValue(globalObject, smallestMaybeAuto, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
         RETURN_IF_EXCEPTION(scope, { });
         smallest = std::get<std::optional<TemporalUnit>>(smallestMaybeAuto);
     }
     auto smallestUnit = smallest.value();
-    validateTemporalUnitValue(globalObject, smallestUnit, UnitGroup::Time, AllowedUnit::None, "smallestUnit"_s);
-    RETURN_IF_EXCEPTION(scope, { });
+    // Steps 11-12: maximum = MaximumTemporalDurationRoundingIncrement(smallestUnit).
     auto maximum = TemporalCore::maximumRoundingIncrement(smallestUnit);
+    // Step 13: ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, false).
     validateTemporalRoundingIncrement(globalObject, roundingIncrement, maximum, Inclusivity::Exclusive);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 14: result = RoundTime(this.[[Time]], increment, smallestUnit, roundingMode).
     auto duration = roundTime(m_plainTime, roundingIncrement, smallestUnit, roundingMode, std::nullopt);
-    RELEASE_AND_RETURN(scope, toPlainTime(globalObject, duration));
+    // Step 15: Return ! CreateTemporalTime(result).
+    RELEASE_AND_RETURN(scope, validateAndCreateTimeRecord(globalObject, duration));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tostring
@@ -320,27 +357,34 @@ String TemporalPlainTime::toString(JSGlobalObject* globalObject, JSValue options
     // Step 10: Let precision be ToSecondsStringPrecisionRecord(smallestUnit, digits).
     auto data = toSecondsStringPrecisionRecord(smallestUnit, digits);
 
-    // No need to round if given explicit defaults (steps 11-12 are no-ops when precision=auto, roundingMode=trunc).
-    if (std::get<0>(data.precision) == Precision::Auto && roundingMode == RoundingMode::Trunc)
+    // Step 11 (fast path): precision=Auto ⇒ {Auto, Nanosecond, 1}; RoundTime at ns/1 is identity
+    //   for any mode (each PlainTime field is already an integer ns), so we skip rounding entirely.
+    if (std::get<0>(data.precision) == Precision::Auto)
         return toString();
 
-    // Step 11: Let roundResult be RoundTime(plainTime.[[Time]], precision.[[Increment]], precision.[[Unit]], roundingMode).
+    // Step 11: roundResult = RoundTime(this.[[Time]], precision.[[Increment]], precision.[[Unit]], roundingMode).
     // Step 12: Return TimeRecordToString(roundResult, precision.[[Precision]]).
-    // roundTime() is RoundTime — returns ISO8601::Duration (our Time Record, which has [[Days]] per spec).
-    // toPlainTime() extracts the clock fields, equivalent to TimeRecordToString ignoring [[Days]].
+    //   roundTime returns ISO8601::Duration (Time Record with [[Days]]); validateAndCreateTimeRecord
+    //   extracts the clock fields, equivalent to TimeRecordToString ignoring [[Days]].
     auto duration = roundTime(m_plainTime, data.increment, data.unit, roundingMode, std::nullopt);
-    auto plainTime = toPlainTime(globalObject, duration);
+    auto plainTime = validateAndCreateTimeRecord(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
     return ISO8601::temporalTimeToString(plainTime, data.precision);
 }
 
+// ToTemporalTimeRecord ( temporalTimeLike [ , completeness ] ) — completeness = ~complete~ here:
+// missing fields default to 0. Partial-record variant is toPartialTime below.
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimerecord
 ISO8601::Duration TemporalPlainTime::toTemporalTimeRecord(JSGlobalObject* globalObject, JSObject* temporalTimeLike, bool skipRelevantPropertyCheck)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-3: result with each field set to 0; any = false.
     ISO8601::Duration duration { };
     auto hasRelevantProperty = false;
+    // Steps 4-21: per-property Get + ToIntegerWithTruncation in spec alphabetical order
+    //   (hour, microsecond, millisecond, minute, nanosecond, second). Date units skipped.
     for (TemporalUnit unit : temporalUnitsInTableOrder) {
         if (unit < TemporalUnit::Hour)
             continue;
@@ -361,21 +405,27 @@ ISO8601::Duration TemporalPlainTime::toTemporalTimeRecord(JSGlobalObject* global
         duration.setField(unit, integer);
     }
 
+    // Step 22: If any is false, throw TypeError.
     if (!hasRelevantProperty && !skipRelevantPropertyCheck) [[unlikely]] {
         throwTypeError(globalObject, scope, "Object must contain at least one Temporal time property"_s);
         return { };
     }
 
+    // Step 23: Return result.
     return duration;
 }
 
+// ToTemporalTimeRecord variant with completeness = ~partial~: missing fields stay nullopt.
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporaltimerecord
 std::array<std::optional<double>, numberOfTemporalPlainTimeUnits> TemporalPlainTime::toPartialTime(JSGlobalObject* globalObject, JSObject* temporalTimeLike, bool skipRelevantPropertyCheck)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: result with each field set to ~unset~. Step 3: any = false.
     bool hasAnyFields = false;
     std::array<std::optional<double>, numberOfTemporalPlainTimeUnits> partialTime { };
+    // Steps 4-21: per-property Get + ToIntegerWithTruncation, alphabetical.
     for (TemporalUnit unit : temporalUnitsInTableOrder) {
         if (unit < TemporalUnit::Hour)
             continue;
@@ -394,13 +444,16 @@ std::array<std::optional<double>, numberOfTemporalPlainTimeUnits> TemporalPlainT
             partialTime[static_cast<unsigned>(unit) - static_cast<unsigned>(TemporalUnit::Hour)] = doubleValue;
         }
     }
+    // Step 22: If any is false, throw TypeError.
     if (!hasAnyFields && !skipRelevantPropertyCheck) [[unlikely]] {
         throwTypeError(globalObject, scope, "Object must contain at least one Temporal time property"_s);
         return { };
     }
+    // Step 23: Return result.
     return partialTime;
 }
 
+// RegulateTime constrain branch (Step 1): clamp each field into its valid range.
 static ISO8601::PlainTime constrainTime(ISO8601::Duration&& duration)
 {
     return ISO8601::PlainTime(
@@ -412,13 +465,17 @@ static ISO8601::PlainTime constrainTime(ISO8601::Duration&& duration)
         clampTo<unsigned>(static_cast<double>(duration.nanoseconds()), 0u, 999u));
 }
 
+// RegulateTime ( hour, minute, second, millisecond, microsecond, nanosecond, overflow )
+// https://tc39.es/proposal-temporal/#sec-temporal-regulatetime
 ISO8601::PlainTime TemporalPlainTime::regulateTime(JSGlobalObject* globalObject, ISO8601::Duration&& duration, TemporalOverflow overflow)
 {
     switch (overflow) {
+    // Step 1: If overflow is ~constrain~, clamp each field then CreateTimeRecord.
     case TemporalOverflow::Constrain:
         return constrainTime(WTF::move(duration));
+    // Step 2: Else overflow is ~reject~: IsValidTime → throw on out-of-range, else CreateTimeRecord.
     case TemporalOverflow::Reject:
-        return TemporalPlainTime::toPlainTime(globalObject, duration);
+        return TemporalPlainTime::validateAndCreateTimeRecord(globalObject, duration);
     }
     return { };
 }
@@ -530,7 +587,8 @@ TemporalPlainTime* TemporalPlainTime::from(JSGlobalObject* globalObject, JSValue
     return { };
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-comparetemporaltime
+// CompareTimeRecord ( time1, time2 ) — returns -1/0/+1.
+// https://tc39.es/proposal-temporal/#sec-temporal-comparetimerecord
 int32_t TemporalPlainTime::compare(const ISO8601::PlainTime& t1, const ISO8601::PlainTime& t2)
 {
     if (t1.hour() > t2.hour())
@@ -560,14 +618,14 @@ int32_t TemporalPlainTime::compare(const ISO8601::PlainTime& t1, const ISO8601::
     return 0;
 }
 
+// AddTime ( time, timeDuration )
 // https://tc39.es/proposal-temporal/#sec-temporal-addtime
 ISO8601::Duration TemporalPlainTime::addTime(const ISO8601::PlainTime& plainTime, const ISO8601::Duration& duration)
 {
+    // Step 1: Return BalanceTime(time fields + timeDuration fields).
+    //   Spec NOTE: add per-field then balance; sub-second fields can be MAX_SAFE_INTEGER,
+    //   so widen to Int128 first.
     return balanceTime(
-        // The seconds, milliseconds, microseconds, or nanoseconds fields can be up to
-        // MAX_SAFE_INTEGER. So to do the addition, we have to convert to Int128.
-        // The hour and minute fields are more constrained, but for consistency, these
-        // arguments are Int128 as well.
         static_cast<Int128>(plainTime.hour()) + static_cast<Int128>(duration.hours()),
         static_cast<Int128>(plainTime.minute()) + static_cast<Int128>(duration.minutes()),
         static_cast<Int128>(plainTime.second()) + static_cast<Int128>(duration.seconds()),
@@ -576,23 +634,32 @@ ISO8601::Duration TemporalPlainTime::addTime(const ISO8601::PlainTime& plainTime
         static_cast<Int128>(plainTime.nanosecond()) + static_cast<Int128>(duration.nanoseconds()));
 }
 
+// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.with
 ISO8601::PlainTime TemporalPlainTime::with(JSGlobalObject* globalObject, JSObject* temporalTimeLike, JSValue optionsValue) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding done by caller.
+
+    // Step 3: If ? IsPartialTemporalObject(temporalTimeLike) is false, throw TypeError.
+    //   rejectObjectWithCalendarOrTimeZone handles both rejection cases (Temporal.* instance, or calendar/timeZone property).
     rejectObjectWithCalendarOrTimeZone(globalObject, temporalTimeLike);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 4: Let partialTime be ? ToTemporalTimeRecord(temporalTimeLike, ~partial~).
     auto [hourOptional, minuteOptional, secondOptional, millisecondOptional, microsecondOptional, nanosecondOptional] = toPartialTime(globalObject, temporalTimeLike);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 17: resolvedOptions = ? GetOptionsObject(options).
     JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 18: overflow = ? GetTemporalOverflowOption(resolvedOptions).
     TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Steps 5-16 (per field): if partialTime.X is not undefined, x = partialTime.X; else x = this.X.
     ISO8601::Duration duration { };
     duration.setField(TemporalUnit::Hour, hourOptional.value_or(hour()));
     duration.setField(TemporalUnit::Minute, minuteOptional.value_or(minute()));
@@ -601,12 +668,16 @@ ISO8601::PlainTime TemporalPlainTime::with(JSGlobalObject* globalObject, JSObjec
     duration.setField(TemporalUnit::Microsecond, microsecondOptional.value_or(microsecond()));
     duration.setField(TemporalUnit::Nanosecond, nanosecondOptional.value_or(nanosecond()));
 
+    // Step 19: result = ? RegulateTime(h, m, s, ms, us, ns, overflow).
+    // Step 20: Return ! CreateTemporalTime(result). (Caller wraps.)
     RELEASE_AND_RETURN(scope, regulateTime(globalObject, WTF::move(duration), overflow));
 }
 
+// DifferenceTime ( time1, time2 ) — returns a time duration (in nanoseconds).
 // https://tc39.es/proposal-temporal/#sec-temporal-differencetime
 static Int128 differenceTime(ISO8601::PlainTime time1, ISO8601::PlainTime time2)
 {
+    // Steps 1-6: per-field time2 - time1 (hours, minutes, seconds, ms, µs, ns).
     double hours = static_cast<double>(time2.hour()) - static_cast<double>(time1.hour());
     double minutes = static_cast<double>(time2.minute()) - static_cast<double>(time1.minute());
     double seconds = static_cast<double>(time2.second()) - static_cast<double>(time1.second());
@@ -615,37 +686,47 @@ static Int128 differenceTime(ISO8601::PlainTime time1, ISO8601::PlainTime time2)
     double nanoseconds = static_cast<double>(time2.nanosecond()) - static_cast<double>(time1.nanosecond());
     dataLogLnIf(TemporalPlainTimeInternal::verbose, "Diff ", hours, " ", minutes, " ", seconds, " ", milliseconds, " ", microseconds, " ", nanoseconds);
 
+    // Steps 7-9: TimeDurationFromComponents (Step 8 |result| < nsPerDay assert is guaranteed
+    //   here since inputs are valid Time Records).
     return TemporalCore::timeDurationFromComponents(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaintime
 // DifferenceTemporalPlainTime ( operation, temporalTime, other, options )
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaintime
 ISO8601::Duration TemporalPlainTime::differenceTemporalPlainTime(DifferenceOperation operation, JSGlobalObject* globalObject, TemporalPlainTime* other, JSValue optionsValue) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: ToTemporalTime(other) — done by caller (from()).
+    // Steps 2-3: GetOptionsObject + GetDifferenceSettings. We pass operation=Until (default) so
+    //   the rounding mode is NOT flipped for Since — the operand swap below relies on this.
+    //   Stress test: JSTests/stress/temporal-plain-time-since-operand-swap.js.
     auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Time, TemporalUnit::Nanosecond, TemporalUnit::Hour);
     RETURN_IF_EXCEPTION(scope, { });
 
     Int128 timeDuration;
 
-    // The sign of the argument to roundTimeDuration() determines the choice
-    // of rounding mode, so the sign should be preserved here instead of
-    // negating the duration at the end
+    // Steps 4, 5, 8 fused: swap operands for Since (rounded magnitude carries the right sign).
+    //   Spec-equivalent by round(-x, mode) = -round(x, NegateRoundingMode(mode)), which holds
+    //   for every mode (Ceil↔Floor flip; Expand/Trunc/HalfX are sign-aware).
     if (operation == DifferenceOperation::Since)
         timeDuration = differenceTime(other->plainTime(), plainTime());
     else
         timeDuration = differenceTime(plainTime(), other->plainTime());
 
+    // Step 5 (cont): RoundTimeDuration(timeDuration, increment, smallestUnit, roundingMode).
     auto d = ISO8601::roundTimeDuration(globalObject, timeDuration, increment, smallestUnit, roundingMode);
     RETURN_IF_EXCEPTION(scope, { });
+    // Step 6: duration = CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
     auto duration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), d);
+    // Step 7: result = ! TemporalDurationFromInternal(duration, largestUnit).
     auto durResult = TemporalCore::temporalDurationFromInternal(duration, largestUnit);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };
     }
+    // Step 9: Return result. (Step 8 negate-if-since folded into the operand swap above.)
     return *durResult;
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.h
@@ -45,7 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static ISO8601::PlainTime toPlainTime(JSGlobalObject*, const ISO8601::Duration&);
+    static ISO8601::PlainTime validateAndCreateTimeRecord(JSGlobalObject*, const ISO8601::Duration&);
     static ISO8601::Duration roundTime(ISO8601::PlainTime, double increment, TemporalUnit, RoundingMode, std::optional<double> dayLengthNs);
     static ISO8601::Duration toTemporalTimeRecord(JSGlobalObject*, JSObject*, bool skipRelevantPropertyCheck = false);
     static std::array<std::optional<double>, numberOfTemporalPlainTimeUnits> toPartialTime(JSGlobalObject*, JSObject*, bool skipRelevantPropertyCheck = false);
@@ -76,10 +76,6 @@ public:
 private:
     TemporalPlainTime(VM&, Structure*, ISO8601::PlainTime&&);
     DECLARE_DEFAULT_FINISH_CREATION;
-
-    template<typename CharacterType>
-    static std::optional<ISO8601::PlainTime> parse(StringParsingBuffer<CharacterType>&);
-    static ISO8601::PlainTime fromObject(JSGlobalObject*, JSObject*);
 
     ISO8601::Duration differenceTemporalPlainTime(DifferenceOperation, JSGlobalObject*, TemporalPlainTime*, JSValue) const;
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimeConstructor.cpp
@@ -128,6 +128,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimeConstructorFuncFrom, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: Return ? ToTemporalTime(item, options).
     JSValue itemValue = callFrame->argument(0);
     JSValue optionsValue = callFrame->argument(1);
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainTime::from(globalObject, itemValue, optionsValue)));
@@ -139,12 +140,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimeConstructorFuncCompare, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: Set one to ? ToTemporalTime(one).
     auto* one = TemporalPlainTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 2: Set two to ? ToTemporalTime(two).
     auto* two = TemporalPlainTime::from(globalObject, callFrame->argument(1), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 3: Return CompareTimeRecord(one.[[Time]], two.[[Time]]).
     return JSValue::encode(jsNumber(TemporalPlainTime::compare(one->plainTime(), two->plainTime())));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTimePrototype.cpp
@@ -114,14 +114,18 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncAdd, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.add called on value that's not a PlainTime"_s);
 
+    // Step 3: Return ? AddDurationToTime(~add~, this, temporalDurationLike).
+    //   Step 1: ? ToTemporalDuration. Steps 3-4: AddTime ignores date fields per spec.
     auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto result = TemporalPlainTime::toPlainTime(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), duration));
+    //   Step 5: Return ! CreateTemporalTime(result).
+    auto result = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), duration));
     RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(result)));
@@ -133,14 +137,17 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSubtract, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.subtract called on value that's not a PlainTime"_s);
 
+    // Step 3: Return ? AddDurationToTime(~subtract~, this, temporalDurationLike).
+    //   Step 1: ? ToTemporalDuration. Step 2: `-duration` is CreateNegatedTemporalDuration. Steps 3-5: as in add.
     auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto result = TemporalPlainTime::toPlainTime(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), -duration));
+    auto result = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, TemporalPlainTime::addTime(plainTime->plainTime(), -duration));
     RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(TemporalPlainTime::create(vm, globalObject->plainTimeStructure(), WTF::move(result)));
@@ -172,10 +179,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncUntil, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.until called on value that's not a PlainTime"_s);
 
+    // Step 3: Return ? DifferenceTemporalPlainTime(~until~, this, other, options).
     auto* other = TemporalPlainTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -191,10 +200,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncSince, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.since called on value that's not a PlainTime"_s);
 
+    // Step 3: Return ? DifferenceTemporalPlainTime(~since~, this, other, options).
     auto* other = TemporalPlainTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -230,13 +241,17 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncEquals, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.equals called on value that's not a PlainTime"_s);
 
+    // Step 3: Set other to ? ToTemporalTime(other).
     auto* other = TemporalPlainTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Steps 4-5: If CompareTimeRecord(this.[[Time]], other.[[Time]]) = 0 return true, else false.
+    //   operator== compares all six fields ≡ CompareTimeRecord = 0.
     return JSValue::encode(jsBoolean(plainTime->plainTime() == other->plainTime()));
 }
 
@@ -246,10 +261,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToString, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toString called on value that's not a PlainTime"_s);
 
+    // Steps 3-11: option parsing + RoundTime + TimeRecordToString — see instance method.
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, plainTime->toString(globalObject, callFrame->argument(0)))));
 }
 
@@ -259,23 +276,27 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToJSON, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toJSON called on value that's not a PlainTime"_s);
 
+    // Step 3: Return TimeRecordToString(this.[[Time]], ~auto~).
     return JSValue::encode(jsString(vm, plainTime->toString()));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.plaintime.prototype.tolocalestring
+// https://tc39.es/proposal-temporal/#sup-temporal.plaintime.prototype.tolocalestring
 JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToLocaleString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainTime = dynamicDowncast<TemporalPlainTime>(callFrame->thisValue());
     if (!plainTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.toLocaleString called on value that's not a PlainTime"_s);
 
+    // Step 3: dateFormat = ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, ~time~, ~time~).
     JSValue locales = callFrame->argument(0);
     JSValue options = callFrame->argument(1);
     IntlDateTimeFormat* formatter;
@@ -287,6 +308,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncToLocaleString, (JSGlobal
     }
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 4: Return ? FormatDateTime(dateFormat, plainTime).
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
@@ -296,9 +318,11 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainTimePrototypeFuncValueOf, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: Throw a TypeError exception.
     return throwVMTypeError(globalObject, scope, "Temporal.PlainTime.prototype.valueOf must not be called. To compare PlainTime values, use Temporal.PlainTime.compare"_s);
 }
 
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.hour
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterHour, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -311,6 +335,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterHour, (JSGlobalObject* 
     return JSValue::encode(jsNumber(plainTime->hour()));
 }
 
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.minute
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMinute, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -323,6 +348,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMinute, (JSGlobalObject
     return JSValue::encode(jsNumber(plainTime->minute()));
 }
 
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.second
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterSecond, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -335,6 +361,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterSecond, (JSGlobalObject
     return JSValue::encode(jsNumber(plainTime->second()));
 }
 
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.millisecond
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMillisecond, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -347,6 +374,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMillisecond, (JSGlobalO
     return JSValue::encode(jsNumber(plainTime->millisecond()));
 }
 
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.microsecond
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMicrosecond, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();
@@ -359,6 +387,7 @@ JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterMicrosecond, (JSGlobalO
     return JSValue::encode(jsNumber(plainTime->microsecond()));
 }
 
+// https://tc39.es/proposal-temporal/#sec-get-temporal.plaintime.prototype.nanosecond
 JSC_DEFINE_CUSTOM_GETTER(temporalPlainTimePrototypeGetterNanosecond, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
 {
     VM& vm = globalObject->vm();


### PR DESCRIPTION
#### ef770f685580534704c41621b16f0b4ae41204e1
<pre>
[JSC][Temporal] Polish Temporal.PlainTime: spec alignment and helper rename
<a href="https://bugs.webkit.org/show_bug.cgi?id=317978">https://bugs.webkit.org/show_bug.cgi?id=317978</a>
<a href="https://rdar.apple.com/180760547">rdar://180760547</a>

Reviewed by Yusuke Suzuki.

Annotate every Temporal.PlainTime operation against the Stage 4
spec; fix two dead spec anchors and a misleading ECMA-402 link.

Rename the fused IsValidTime + CreateTimeRecord helper from
toPlainTime to validateAndCreateTimeRecord, with a header
explaining that the fusion mirrors the spec&apos;s repeating
&quot;if IsValidTime is false throw; else CreateTimeRecord&quot; pattern.

Drop the dead parse&lt;&gt; template and fromObject() static (declared
but never defined or called) and the duplicate
validateTemporalUnitValue call in round().

Lock in the operand-swap optimization in DifferenceTemporalPlainTime
with a new stress test covering since() across all nine rounding
modes — the swap depends on the rounding mode not being flipped
by extractDifferenceOptions for since.

Test: JSTests/stress/temporal-plain-time-since-operand-swap.js
Canonical link: <a href="https://commits.webkit.org/315942@main">https://commits.webkit.org/315942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afafd31852df19f7ece13802580d2f7b47a8bc2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128223 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b4e27ab-8925-48e6-a5e4-5b2e237d279f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f0bd369-8b9c-4bd4-9866-029189bcc4de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f68645f1-b296-4965-803c-467f8326dfd7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28568 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1813 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182470 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31765 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141419 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44091 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141236 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44780 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109284 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36504 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43290 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7885 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54412 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42695 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42826 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->