### PR TITLE
runtime.sendMessage from a content script is dropped if sent while the background content is still loading.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -351,6 +351,7 @@ Expected<bool, RefPtr<API::Error>> WebExtensionContext::unload()
 
     m_actionsToPerformAfterBackgroundContentLoads.clear();
     m_backgroundContentEventListeners.clear();
+    m_backgroundContentHasLoadedOnce = false;
     m_eventListenerFrames.clear();
     m_installReason = InstallReason::None;
     m_previousVersion = nullString();
@@ -1275,7 +1276,7 @@ void WebExtensionContext::didOpenWindow(WebExtensionWindow& window, UpdateWindow
     }
 
     for (Ref tab : window.tabs())
-        didOpenTab(tab);
+        didOpenTab(tab, suppressEvents);
 
     if (!isLoaded() || !window.extensionHasAccess() || suppressEvents == SuppressEvents::Yes)
         return;
@@ -2778,6 +2779,7 @@ void WebExtensionContext::performTasksAfterBackgroundContentLoads()
         action();
 
     m_backgroundContentIsLoaded = true;
+    m_backgroundContentHasLoadedOnce = true;
     m_actionsToPerformAfterBackgroundContentLoads.clear();
 
     saveBackgroundPageListenersToStorage();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1879,8 +1879,13 @@ void WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents(EventLi
             }
         }
 
+        // Until the background content has loaded once, an empty listener set means the listeners
+        // aren't known yet, not that the event is unhandled. Queue rather than drop it, so a content
+        // script that calls runtime.sendMessage while racing the initial background load isn't lost.
+        bool backgroundContentListenersAreUnknown = m_backgroundContentEventListeners.isEmpty() && !m_backgroundContentHasLoadedOnce;
+
         // Don't load the background page if it isn't expecting these events.
-        if (!backgroundContentListensToAtLeastOneEvent) {
+        if (!backgroundContentListensToAtLeastOneEvent && !backgroundContentListenersAreUnknown) {
             completionHandler();
             return;
         }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -1099,6 +1099,7 @@ private:
     std::unique_ptr<RunLoop::Timer> m_unloadBackgroundWebViewTimer;
     MonotonicTime m_lastBackgroundPortActivityTime;
     bool m_backgroundContentIsLoaded { false };
+    bool m_backgroundContentHasLoadedOnce { false };
     bool m_safeToLoadBackgroundContent { false };
 
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
@@ -532,6 +532,46 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScript)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWhileBackgroundIsLoading)
+{
+    // A content script sends runtime.sendMessage while the non-persistent background content
+    // is still loading on initial load (before its onMessage listener has registered). The
+    // message must be queued and delivered once the background loads, not dropped.
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message?.content, 'Hello', 'Should receive the message sent while the background was loading')",
+        @"  sendResponse({ content: 'Received' })",
+        @"})",
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"(async () => {",
+        @"  const response = await browser.runtime.sendMessage({ content: 'Hello' })",
+
+        @"  browser.test.assertEq(response?.content, 'Received', 'Should get the response from the background script')",
+
+        @"  browser.test.notifyPass()",
+        @"})()"
+    ]);
+
+    auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    // Load the tab immediately, without waiting for the background to be ready, so the content script's
+    // runtime.sendMessage races the initial background content load.
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPIRuntime, SendMessageFromContentScriptWithAsyncReply)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 7682d9817bed6645aa2516eb20a1b5a2ca48d735
<pre>
runtime.sendMessage from a content script is dropped if sent while the background content is still loading.
<a href="https://webkit.org/b/317981">https://webkit.org/b/317981</a>
<a href="https://rdar.apple.com/177298426">rdar://177298426</a>

Reviewed by Kiara Rose.

When a content script called runtime.sendMessage before a non-persistent
background page or service worker had finished its initial load and registered
its runtime.onMessage listener, the message was delivered to no listener and
silently dropped instead of being queued until the background content loaded.
This happened reliably on the first load after install, or whenever the
persisted background listener state had been cleared, because the empty
listener set made wakeUpBackgroundContentIfNecessaryToFireEvents() treat the
event as unhandled rather than deferring it.

Until the background content has loaded once, an empty listener set means the
listeners aren&apos;t known yet, not that the event is unhandled, so queue the task
to fire after the background content loads rather than dropping it. Track this
with m_backgroundContentHasLoadedOnce so that once the background has loaded an
empty set remains authoritative and unhandled events still avoid waking it.

Forwarding events during the initial load also exposed a latent bug where
didOpenWindow() did not forward its SuppressEvents argument to didOpenTab(),
causing pre-existing tabs enumerated by populateWindowsAndTabs() to fire
tabs.onCreated; that spurious event was previously masked by the early-out.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload): Reset m_backgroundContentHasLoadedOnce so the
cleared listener set is treated as unknown again on the next load.
(WebKit::WebExtensionContext::didOpenWindow): Forward suppressEvents to didOpenTab() so
tabs of windows enumerated during the initial population don&apos;t fire tabs.onCreated.
(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads): Set
m_backgroundContentHasLoadedOnce once the background content has finished loading.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessaryToFireEvents): Queue the
event instead of dropping it when the listener set is empty and the background has never
loaded, since the handling listener may register during the in-flight load.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Add m_backgroundContentHasLoadedOnce.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST): Add SendMessageFromContentScriptWhileBackgroundIsLoading, which
sends a content-script message while the background content races its initial load.

Canonical link: <a href="https://commits.webkit.org/315975@main">https://commits.webkit.org/315975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cde3786b9ab4ee96732079318e0f8bfbfcd9266

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128232 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c131588f-15b9-41f9-b15d-5b0bb2db42c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132974 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75e2d6a2-5165-4819-85a9-27503f158ba9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f81d1a96-9c0a-4763-aa6e-5875e92c9a4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34776 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33119 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28577 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182479 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141429 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44100 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44789 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29792 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109302 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36512 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116678 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7894 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42704 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->