### PR TITLE
Lowercase CSP directive names eagerly

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: The Content Security Policy directive 'frame-ancestors' is ignored when delivered via an HTML meta element.
+CONSOLE MESSAGE: The Content Security Policy directive 'report-uri' is ignored when delivered via an HTML meta element.
+CONSOLE MESSAGE: Unrecognized Content-Security-Policy directive 'aaa'.
+
+This tests that mixed-case Content Security Policy directive names are lowercased, so the console warnings refer to them in lowercase.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/simpleSourcedScript.js because it does not appear in the script-src directive of the Content Security Policy.
+
+PASS An uppercase SCRIPT-SRC directive still applies strict-dynamic, so a parser-inserted script is blocked.
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="SCRIPT-SRC 'strict-dynamic' 'self' 'nonce-dummy'">
+        <script src="/js-test-resources/testharness.js" nonce='dummy'></script>
+        <script src="/js-test-resources/testharnessreport.js" nonce='dummy'></script>
+</head>
+<body>
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+                assert_equals(e.effectiveDirective, 'script-src-elem');
+            }));
+        }, 'An uppercase SCRIPT-SRC directive still applies strict-dynamic, so a parser-inserted script is blocked.');
+    </script>
+    <script id='blockedScript' src='resources/simpleSourcedScript.js'></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="Frame-Ancestors 'none'; Report-URI /report; Aaa">
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+</head>
+<body>
+<p>This tests that mixed-case Content Security Policy directive names are lowercased, so the console warnings refer to them in lowercase.</p>
+</body>
+</html>

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -911,7 +911,7 @@ std::optional<CodePosition> ContentSecurityPolicy::getCurrentCodePosition()
 void ContentSecurityPolicy::reportViolation(const ContentSecurityPolicyDirective& violatedDirective, const String& blockedURL, const String& consoleMessage, JSC::JSGlobalObject* state, StringView sourceContent) const
 {
     // FIXME: Extract source file, and position from JSC::ExecState.
-    return reportViolation(violatedDirective.nameForReporting().convertToASCIILowercase(), violatedDirective.directiveList(), blockedURL, consoleMessage, String(), sourceContent.left(40), { }, state);
+    return reportViolation(violatedDirective.nameForReporting(), violatedDirective.directiveList(), blockedURL, consoleMessage, String(), sourceContent.left(40), { }, state);
 }
 
 void ContentSecurityPolicy::reportViolation(const String& violatedDirective, const ContentSecurityPolicyDirectiveList& violatedDirectiveList, const String& blockedURL, const String& consoleMessage, JSC::JSGlobalObject* state) const
@@ -922,7 +922,7 @@ void ContentSecurityPolicy::reportViolation(const String& violatedDirective, con
 
 void ContentSecurityPolicy::reportViolation(const ContentSecurityPolicyDirective& violatedDirective, const String& blockedURL, const String& consoleMessage, const String& sourceURL, StringView sourceContent, std::optional<TextPosition>&& sourcePosition, const URL& preRedirectURL, JSC::JSGlobalObject* state, Element* element) const
 {
-    return reportViolation(violatedDirective.nameForReporting().convertToASCIILowercase(), violatedDirective.directiveList(), blockedURL, consoleMessage, sourceURL, sourceContent.left(40), WTF::move(sourcePosition), state, preRedirectURL, element);
+    return reportViolation(violatedDirective.nameForReporting(), violatedDirective.directiveList(), blockedURL, consoleMessage, sourceURL, sourceContent.left(40), WTF::move(sourcePosition), state, preRedirectURL, element);
 }
 
 void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirective, const ContentSecurityPolicyDirectiveList& violatedDirectiveList, const String& blockedURLString, const String& consoleMessage, const String& sourceURL, StringView sourceContent, std::optional<TextPosition>&& maybeSourcePosition, JSC::JSGlobalObject* state, const URL& preRedirectURL, Element* element) const

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -487,20 +487,20 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
             if (auto directive = parseDirective(std::span { directiveBegin, buffer.position() })) {
                 ASSERT(!directive->name.isEmpty());
                 if (policyFrom == ContentSecurityPolicy::PolicyFrom::Inherited) {
-                    if (equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests)
-                        || equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::sandbox))
+                    if (directive->name == ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests
+                        || directive->name == ContentSecurityPolicyDirectiveNames::sandbox)
                         continue;
                 } else if (policyFrom == ContentSecurityPolicy::PolicyFrom::HTTPEquivMeta) {
-                    if (equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::sandbox)
-                        || equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::reportURI)
-                        || equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::frameAncestors)) {
+                    if (directive->name == ContentSecurityPolicyDirectiveNames::sandbox
+                        || directive->name == ContentSecurityPolicyDirectiveNames::reportURI
+                        || directive->name == ContentSecurityPolicyDirectiveNames::frameAncestors) {
                         m_policy->reportInvalidDirectiveInHTTPEquivMeta(directive->name);
                         continue;
                     }
                 } else if (policyFrom == ContentSecurityPolicy::PolicyFrom::InheritedForPluginDocument) {
-                    if (!equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::pluginTypes)
-                        && !equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::reportURI)
-                        && !equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::reportTo))
+                    if (directive->name != ContentSecurityPolicyDirectiveNames::pluginTypes
+                        && directive->name != ContentSecurityPolicyDirectiveNames::reportURI
+                        && directive->name != ContentSecurityPolicyDirectiveNames::reportTo)
                         continue;
                 }
                 addDirective(WTF::move(*directive));
@@ -535,7 +535,8 @@ template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseD
         return std::nullopt;
     }
 
-    String name { nameBegin.first(buffer.position() - nameBegin.data()) };
+    // Lowercase the directive name eagerly so downstream code can use case-sensitive comparisons.
+    String name = StringView { nameBegin.first(buffer.position() - nameBegin.data()) }.convertToASCIILowercase();
 
     if (buffer.atEnd())
         return ParsedDirective { WTF::move(name), { } };
@@ -689,75 +690,75 @@ void ContentSecurityPolicyDirectiveList::addDirective(ParsedDirective&& directiv
 {
     ASSERT(!directive.name.isEmpty());
 
-    if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::defaultSrc)) {
+    if (directive.name == ContentSecurityPolicyDirectiveNames::defaultSrc) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_defaultSrc);
         m_policy->addHashAlgorithmsForInlineScripts(m_defaultSrc->hashAlgorithmsUsed());
         m_policy->addHashAlgorithmsForInlineStylesheets(m_defaultSrc->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::scriptSrc)) {
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::scriptSrc) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_scriptSrc);
         m_policy->addHashAlgorithmsForInlineScripts(m_scriptSrc->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::scriptSrcElem)) {
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::scriptSrcElem) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_scriptSrcElem);
         m_policy->addHashAlgorithmsForInlineScripts(m_scriptSrcElem->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::scriptSrcAttr)) {
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::scriptSrcAttr) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_scriptSrcAttr);
         m_policy->addHashAlgorithmsForInlineScripts(m_scriptSrcAttr->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::styleSrc)) {
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::styleSrc) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_styleSrc);
         m_policy->addHashAlgorithmsForInlineStylesheets(m_styleSrc->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::styleSrcElem)) {
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::styleSrcElem) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_styleSrcElem);
         m_policy->addHashAlgorithmsForInlineStylesheets(m_styleSrcElem->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::styleSrcAttr)) {
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::styleSrcAttr) {
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_styleSrcAttr);
         m_policy->addHashAlgorithmsForInlineStylesheets(m_styleSrcAttr->hashAlgorithmsUsed());
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::objectSrc))
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::objectSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_objectSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::workerSrc))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::workerSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_workerSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::frameSrc)) {
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::frameSrc) {
         // FIXME: Log to console "The frame-src directive is deprecated. Use the child-src directive instead."
         // See <https://bugs.webkit.org/show_bug.cgi?id=155773>.
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_frameSrc);
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::imgSrc))
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::imgSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_imgSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::fontSrc))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::fontSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_fontSrc);
 #if ENABLE(APPLICATION_MANIFEST)
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::manifestSrc))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::manifestSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_manifestSrc);
 #endif
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::mediaSrc))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::mediaSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_mediaSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::connectSrc))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::connectSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_connectSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::childSrc))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::childSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_childSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::formAction))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::formAction)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_formAction);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::baseURI))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::baseURI)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_baseURI);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::frameAncestors))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::frameAncestors)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_frameAncestors);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::pluginTypes)) {
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::pluginTypes) {
         auto name = directive.name;
         setCSPDirective<ContentSecurityPolicyMediaListDirective>(WTF::move(directive), m_pluginTypes);
         m_policy->reportDeprecatedDirectiveToConsole(name);
-    } else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::prefetchSrc))
+    } else if (directive.name == ContentSecurityPolicyDirectiveNames::prefetchSrc)
         setCSPDirective<ContentSecurityPolicySourceListDirective>(WTF::move(directive), m_prefetchSrc);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::sandbox))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::sandbox)
         applySandboxPolicy(WTF::move(directive));
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::reportTo))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::reportTo)
         parseReportTo(WTF::move(directive));
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::reportURI))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::reportURI)
         parseReportURI(WTF::move(directive));
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests)
         setUpgradeInsecureRequests(WTF::move(directive));
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::blockAllMixedContent))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::blockAllMixedContent)
         setBlockAllMixedContentEnabled(WTF::move(directive));
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::trustedTypes))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::trustedTypes)
         setCSPDirective<ContentSecurityPolicyTrustedTypesDirective>(WTF::move(directive), m_trustedTypes);
-    else if (equalIgnoringASCIICase(directive.name, ContentSecurityPolicyDirectiveNames::requireTrustedTypesFor))
+    else if (directive.name == ContentSecurityPolicyDirectiveNames::requireTrustedTypesFor)
         parseRequireTrustedTypesFor(WTF::move(directive));
     else
         m_policy->reportUnsupportedDirective(WTF::move(directive.name));

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -43,6 +43,7 @@ namespace WebCore {
 
 static bool NODELETE isCSPDirectiveName(StringView name)
 {
+    // Called with a source-expression token, not a parsed directive name, so it is not lowercased.
     return equalIgnoringASCIICase(name, ContentSecurityPolicyDirectiveNames::baseURI)
         || equalIgnoringASCIICase(name, ContentSecurityPolicyDirectiveNames::connectSrc)
         || equalIgnoringASCIICase(name, ContentSecurityPolicyDirectiveNames::defaultSrc)
@@ -120,9 +121,9 @@ bool ContentSecurityPolicySourceList::isProtocolAllowedByStar(const URL& url) co
     bool isAllowed = url.protocolIsInHTTPFamily() || url.protocolIs("ws"_s) || url.protocolIs("wss"_s) || url.protocolIs(m_policy->selfProtocol());
     // Also not allowed by the Content Security Policy Level 3 spec., we allow a data URL to match
     // "img-src *" and either a data URL or blob URL to match "media-src *" for web compatibility.
-    if (equalIgnoringASCIICase(m_directiveName, ContentSecurityPolicyDirectiveNames::imgSrc))
+    if (m_directiveName == ContentSecurityPolicyDirectiveNames::imgSrc)
         isAllowed |= url.protocolIsData();
-    else if (equalIgnoringASCIICase(m_directiveName, ContentSecurityPolicyDirectiveNames::mediaSrc))
+    else if (m_directiveName == ContentSecurityPolicyDirectiveNames::mediaSrc)
         isAllowed |= url.protocolIsData() || url.protocolIsBlob();
     return isAllowed;
 }


### PR DESCRIPTION
#### 00534948835e357313fb11e13bda0e58486df5fc
<pre>
Lowercase CSP directive names eagerly
<a href="https://bugs.webkit.org/show_bug.cgi?id=317730">https://bugs.webkit.org/show_bug.cgi?id=317730</a>
<a href="https://rdar.apple.com/180530658">rdar://180530658</a>

Reviewed by Anne van Kesteren.

Lowercase each CSP directive name as soon as it is read, aligning with the &apos;Parse a serialized CSP&apos;
section of the CSP Level 3 spec (<a href="https://w3c.github.io/webappsec-csp/#parse-serialized-policy).">https://w3c.github.io/webappsec-csp/#parse-serialized-policy).</a>
The case insensitive name comparisons become plain equality checks, and the extra lowercasing in the
reporting path is removed. When an author writes a directive name in some casing other than the spec&apos;s
lowercase form, it now behaves like the lowercase form.

Test: http/tests/security/contentSecurityPolicy/directive-name-case-insensitive.html
      http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic.html

* LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive-strict-dynamic.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/directive-name-case-insensitive.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::reportViolation const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parse):
(WebCore::ContentSecurityPolicyDirectiveList::parseDirective):
(WebCore::ContentSecurityPolicyDirectiveList::addDirective):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::isProtocolAllowedByStar const):

Canonical link: <a href="https://commits.webkit.org/316160@main">https://commits.webkit.org/316160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17865a051367db720b2c2f6e7f890fdda0e677da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128520 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80f6fec0-ea0f-48f5-bf57-a16591a89e5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133224 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94014 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5036e1ed-478f-4452-9835-8d1d4aaf8ac2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a14ef11f-cef8-49e9-9f38-e52ec69bdced) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170126 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35063 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33381 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28864 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2070 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182770 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32061 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141685 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/170206 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44387 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153121 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141496 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45076 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30041 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109777 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36762 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116967 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203484 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43587 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8145 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54485 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42991 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43233 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43122 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->