### PR TITLE
[GFC] Items with auto or calc margins are not supported

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-explicit-row-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-explicit-row-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: block-axis 'auto' margins with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<!-- Same layout achieved with align-items:center instead of auto margins. -->
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 100px;
+      grid-template-rows: 100px 100px;
+      align-items: center;     /* center within the row in the block axis */
+  }
+  #grid div {
+      width: 100px;
+  }
+  #item1 {
+      grid-row: 1 / 2;
+      height: 20px;
+      background: green;
+  }
+  #item2 {
+      grid-row: 2 / 3;
+      height: 40px;
+      background: blue;
+  }
+</style>
+<p>The test passes if the green box and the blue box are each centered vertically within their grid row.</p>
+<div id="grid">
+    <div id="item1"></div>
+    <div id="item2"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-explicit-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-block-axis-alignment-auto-margins-explicit-row.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: block-axis 'auto' margins with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" title="10.2 Aligning with auto margins" href="https://drafts.csswg.org/css-grid/#auto-margins">
+<link rel="match" href="../reference/grid-block-axis-alignment-auto-margins-explicit-row-ref.html">
+<meta name="assert" content="Block-axis 'auto' margins center an explicitly-placed grid item within its row.">
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 100px;
+      grid-template-rows: 100px 100px;
+  }
+  #grid div {
+      margin: auto 0;          /* center within the row in the block axis */
+      width: 100px;
+  }
+  #item1 {
+      grid-row: 1 / 2;
+      height: 20px;
+      background: green;
+  }
+  #item2 {
+      grid-row: 2 / 3;
+      height: 40px;
+      background: blue;
+  }
+</style>
+<p>The test passes if the green box and the blue box are each centered vertically within their grid row.</p>
+<div id="grid">
+    <div id="item1"></div>
+    <div id="item2"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-calc-margins-explicit-row-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-calc-margins-explicit-row-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: calc() margin on a grid item with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<!-- Same layout achieved with a resolved fixed margin instead of calc(). -->
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 200px;
+      grid-template-rows: 100px;
+  }
+  #item {
+      grid-row: 1 / 2;
+      width: 50px;
+      height: 50px;
+      margin-left: 70px;
+      background: green;
+  }
+</style>
+<p>The test passes if the left edge of the green box is 70px from the left edge of the grey grid.</p>
+<div id="grid">
+    <div id="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-calc-margins-explicit-row.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-calc-margins-explicit-row.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: calc() margin on a grid item with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" title="6.4 Grid Item Margins and Paddings" href="https://drafts.csswg.org/css-grid/#item-margins">
+<link rel="match" href="../reference/grid-calc-margins-explicit-row-ref.html">
+<meta name="assert" content="A percentage in a calc() margin on a grid item resolves against the inline size of its containing block (the grid area).">
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 200px;
+      grid-template-rows: 100px;
+  }
+  #item {
+      grid-row: 1 / 2;
+      width: 50px;
+      height: 50px;
+      /* margin % resolves against the grid area inline size (200px):
+         30% -> 60px, + 10px -> 70px left offset. */
+      margin-left: calc(10px + 30%);
+      background: green;
+  }
+</style>
+<p>The test passes if the left edge of the green box is 70px from the left edge of the grey grid.</p>
+<div id="grid">
+    <div id="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/reference/grid-block-axis-alignment-auto-margins-explicit-row-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/reference/grid-block-axis-alignment-auto-margins-explicit-row-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: block-axis 'auto' margins with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<!-- Same layout achieved with align-items:center instead of auto margins. -->
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 100px;
+      grid-template-rows: 100px 100px;
+      align-items: center;     /* center within the row in the block axis */
+  }
+  #grid div {
+      width: 100px;
+  }
+  #item1 {
+      grid-row: 1 / 2;
+      height: 20px;
+      background: green;
+  }
+  #item2 {
+      grid-row: 2 / 3;
+      height: 40px;
+      background: blue;
+  }
+</style>
+<p>The test passes if the green box and the blue box are each centered vertically within their grid row.</p>
+<div id="grid">
+    <div id="item1"></div>
+    <div id="item2"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/reference/grid-calc-margins-explicit-row-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/reference/grid-calc-margins-explicit-row-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: calc() margin on a grid item with explicit row placement</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<!-- Same layout achieved with a resolved fixed margin instead of calc(). -->
+<style>
+  #grid {
+      display: grid;
+      background: grey;
+      grid-template-columns: 200px;
+      grid-template-rows: 100px;
+  }
+  #item {
+      grid-row: 1 / 2;
+      width: 50px;
+      height: 50px;
+      margin-left: 70px;
+      background: green;
+  }
+</style>
+<p>The test passes if the left edge of the green box is 70px from the left edge of the grey grid.</p>
+<div id="grid">
+    <div id="item"></div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -474,7 +474,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
         auto gridItemHasMargins = [&] {
             return gridItemStyle->marginBox().anyOf([](const Style::MarginEdge& marginEdge) {
-                return !marginEdge.isPossiblyZero();
+                return marginEdge.isAuto() || marginEdge.isCalculated() || !marginEdge.isPossiblyZero();
             });
         };
         if (gridItemHasMargins())


### PR DESCRIPTION
#### 3d436acad33f6ebc79a75acf0aed418a489c37f9
<pre>
[GFC] Items with auto or calc margins are not supported
<a href="https://bugs.webkit.org/show_bug.cgi?id=317983">https://bugs.webkit.org/show_bug.cgi?id=317983</a>
<a href="https://rdar.apple.com/problem/180765717">rdar://problem/180765717</a>

Reviewed by Alan Baradlay.

The grid coverage check uses MarginEdge::isPossiblyZero() to decide whether a
grid item has margins that force the legacy path. However, isPossiblyZero()
returns true for both the `auto` keyword and calc() values (keywords and calc()
are always treated as possibly-zero), so a grid item with an `auto` margin or a
calc() margin was not detected as having a margin and was allowed onto the
modern GFC path.

The modern path does not support these margins:
- auto margins were treated as zero, so the item was start-aligned within its
  grid area instead of having the auto margin absorb the free space (e.g. a
  `margin: auto 0` item was not centered in its row).
- a calc() margin containing a percentage was treated as a zero offset, so the
  item was placed at the start of its grid area (e.g. `margin-left: calc(10px +
  30%)` produced a 0px offset instead of 70px against a 200px grid area).

Detect both cases explicitly via MarginEdge::isAuto() and
MarginEdge::isCalculated() so these items fall back to the legacy grid layout
path, which resolves the margins correctly. Non-zero fixed and percentage
margins were already routed to legacy by the existing isPossiblyZero() check.

Add two reftests (reduced from grid-block-axis-alignment-auto-margins-008.html)
that use explicit row placement so the items stay on the modern path,
exercising the auto-margin and calc()-margin cases directly.

Canonical link: <a href="https://commits.webkit.org/316050@main">https://commits.webkit.org/316050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa02f522e798228283d89b94fde21bb790753c23

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128493 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e363e495-3e13-4e84-9d3a-24a8b0fc2b43) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44339 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/827af4dd-dcfd-4411-b142-44660bb57640) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173737 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ad09f64-b796-4726-8c98-c6d4e047bd9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35038 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28837 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145494 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182742 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45049 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109746 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36743 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43560 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8124 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42964 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43206 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->