### PR TITLE
Mismatch in model orientation between VisionOS and MacOS

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -461,7 +461,16 @@ static simd_float4x4 buildRotation(float azimuth, float elevation)
 void RemoteMeshProxy::setRotation(float yaw, float pitch, float roll)
 {
     UNUSED_PARAM(roll);
-    m_transform = buildRotation(yaw, pitch);
+    simd_float4x4 userRotation = buildRotation(yaw, pitch);
+    m_transform = simd_mul(userRotation, static_cast<simd_float4x4>(m_baseRotation));
+    setStageMode(m_stageMode);
+}
+
+void RemoteMeshProxy::setBaseRotation(float yaw, float pitch, float roll)
+{
+    UNUSED_PARAM(roll);
+    m_baseRotation = buildRotation(yaw, pitch);
+    m_transform = m_baseRotation;
     setStageMode(m_stageMode);
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -120,6 +120,7 @@ private:
 #if ENABLE(GPU_PROCESS_MODEL)
     void computeTransform();
     void setRotation(float yaw, float pitch, float roll) final;
+    void setBaseRotation(float yaw, float pitch, float roll) final;
 #endif
     void setEnvironmentMap(WebModel::UpdateTextureDescriptor&&) final;
     void updateContentsHeadroom(float) final;
@@ -138,6 +139,7 @@ private:
     float m_viewportHeight { 0.f };
     WebCore::StageModeOperation m_stageMode { WebCore::StageModeOperation::None };
     bool m_entityTransformSetByScript { false };
+    WebModel::Float4x4 m_baseRotation { matrix_identity_float4x4 };
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -85,6 +85,7 @@ public:
     virtual void setViewportSize(float, float) { }
     virtual void setStageMode(WebCore::StageModeOperation) { }
     virtual void setRotation(float, float = 0.f, float = 0.f) { }
+    virtual void setBaseRotation(float, float = 0.f, float = 0.f) { }
     virtual void play(bool) = 0;
     virtual void setEnvironmentMap(WebModel::UpdateTextureDescriptor&&) = 0;
     virtual void updateContentsHeadroom(float) = 0;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -270,6 +270,13 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
                 client->didFinishLoading(protectedThis.get());
                 auto [center, extents] = protectedThis->boundingBoxCenterAndExtents();
                 client->didUpdateBoundingBox(protectedThis.get(), center, extents);
+
+                // For models whose up axis is Z (e.g. many USD assets), rotate the model into the
+                // renderer's Y-up space so it appears upright on screen. This matches the rotation
+                // already applied to the reported bounding box in boundingBoxCenterAndExtents().
+                if ([protectedThis->m_modelLoader treatZAsUpAxis])
+                    model->setBaseRotation(0.f, -static_cast<float>(M_PI_2));
+
                 protectedThis->notifyEntityTransformUpdated();
 
                 if (auto environmentMap = protectedThis->m_environmentMap)
@@ -379,12 +386,16 @@ void WebModelPlayer::handleMouseDown(const WebCore::LayoutPoint& startingPoint, 
     if (!m_orbitSimulator) {
         m_orbitSimulator = adoptNS([[WKStageModeOrbitSimulator alloc] init]);
         // Seed from the current pose so a gesture after reload doesn't snap to default.
+        // The orbit simulator tracks user-space yaw/pitch, applied on top of the model's
+        // up-axis correction (a -π/2 pitch for Z-up models). Subtract that base pitch so
+        // the simulator starts at the user's effective (0, 0) when no orbit has occurred.
         if (auto transform = entityTransform()) {
             auto matrix = static_cast<simd_float4x4>(*transform);
             simd_float3 c0 = simd_normalize(simd_make_float3(matrix.columns[0]));
             simd_float3 c1 = simd_normalize(simd_make_float3(matrix.columns[1]));
             simd_float3 c2 = simd_normalize(simd_make_float3(matrix.columns[2]));
-            [m_orbitSimulator setCurrentYaw:std::atan2(-c2.x, c0.x) pitch:std::atan2(-c1.z, c1.y)];
+            float basePitch = [m_modelLoader treatZAsUpAxis] ? -static_cast<float>(M_PI_2) : 0.f;
+            [m_orbitSimulator setCurrentYaw:std::atan2(-c2.x, c0.x) pitch:std::atan2(-c1.z, c1.y) - basePitch];
         }
     }
     [m_orbitSimulator gestureDidBegin];


### PR DESCRIPTION
#### 6ece7cb2c0f7109181b23e00e59fd831eca9d939
<pre>
Mismatch in model orientation between VisionOS and MacOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=317984">https://bugs.webkit.org/show_bug.cgi?id=317984</a>
<a href="https://rdar.apple.com/180665427">rdar://180665427</a>

Reviewed by NOBODY (OOPS!).

USD files with a +Z up axis, as opposed to +Y, should appear rotated
to match visionOS.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::setRotation):
(WebKit::RemoteMeshProxy::setBaseRotation):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/Model/Mesh.h:
(WebKit::Mesh::setBaseRotation):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::handleMouseDown):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ece7cb2c0f7109181b23e00e59fd831eca9d939

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128244 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c8fe8f4-1093-4102-99d5-626403e0c87b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132983 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93775 "17 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7389c54f-b648-46ab-b1ba-979948cdd1cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113480 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5333267b-6e41-466f-a7b9-1ef4792d0626) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33127 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182492 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141438 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44112 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141255 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44801 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109315 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36521 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116690 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43311 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7902 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42847 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->