### PR TITLE
[Site Isolation] Clear orphan frameIDs in BF list when WebFrameProxy is destroyed

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2399,6 +2399,4 @@ webkit.org/b/317857 [ Debug ] http/tests/site-isolation/frame-index.html [ Skip 
 
 webkit.org/b/317884 imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Failure ]
 
-webkit.org/b/317799 [ Debug ] http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html [ Skip ]
-
 webkit.org/b/317962 [ Debug ] ipc/networksessioncocoa-empty-resource-request.html [ Failure ]

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -141,12 +141,20 @@ void WebBackForwardListFrameItem::setWasRestoredFromSession()
 
 void WebBackForwardListFrameItem::updateFrameStatePayload(Ref<FrameState>&& frameState)
 {
-    m_frameState->replacePayloadFrom(WTF::move(frameState));
+    protect(m_frameState)->replacePayloadFrom(WTF::move(frameState));
 }
 
 void WebBackForwardListFrameItem::updateFrameID(FrameIdentifier newFrameID)
 {
     m_frameState->frameID = newFrameID;
+}
+
+void WebBackForwardListFrameItem::clearFrameIDIfMatches(FrameIdentifier frameID)
+{
+    if (m_frameState->frameID == frameID)
+        m_frameState->frameID = std::nullopt;
+    for (auto& child : m_children)
+        child->clearFrameIDIfMatches(frameID);
 }
 
 Ref<FrameState> WebBackForwardListFrameItem::copyFrameState()

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -69,6 +69,7 @@ public:
     void clearChildren() { m_children.clear(); }
 
     void NODELETE updateFrameID(WebCore::FrameIdentifier);
+    void NODELETE clearFrameIDIfMatches(WebCore::FrameIdentifier);
 
     void NODELETE setWasRestoredFromSession();
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -219,4 +219,11 @@ void WebBackForwardListItem::updateFrameID(FrameIdentifier oldFrameID, FrameIden
         m_navigatedFrameID = newFrameID;
 }
 
+void WebBackForwardListItem::clearFrameID(FrameIdentifier frameID)
+{
+    m_mainFrameItem->clearFrameIDIfMatches(frameID);
+    if (m_navigatedFrameID && *m_navigatedFrameID == frameID)
+        m_navigatedFrameID = std::nullopt;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -105,6 +105,7 @@ public:
     EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
 
     void updateFrameID(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+    void clearFrameID(WebCore::FrameIdentifier);
 
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -864,6 +864,12 @@ void WebBackForwardList::updateFrameIdentifier(FrameIdentifier oldFrameID, Frame
         entry->updateFrameID(oldFrameID, newFrameID);
 }
 
+void WebBackForwardList::clearFrameIdentifier(FrameIdentifier frameID)
+{
+    for (auto& entry : m_entries)
+        entry->clearFrameID(frameID);
+}
+
 void WebBackForwardList::replaceFrameStateForChild(WebBackForwardListItem& item, WebCore::FrameIdentifier frameID, Ref<FrameState>&& newFrameState)
 {
     RefPtr targetFrameItem = item.mainFrameItem().childItemForFrameID(frameID);

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -104,6 +104,7 @@ public:
 
     FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
     void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+    void clearFrameIdentifier(WebCore::FrameIdentifier);
 
     void replaceFrameStateForChild(WebBackForwardListItem&, WebCore::FrameIdentifier, Ref<FrameState>&& newFrameState);
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -735,6 +735,13 @@ final class WebBackForwardList {
         }
     }
 
+    @used
+    func clearFrameIdentifier(frameID: WebCore.FrameIdentifier) {
+        for entry in entries {
+            entry.clearFrameID(frameID)
+        }
+    }
+
     func didRemoveItem(item: WebKit.WebBackForwardListItem) {
         item.wasRemovedFromBackForwardList()
         // swift-format-ignore: NeverForceUnwrap

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -153,8 +153,10 @@ WebFrameProxy::WebFrameProxy(WebPageProxy& page, FrameProcess& process, FrameIde
 
 WebFrameProxy::~WebFrameProxy()
 {
-    if (RefPtr page = m_page.get())
+    if (RefPtr page = m_page.get()) {
         page->inspectorController().willDestroyFrame(*this);
+        page->frameWasDestroyed(m_frameID);
+    }
 
     WebProcessPool::statistics().wkFrameCount--;
 #if PLATFORM(GTK)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7597,6 +7597,11 @@ void WebPageProxy::didDestroyFrame(IPC::Connection& connection, FrameIdentifier 
     });
 }
 
+void WebPageProxy::frameWasDestroyed(FrameIdentifier frameID)
+{
+    backForwardList().clearFrameIdentifier(frameID);
+}
+
 void WebPageProxy::disconnectFramesFromPage()
 {
     if (RefPtr mainFrame = std::exchange(m_mainFrame, nullptr))

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2696,6 +2696,8 @@ public:
     void didDestroyFrame(IPC::Connection&, WebCore::FrameIdentifier);
     void disconnectFramesFromPage();
 
+    void frameWasDestroyed(WebCore::FrameIdentifier);
+
     void didCommitLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool wasPrivateRelayed, String&& proxyName, const WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, WebCore::DocumentSecurityPolicy&&, HashSet<WebCore::SecurityOriginData>&& cspOriginsThatUpgradeInsecureNavigations, const UserData&, WebCore::RestoredFromBackForwardCache, RefPtr<FrameState>&& redirectReplaceFrameState);
 
     void didCreateSleepDisabler(IPC::Connection&, WebCore::SleepDisablerIdentifier, const String& reason, bool display);


### PR DESCRIPTION
#### 77233b1e1bd7693a002634ae3accd96f9e03e453
<pre>
[Site Isolation] Clear orphan frameIDs in BF list when WebFrameProxy is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=317814">https://bugs.webkit.org/show_bug.cgi?id=317814</a>
<a href="https://rdar.apple.com/180584464">rdar://180584464</a>

Reviewed by NOBODY (OOPS!).

Follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a>, which added a
defensive skip at the per-frame walk-as-replacement dispatch site. This is the
underlying fix at the source.

The BF list (WebBackForwardListFrameItem::m_frameState-&gt;frameID) was never
cleared when an iframe is removed. WebFrameProxy::~WebFrameProxy() only
removed itself from the static allFrames() map; no BF entry&apos;s stored frameID
was touched. Tolerable in the legacy non-BFCache path — every back/forward
rebuilt frames from scratch — but with multi-process BFCache under Site
Isolation reusing the WebPageProxy frame tree, the BF tree&apos;s frameIDs and
the live frame graph are coupled, and orphan frameIDs surface at the
dispatch site.

When a WebFrameProxy is destroyed, walk the page&apos;s BF list entries and null
out any matching frameIDs. The new API mirrors the existing updateFrameID /
updateFrameIdentifier pattern, with one deliberate divergence:
WebBackForwardListFrameItem::clearFrameIDIfMatches walks the entire frame
subtree and clears every match (vs. updateFrameID&apos;s single childItemForFrameID
lookup). &quot;Clear&quot; carries no information-loss risk from over-applying, while
leaving any sibling orphan in place would defeat the fix.

The cleanup is driven only from WebFrameProxy&apos;s destructor, which calls
page-&gt;frameWasDestroyed(m_frameID) before the allFrames() map removal. It is
deliberately NOT driven from WebFrameProxy::webProcessWillShutDown(): a frame
whose hosting WebProcess shuts down (for example a cross-process navigation
that tears down the previous process while back/forward cache is disabled) is
not removed from session history — its BF entry&apos;s frameID is still needed to
route the subsequent back/forward navigation to the restored frame. Clearing
it there strands the entry: the iframe never restores and the navigation
hangs. This regressed http/tests/navigation/back-iframe-no-bf-cache.html and
http/tests/navigation/cross-site-iframe-nav.html with unexpected timeouts on
GTK and WPE WK2, where the process is torn down on navigation (on macOS the
process is kept alive by the WebProcess cache, so the path was not exercised).
The process-teardown / cross-process orphan case is left to the defensive
dispatch-site guard from bug 317799.

Cross-process BCG, SuspendedPage, and BFCache eviction paths can still leave
orphan frameIDs in BF entries on a different WebPageProxy&apos;s list. That
fan-out cleanup is a separate follow-up; the defensive dispatch-site guard
from <a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a> stays as defense-in-depth
until covered.

Covered by existing tests. With the defensive guard from
<a href="https://bugs.webkit.org/show_bug.cgi?id=317799">https://bugs.webkit.org/show_bug.cgi?id=317799</a> temporarily disabled,
http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
still passes 4/4 (defensive guard hit count under proper fix: 0). Bug 317799
added a Debug-only Skip of that test until this root-cause fix landed; remove
the skip now that the duplicate-frameID HistoryItem::addChildItem assertion no
longer fires, and the test passes 4/4 on Debug.

Drive-by Safer C++ fix folded in: updateFrameStatePayload (added by bug
317857) called m_frameState-&gt;replacePayloadFrom() without protecting the
receiver Ref; protect m_frameState across the call, matching copyFrameState().

* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::clearFrameIDIfMatches):
(WebKit::WebBackForwardListFrameItem::updateFrameStatePayload): Protect m_frameState across replacePayloadFrom().
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::clearFrameID):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::clearFrameIdentifier):
* Source/WebKit/UIProcess/WebBackForwardList.swift: Mirror clearFrameIdentifier in the Swift reimplementation.
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::~WebFrameProxy):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::frameWasDestroyed):
* LayoutTests/platform/mac-wk2/TestExpectations: Remove the bug 317799 Debug skip; the proper fix lets the test pass on Debug.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77233b1e1bd7693a002634ae3accd96f9e03e453

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128488 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44333 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133197 "Found 2 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173732 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36410 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153643 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113690 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35033 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33350 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache, TestWebKitAPI.ResourceLoadStatistics.StorageAccessOnRedirectSitesWithOutQuirk (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28832 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145489 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache, TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33030 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182737 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35533 "Found 488 new failures in UIProcess/WebBackForwardList.cpp, css/typedom/transform/CSSTransformValue.cpp, html/HTMLFormControlsCollection.cpp, platform/graphics/WidthIterator.cpp, loader/ResourceMonitor.cpp, platform/network/BlobResourceHandleBase.cpp, Modules/webaudio/AudioNodeInput.cpp, Modules/webauthn/cbor/CBORWriter.cpp, loader/TextResourceDecoder.cpp, mac/WebCoreSupport/WebFrameLoaderClient.mm ...") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37525 "Found 3 new test failures: http/tests/navigation/back-iframe-no-bf-cache.html http/tests/navigation/cross-site-iframe-nav.html http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141659 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44355 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141470 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45044 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109740 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36739 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116934 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43555 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8120 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42959 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43090 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->