### PR TITLE
[YARR] Add latin1Table for efficient Char8 filtering

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1140,6 +1140,18 @@ class YarrGenerator final : public YarrJITInfo {
             return;
         }
 
+        if (m_charSize == CharSize::Char8 && charClass->m_latin1Table) {
+            const auto* table = m_boyerMooreData->addLatin1Table(*charClass->m_latin1Table);
+            if (matchTargets.hasFailedTarget()) {
+                MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(table));
+                matchTargets.appendFailed(m_jit.branchTest8(MacroAssembler::Zero, tableEntry));
+                return;
+            }
+            MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(table));
+            matchTargets.appendSucceeded(m_jit.branchTest8(MacroAssembler::NonZero, tableEntry));
+            return;
+        }
+
         Vector<char32_t, 32> unifiedMatches;
         Vector<CharacterRange, 32> unifiedRanges;
         unifiedMatches.appendVector(charClass->m_matches8);

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -221,6 +221,7 @@ public:
     void clearMaps()
     {
         m_maps.clear();
+        m_latin1Tables.clear();
     }
 
     const std::span<BoyerMooreBitmap::Map::WordType> tryReuseBoyerMooreBitmap(const BoyerMooreBitmap::Map& map) const
@@ -232,8 +233,15 @@ public:
         return { };
     }
 
+    const uint8_t* addLatin1Table(const CharacterClass::ByteTable& table)
+    {
+        m_latin1Tables.append(makeUniqueRef<CharacterClass::ByteTable>(table));
+        return m_latin1Tables.last()->data.data();
+    }
+
 private:
     Vector<UniqueRef<BoyerMooreBitmap::Map>> m_maps;
+    Vector<UniqueRef<CharacterClass::ByteTable>> m_latin1Tables;
 };
 
 class YarrCodeBlock final : public YarrBoyerMooreData {

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -478,6 +478,8 @@ public:
         characterClass->m_anyCharacter = anyCharacter();
         characterClass->m_characterWidths = characterWidths();
 
+        buildLatin1TableIfBeneficial(*characterClass);
+
         m_anyCharacter = false;
         m_characterWidths = CharacterClassWidths::Unknown;
 
@@ -487,6 +489,44 @@ public:
     void NODELETE setIsCaseInsensitive(bool ignoreCase)
     {
         m_isCaseInsensitive = ignoreCase;
+    }
+
+    static void buildLatin1TableIfBeneficial(CharacterClass& characterClass)
+    {
+        if (!characterClass.m_strings.isEmpty() || characterClass.m_anyCharacter || characterClass.m_table)
+            return;
+
+        const auto& matches = characterClass.m_matches8;
+        const auto& ranges = characterClass.m_ranges8;
+
+        // A single range is already one subtract + one compare in the JIT, so a table would not help.
+        unsigned entryCount = matches.size() + ranges.size();
+        if (entryCount < 2)
+            return;
+
+        constexpr char32_t maxLatin1 = CharacterClass::latin1TableSize - 1;
+        char32_t low = !ranges.isEmpty() ? ranges.first().begin : matches.first();
+        char32_t high = !ranges.isEmpty() ? ranges.last().end : matches.last();
+        if (!matches.isEmpty()) {
+            low = std::min<char32_t>(low, matches.first());
+            high = std::max<char32_t>(high, matches.last());
+        }
+        ASSERT_UNUSED(maxLatin1, low <= maxLatin1 && high <= maxLatin1);
+        constexpr char32_t bitTestFootprint = 64;
+        if (high - low < bitTestFootprint)
+            return;
+
+        auto table = makeUnique<CharacterClass::ByteTable>();
+        for (auto match : matches) {
+            ASSERT(match <= maxLatin1);
+            table->data[match] = 1;
+        }
+        for (auto range : ranges) {
+            ASSERT(range.end <= maxLatin1);
+            for (char32_t ch = range.begin; ch <= range.end; ++ch)
+                table->data[ch] = 1;
+        }
+        characterClass.m_latin1Table = WTF::move(table);
     }
 
 private:

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/YarrErrorCode.h>
 #include <JavaScriptCore/YarrFlags.h>
 #include <JavaScriptCore/YarrUnicodeProperties.h>
+#include <array>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
@@ -146,6 +147,14 @@ public:
     Vector<CharacterRange> m_ranges8;
     Vector<char32_t> m_matches32;
     Vector<CharacterRange> m_ranges32;
+
+    static constexpr unsigned latin1TableSize = 256;
+    struct ByteTable {
+        WTF_MAKE_TZONE_ALLOCATED(ByteTable);
+    public:
+        std::array<uint8_t, latin1TableSize> data { { } };
+    };
+    std::unique_ptr<ByteTable> m_latin1Table;
 
     Table m_table;
     CharacterClassWidths m_characterWidths;

--- a/Source/JavaScriptCore/yarr/YarrTZoneImpls.cpp
+++ b/Source/JavaScriptCore/yarr/YarrTZoneImpls.cpp
@@ -30,6 +30,7 @@
 namespace JSC { namespace Yarr {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CharacterClass);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CharacterClass::ByteTable);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ClassSet);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PatternAlternative);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PatternDisjunction);


### PR DESCRIPTION
#### 8847f4666db3a6e8402489b2bfe627fb6949d0db
<pre>
[YARR] Add latin1Table for efficient Char8 filtering
<a href="https://bugs.webkit.org/show_bug.cgi?id=317989">https://bugs.webkit.org/show_bug.cgi?id=317989</a>
<a href="https://rdar.apple.com/180768852">rdar://180768852</a>

Reviewed by Sosuke Suzuki.

Let&apos;s have ByteTable-based latin1-table which converts CharacterClass
matching to table-based one when it is Char8 and matching is
complicated. We use ByteTable for now as BitSet based one is slower than
this ByteTable-based one.

* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrJIT.h:
(JSC::Yarr::YarrBoyerMooreData::clearMaps):
(JSC::Yarr::YarrBoyerMooreData::addLatin1Table):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::charClass):
(JSC::Yarr::CharacterClassConstructor::buildLatin1TableIfBeneficial):
* Source/JavaScriptCore/yarr/YarrPattern.h:
* Source/JavaScriptCore/yarr/YarrTZoneImpls.cpp:

Canonical link: <a href="https://commits.webkit.org/315985@main">https://commits.webkit.org/315985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33db2ccc521d8e7edb894a5c388a19dc169c4330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128250 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132987 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93779 "16 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153429 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113484 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34792 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33134 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28595 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1839 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182498 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31792 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141445 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44118 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141262 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44807 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109322 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26013 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36528 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116696 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203216 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43317 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7911 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54420 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42722 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->