### PR TITLE
[Text Extraction] `replacementStrings` should apply case- and diacritic-insensitively

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1489,6 +1489,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     editing/FontShadow.h
     editing/FrameSelection.h
     editing/HTMLInterchange.h
+    editing/ICUSearcher.h
     editing/InlineRunAndOffset.h
     editing/MarkupExclusionRule.h
     editing/SelectionGeometryGatherer.h

--- a/Source/WebCore/PlatformCocoa.cmake
+++ b/Source/WebCore/PlatformCocoa.cmake
@@ -1035,8 +1035,6 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/EventLoop.h
     dom/WindowEventLoop.h
 
-    editing/ICUSearcher.h
-
     editing/cocoa/AlternativeTextContextController.h
     editing/cocoa/AlternativeTextUIController.h
     editing/cocoa/AttributedString.h

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -27,6 +27,7 @@
 #include "TextExtractionToStringConversion.h"
 
 #include <WebCore/HTMLNames.h>
+#include <WebCore/ICUSearcher.h>
 #include <WebCore/TextExtractionTypes.h>
 #include <wtf/EnumSet.h>
 #include <wtf/JSONValues.h>
@@ -34,6 +35,9 @@
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <unicode/ubrk.h>
+#include <unicode/uchar.h>
+#include <unicode/unorm2.h>
+#include <unicode/utf16.h>
 #include <wtf/text/CharacterProperties.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
@@ -413,6 +417,88 @@ enum class HasAdjacentLinkAfter : bool { No, Yes };
 
 static String lineWithoutNodeIdentifier(const String&, const std::optional<String>&);
 
+struct FoldedTextResult {
+    String text;
+    Vector<unsigned> sourceOffsetByFoldedIndex;
+};
+
+static FoldedTextResult foldForReplacement(const String& source)
+{
+    auto quoteFolded = foldQuoteMarks(source);
+
+    UErrorCode status = U_ZERO_ERROR;
+    auto* normalizer = unorm2_getNFDInstance(&status);
+    ASSERT(U_SUCCESS(status));
+
+    StringBuilder builder;
+    builder.reserveCapacity(quoteFolded.length());
+    Vector<unsigned> sourceOffsetByFoldedIndex;
+    sourceOffsetByFoldedIndex.reserveCapacity(quoteFolded.length() + 1);
+
+    auto appendCodePoint = [&](StringView chunk, unsigned originalStart) {
+        auto folded = chunk.toString().foldCase();
+        if (folded.containsOnlyASCII()) {
+            for (unsigned i = 0; i < folded.length(); ++i) {
+                builder.append(folded[i]);
+                sourceOffsetByFoldedIndex.append(originalStart);
+            }
+            return;
+        }
+
+        auto upconverted = StringView { folded }.upconvertedCharacters();
+        auto foldedSpan = upconverted.span();
+
+        std::array<char16_t, 16> stackBuffer;
+        Vector<char16_t> heapBuffer;
+        std::span<const char16_t> decomposed;
+        status = U_ZERO_ERROR;
+        int32_t needed = unorm2_normalize(normalizer, foldedSpan.data(), foldedSpan.size(), stackBuffer.data(), stackBuffer.size(), &status);
+        if (U_SUCCESS(status))
+            decomposed = std::span { stackBuffer }.first(static_cast<size_t>(needed));
+        else {
+            ASSERT(status == U_BUFFER_OVERFLOW_ERROR);
+            heapBuffer.grow(needed);
+            status = U_ZERO_ERROR;
+            unorm2_normalize(normalizer, foldedSpan.data(), foldedSpan.size(), heapBuffer.mutableSpan().data(), heapBuffer.size(), &status);
+            ASSERT(U_SUCCESS(status));
+            decomposed = heapBuffer.span();
+        }
+
+        for (size_t i = 0; i < decomposed.size();) {
+            char32_t codePoint = 0;
+            U16_NEXT(decomposed, i, decomposed.size(), codePoint);
+            if (u_charType(codePoint) == U_NON_SPACING_MARK)
+                continue;
+
+            if (U_IS_BMP(codePoint)) {
+                builder.append(static_cast<char16_t>(codePoint));
+                sourceOffsetByFoldedIndex.append(originalStart);
+            } else {
+                builder.append(U16_LEAD(codePoint));
+                sourceOffsetByFoldedIndex.append(originalStart);
+                builder.append(U16_TRAIL(codePoint));
+                sourceOffsetByFoldedIndex.append(originalStart);
+            }
+        }
+    };
+
+    auto quoteFoldedView = StringView { quoteFolded };
+    for (unsigned i = 0; i < quoteFoldedView.length();) {
+        unsigned start = i;
+        char32_t codePoint;
+        U16_NEXT(quoteFoldedView, i, quoteFoldedView.length(), codePoint);
+        appendCodePoint(quoteFoldedView.substring(start, i - start), start);
+    }
+    sourceOffsetByFoldedIndex.append(quoteFolded.length());
+
+    return { builder.toString(), WTF::move(sourceOffsetByFoldedIndex) };
+}
+
+String foldTextForReplacement(const String& source)
+{
+    return foldForReplacement(source).text;
+}
+
 class TextExtractionAggregator : public RefCounted<TextExtractionAggregator> {
     WTF_MAKE_NONCOPYABLE(TextExtractionAggregator);
     WTF_MAKE_TZONE_ALLOCATED(TextExtractionAggregator);
@@ -630,9 +716,38 @@ public:
 
     void applyReplacements(String& text)
     {
-        for (auto& [original, replacement] : m_options.replacementStrings)
-            text = makeStringByReplacingAll(text, original, replacement);
+        if (m_options.replacementStrings.isEmpty())
+            return;
+
+        auto folded = foldForReplacement(text);
+        StringBuilder result;
+        result.reserveCapacity(text.length());
+        unsigned cursor = 0;
+        while (cursor < folded.text.length()) {
+            bool matched = false;
+            for (auto& [foldedKey, replacement] : m_options.replacementStrings) {
+                if (foldedKey.length() > folded.text.length() - cursor)
+                    continue;
+                if (StringView { folded.text }.substring(cursor, foldedKey.length()) != foldedKey)
+                    continue;
+
+                result.append(replacement);
+                cursor += foldedKey.length();
+                matched = true;
+                break;
+            }
+
+            if (matched)
+                continue;
+
+            unsigned originalStart = folded.sourceOffsetByFoldedIndex[cursor];
+            unsigned originalEnd = folded.sourceOffsetByFoldedIndex[cursor + 1];
+            result.append(StringView { text }.substring(originalStart, originalEnd - originalStart));
+            ++cursor;
+        }
+        text = result.toString();
     }
+
 
     void truncateTextByWordLimitIfNeeded(String& text, const Vector<CharacterRange>& linkCharacterRanges = { }, HasAdjacentLinkAfter hasAdjacentLinkAfter = HasAdjacentLinkAfter::No)
     {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -84,7 +84,7 @@ struct TextExtractionOptions {
     {
     }
 
-    TextExtractionOptions(WebCore::FrameIdentifier&& mainFrameIdentifier, Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, HashMap<String, String>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr, std::optional<uint64_t> maxWordsPerParagraph = std::nullopt, String&& topHostName = { })
+    TextExtractionOptions(WebCore::FrameIdentifier&& mainFrameIdentifier, Vector<TextExtractionFilterCallback>&& filters, Vector<String>&& items, Vector<std::pair<String, String>>&& replacementStrings, std::optional<TextExtractionVersion> version, TextExtractionOptionFlags flags, TextExtractionOutputFormat outputFormat, TextExtractionURLCache* urlCache = nullptr, std::optional<uint64_t> maxWordsPerParagraph = std::nullopt, String&& topHostName = { })
         : mainFrameIdentifier(WTF::move(mainFrameIdentifier))
         , filterCallbacks(WTF::move(filters))
         , nativeMenuItems(WTF::move(items))
@@ -101,7 +101,7 @@ struct TextExtractionOptions {
     WebCore::FrameIdentifier mainFrameIdentifier;
     Vector<TextExtractionFilterCallback> filterCallbacks;
     Vector<String> nativeMenuItems;
-    HashMap<String, String> replacementStrings;
+    Vector<std::pair<String, String>> replacementStrings;
     std::optional<TextExtractionVersion> version;
     std::optional<uint64_t> maxWordsPerParagraph;
     TextExtractionOptionFlags flags;
@@ -128,5 +128,7 @@ void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, Com
 String formatPDFMarkdownForOutput(const String& pdfText, TextExtractionOutputFormat);
 
 std::optional<ExtractedNodeInfo> parseExtractedNodeInfo(StringView);
+
+String foldTextForReplacement(const String& source);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7155,16 +7155,26 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
 #endif
 }
 
-static HashMap<String, String> extractReplacementStrings(_WKTextExtractionConfiguration *configuration)
+static Vector<std::pair<String, String>> extractReplacementStrings(_WKTextExtractionConfiguration *configuration)
 {
-    HashMap<String, String> result;
+    Vector<std::pair<String, String>> result;
     RetainPtr replacementStrings = [configuration replacementStrings];
     for (NSString *replacement in replacementStrings.get()) {
         if (!replacement.length)
             continue;
 
-        result.set(String { replacement }, String { [replacementStrings objectForKey:replacement] });
+        auto foldedKey = WebKit::foldTextForReplacement(String { replacement });
+        if (foldedKey.isEmpty())
+            continue;
+
+        result.append({ WTF::move(foldedKey), String { [replacementStrings objectForKey:replacement] } });
     }
+
+    std::ranges::sort(result, [](auto& a, auto& b) {
+        if (a.first.length() != b.first.length())
+            return a.first.length() > b.first.length();
+        return codePointCompareLessThan(a.first, b.first);
+    });
     return result;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -213,7 +213,8 @@ WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
 /*!
  A mapping of strings to replace in text extraction output.
  Each key represents a string that should be replaced, and the corresponding
- value represents the string to replace it with.
+ value represents the string to replace it with. Replacements are applied with
+ case- and diacritic-insensitivity, and with quote marks folded.
  The default value is `nil`.
  */
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *replacementStrings;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -550,6 +550,74 @@ TEST(TextExtractionTests, ReplacementStrings)
     EXPECT_TRUE([debugTextWithReplacements containsString:@"The quick brown cat jumped over the  mouse"]);
 }
 
+TEST(TextExtractionTests, ReplacementStringsLongestMatchWins)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+    [webView synchronouslyLoadHTMLString:@"<p>John Appleseed met John.</p>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setReplacementStrings:@{
+            @"John": @"<redacted-name>",
+            @"John Appleseed": @"<redacted-full-name>",
+        }];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([debugText containsString:@"<redacted-full-name> met <redacted-name>."]);
+    EXPECT_FALSE([debugText containsString:@"<redacted-name> Appleseed"]);
+}
+
+TEST(TextExtractionTests, ReplacementStringsCaseAndQuoteInsensitive)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+    [webView synchronouslyLoadHTMLString:@"<p>Hello WORLD. It’s a test.</p>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setReplacementStrings:@{
+            @"hello world": @"<greeting>",
+            @"it's": @"<contraction>",
+        }];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([debugText containsString:@"<greeting>"]);
+    EXPECT_TRUE([debugText containsString:@"<contraction>"]);
+    EXPECT_FALSE([debugText containsString:@"Hello WORLD"]);
+    EXPECT_FALSE([debugText containsString:@"It’s"]);
+}
+
+TEST(TextExtractionTests, ReplacementStringsDiacriticInsensitive)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+    [webView synchronouslyLoadHTMLString:@"<p>Visited café in Zürich.</p>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setReplacementStrings:@{
+            @"cafe": @"<spot>",
+        }];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([debugText containsString:@"Visited <spot> in Zürich."]);
+    EXPECT_FALSE([debugText containsString:@"café"]);
+    EXPECT_FALSE([debugText containsString:@"Zurich"]);
+}
+
 TEST(TextExtractionTests, VisibleTextOnly)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{


### PR DESCRIPTION
#### 494a85cc8e3931ca3faffc009cb57656658bb3af
<pre>
[Text Extraction] `replacementStrings` should apply case- and diacritic-insensitively
<a href="https://bugs.webkit.org/show_bug.cgi?id=317987">https://bugs.webkit.org/show_bug.cgi?id=317987</a>
<a href="https://rdar.apple.com/180636729">rdar://180636729</a>

Reviewed by Abrar Rahman Protyasha.

Make several small adjustments to how client-specified `replacementStrings` works:

-   Make matching case-insensitive
-   Make matching diacritic-insensitive
-   Fold quotes when finding replacements
-   Apply longer replacements before shorter ones (so that a shorter replacement string that&apos;s
    contained in another longer replacement string doesn&apos;t cause the longer replacement string to
    not apply).

Tests:  TextExtractionTests.ReplacementStringsLongestMatchWins
        TextExtractionTests.ReplacementStringsCaseAndQuoteInsensitive
        TextExtractionTests.ReplacementStringsDiacriticInsensitive

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformCocoa.cmake:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::foldForReplacement):
(WebKit::foldTextForReplacement):
(WebKit::TextExtractionAggregator::applyReplacements):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
(WebKit::TextExtractionOptions::TextExtractionOptions):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(extractReplacementStrings):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, ReplacementStringsLongestMatchWins)):
(TestWebKitAPI::TEST(TextExtractionTests, ReplacementStringsCaseAndQuoteInsensitive)):
(TestWebKitAPI::TEST(TextExtractionTests, ReplacementStringsDiacriticInsensitive)):

Canonical link: <a href="https://commits.webkit.org/316028@main">https://commits.webkit.org/316028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38655a0bef70d3447a836e4e7604315a36ffe083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128471 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c21bf9ae-a6ba-4da2-ae01-bd2cf704650e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133180 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6379d45-1f2e-4b4b-99fd-692d4fda578d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173717 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26cb6649-2adc-4abe-b81c-4d68dbf85b56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35008 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28816 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182721 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141640 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44339 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141456 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38104 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45028 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109715 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36724 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116917 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43539 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8109 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->