### PR TITLE
[Site Isolation] Per-frame back/forward walk regresses iframe to stale initial about:blank

### DIFF
--- a/LayoutTests/http/wpt/site-isolation/history-traversal/history-traversal-navigate-parent-while-child-loading-expected.txt
+++ b/LayoutTests/http/wpt/site-isolation/history-traversal/history-traversal-navigate-parent-while-child-loading-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS pushState() in parent while child is doing initial navigation, then go back
+

--- a/LayoutTests/http/wpt/site-isolation/history-traversal/history-traversal-navigate-parent-while-child-loading.html
+++ b/LayoutTests/http/wpt/site-isolation/history-traversal/history-traversal-navigate-parent-while-child-loading.html
@@ -1,0 +1,31 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UseUIProcessForBackForwardItemLoading=true ] -->
+<!doctype html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="i"></iframe>
+<body>
+<script>
+async_test(t => {
+  let starting_history_length = history.length;
+  let iframe_url = (new URL("/common/blank.html", location.href)).href;
+  i.src = iframe_url;
+
+  history.pushState("a", "", "#a");
+  assert_equals(history.length, starting_history_length + 1, "First history length");
+
+  i.onload = t.step_func(() => {
+    assert_equals(history.length, starting_history_length + 1, "Second history length");
+    assert_equals(i.contentWindow.location.href, iframe_url);
+    assert_equals(location.hash, "#a");
+    history.back();
+    // Wait a while for a back navigation. Since all of the possible outcomes
+    // are either same-document or navigating to about:blank, this doesn't need
+    // to wait terribly long.
+    t.step_timeout(t.step_func_done(() => {
+      assert_equals(location.hash, "", "top frame should have navigated back");
+      assert_equals(i.contentWindow.location.href, iframe_url, "iframe should not have navigated");
+    }), 100);
+  });
+}, "pushState() in parent while child is doing initial navigation, then go back");
+</script>
+</body>

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -227,6 +227,9 @@ public:
     WEBCORE_EXPORT void setWasCreatedByJSWithoutUserInteraction(bool);
     bool wasCreatedByJSWithoutUserInteraction() const { return m_wasCreatedByJSWithoutUserInteraction; }
 
+    void setIsInitialAboutBlank(bool isInitialAboutBlank) { m_isInitialAboutBlank = isInitialAboutBlank; }
+    bool isInitialAboutBlank() const { return m_isInitialAboutBlank; }
+
 #if !LOG_DISABLED
     String logString() const;
 #endif
@@ -260,6 +263,7 @@ private:
     bool m_lastVisitWasFailure { false };
     bool m_wasRestoredFromSession { false };
     bool m_wasCreatedByJSWithoutUserInteraction { false };
+    bool m_isInitialAboutBlank { false };
     bool m_shouldRestoreScrollPosition { true };
     bool m_isTargetItem { false };
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -886,6 +886,8 @@ void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader>
 
     item.setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 
+    item.setIsInitialAboutBlank(documentLoader->isInitialAboutBlank());
+
     // Save form state if this is a POST
     item.setFormInfoFromRequest(documentLoader->request());
 }

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -43,7 +43,7 @@ FrameState::FrameState()
     RELEASE_ASSERT(RunLoop::isMain());
 }
 
-FrameState::FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, String&& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&& policyContainer,
+FrameState::FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, String&& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, bool isInitialAboutBlank,  std::optional<WebCore::PolicyContainer>&& policyContainer,
 #if PLATFORM(IOS_FAMILY)
     WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
@@ -69,6 +69,7 @@ FrameState::FrameState(String&& urlString, String&& originalURLString, String&& 
     , sessionStateObject(WTF::move(sessionStateObject))
     , wasCreatedByJSWithoutUserInteraction(wasCreatedByJSWithoutUserInteraction)
     , wasRestoredFromSession(wasRestoredFromSession)
+    , isInitialAboutBlank(isInitialAboutBlank)
     , policyContainer(WTF::move(policyContainer))
 #if PLATFORM(IOS_FAMILY)
     , exposedContentRect(exposedContentRect)
@@ -83,7 +84,7 @@ FrameState::FrameState(String&& urlString, String&& originalURLString, String&& 
 {
 }
 
-FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>& policyContainer,
+FrameState::FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier> frameID, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>& httpBody, std::optional<WebCore::BackForwardItemIdentifier> itemID, std::optional<WebCore::BackForwardFrameItemIdentifier> frameItemID, const String& title, WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, bool isInitialAboutBlank, const std::optional<WebCore::PolicyContainer>& policyContainer,
 #if PLATFORM(IOS_FAMILY)
     WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
@@ -109,6 +110,7 @@ FrameState::FrameState(const String& urlString, const String& originalURLString,
     , sessionStateObject(WTF::move(sessionStateObject))
     , wasCreatedByJSWithoutUserInteraction(wasCreatedByJSWithoutUserInteraction)
     , wasRestoredFromSession(wasRestoredFromSession)
+    , isInitialAboutBlank(isInitialAboutBlank)
     , policyContainer(policyContainer)
 #if PLATFORM(IOS_FAMILY)
     , exposedContentRect(exposedContentRect)
@@ -146,6 +148,7 @@ Ref<FrameState> FrameState::copy()
         sessionStateObject.copyRef(),
         wasCreatedByJSWithoutUserInteraction,
         wasRestoredFromSession,
+        isInitialAboutBlank,
         policyContainer,
 #if PLATFORM(IOS_FAMILY)
         exposedContentRect,
@@ -184,6 +187,7 @@ void FrameState::replacePayloadFrom(Ref<FrameState>&& other)
     sessionStateObject = WTF::move(other->sessionStateObject);
     wasCreatedByJSWithoutUserInteraction = other->wasCreatedByJSWithoutUserInteraction;
     wasRestoredFromSession = other->wasRestoredFromSession;
+    isInitialAboutBlank = other->isInitialAboutBlank;
     policyContainer = WTF::move(other->policyContainer);
 #if PLATFORM(IOS_FAMILY)
     exposedContentRect = other->exposedContentRect;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -117,6 +117,7 @@ public:
     RefPtr<WebCore::SerializedScriptValue> sessionStateObject;
     bool wasCreatedByJSWithoutUserInteraction { false };
     bool wasRestoredFromSession { false };
+    bool isInitialAboutBlank { false };
     std::optional<WebCore::PolicyContainer> policyContainer;
 
     // FIXME: These should not be per frame.
@@ -137,14 +138,14 @@ private:
     // This is used to help debug <rdar://problem/48634553>.
     FrameState();
 
-    FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, String&& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession,  std::optional<WebCore::PolicyContainer>&&,
+    FrameState(String&& urlString, String&& originalURLString, String&& referrer, AtomString&& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>>&& stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, std::optional<HTTPBody>&&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, String&& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, bool isInitialAboutBlank,  std::optional<WebCore::PolicyContainer>&&,
 #if PLATFORM(IOS_FAMILY)
         WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif
         Vector<Ref<FrameState>>&& children, Vector<AtomString>&& documentState
     );
 
-    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, const std::optional<WebCore::PolicyContainer>&,
+    FrameState(const String& urlString, const String& originalURLString, const String& referrer, const AtomString& target, std::optional<WebCore::FrameIdentifier>, std::optional<Vector<uint8_t>> stateObjectData, int64_t documentSequenceNumber, int64_t itemSequenceNumber, std::optional<WTF::UUID> navigationAPIKey, WebCore::IntPoint scrollPosition, bool shouldRestoreScrollPosition, float pageScaleFactor, const std::optional<HTTPBody>&, std::optional<WebCore::BackForwardItemIdentifier>, std::optional<WebCore::BackForwardFrameItemIdentifier>, const String& title, WebCore::ShouldOpenExternalURLsPolicy, RefPtr<WebCore::SerializedScriptValue>&& sessionStateObject, bool wasCreatedByJSWithoutUserInteraction, bool wasRestoredFromSession, bool isInitialAboutBlank, const std::optional<WebCore::PolicyContainer>&,
 #if PLATFORM(IOS_FAMILY)
         WebCore::FloatRect exposedContentRect, WebCore::IntRect unobscuredContentRect, WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates, WebCore::IntSize contentSize, bool scaleIsInitial, WebCore::FloatBoxExtent obscuredInsets,
 #endif

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -64,6 +64,7 @@ header: "SessionState.h"
     RefPtr<WebCore::SerializedScriptValue> sessionStateObject;
     bool wasCreatedByJSWithoutUserInteraction;
     bool wasRestoredFromSession;
+    bool isInitialAboutBlank;
     std::optional<WebCore::PolicyContainer> policyContainer;
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2874,10 +2874,28 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     return RefPtr<API::Navigation> { WTF::move(navigation) };
 }
 
+// The HTML spec replaces an iframe's initial about:blank entry on the frame's first real
+// navigation; WebKit's BF list keeps the stale state in older entries, so dispatching a
+// traversal into one would regress the live iframe. The target entry is identified by the
+// authoritative isInitialAboutBlank flag (set from DocumentLoader::isInitialAboutBlank when the
+// history item is created), not by a URL-string match, so an intentional iframe.src="about:blank"
+// navigation — which is not the initial empty document — is correctly dispatched.
+static bool isStaleInitialAboutBlankIframeTarget(WebBackForwardListFrameItem& toFrame)
+{
+    if (!toFrame.frameState().isInitialAboutBlank)
+        return false;
+    auto toFrameID = toFrame.frameID();
+    if (!toFrameID)
+        return false;
+    RefPtr toLiveFrame = WebFrameProxy::webFrame(*toFrameID);
+    return toLiveFrame && !toLiveFrame->isMainFrame();
+}
+
 bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromFrame, WebBackForwardListFrameItem& toFrame, NavigationIdentifier navigationID, FrameLoadType frameLoadType, ShouldRestoreFromBackForwardCache shouldRestore, const WebCore::PublicSuffix& publicSuffix)
 {
     bool anySent = false;
-    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber)
+    if (fromFrame.frameState().itemSequenceNumber != toFrame.frameState().itemSequenceNumber
+        && !isStaleInitialAboutBlankIframeTarget(toFrame))
         anySent = sendGoToBackForwardItemForFrame(toFrame, navigationID, frameLoadType, shouldRestore, publicSuffix);
 
     bool sameDocument = fromFrame.frameState().documentSequenceNumber == toFrame.frameState().documentSequenceNumber;

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -101,6 +101,7 @@ Ref<FrameState> toFrameState(const HistoryItem& historyItem)
     frameState->sessionStateObject = historyItem.stateObject();
     frameState->wasCreatedByJSWithoutUserInteraction = historyItem.wasCreatedByJSWithoutUserInteraction();
     frameState->wasRestoredFromSession = historyItem.wasRestoredFromSession();
+    frameState->isInitialAboutBlank = historyItem.isInitialAboutBlank();
     frameState->policyContainer = historyItem.policyContainer();
 
     static constexpr auto maxTitleLength = 1000u; // Closest power of 10 above the W3C recommendation for Title length.
@@ -174,6 +175,7 @@ static void applyFrameState(HistoryItemClient& client, HistoryItem& historyItem,
     historyItem.setStateObject(frameState.sessionStateObject.get());
     historyItem.setWasCreatedByJSWithoutUserInteraction(frameState.wasCreatedByJSWithoutUserInteraction);
     historyItem.setWasRestoredFromSession(frameState.wasRestoredFromSession);
+    historyItem.setIsInitialAboutBlank(frameState.isInitialAboutBlank);
     if (auto policyContainer = frameState.policyContainer)
         historyItem.setPolicyContainer(*policyContainer);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -4961,6 +4961,47 @@ TEST(SiteIsolation, NavigateFrameWithSiblingsBackForward)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "c");
 }
 
+TEST(SiteIsolation, IntentionalAboutBlankIframeBackForwardNotSkipped)
+{
+    // Regression test for the URL-heuristic gap in isStaleInitialAboutBlankIframeTarget
+    // (https://bugs.webkit.org/show_bug.cgi?id=317458). A child frame that navigates
+    // *intentionally* to about:blank after its first real load produces a legitimate,
+    // traversable back/forward entry — distinct from the frame's initial empty document.
+    // A URL-string guard would wrongly skip the traversal into that entry; the
+    // authoritative isInitialAboutBlank flag lets it through.
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/a'></iframe>"_s } },
+        { "/a"_s, { "<script> alert('a'); </script>"_s } },
+        { "/c"_s, { "<script> alert('c'); </script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "a");
+
+    auto childURLIs = [webView = RetainPtr { webView }] (NSString *expected) {
+        for (int i = 0; i < 100; ++i) {
+            RetainPtr value = [webView objectByEvaluatingJavaScript:@"location.href" inFrame:[webView firstChildFrame]];
+            if ([value isKindOfClass:[NSString class]] && [(NSString *)value.get() isEqualToString:expected])
+                return true;
+            TestWebKitAPI::Util::runFor(0.05_s);
+        }
+        return false;
+    };
+
+    // Intentional about:blank navigation in the child frame, after its first real load.
+    [webView evaluateJavaScript:@"location.href = 'about:blank'" inFrame:[webView firstChildFrame] completionHandler:nil];
+    EXPECT_TRUE(childURLIs(@"about:blank"));
+
+    // Navigate the child to a real URL so the live frame is on a real document.
+    [webView evaluateJavaScript:@"location.href = 'https://webkit.org/c'" inFrame:[webView firstChildFrame] completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "c");
+
+    // Going back must traverse the child back to the intentional about:blank entry,
+    // not leave it stranded on /c. With the old URL heuristic this was skipped.
+    [webView goBack];
+    EXPECT_TRUE(childURLIs(@"about:blank"));
+}
+
 TEST(SiteIsolation, RedirectToCSP)
 {
     HTTPServer server({


### PR DESCRIPTION
#### e23afe633acbe60a383dea12b39e33856b074239
<pre>
[Site Isolation] Per-frame back/forward walk regresses iframe to stale initial about:blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=317458">https://bugs.webkit.org/show_bug.cgi?id=317458</a>
<a href="https://rdar.apple.com/180077264">rdar://180077264</a>

Reviewed by Sihui Liu.

Under UseUIProcessForBackForwardItemLoading, WebPageProxy::dispatchPerFrameTraversals
walks the (current, target) BF frame trees and dispatches a per-frame
GoToBackForwardItem whenever itemSequenceNumber differs. When the target entry
holds the stale &quot;initial about:blank&quot; state for an iframe whose live document has
since loaded a real URL, the walk dispatches a navigation back to about:blank and
regresses the live iframe.

The HTML spec (<a href="https://html.spec.whatwg.org/#initialise-the-document-object)">https://html.spec.whatwg.org/#initialise-the-document-object)</a>
requires the iframe&apos;s initial about:blank entry to be replaced by the iframe&apos;s
first real navigation, but WebKit&apos;s BF list does not propagate that replacement
to non-current entries. The legacy navigatedFrameID-heuristic routing path
masked the issue by never dispatching a per-frame iframe traversal in the first
place; the walk-as-replacement (<a href="https://bugs.webkit.org/show_bug.cgi?id=317090)">https://bugs.webkit.org/show_bug.cgi?id=317090)</a>
exposes it because it compares each frame&apos;s state pair-wise.

Reproduction is the imported WPT
imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/history-traversal-navigate-parent-while-child-loading.html
which performs a parent pushState() while an iframe is mid-initial-navigation,
then asserts on history.back() that the iframe URL is preserved. Without the
fix, the iframe regresses:

  FAIL pushState() in parent while child is doing initial navigation, then go back
  assert_equals: expected &quot;<a href="http://web-platform.test">http://web-platform.test</a>:8800/common/blank.html&quot; but got &quot;about:blank&quot;

This regression surfaces only when UseUIProcessForBackForwardItemLoading is
enabled under SiteIsolationEnabled, the configuration that PR #67459
(<a href="https://bugs.webkit.org/show_bug.cgi?id=316588)">https://bugs.webkit.org/show_bug.cgi?id=316588)</a> re-enables in the test harness.

Fix: introduce a walk-side guard isStaleInitialAboutBlankIframeTarget that skips
dispatching a per-frame traversal into a non-main child frame&apos;s stale initial
about:blank entry. The stale entry is identified by an authoritative
isInitialAboutBlank flag, not a URL-string match. The flag rides the existing
HistoryItem -&gt; FrameState pipeline (mirroring wasCreatedByJSWithoutUserInteraction):
HistoryController::initializeItem sets it from DocumentLoader::isInitialAboutBlank(),
which is true only for the frame&apos;s initial empty document; toFrameState /
applyFrameState round-trip it through SessionState serialization. Because an
intentional iframe.src=&quot;about:blank&quot; navigation happens after
committedFirstRealDocumentLoad() its DocumentLoader is not the initial empty
document, so its flag is false and the walk dispatches the traversal as a real
navigation. The earlier URL-string heuristic (toURL is empty or &quot;about:blank&quot;)
could not distinguish the initial empty document from an intentional about:blank
load and so would have wrongly skipped the latter; the flag closes that gap.

A spec-level fix would be to propagate the initial about:blank replacement to
older BF entries when an iframe completes its first real navigation; that is a
separate follow-up bug and is not attempted here because it touches
BackForwardClient / HistoryController across processes and is out of scope for
this regression.

The imported WPT
imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/history-traversal-navigate-parent-while-child-loading.html
covers the behavior but shares the upstream baseline across configurations, so
it cannot pin SiteIsolationEnabled / UseUIProcessForBackForwardItemLoading via a
webkit-test-runner header and only exercises this fix once the test harness
auto-couples the flags (bug 316588). Add a http/wpt/site-isolation copy that
pins both flags in its header, so the regression is covered on this PR
independently of 316588. Verified negatively: the copy fails (iframe regresses
to about:blank) without this fix and passes with it.

Add an API test that covers the gap the flag closes, which the WPT above does
not: a child frame that navigates intentionally to about:blank after its first
real load, then back. With the old URL-string heuristic the back traversal into
that intentional about:blank entry was wrongly skipped and the child was
stranded on the prior real URL; with the isInitialAboutBlank flag it is
dispatched. Verified negatively: the test fails at the go-back assertion with
the old heuristic and passes with the flag.

* LayoutTests/http/wpt/site-isolation/history-traversal/history-traversal-navigate-parent-while-child-loading.html: Added.
* LayoutTests/http/wpt/site-isolation/history-traversal/history-traversal-navigate-parent-while-child-loading-expected.txt: Added.
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::setIsInitialAboutBlank):
(WebCore::HistoryItem::isInitialAboutBlank const):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::initializeItem):
* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::FrameState):
(WebKit::FrameState::copy):
(WebKit::FrameState::replacePayloadFrom):
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFrameState):
(WebKit::applyFrameState):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::isStaleInitialAboutBlankIframeTarget):
(WebKit::WebPageProxy::dispatchPerFrameTraversals):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/316161@main">https://commits.webkit.org/316161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50da0a7bf2804b50903039fd9355e1f371851e92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128578 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68f16700-d2c9-46af-988c-f02d98223386) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133270 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94042 "18 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1795860d-2a90-4bb3-8a59-47b08bde741c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113756 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e9bd2a0-a445-43e4-b1c5-523978565197) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28921 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145567 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182827 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141727 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44444 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45133 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30094 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109838 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36807 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117024 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43644 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8198 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43048 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43179 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->