### PR TITLE
[JSC] Optimize AirEliminateDeadCode

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp
@@ -60,10 +60,7 @@ bool eliminateDeadCode(Code& code)
         }
     };
 
-    auto isInstLive = [&] (Inst& inst) -> bool {
-        if (inst.hasNonArgEffects())
-            return true;
-
+    auto isInstLiveByDefs = [&] (Inst& inst) -> bool {
         // This instruction should be presumed dead, if its Args are all dead.
         bool storesToLive = false;
         inst.forEachArg(
@@ -76,14 +73,12 @@ bool eliminateDeadCode(Code& code)
             });
         return storesToLive;
     };
-    
-    // Returns true if it's live.
-    auto handleInst = [&] (Inst& inst) -> bool {
-        if (!isInstLive(inst))
-            return false;
 
-        // We get here if the Inst is live. For simplicity we say that a live instruction forces
-        // liveness upon everything it mentions.
+    auto isInstLive = [&] (Inst& inst) -> bool {
+        return inst.hasNonArgEffects() || isInstLiveByDefs(inst);
+    };
+
+    auto markArgsLive = [&] (Inst& inst) {
         for (Arg& arg : inst.args) {
             if (arg.isStack() && !arg.stackSlot()->isLocked())
                 changed |= liveStackSlots.add(arg.stackSlot());
@@ -93,18 +88,28 @@ bool eliminateDeadCode(Code& code)
                         changed |= liveTmps.add(tmp);
                 });
         }
-        return true;
     };
 
     Vector<Inst*> possiblyDead;
-    
+
     for (BasicBlock* block : code) {
         for (Inst& inst : *block) {
-            if (!handleInst(inst))
+            if (!isInstLive(inst))
                 possiblyDead.append(&inst);
+            else
+                markArgsLive(inst);
         }
     }
-    
+
+    // Inst in possiblyDead already have hasNonArgEffects() == false, invariant
+    // under live-set growth, so the fixpoint skips that re-check.
+    auto handleInst = [&] (Inst& inst) -> bool {
+        if (!isInstLiveByDefs(inst))
+            return false;
+        markArgsLive(inst);
+        return true;
+    };
+
     auto runForward = [&] () -> bool {
         changed = false;
         possiblyDead.removeAllMatching(
@@ -141,15 +146,22 @@ bool eliminateDeadCode(Code& code)
             break;
     }
 
-    unsigned removedInstCount = 0;
+    // After the fixpoint, possiblyDead holds exactly the dead Insts. Null them
+    // out and sweep with the cheap !inst predicate.
+    if (possiblyDead.isEmpty())
+        return false;
+
+    for (Inst* inst : possiblyDead)
+        *inst = Inst();
+
     for (BasicBlock* block : code) {
-        removedInstCount += block->insts().removeAllMatching(
+        block->insts().removeAllMatching(
             [&] (Inst& inst) -> bool {
-                return !isInstLive(inst);
+                return !inst;
             });
     }
 
-    return !!removedInstCount;
+    return true;
 }
 
 } } } // namespace JSC::B3::Air


### PR DESCRIPTION
#### 05e7708cbdfa61ccab541ec3308a2e38d6ef2bfc
<pre>
[JSC] Optimize AirEliminateDeadCode
<a href="https://bugs.webkit.org/show_bug.cgi?id=317991">https://bugs.webkit.org/show_bug.cgi?id=317991</a>
<a href="https://rdar.apple.com/180771298">rdar://180771298</a>

Reviewed by Dan Hecht.

Inst::hasNonArgEffects() is relatively costly operation but this is pure
operation. When we collected possiblyDead list, they are guaranteed to
return false from Inst::hasNonArgEffects(). So skip calling this.
Also after the fix-point iteration, possiblyDead is the set of dead Insts.
So if it is empty, we do not need to iterate a graph. And we can nullify
Inst so that elimination becomes quicker.

* Source/JavaScriptCore/b3/air/AirEliminateDeadCode.cpp:
(JSC::B3::Air::eliminateDeadCode):

Canonical link: <a href="https://commits.webkit.org/315954@main">https://commits.webkit.org/315954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c39d9b2f353d3988c3149ccaeda4e02745a60f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128257 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3858ca4d-4333-40d9-b8f1-3a0029bc3de8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/610e803c-d5da-4bdc-b60d-4a9bd035e56b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d23f600-f25f-4444-937d-b4d96bb134e7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28602 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1846 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182505 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31799 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141451 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44125 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141269 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44814 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109330 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36533 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116703 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203223 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43324 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7918 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54421 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42729 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->