### PR TITLE
"InvalidStateError: The object is in an invalid state" is not very helpful

### DIFF
--- a/LayoutTests/fast/dom/Selection/collapseToX-empty-selection-expected.txt
+++ b/LayoutTests/fast/dom/Selection/collapseToX-empty-selection-expected.txt
@@ -3,8 +3,8 @@ Test that collapseToStart() and collapseToEnd() throw INVALID_STATE_ERR if no se
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS sel.collapseToStart() threw exception InvalidStateError: The object is in an invalid state..
-PASS sel.collapseToEnd() threw exception InvalidStateError: The object is in an invalid state..
+PASS sel.collapseToStart() threw exception InvalidStateError: collapseToStart() requires a Range to be associated with Selection.
+PASS sel.collapseToEnd() threw exception InvalidStateError: collapseToEnd() requires a Range to be associated with Selection.
 PASS sel.collapseToStart() is undefined
 PASS sel.collapseToEnd() is undefined
 PASS successfullyParsed is true

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -188,7 +188,7 @@ ExceptionOr<void> DOMSelection::collapseToEnd()
         return { };
     CheckedRef selection = frame->selection();
     if (selection->isNone())
-        return Exception { ExceptionCode::InvalidStateError };
+        return Exception { ExceptionCode::InvalidStateError, "collapseToEnd() requires a Range to be associated with Selection"_s };
     selection->disassociateLiveRange();
     selection->moveTo(selection->selection().uncanonicalizedEnd(), Affinity::Downstream);
     return { };
@@ -201,7 +201,7 @@ ExceptionOr<void> DOMSelection::collapseToStart()
         return { };
     CheckedRef selection = frame->selection();
     if (selection->isNone())
-        return Exception { ExceptionCode::InvalidStateError };
+        return Exception { ExceptionCode::InvalidStateError, "collapseToStart() requires a Range to be associated with Selection"_s };
     selection->disassociateLiveRange();
     selection->moveTo(selection->selection().uncanonicalizedStart(), Affinity::Downstream);
     return { };


### PR DESCRIPTION
#### a60e1ec074fd0dcb2abf5203d02328f68b2f789b
<pre>
&quot;InvalidStateError: The object is in an invalid state&quot; is not very helpful
<a href="https://bugs.webkit.org/show_bug.cgi?id=278290">https://bugs.webkit.org/show_bug.cgi?id=278290</a>
<a href="https://rdar.apple.com/134645414">rdar://134645414</a>

Reviewed by Chris Dumez.

DOMSelection::collapseToEnd() and collapseToStart() threw a bare
InvalidStateError with the generic &quot;The object is in an invalid state.&quot;
message, giving developers no indication of which call failed or why.
Provide a descriptive message naming the method and its precondition,
matching the existing convention already used by DOMSelection::extend().

* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::collapseToEnd):
(WebCore::DOMSelection::collapseToStart):
* LayoutTests/fast/dom/Selection/collapseToX-empty-selection-expected.txt:

Canonical link: <a href="https://commits.webkit.org/318520@main">https://commits.webkit.org/318520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b2df40b0835f1c1b9b752bf9acc1336f814ffd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/96580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39661 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39340 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36475 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190447 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52011 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39835 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52692 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148011 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42725 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124957 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/119593 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51210 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14315 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->