### PR TITLE
[CSS Scroll Snap] Re-snap should select the innermost aligned snap area per axis

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/nested-supercedes-common-to-both-axes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/nested-supercedes-common-to-both-axes-expected.txt
@@ -1,4 +1,4 @@
 Box 1 Box 2 Box 3
 
-FAIL scroller prefers nested area over area aligned in both axes. assert_equals: scroller followed box2 in y axis after layout change expected 100 but got 0
+PASS scroller prefers nested area over area aligned in both axes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-inner-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-inner-target-expected.txt
@@ -1,5 +1,5 @@
 Top LeftTop RightOuter I1 I2 I3 I4
 
-FAIL snap container selects innermost area as snap target assert_equals: scroll position should follow inner3 snap target after relayout expected 250 but got 150
-FAIL snap container follows the innermost snap target after layout change (not the co-located outer target) assert_equals: scroll position should follow the innermost snap target after relayout expected 500 but got 400
+PASS snap container selects innermost area as snap target
+PASS snap container follows the innermost snap target after layout change (not the co-located outer target)
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -104,9 +104,20 @@ bool ScrollSnapAnimatorState::preserveCurrentTargetForAxis(ScrollEventAxis axis,
 {
     auto snapOffsets = snapOffsetsForAxis(axis);
 
-    auto found = std::ranges::find_if(snapOffsets, [boxID](const SnapOffset<LayoutUnit>& p) -> bool {
-        return p.snapTargetID && *p.snapTargetID == boxID;
-    });
+    // A single snap offset can be shared by several snap areas, but only one of them is recorded
+    // as the offset's representative snapTargetID. Our box may be one of the other areas at that
+    // offset, so check every area contributing to the offset, not just snapTargetID.
+    auto offsetContainsBox = [&](const SnapOffset<LayoutUnit>& offset) {
+        if (offset.snapTargetID && *offset.snapTargetID == boxID)
+            return true;
+        for (auto areaIndex : offset.snapAreaIndices) {
+            if (areaIndex < m_snapOffsetsInfo.snapAreasIDs.size() && m_snapOffsetsInfo.snapAreasIDs[areaIndex] == boxID)
+                return true;
+        }
+        return false;
+    };
+
+    auto found = std::ranges::find_if(snapOffsets, offsetContainsBox);
     if (found == snapOffsets.end()) {
         setActiveSnapIndexForAxis(axis, std::nullopt);
         return false;
@@ -155,49 +166,71 @@ void ScrollSnapAnimatorState::setActiveSnapIndexForAxis(ScrollEventAxis axis, st
     updateCurrentlySnappedBoxes();
 }
 
+// Selects this axis's snap target among the boxes aligned at the active offset, per
+// https://drafts.csswg.org/css-scroll-snap-1/#multiple-aligned: focused, then targeted, then
+// innermost, then first in tree order. snapTargetID is the focused/targeted representative; this
+// adds the innermost step.
+std::optional<NodeIdentifier> ScrollSnapAnimatorState::selectSnapTargetForAxis(ScrollEventAxis axis) const
+{
+    auto offsets = currentlySnappedOffsetsForAxis(axis);
+    if (offsets.isEmpty())
+        return std::nullopt;
+    const auto& offset = offsets[0];
+
+    // A focused or fragment-targeted box wins outright.
+    if ((offset.isFocused || offset.isTarget) && offset.snapTargetID)
+        return *offset.snapTargetID;
+
+    const auto& areas = m_snapOffsetsInfo.snapAreas;
+    const auto& areaIDs = m_snapOffsetsInfo.snapAreasIDs;
+    const auto& indices = offset.snapAreaIndices;
+
+    auto enclosesAnotherArea = [&](size_t areaIndex) {
+        return std::ranges::any_of(indices, [&](size_t other) {
+            return other != areaIndex && other < areas.size()
+                && areas[areaIndex] != areas[other] && areas[areaIndex].contains(areas[other]);
+        });
+    };
+
+    // The innermost box is the first in tree order (snapAreaIndices are ascending) whose area does
+    // not enclose another aligned area.
+    for (auto areaIndex : indices) {
+        if (areaIndex < areas.size() && areaIndex < areaIDs.size() && !enclosesAnotherArea(areaIndex))
+            return areaIDs[areaIndex];
+    }
+    if (offset.snapTargetID)
+        return *offset.snapTargetID;
+    return std::nullopt;
+}
+
 void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
 {
     auto horizontalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Horizontal);
     auto verticalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Vertical);
 
     m_currentlySnappedBoxes = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
+    m_currentSnapTargetForHorizontalAxis = selectSnapTargetForAxis(ScrollEventAxis::Horizontal);
+    m_currentSnapTargetForVerticalAxis = selectSnapTargetForAxis(ScrollEventAxis::Vertical);
 }
 
-// Among aligned snap targets, returns the box that an explicit preference points to: a focused box
-// first, then a fragment-targeted box, per https://drafts.csswg.org/css-scroll-snap-1/#re-snap
-// ("prefer the focused box, followed by the targeted box"). snapTargetID records the highest-priority
-// box at each offset (see addOrUpdateStopForSnapOffset). Returns nullopt when none of the snapped
-// boxes is focused or targeted.
-static std::optional<NodeIdentifier> preferredSnapTarget(const HashSet<NodeIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
+// Returns the snapped box this axis is focused/targeted on, evaluated fresh: focus and :target can
+// change after the snap, and the re-snap algorithm evaluates them at re-snap time.
+static std::optional<NodeIdentifier> focusedOrTargetedBox(const Vector<SnapOffset<LayoutUnit>>& offsets, const HashSet<NodeIdentifier>& snappedBoxes)
 {
-    auto findFlagged = [&](const Vector<SnapOffset<LayoutUnit>>& offsets, bool SnapOffset<LayoutUnit>::*flag) -> std::optional<NodeIdentifier> {
-        auto found = std::ranges::find_if(offsets, [&](const SnapOffset<LayoutUnit>& p) {
-            return p.snapTargetID && snappedBoxes.contains(*p.snapTargetID) && p.*flag;
+    auto findFlagged = [&](bool SnapOffset<LayoutUnit>::*flag) -> std::optional<NodeIdentifier> {
+        auto found = std::ranges::find_if(offsets, [&](const SnapOffset<LayoutUnit>& offset) {
+            return offset.snapTargetID && snappedBoxes.contains(*offset.snapTargetID) && offset.*flag;
         });
         if (found != offsets.end())
             return *found->snapTargetID;
         return std::nullopt;
     };
 
-    if (auto box = findFlagged(horizontalOffsets, &SnapOffset<LayoutUnit>::isFocused))
+    if (auto box = findFlagged(&SnapOffset<LayoutUnit>::isFocused))
         return box;
-    if (auto box = findFlagged(verticalOffsets, &SnapOffset<LayoutUnit>::isFocused))
-        return box;
-    if (auto box = findFlagged(horizontalOffsets, &SnapOffset<LayoutUnit>::isTarget))
-        return box;
-    if (auto box = findFlagged(verticalOffsets, &SnapOffset<LayoutUnit>::isTarget))
+    if (auto box = findFlagged(&SnapOffset<LayoutUnit>::isTarget))
         return box;
     return std::nullopt;
-}
-
-static NodeIdentifier chooseBoxToResnapTo(const HashSet<NodeIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
-{
-    ASSERT(snappedBoxes.size());
-
-    if (auto box = preferredSnapTarget(snappedBoxes, horizontalOffsets, verticalOffsets))
-        return *box;
-
-    return *snappedBoxes.begin();
 }
 
 bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
@@ -205,41 +238,40 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
     bool snapPointChanged = false;
     auto activeHorizontalIndex = activeSnapIndexForAxis(ScrollEventAxis::Horizontal);
     auto activeVerticalIndex = activeSnapIndexForAxis(ScrollEventAxis::Vertical);
-    auto snapOffsetsVertical = snapOffsetsForAxis(ScrollEventAxis::Vertical);
-    auto snapOffsetsHorizontal = snapOffsetsForAxis(ScrollEventAxis::Horizontal);
-    
     auto previouslySnappedBoxes = std::exchange(m_currentlySnappedBoxes, { });
-    
+    auto previousSnapTargetForHorizontalAxis = std::exchange(m_currentSnapTargetForHorizontalAxis, { });
+    auto previousSnapTargetForVerticalAxis = std::exchange(m_currentSnapTargetForVerticalAxis, { });
+
     // Check if we need to set the current indices
-    if (!activeVerticalIndex || *activeVerticalIndex >= snapOffsetsForAxis(ScrollEventAxis::Vertical).size()) {
+    if (!activeVerticalIndex || *activeVerticalIndex >= snapOffsetsForAxis(ScrollEventAxis::Vertical).size())
         snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
-        activeVerticalIndex = activeSnapIndexForAxis(ScrollEventAxis::Vertical);
-    }
-    if (!activeHorizontalIndex || *activeHorizontalIndex >= snapOffsetsForAxis(ScrollEventAxis::Horizontal).size()) {
+    if (!activeHorizontalIndex || *activeHorizontalIndex >= snapOffsetsForAxis(ScrollEventAxis::Horizontal).size())
         snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Horizontal, scrollOffset, scrollExtents, pageScale);
-        activeHorizontalIndex = activeSnapIndexForAxis(ScrollEventAxis::Horizontal);
-    }
 
     updateCurrentlySnappedBoxes();
     LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - previouslySnappedBoxes " << previouslySnappedBoxes << " m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
 
-    auto wasSnappedToMultipleBoxes = previouslySnappedBoxes.size() > 1;
-    auto currentlySnappedToMultipleBoxes = m_currentlySnappedBoxes.size() > 1;
+    // Re-snap each axis independently to its selected box, following it to its post-layout offset.
+    // Focused/targeted boxes are re-evaluated fresh; otherwise the box recorded before the layout
+    // change (innermost / first-in-tree) is used. Per-axis selection keeps a box tied only in the
+    // other axis from dragging this axis off its snap position.
+    if (previouslySnappedBoxes.size() > 1) {
+        auto targetForAxis = [&](ScrollEventAxis axis, const Markable<NodeIdentifier>& recordedTarget) -> std::optional<NodeIdentifier> {
+            if (auto box = focusedOrTargetedBox(snapOffsetsForAxis(axis), previouslySnappedBoxes))
+                return box;
+            return recordedTarget ? std::optional<NodeIdentifier> { *recordedTarget } : std::nullopt;
+        };
 
-    if (wasSnappedToMultipleBoxes) {
-        // A fragment-targeted or focused box is followed to its post-layout offset even if other
-        // boxes remain aligned at the old offset (https://drafts.csswg.org/css-scroll-snap-1/#re-snap).
-        // Without such an explicit preference, only re-choose a target when the tie has collapsed to a
-        // single box, preserving the scroll position otherwise.
-        auto preferred = preferredSnapTarget(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
-        if (preferred || !currentlySnappedToMultipleBoxes) {
-            auto box = preferred ? *preferred : chooseBoxToResnapTo(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
-            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, box);
-            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, box);
+        auto targetForHorizontalAxis = targetForAxis(ScrollEventAxis::Horizontal, previousSnapTargetForHorizontalAxis);
+        auto targetForVerticalAxis = targetForAxis(ScrollEventAxis::Vertical, previousSnapTargetForVerticalAxis);
 
-            updateCurrentlySnappedBoxes();
-            LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose " << box << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
-        }
+        if (targetForHorizontalAxis)
+            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, *targetForHorizontalAxis);
+        if (targetForVerticalAxis)
+            snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, *targetForVerticalAxis);
+
+        updateCurrentlySnappedBoxes();
+        LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose H " << targetForHorizontalAxis << " V " << targetForVerticalAxis << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
     }
 
     return snapPointChanged;

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -104,6 +104,11 @@ private:
     Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
     HashSet<NodeIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
 
+    // This axis's snap target among the boxes aligned at the active offset, per
+    // https://drafts.csswg.org/css-scroll-snap-1/#multiple-aligned (focused, targeted, innermost,
+    // then first in tree order).
+    std::optional<NodeIdentifier> selectSnapTargetForAxis(ScrollEventAxis) const;
+
     bool setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
     void updateCurrentlySnappedBoxes();
 
@@ -124,6 +129,8 @@ private:
     std::optional<unsigned> m_activeSnapIndexX;
     std::optional<unsigned> m_activeSnapIndexY;
     HashSet<NodeIdentifier> m_currentlySnappedBoxes;
+    Markable<NodeIdentifier> m_currentSnapTargetForHorizontalAxis;
+    Markable<NodeIdentifier> m_currentSnapTargetForVerticalAxis;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollSnapAnimatorState&);


### PR DESCRIPTION
#### a30df7ba2f8b4f0c90f96d2170b5dd1997f8ee73
<pre>
[CSS Scroll Snap] Re-snap should select the innermost aligned snap area per axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=317992">https://bugs.webkit.org/show_bug.cgi?id=317992</a>
<a href="https://rdar.apple.com/180779865">rdar://180779865</a>

Reviewed by Simon Fraser.

When several snap areas are aligned at the same offset, the re-snap algorithm
(<a href="https://drafts.csswg.org/css-scroll-snap-1/#multiple-aligned)">https://drafts.csswg.org/css-scroll-snap-1/#multiple-aligned)</a> selects, per axis,
the focused box, then the targeted box, then the innermost box, then the first in
tree order. WebCore had no notion of &quot;innermost&quot; and applied a single chosen box
to both axes, so it could not follow a nested snap area and a box tied only in the
other axis could drag an axis off its snap position.

Select a snap target per axis among the boxes aligned at the active offset:

- selectSnapTargetForAxis() returns the focused/targeted representative, else the
  innermost box (one whose snap area does not enclose another aligned area), else
  the first in tree order; recorded per axis in updateCurrentlySnappedBoxes().
- resnapAfterLayout() follows each axis&apos;s target independently. Focused and
  targeted boxes are re-evaluated fresh at re-snap (they can change after the
  snap); otherwise the box recorded before the layout change is used.
- preserveCurrentTargetForAxis() matches the target against all areas contributing
  to an offset, so a box sharing its post-layout offset with another is still found.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/nested-supercedes-common-to-both-axes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-snap/snap-after-relayout/multiple-aligned-targets/prefer-inner-target-expected.txt:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::preserveCurrentTargetForAxis):
(WebCore::ScrollSnapAnimatorState::selectSnapTargetForAxis const):
(WebCore::ScrollSnapAnimatorState::updateCurrentlySnappedBoxes):
(WebCore::focusedOrTargetedBox):
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout):
(WebCore::preferredSnapTarget): Deleted.
(WebCore::chooseBoxToResnapTo): Deleted.
* Source/WebCore/platform/ScrollSnapAnimatorState.h:

Canonical link: <a href="https://commits.webkit.org/317225@main">https://commits.webkit.org/317225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cc4e875d7fef889215bcb11001ee4059f855697

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132478 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/27a670e9-37a9-411d-b11f-374f1b272c0c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135855 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116333 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37931 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36304 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32668 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144777 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48210 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144636 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38996 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48889 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39515 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120890 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47396 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11107 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46798 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->