### PR TITLE
Remove duplicate #includes in WebCore

### DIFF
--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -31,7 +31,6 @@
 #include "LocalFrame.h"
 #include "ScriptController.h"
 #include "Settings.h"
-#include "FrameDestructionObserverInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -28,7 +28,6 @@
 
 #include "InlineFormattingContext.h"
 #include "FontCascadeInlines.h"
-#include "LayoutBoxInlines.h"
 #include "InlineLineBox.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutBoxInlines.h"

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -47,7 +47,6 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLSrcsetParser.h"
-#include <JavaScriptCore/ConsoleTypes.h>
 #include "JSFetchRequestDestination.h"
 #include "LinkHeader.h"
 #include "LinkPreloadResourceClients.h"

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -28,7 +28,6 @@
 
 #include "Logging.h"
 #include <wtf/CrossThreadCopier.h>
-#include <wtf/CrossThreadCopier.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/Expected.h>
 #include <wtf/URL.h>

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -56,8 +56,6 @@
 #include "MultiRepresentationHEICMetrics.h"
 #endif
 
-#include <pal/cf/CoreTextSoftLink.h>
-
 namespace WebCore {
 
 static inline bool caseInsensitiveCompare(CFStringRef a, CFStringRef b)


### PR DESCRIPTION
#### dda719db21012ddb90b9508784a5273522443f9a
<pre>
Remove duplicate #includes in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=317993">https://bugs.webkit.org/show_bug.cgi?id=317993</a>
<a href="https://rdar.apple.com/180780348">rdar://180780348</a>

Reviewed by Vitor Roriz.

Each of these files included the same header twice. Removed the
redundant copy that was out of alphabetical/group order, keeping
the one in its correct sorted position.

* Source/WebCore/html/parser/HTMLParserOptions.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:

Canonical link: <a href="https://commits.webkit.org/315956@main">https://commits.webkit.org/315956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8de0bb3502d177a66017960ac2029f36b9ec469

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179930 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128266 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b6331f6-2e82-43e9-9e50-6e06c25a7a1b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133004 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aab4b88e-9b53-4172-bcfb-07d5c210d13d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113501 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11391910-c569-4a34-a991-1d2d31fe7d91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34807 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28611 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182514 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37328 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141460 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44134 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38047 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44823 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109343 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36543 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116712 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43333 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7926 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42738 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->