### PR TITLE
REGRESSION(313624@main): [AppKit Gestures] Cannot scroll the enclosing scroll view by scrolling over an image

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -1571,6 +1571,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (!webView)
         return NO;
 
+    // None of our gesture recognizers may prevent an enclosing scroll view's pan (or any other
+    // scroll/zoom) gesture, so that a scroll can always be handed off to the enclosing scroll view
+    // e.g. a scroll over a draggable <img> in a non-scrollable web view.
+    if ([self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer])
+        return NO;
+
     bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer
         || preventingGestureRecognizer == _secondaryClickGestureRecognizer
         || preventingGestureRecognizer == _mouseTrackingGestureRecognizer
@@ -1578,9 +1584,6 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
     if (!isOurClickGesture)
         return YES;
-
-    if ([self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer])
-        return NO;
 
     // Don't let other click gestures prevent the secondary click GR; it must be allowed to fire its
     // press timer (0.72s) without being short-circuited by gestures that recognize earlier

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -529,7 +529,9 @@
 		07AA27602F83C3A900FE10FC /* Exceptions for "Tests" folder in "TestWebKitAPI" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				WebKit/WebPage/AppKitGesturesTests.swift,
+				"WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift",
+				"WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift",
+				"WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift",
 				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/JavaScriptExpressionTests.swift,
 				WebKit/WebPage/NavigatorWebDriverOverride.swift,
@@ -1294,7 +1296,9 @@
 		07C913DE2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWebKitAPIBundle" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				WebKit/WebPage/AppKitGesturesTests.swift,
+				"WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift",
+				"WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift",
+				"WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift",
 				WebKit/WebPage/EditingFontSizeTests.swift,
 				WebKit/WebPage/JavaScriptExpressionTests.swift,
 				WebKit/WebPage/NavigatorWebDriverOverride.swift,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+import struct Foundation.URL
+@_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
+import SwiftUI
+import struct Swift.String
+import struct _Concurrency.Task
+import struct TestWebKitAPILibrary.DOMRect
+import Testing
+import TestWebKitAPILibrary
+import Recap
+private import AppKit_Private.NSMenu_Private
+
+actor Recap {
+    static let shared = Recap()
+
+    func play(events: @Sendable (_ composer: any RCPEventStreamComposer) -> Void) async {
+        let eventStream: RCPSyntheticEventStream = RCPSyntheticEventStream { composer in
+            guard let composer else {
+                preconditionFailure()
+            }
+            composer.senderProperties = ._wk_trackpadSender()
+            events(composer)
+        }
+
+        await RCPInlinePlayer.play(eventStream, options: .init())
+    }
+}
+
+@MainActor
+protocol AppKitGestureTestSuite {
+    static var text: String { get }
+
+    var recap: Recap { get }
+
+    var page: WebPage { get }
+
+    var window: NSWindow { get }
+
+    init() async throws
+}
+
+extension AppKitGestureTestSuite {
+}
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct AppKitGesturesTests {
+}
+
+@MainActor
+private func convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: CGPoint, window: NSWindow) -> CGPoint {
+    guard let screen = window.screen else {
+        preconditionFailure()
+    }
+
+    let inAppKitScreenCoordinates = window.convertPoint(toScreen: pointInWindowCoordinates)
+
+    let inCoreGraphicsScreenCoordinates = CGPoint(
+        x: inAppKitScreenCoordinates.x,
+        y: screen.frame.maxY - inAppKitScreenCoordinates.y
+    )
+
+    return inCoreGraphicsScreenCoordinates
+}
+
+@MainActor
+private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow) -> CGRect {
+    guard let contentViewController = window.contentViewController else {
+        preconditionFailure()
+    }
+
+    guard let screen = window.screen else {
+        preconditionFailure()
+    }
+
+    let inViewportCoordinates = CGRect(rectInViewportCoordinates)
+
+    let inWindowCoordinates = CGRect(
+        x: inViewportCoordinates.origin.x,
+        y: contentViewController.view.frame.height - inViewportCoordinates.origin.y - inViewportCoordinates.size.height,
+        width: inViewportCoordinates.size.width,
+        height: inViewportCoordinates.size.height,
+    )
+
+    let inAppKitScreenCoordinates = window.convertToScreen(inWindowCoordinates)
+
+    let inCoreGraphicsScreenCoordinates = CGRect(
+        x: inAppKitScreenCoordinates.origin.x,
+        y: screen.frame.maxY - inAppKitScreenCoordinates.maxY,
+        width: inAppKitScreenCoordinates.width,
+        height: inAppKitScreenCoordinates.height,
+    )
+
+    return inCoreGraphicsScreenCoordinates
+}
+
+extension AppKitGestureTestSuite {
+    func screenBoundsOfText(_ text: String) async throws -> CGRect {
+        let range = try #require(Self.text.utf16Range(of: text))
+
+        let viewportCoordinates = try await page.callJavaScript(
+            JavaScriptMessages.BoundingClientRect(in: "div", range: range)
+        )
+
+        let screenCoordinates = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: viewportCoordinates,
+            window: window
+        )
+
+        return screenCoordinates
+    }
+
+    func screenBounds(ofElementWithID id: String) async throws -> CGRect {
+        let viewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: id))
+        return convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: viewportCoordinates, window: window)
+    }
+
+    func screenBounds(ofPointInWindowCoordinates point: NSPoint) -> NSPoint {
+        convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: point, window: window)
+    }
+
+    func screenBounds(ofRectInViewportCoordinates point: DOMRect) -> CGRect {
+        convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: point, window: window)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -35,49 +35,37 @@ private import TestWebKitAPILibrary
 private import Recap
 private import AppKit_Private.NSMenu_Private
 
-private actor Recap {
-    static let shared = Recap()
+extension AppKitGesturesTests {
+    @MainActor
+    @Suite(.serialized, .timeLimit(.minutes(1)))
+    struct Basic: AppKitGestureTestSuite {
+        static let text = "Here's to the crazy ones."
 
-    func play(events: @Sendable (_ composer: any RCPEventStreamComposer) -> Void) async {
-        let eventStream: RCPSyntheticEventStream = RCPSyntheticEventStream { composer in
-            guard let composer else {
-                preconditionFailure()
+        let recap = Recap.shared
+
+        let page: WebPage = {
+            var configuration = WebPage.Configuration()
+            configuration.requiresUserActionForEditingControlsManager = true
+            return WebPage(configuration: configuration)
+        }()
+
+        let window: NSWindow
+
+        init() async throws {
+            let contentSize = NSSize(width: 800, height: 600)
+
+            self.window = NSWindow(size: contentSize) { [page] in
+                WebView(page)
             }
-            composer.senderProperties = ._wk_trackpadSender()
-            events(composer)
-        }
 
-        await RCPInlinePlayer.play(eventStream, options: .init())
+            self.window.setFrameOrigin(.zero)
+            NSApp.activate(ignoringOtherApps: true)
+            self.window.makeKeyAndOrderFront(nil)
+        }
     }
 }
 
-@MainActor
-@Suite(.serialized, .timeLimit(.minutes(1)))
-struct AppKitGesturesTests {
-    private static let text = "Here's to the crazy ones."
-
-    private let recap = Recap.shared
-
-    private let page: WebPage = {
-        var configuration = WebPage.Configuration()
-        configuration.requiresUserActionForEditingControlsManager = true
-        return WebPage(configuration: configuration)
-    }()
-
-    private let window: NSWindow
-
-    init() async throws {
-        let contentSize = NSSize(width: 800, height: 600)
-
-        self.window = NSWindow(size: contentSize) { [page] in
-            WebView(page)
-        }
-
-        self.window.setFrameOrigin(.zero)
-        NSApp.activate(ignoringOtherApps: true)
-        self.window.makeKeyAndOrderFront(nil)
-    }
-
+extension AppKitGesturesTests.Basic {
     @Test(
         .bug("https://webkit.org/b/314880", "Only mouse tracking mode produces pointer events"),
         arguments: [true, false]
@@ -168,7 +156,7 @@ struct AppKitGesturesTests {
         await page.waitForNextPresentationUpdate()
 
         let startViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "line97"))
-        let startBounds = convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: startViewportCoordinates, window: window)
+        let startBounds = screenBounds(ofRectInViewportCoordinates: startViewportCoordinates)
 
         // Recap requires this test to be ran within an app host.
         guard NSApp.isActive else {
@@ -323,7 +311,7 @@ struct AppKitGesturesTests {
         #expect(scrollLater.y == scrollAfterLift.y)
     }
 
-    @Test()
+    @Test
     func draggingSelectionToTopEdgeScrollsUp() async throws {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
@@ -792,7 +780,7 @@ struct AppKitGesturesTests {
         }
 
         let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: elementID))
-        let convertedSliderBounds = convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: sliderBounds, window: window)
+        let convertedSliderBounds = screenBounds(ofRectInViewportCoordinates: sliderBounds)
 
         let start = convertedSliderBounds.center
         let end = CGPoint(x: convertedSliderBounds.maxX, y: convertedSliderBounds.center.y)
@@ -887,10 +875,7 @@ struct AppKitGesturesTests {
             let viewportCoordinates = try await page.callJavaScript(
                 JavaScriptMessages.BoundingClientRect(in: "link", range: linkRange)
             )
-            return convertToCoreGraphicsScreenCoordinates(
-                rectInViewportCoordinates: viewportCoordinates,
-                window: window
-            )
+            return screenBounds(ofRectInViewportCoordinates: viewportCoordinates)
         }()
 
         let dragEnd = CGPoint(x: linkBounds.maxX + 50, y: linkBounds.midY)
@@ -948,10 +933,7 @@ struct AppKitGesturesTests {
         }
 
         let imgViewportBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "img"))
-        let imgBounds = convertToCoreGraphicsScreenCoordinates(
-            rectInViewportCoordinates: imgViewportBounds,
-            window: window
-        )
+        let imgBounds = screenBounds(ofRectInViewportCoordinates: imgViewportBounds)
 
         let dragEnd = CGPoint(x: imgBounds.maxX + 50, y: imgBounds.midY)
 
@@ -1050,55 +1032,6 @@ struct AppKitGesturesTests {
     }
 }
 
-// MARK: Helpers
-
-@MainActor
-private func convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: CGPoint, window: NSWindow) -> CGPoint {
-    guard let screen = window.screen else {
-        preconditionFailure()
-    }
-
-    let inAppKitScreenCoordinates = window.convertPoint(toScreen: pointInWindowCoordinates)
-
-    let inCoreGraphicsScreenCoordinates = CGPoint(
-        x: inAppKitScreenCoordinates.x,
-        y: screen.frame.maxY - inAppKitScreenCoordinates.y
-    )
-
-    return inCoreGraphicsScreenCoordinates
-}
-
-@MainActor
-private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow) -> CGRect {
-    guard let contentViewController = window.contentViewController else {
-        preconditionFailure()
-    }
-
-    guard let screen = window.screen else {
-        preconditionFailure()
-    }
-
-    let inViewportCoordinates = CGRect(rectInViewportCoordinates)
-
-    let inWindowCoordinates = CGRect(
-        x: inViewportCoordinates.origin.x,
-        y: contentViewController.view.frame.height - inViewportCoordinates.origin.y - inViewportCoordinates.size.height,
-        width: inViewportCoordinates.size.width,
-        height: inViewportCoordinates.size.height,
-    )
-
-    let inAppKitScreenCoordinates = window.convertToScreen(inWindowCoordinates)
-
-    let inCoreGraphicsScreenCoordinates = CGRect(
-        x: inAppKitScreenCoordinates.origin.x,
-        y: screen.frame.maxY - inAppKitScreenCoordinates.maxY,
-        width: inAppKitScreenCoordinates.width,
-        height: inAppKitScreenCoordinates.height,
-    )
-
-    return inCoreGraphicsScreenCoordinates
-}
-
 nonisolated(nonsending) private func withSwizzledContextMenu(perform body: () async -> Void) async {
     typealias CompletionHandler = @convention(block) () -> Void
     typealias ObjCImplementation = @convention(block) (NSMenu.Type, NSMenu, _NSViewMenuContext, NSView, CompletionHandler?) -> Void
@@ -1122,7 +1055,7 @@ nonisolated(nonsending) private func withSwizzledContextMenu(perform body: () as
     }
 }
 
-extension AppKitGesturesTests {
+extension AppKitGesturesTests.Basic {
     private func loadHTML(contentEditable: Bool = false, clickHandler: Bool = false) async throws {
         let contentEditableMarkup = contentEditable ? "contenteditable" : ""
         let clickHandlerMarkup = clickHandler ? "onclick='void(0)'" : ""
@@ -1132,21 +1065,6 @@ extension AppKitGesturesTests {
             """
 
         try await page.load(html: html).wait()
-    }
-
-    private func screenBoundsOfText(_ text: String) async throws -> CGRect {
-        let range = try #require(Self.text.utf16Range(of: text))
-
-        let viewportCoordinates = try await page.callJavaScript(
-            JavaScriptMessages.BoundingClientRect(in: "div", range: range)
-        )
-
-        let screenCoordinates = convertToCoreGraphicsScreenCoordinates(
-            rectInViewportCoordinates: viewportCoordinates,
-            window: window
-        )
-
-        return screenCoordinates
     }
 
     private func loadScrollableText() async throws {
@@ -1160,15 +1078,6 @@ extension AppKitGesturesTests {
             """
         try await page.load(html: html).wait()
     }
-
-    private func screenBounds(ofElementWithID id: String) async throws -> CGRect {
-        let viewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: id))
-        return convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: viewportCoordinates, window: window)
-    }
-
-    private func screenBounds(ofPointInWindowCoordinates point: NSPoint) -> NSPoint {
-        convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: point, window: window)
-    }
 }
 
-#endif // HAVE_APPKIT_GESTURES_SUPPORT
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
@@ -1,0 +1,211 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+import struct Foundation.URL
+@_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
+import SwiftUI
+import struct Swift.String
+import struct _Concurrency.Task
+private import struct TestWebKitAPILibrary.DOMRect
+import Testing
+private import TestWebKitAPILibrary
+private import Recap
+private import AppKit_Private.NSMenu_Private
+
+extension AppKitGesturesTests {
+    @MainActor
+    @Suite(.serialized, .timeLimit(.minutes(1)))
+    struct Embedded: AppKitGestureTestSuite {
+        @MainActor
+        private final class ContentOffsetStorage {
+            var value = CGPoint.zero
+        }
+
+        static let text = "Here's to the crazy ones."
+
+        let recap = Recap.shared
+
+        let page: WebPage = {
+            var configuration = WebPage.Configuration()
+            configuration.requiresUserActionForEditingControlsManager = true
+            return WebPage(configuration: configuration)
+        }()
+
+        let window: NSWindow
+
+        private let windowSize = NSSize(width: 800, height: 600)
+        private let contentHeight: CGFloat = 2000
+
+        private var contentOffset = ContentOffsetStorage()
+
+        init() async throws {
+            self.window = NSWindow(size: windowSize) { [windowSize, contentHeight, contentOffset, page] in
+                ScrollView {
+                    VStack(spacing: 0) {
+                        WebView(page)
+                            .frame(width: windowSize.width, height: windowSize.height)
+                        Color.clear
+                            .frame(height: contentHeight - windowSize.height)
+                    }
+                }
+                .onScrollGeometryChange(for: CGPoint.self) { geometry in
+                    geometry.contentOffset
+                } action: { _, newContentOffset in
+                    contentOffset.value = newContentOffset
+                }
+            }
+
+            self.window.setFrameOrigin(.zero)
+            NSApp.activate(ignoringOtherApps: true)
+            self.window.makeKeyAndOrderFront(nil)
+        }
+    }
+}
+
+extension AppKitGesturesTests.Embedded {
+    @Test
+    func scrollOverNonScrollableWebViewPropagatesToEnclosingScrollView() async throws {
+        let html = """
+            <body style='margin:0; background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);'>
+                <p>not scrollable</p>
+                <img id="img" src="400x400-green.png" style="display: block; margin: 50px;">
+            </body>
+            """
+
+        let baseURL = try #require(Bundle.testResources.resourceURL)
+
+        try await page.load(html: html, baseURL: baseURL).wait()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let cgScreenOrigin = screenBounds(ofPointInWindowCoordinates: .init(x: 0, y: windowSize.height))
+        let viewportInCGScreen = CGRect(origin: cgScreenOrigin, size: windowSize)
+
+        let dragDistance: CGFloat = 100
+        let center = viewportInCGScreen.center
+        let startPoint = CGPoint(x: center.x, y: center.y + dragDistance / 2)
+        let endPoint = CGPoint(x: center.x, y: center.y - dragDistance / 2)
+
+        let initialContentOffset = contentOffset.value
+
+        await recap.play { composer in
+            composer.drag(withStart: startPoint, end: endPoint, duration: 0.5)
+            composer.advanceTime(0.1)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        // The test passes if the enclosing SwiftUI ScrollView scrolled.
+        #expect(contentOffset.value != initialContentOffset)
+    }
+
+    @Test
+    func pressDragOverTextInWebViewInsideEnclosingScrollViewCreatesSelection() async throws {
+        // Center the text vertically so the press-drag stays well within the visible scroll area.
+        let html = """
+            <body style='margin:0;'>
+                <div id="div" style="font-size: 30px; padding-top: 280px;">\(Self.text)</div>
+            </body>
+            """
+
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let toBounds = try await screenBoundsOfText("to")
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+        await page.waitForNextPresentationUpdate()
+
+        await recap.play { composer in
+            composer._wk_drag(
+                withStart: toBounds.center,
+                end: crazyBounds.center,
+                duration: .seconds(1.5),
+                pressAndWait: .seconds(1.0)
+            )
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        guard case .range = selection else {
+            Issue.record("expected press-drag over text in an enclosing scroll view to create a range selection, got \(selection)")
+            return
+        }
+    }
+
+    @Test
+    func quickDragOverTextInWebViewInsideEnclosingScrollViewScrolls() async throws {
+        let html = """
+            <body style='margin:0; background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);'>
+                <div id="div" style="font-size: 30px; padding-top: 280px;">\(Self.text)</div>
+            </body>
+            """
+
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        // A quick (non-press) drag whose touch-down is over selectable text must still hand off to the
+        // enclosing scroll view, just like over an image.
+        let dragDistance: CGFloat = 100
+        let center = crazyBounds.center
+        let startPoint = CGPoint(x: center.x, y: center.y + dragDistance / 2)
+        let endPoint = CGPoint(x: center.x, y: center.y - dragDistance / 2)
+
+        let initialContentOffset = contentOffset.value
+
+        await recap.play { composer in
+            composer.drag(withStart: startPoint, end: endPoint, duration: 0.5)
+            composer.advanceTime(0.1)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        #expect(contentOffset.value != initialContentOffset)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT


### PR DESCRIPTION
#### 68e05b741c15d45984b7df829663146d36eeb42e
<pre>
REGRESSION(313624@main): [AppKit Gestures] Cannot scroll the enclosing scroll view by scrolling over an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=317994">https://bugs.webkit.org/show_bug.cgi?id=317994</a>
<a href="https://rdar.apple.com/180052761">rdar://180052761</a>

Reviewed by Abrar Rahman Protyasha.

In 313624@main, image position information began being computed on macOS, so
InteractionInformationAtPosition::isImage (and therefore
representsDraggableElement()) is now true over &lt;img&gt; elements. As a result,
when a scroll begins over an image in non-scrollable web content, the drag-deferring
gesture recognizer resolves to the recognized (.ended) state rather than failing.

-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]
only exempted our click gesture recognizers from preventing scroll and zoom
gesture recognizers (313208@main); the deferring gesture recognizers fell
through to the default and were allowed to prevent anything. So once the
drag-deferring gesture recognized over an image, it prevented the enclosing
scroll view&apos;s pan gesture recognizer, and a non-scrollable web view&apos;s scroll
was never handed off to it. Non-draggable content was unaffected because the
deferring gesture fails there.

Hoist the scroll-or-zoom check above the click-gesture early return so that
none of our gesture recognizers — click or deferring — can prevent an
enclosing scroll view&apos;s pan (or any other scroll/zoom) gesture. The deferring
gesture recognizers still prevent text selection gestures, so
drag-and-drop over draggable content is unchanged.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift: Added.
(TestWebKitAPILibrary.play(_:)):
(AppKitGestureTestSuite.text):
(AppKitGestureTestSuite.recap):
(AppKitGestureTestSuite.page):
(AppKitGestureTestSuite.window):
(convertToCoreGraphicsScreenCoordinates(_:window:)):
(AppKitGestureTestSuite.screenBoundsOfText(_:)):
(AppKitGestureTestSuite.screenBounds(ofElementWithID:)):
(AppKitGestureTestSuite.screenBounds(ofPointInWindowCoordinates:)):
(AppKitGestureTestSuite.screenBounds(ofRectInViewportCoordinates:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift: Renamed from Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift.
(AppKitGesturesTests.draggingSelectionToWindowEdgeAutoscrolls(_:)):
(AppKitGesturesTests.pressDragOverRangeInputChangesInputValue(_:)):
(AppKitGesturesTests.pressDragOnLinkInitiatesDragAndDrop):
(AppKitGesturesTests.pressDragOnImageInitiatesDragAndDrop):
(AppKitGesturesTests.pressDragOnExistingSelectionDoesNotExtendSelection):
(AppKitGesturesTests.loadScrollableText):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift: Added.
(AppKitGesturesTests.scrollOverNonScrollableWebViewPropagatesToEnclosingScrollView):
(AppKitGesturesTests.pressDragOverTextInWebViewInsideEnclosingScrollViewCreatesSelection):
(AppKitGesturesTests.quickDragOverTextInWebViewInsideEnclosingScrollViewScrolls):

Canonical link: <a href="https://commits.webkit.org/315958@main">https://commits.webkit.org/315958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e916798c692ac3bb54f39bc8b3db743b8359873f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44493 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/37911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128281 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7df3540c-887d-4f90-b6f1-613e2d654a4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c202cec9-63a1-4e87-ab42-5326866ef0ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36206 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113514 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ded1cd4f-4e6d-4a61-ac4e-2b257770ee60) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28626 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182529 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35326 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44149 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/152922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44838 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109371 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36557 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116727 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43348 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42753 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->