### PR TITLE
GraphicsContext::fillRoundedRect and fillRect clobber an active non-Normal blend mode

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -486,18 +486,19 @@ void GraphicsContext::fillRect(const FloatRect& rect, Gradient& gradient)
 
 void GraphicsContext::fillRect(const FloatRect& rect, const Color& color, CompositeOperator op, BlendMode blendMode)
 {
-    CompositeOperator previousOperator = compositeOperation();
+    auto previousCompositeMode = compositeMode();
     setCompositeOperation(op, blendMode);
     fillRect(rect, color);
-    setCompositeOperation(previousOperator);
+    setCompositeMode(previousCompositeMode);
 }
 
 void GraphicsContext::fillRoundedRect(const FloatRoundedRect& rect, const Color& color, BlendMode blendMode)
 {
     if (rect.hasNonZeroRadii()) {
+        auto previousCompositeMode = compositeMode();
         setCompositeOperation(compositeOperation(), blendMode);
         fillRoundedRectImpl(rect, color);
-        setCompositeOperation(compositeOperation());
+        setCompositeMode(previousCompositeMode);
     } else
         fillRect(rect.rect(), color, compositeOperation(), blendMode);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
@@ -31,6 +31,7 @@
 #import <Metal/Metal.h>
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/DestinationColorSpace.h>
+#import <WebCore/FloatRoundedRect.h>
 #import <WebCore/GraphicsContextCG.h>
 #import <WebCore/IOSurface.h>
 #import <WebCore/NativeImage.h>
@@ -94,6 +95,43 @@ TEST(GraphicsContextTests, DrawNativeImageDoesNotLeakCompositeOperator)
 
     EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
     EXPECT_EQ(ctx.blendMode(), BlendMode::Normal);
+}
+
+TEST(GraphicsContextTests, FillRoundedRectPreservesActiveBlendMode)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    GraphicsContextCG ctx(cgContext.get());
+
+    // A non-Normal blend mode that was set on the context before the fill
+    // should still be active afterwards: fillRoundedRect only changes the
+    // blend mode temporarily and must restore the previous state in full.
+    ctx.setCompositeOperation(CompositeOperator::SourceOver, BlendMode::Multiply);
+    EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
+    EXPECT_EQ(ctx.blendMode(), BlendMode::Multiply);
+
+    FloatRoundedRect roundedRect({ 0, 0, contextWidth, contextHeight }, CornerRadii { 1 });
+    ctx.fillRoundedRect(roundedRect, Color::green, BlendMode::Screen);
+
+    EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
+    EXPECT_EQ(ctx.blendMode(), BlendMode::Multiply);
+}
+
+TEST(GraphicsContextTests, FillRectWithBlendModePreservesActiveBlendMode)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    GraphicsContextCG ctx(cgContext.get());
+
+    // Same expectation for the fillRect(rect, color, op, blendMode) overload.
+    ctx.setCompositeOperation(CompositeOperator::SourceOver, BlendMode::Multiply);
+    EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
+    EXPECT_EQ(ctx.blendMode(), BlendMode::Multiply);
+
+    ctx.fillRect(FloatRect(0, 0, contextWidth, contextHeight), Color::green, CompositeOperator::Copy, BlendMode::Screen);
+
+    EXPECT_EQ(ctx.compositeOperation(), CompositeOperator::SourceOver);
+    EXPECT_EQ(ctx.blendMode(), BlendMode::Multiply);
 }
 
 TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)


### PR DESCRIPTION
#### 1bfbf096b177ccd38479b4d3f890db5643efed34
<pre>
GraphicsContext::fillRoundedRect and fillRect clobber an active non-Normal blend mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=317999">https://bugs.webkit.org/show_bug.cgi?id=317999</a>
<a href="https://rdar.apple.com/180786679">rdar://180786679</a>

Reviewed by Kimmo Kinnunen.

GraphicsContext::fillRoundedRect() and the
fillRect(rect, color, op, blendMode) overload save and restore only the
composite operator around their temporary state change. They read the
operator after the blend mode has already been mutated and restore it
with setCompositeOperation(), whose blendMode parameter defaults to
BlendMode::Normal. This silently drops any non-Normal blend mode that was
active on the context before the call.

Capture the full CompositeMode (operator + blend mode) before mutating
and restore it with setCompositeMode().

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::fillRect):
(WebCore::GraphicsContext::fillRoundedRect):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm:
(TestWebKitAPI::TEST(GraphicsContextTests, FillRoundedRectPreservesActiveBlendMode)):
(TestWebKitAPI::TEST(GraphicsContextTests, FillRectWithBlendModePreservesActiveBlendMode)):

Canonical link: <a href="https://commits.webkit.org/315983@main">https://commits.webkit.org/315983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79747551e1751cdd3d748f895f2a427c8f199a63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128278 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92a6841d-4838-4d38-ae4a-3595a3abf37d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133015 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93805 "16 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7942fbcf-e1fe-4adc-bc57-d5b72f9cb4a2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113512 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38c58f68-5184-4ffc-8f28-191cf7b0e4f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33162 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182526 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141472 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44146 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141290 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38064 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29836 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109368 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36555 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116724 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43345 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->