### PR TITLE
GraphicsContext::scaleFactorForDrawing produces a non-finite scale factor for a degenerate source rect

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -533,6 +533,8 @@ FloatSize GraphicsContext::scaleFactor() const
 
 FloatSize GraphicsContext::scaleFactorForDrawing(const FloatRect& destRect, const FloatRect& srcRect) const
 {
+    if (srcRect.isEmpty())
+        return scaleFactor();
     AffineTransform transform = getCTM(GraphicsContext::DefinitelyIncludeDeviceScale);
     auto transformedDestRect = transform.mapRect(destRect);
     return transformedDestRect.size() / srcRect.size();

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm
@@ -276,6 +276,31 @@ TEST(GraphicsContextTests, OutOfGamutSRGBNotDrawn)
         EXPECT_EQ(firstPixel[i], primaryData[i]);
 }
 
+TEST(GraphicsContextTests, ScaleFactorForDrawingHandlesDegenerateSourceRect)
+{
+    auto colorSpace = DestinationColorSpace::SRGB();
+    RetainPtr cgContext = adoptCF(CGBitmapContextCreate(nullptr, contextWidth, contextHeight, 8, 4 * contextWidth, colorSpace.platformColorSpace(), kCGImageAlphaPremultipliedLast));
+    GraphicsContextCG ctx(cgContext.get());
+
+    FloatRect destRect(0, 0, 100, 100);
+
+    // A non-empty source rect yields the dest/src ratio.
+    auto normal = ctx.scaleFactorForDrawing(destRect, FloatRect(0, 0, 50, 25));
+    EXPECT_FLOAT_EQ(normal.width(), 2);
+    EXPECT_FLOAT_EQ(normal.height(), 4);
+
+    // A degenerate source rect must not produce a non-finite scale factor (which would otherwise
+    // propagate into decode-size and subsampling-level decisions). It falls back to the device
+    // scale factor, which is 1x for this untransformed bitmap context.
+    for (auto srcRect : { FloatRect(0, 0, 0, 25), FloatRect(0, 0, 50, 0), FloatRect(0, 0, 0, 0) }) {
+        auto scale = ctx.scaleFactorForDrawing(destRect, srcRect);
+        EXPECT_TRUE(std::isfinite(scale.width()));
+        EXPECT_TRUE(std::isfinite(scale.height()));
+        EXPECT_FLOAT_EQ(scale.width(), 1);
+        EXPECT_FLOAT_EQ(scale.height(), 1);
+    }
+}
+
 } // namespace TestWebKitAPI
 
 #endif // USE(CG)


### PR DESCRIPTION
#### d342b37d36dcf77d843890472b243fc2ed5aeef5
<pre>
GraphicsContext::scaleFactorForDrawing produces a non-finite scale factor for a degenerate source rect
<a href="https://bugs.webkit.org/show_bug.cgi?id=318000">https://bugs.webkit.org/show_bug.cgi?id=318000</a>
<a href="https://rdar.apple.com/180787305">rdar://180787305</a>

Reviewed by NOBODY (OOPS!).

scaleFactorForDrawing() divides the transformed destination rect size by the
source rect size component-wise. When the source rect has a zero width or
height, this divides by zero and yields inf (or NaN when the destination
dimension is also zero) in that axis. The non-finite value then propagates
into the caller&apos;s sizeForDrawing and subsampling-level decisions in
BitmapImage::draw().

Guard against a degenerate source rect and fall back to the context&apos;s device
scale factor, which keeps the result finite and matches the scale that would
apply when drawing at 1:1 in user space.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::scaleFactorForDrawing):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/GraphicsContextCGTests.mm:
(TestWebKitAPI::TEST(GraphicsContextTests, ScaleFactorForDrawingHandlesDegenerateSourceRect)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d342b37d36dcf77d843890472b243fc2ed5aeef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129382 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3537e16d-5d09-4c01-97bc-4928973099c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133675 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94306 "2 flakes 20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa83e7b4-1c3c-45f4-a696-3ca6e3406a30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114147 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44ece3d6-e00f-49e1-bb11-f7574cc54fcf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29881 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183799 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142382 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45412 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46092 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30529 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110727 "Hash d342b37d for PR 68008 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37370 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117780 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44610 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8625 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44010 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44069 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->