### PR TITLE
[GLIB] Double the default timeout for API tests in Debug

### DIFF
--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -67,6 +67,16 @@ class TestRunner(object):
         self._build_type = self._port.get_option('configuration')
         common.set_build_types((self._build_type,))
 
+        # When no explicit timeout is given, use a default of 5s, doubled for
+        # Debug since those builds are slower (no compiler optimizations are
+        # used). An explicit --timeout is used verbatim. This matches the
+        # layout test harness (see GLibPort.default_timeout_ms() and
+        # run_webkit_tests, which only applies the multiplier to the default).
+        if self._options.timeout is not None:
+            self._timeout = self._options.timeout
+        else:
+            self._timeout = 10 if self._build_type == 'Debug' else 5
+
         self._programs_path = common.binary_build_path(self._port)
         expectations_file = os.path.join(common.top_level_path(), "Tools", "TestWebKitAPI", "glib", "TestExpectations.json")
         self._expectations = TestExpectations(self._port.name(), expectations_file, self._build_type, self._port.architecture())
@@ -196,7 +206,7 @@ class TestRunner(object):
         return hasattr(self._options, 'wpe_legacy_api') and self._options.wpe_legacy_api
 
     def _run_test_glib(self, test_program, subtests, skipped_test_cases):
-        timeout = self._options.timeout
+        timeout = self._timeout
         wpe_legacy_api = self._use_wpe_legacy_api()
         if self.is_webxr_test(test_program):
             env = self._monado_env | self._test_env
@@ -225,7 +235,7 @@ class TestRunner(object):
 
         try:
             output = subprocess.check_output([test_program, ], stderr=subprocess.STDOUT,
-                                             env=env, timeout=self._options.timeout)
+                                             env=env, timeout=self._timeout)
         except subprocess.CalledProcessError as exc:
             print(exc.output)
             if exc.returncode > 0:
@@ -266,7 +276,7 @@ class TestRunner(object):
         if self._use_wpe_legacy_api() and os.path.basename(test_program) == 'TestWebKit':
             command.append('--wpe-legacy-api')
 
-        timeout = self._options.timeout
+        timeout = self._timeout
         if self._expectations.is_slow(os.path.basename(test_program), subtest):
             timeout *= 10
 
@@ -566,8 +576,8 @@ def create_option_parser():
                              metavar='skip|ignore|only',
                              help='Specifies how to treat the skipped tests')
     option_parser.add_option('-t', '--timeout',
-                             action='store', type='int', dest='timeout', default=5,
-                             help='Time in seconds until a test times out')
+                             action='store', type='int', dest='timeout', default=None,
+                             help='Time in seconds until a test times out (default: 5, doubled for Debug)')
     option_parser.add_option('-l', '--list-tests',
                              action='store_true', dest='list_tests',
                              help='List the tests (main tests) available to run.')


### PR DESCRIPTION
#### 6ebaa5579156f1e620d7ae7252ec5369cfcb7b0c
<pre>
[GLIB] Double the default timeout for API tests in Debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=318001">https://bugs.webkit.org/show_bug.cgi?id=318001</a>

Reviewed by Carlos Garcia Campos.

The layout test runner doubles the layout test timeout for Debug runs,
so do the same for API tests. This will prevent some tests for timing out
in Debug without having to mark them slow explicitly.

* Tools/glib/api_test_runner.py:
(TestRunner.__init__):
(TestRunner._run_test_glib):
(TestRunner._run_test_qt):
(TestRunner._run_google_test):
(create_option_parser):

Canonical link: <a href="https://commits.webkit.org/315961@main">https://commits.webkit.org/315961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1474c5a6f05ce300ce68957e49509fc59cd21160

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133018 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34825 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28627 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145286 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182530 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141476 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44150 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141293 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44839 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109373 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36559 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43349 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7942 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42885 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->