### PR TITLE
DeleteSelectionCommand leaves an empty trailing table row behind after deletion

### DIFF
--- a/LayoutTests/editing/deleting/delete-empty-end-table-row-expected.txt
+++ b/LayoutTests/editing/deleting/delete-empty-end-table-row-expected.txt
@@ -1,0 +1,5 @@
+Tests that deleting a selection running from inside a table row through a trailing empty row removes the now-fully-selected empty row. This is a regression test for a typo (introduced in 295798@main) that made DeleteSelectionCommand compare the end row against itself (using m_startTableRow in place of m_endTableRow), leaving the empty trailing row behind. The test passes if the table ends up with a single row containing "A".
+
+A
+PASS: empty trailing table row is removed (row count is 1, was 2)
+PASS: the surviving row keeps its remaining text "A"

--- a/LayoutTests/editing/deleting/delete-empty-end-table-row.html
+++ b/LayoutTests/editing/deleting/delete-empty-end-table-row.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that deleting a selection running from inside a table row through a
+trailing empty row removes the now-fully-selected empty row. This is a
+regression test for a typo (introduced in 295798@main) that made
+DeleteSelectionCommand compare the end row against itself (using m_startTableRow
+in place of m_endTableRow), leaving the empty trailing row behind. The test
+passes if the table ends up with a single row containing "A".</p>
+<div id="edit" contenteditable="true">
+<table id="table" border="1"><tbody>
+<tr><td id="start">AAA</td></tr>
+<tr><td id="end"><br></td></tr>
+</tbody></table>
+</div>
+<pre id="result"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+var table = document.getElementById("table");
+var start = document.getElementById("start").firstChild;
+var end = document.getElementById("end");
+
+// Select from the middle of the first row through the empty trailing row.
+window.getSelection().setBaseAndExtent(start, 1, end, 0);
+document.execCommand("Delete");
+
+var rowCount = table.rows.length;
+var firstCellText = table.rows.length ? table.rows[0].textContent : "";
+
+var lines = [];
+function check(description, condition) {
+    lines.push((condition ? "PASS" : "FAIL") + ": " + description);
+}
+
+check("empty trailing table row is removed (row count is 1, was 2)", rowCount === 1);
+check("the surviving row keeps its remaining text \"A\"", firstCellText === "A");
+
+document.getElementById("result").textContent = lines.join("\n");
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -894,7 +894,7 @@ void DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows()
         }
     }
 
-    RefPtr endTableRow = m_startTableRow;
+    RefPtr endTableRow = m_endTableRow;
     if (endTableRow && endTableRow->isConnected() && endTableRow != m_startTableRow) {
         if (isTableRowEmpty(*endTableRow)) {
             // Don't remove m_endTableRow if it's where we're putting the ending selection.


### PR DESCRIPTION
#### 105fc9b52b9ae74666096a6289b9717abde65177
<pre>
DeleteSelectionCommand leaves an empty trailing table row behind after deletion
<a href="https://bugs.webkit.org/show_bug.cgi?id=318002">https://bugs.webkit.org/show_bug.cgi?id=318002</a>

Reviewed by Anne van Kesteren and Darin Adler.

DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows() has a final
block whose job is to remove the *end* table row itself when the deleted
selection left it empty (and the caret is not landing inside it). The block was
guarded by `endTableRow != m_startTableRow`, but a refactoring typo initialized
the local `endTableRow` from `m_startTableRow` instead of `m_endTableRow`. That
made the guard always false, so the block became dead code and an empty trailing
row was never removed.

This regressed in 295798@main (&quot;Reduce incorrect usage of protectedX() in dom
and editing&quot;), which mechanically rewrote:
```
      auto endTableRow = protectedEndTableRow();   // returned m_endTableRow
```
into:
```
      RefPtr endTableRow = m_startTableRow;         // wrong member
```
silently substituting the start row for the end row.

Fix the local to be initialized from m_endTableRow, restoring the intended
behavior. Note this is only observable when the end row is already empty and
falls inside the selection (e.g. a trailing empty row), because table-spanning
deletes preserve the content of the boundary rows.

Test: editing/deleting/delete-empty-end-table-row.html

* LayoutTests/editing/deleting/delete-empty-end-table-row-expected.txt: Added.
* LayoutTests/editing/deleting/delete-empty-end-table-row.html: Added.
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows):

Canonical link: <a href="https://commits.webkit.org/315990@main">https://commits.webkit.org/315990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a7512788030bfab7a0708ce7607eed316ffa9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128285 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/499828f2-a65b-47b3-9fb2-ffd334021baa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133020 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93811 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40896775-9079-428c-b338-3992afc5656b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113517 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73b1779c-bf57-406b-a40a-66d0cd23ece4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28630 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182533 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141478 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141295 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38071 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44842 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36561 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116731 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43352 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7945 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42888 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->