### PR TITLE
FileReader.readAsText() ignores the charset parameter of the Blob's type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS readAsText() uses the charset parameter of the Blob's type (windows-1252)
+PASS readAsText() decodes a windows-1252 Blob body using the type's charset
+PASS readAsText() encoding argument overrides the Blob type's charset
+

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.js
@@ -1,0 +1,51 @@
+// META: title=FileAPI Test: readAsText uses the Blob type's charset when no encoding argument is given
+
+// Per the File API "read as text" algorithm, the encoding is determined in this
+// order: (1) the explicit `encoding` argument if it is a supported encoding;
+// (2) otherwise, if the blob's `type` has a `charset` parameter, that charset;
+// (3) otherwise UTF-8. These tests exercise step (2) with BOM-free data so that
+// the charset parameter is the only thing that can select the right decoder
+// (i.e. they are not accidentally satisfied by BOM sniffing).
+
+async_test(function() {
+    // 0x80 is the Euro sign (U+20AC) in windows-1252. As UTF-8 it is a lone
+    // continuation byte and decodes to U+FFFD.
+    var blob = new Blob([new Uint8Array([0x80])], { type: "text/plain;charset=windows-1252" });
+    var reader = new FileReader();
+
+    reader.onloadend = this.step_func_done(function() {
+        assert_equals(reader.result, "€",
+            "readAsText should honor the windows-1252 charset from the Blob type and decode 0x80 as U+20AC, not UTF-8 U+FFFD.");
+    });
+
+    reader.readAsText(blob);
+}, "readAsText() uses the charset parameter of the Blob's type (windows-1252)");
+
+async_test(function() {
+    // "héllo" in windows-1252: 0xE9 is 'é'. As UTF-8, the lone 0xE9 is an
+    // invalid lead byte and decodes to U+FFFD.
+    var blob = new Blob([new Uint8Array([0x68, 0xE9, 0x6C, 0x6C, 0x6F])], { type: "text/plain;charset=windows-1252" });
+    var reader = new FileReader();
+
+    reader.onloadend = this.step_func_done(function() {
+        assert_equals(reader.result, "héllo",
+            "readAsText should decode the body using the windows-1252 charset declared in the Blob type.");
+    });
+
+    reader.readAsText(blob);
+}, "readAsText() decodes a windows-1252 Blob body using the type's charset");
+
+async_test(function() {
+    // An explicit encoding argument must still win over the Blob type charset
+    // (step 1 of the algorithm). This already works in WebKit and guards against
+    // a fix that over-corrects by always preferring the type charset.
+    var blob = new Blob([new Uint8Array([0x80])], { type: "text/plain;charset=UTF-8" });
+    var reader = new FileReader();
+
+    reader.onloadend = this.step_func_done(function() {
+        assert_equals(reader.result, "€",
+            "An explicit encoding argument takes precedence over the Blob type's charset.");
+    });
+
+    reader.readAsText(blob, "windows-1252");
+}, "readAsText() encoding argument overrides the Blob type's charset");

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+PASS readAsText() uses the charset parameter of the Blob's type (windows-1252)
+PASS readAsText() decodes a windows-1252 Blob body using the type's charset
+PASS readAsText() encoding argument overrides the Blob type's charset
+

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -38,6 +38,7 @@
 #include "ExceptionCode.h"
 #include "FileReaderLoaderClient.h"
 #include "HTTPHeaderNames.h"
+#include "HTTPParsers.h"
 #include "HTTPStatusCodes.h"
 #include "ResourceError.h"
 #include "ResourceRequest.h"
@@ -362,12 +363,19 @@ void FileReaderLoader::convertToText()
         return;
 
     // Decode the data.
-    // The File API spec says that we should use the supplied encoding if it is valid. However, we choose to ignore this
-    // requirement in order to be consistent with how WebKit decodes the web content: always has the BOM override the
-    // provided encoding.     
+    // Per the File API "read as text" algorithm, the encoding is determined in order: the explicit
+    // encoding argument if it is a supported encoding; otherwise the charset parameter of the Blob's
+    // type, if any; otherwise UTF-8.
+    // We intentionally deviate from the spec in one respect, for consistency with how WebKit decodes
+    // web content: a BOM in the data always overrides the selected encoding (handled by
+    // TextResourceDecoder), whereas the spec gives precedence to the explicitly supplied encoding.
     // FIXME: consider supporting incremental decoding to improve the perf.
-    if (!m_decoder)
-        m_decoder = TextResourceDecoder::create("text/plain"_s, m_encoding.isValid() ? m_encoding : PAL::UTF8Encoding());
+    if (!m_decoder) {
+        auto encoding = m_encoding;
+        if (!encoding.isValid())
+            encoding = extractCharsetFromMediaType(m_dataType);
+        m_decoder = TextResourceDecoder::create("text/plain"_s, encoding.isValid() ? encoding : PAL::UTF8Encoding());
+    }
     Ref decoder = *m_decoder;
     Ref rawData = *m_rawData;
     if (isCompleted())

--- a/Source/WebCore/fileapi/FileReaderSync.cpp
+++ b/Source/WebCore/fileapi/FileReaderSync.cpp
@@ -61,6 +61,7 @@ ExceptionOr<String> FileReaderSync::readAsText(ScriptExecutionContext& scriptExe
 {
     Ref loader = FileReaderLoader::create(FileReaderLoader::ReadAsText, nullptr);
     loader->setEncoding(encoding);
+    loader->setDataType(blob.type());
     return startLoadingString(scriptExecutionContext, loader, blob);
 }
 


### PR DESCRIPTION
#### 90c69edf1c0ebeef9a60ead6ad3e6cae9a19577a
<pre>
FileReader.readAsText() ignores the charset parameter of the Blob&apos;s type
<a href="https://bugs.webkit.org/show_bug.cgi?id=318003">https://bugs.webkit.org/show_bug.cgi?id=318003</a>

Reviewed by Anne van Kesteren and Darin Adler.

Per the File API &quot;read as text&quot; algorithm, the text encoding is determined in
the following order of precedence:
  1. the explicit `encoding` argument, if it is a supported encoding;
  2. otherwise, the `charset` parameter of the Blob&apos;s `type`, if present;
  3. otherwise, UTF-8.
See the &quot;package data&quot; steps (Text case) in the specification:
<a href="https://w3c.github.io/FileAPI/#blob-package-data">https://w3c.github.io/FileAPI/#blob-package-data</a>

WebKit implemented steps (1) and (3) but skipped (2): convertToText() hard-coded
&quot;text/plain&quot; and only chose between the explicit encoding argument and UTF-8,
never consulting the Blob&apos;s type. As a result, reading a Blob whose type carries
a non-UTF-8 charset (e.g. `new Blob([bytes], { type: &quot;text/plain;charset=windows-1252&quot; })`)
with `FileReader.readAsText(blob)` (no encoding argument) decoded the data as
UTF-8 instead of windows-1252, producing incorrect characters (U+FFFD).

This is a spec-conformance and interoperability bug: Firefox correctly honors the
Blob type&apos;s charset, while WebKit and Chrome (which share the same FileReaderLoader
heritage) both ignored it. This change brings WebKit in line with the specification
and with Firefox. BOM detection continues to override the selected encoding, and an
explicit encoding argument still takes precedence over the Blob type&apos;s charset.

FileReaderSync::readAsText() additionally never forwarded the Blob&apos;s type to the
loader, so the synchronous reader could not honor the charset either; it now sets
the data type to match the asynchronous FileReader path.

Note that Blob.text() is unaffected and remains UTF-8-only as required by its own
specification: it loads via BlobLoader, which never sets the loader&apos;s data type, so
the charset fallback resolves to UTF-8.

Test: imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.js

* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::convertToText): Fall back to the charset parameter of
the Blob&apos;s type (m_dataType) when no valid explicit encoding was supplied, before
defaulting to UTF-8.

* Source/WebCore/fileapi/FileReaderSync.cpp:
(WebCore::FileReaderSync::readAsText): Forward the Blob&apos;s type to the loader so the
synchronous reader applies the same encoding-determination rules.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsText_blob_type_charset.any.worker-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/315996@main">https://commits.webkit.org/315996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09914947643d917227f6e1ff2365c1417af66d29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128405 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f7f6c48-dbc7-4c0f-ac74-3418262c1a91) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133118 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec615128-19cb-4992-9df4-ad236954dc7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153566 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113615 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dee43f46-b20c-4354-a29c-b1e6238ee1e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34940 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33271 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28750 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182653 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141579 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44273 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153027 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38076 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44962 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29946 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109609 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36664 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116851 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43472 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8048 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42877 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43118 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43008 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->