### PR TITLE
Missing iOS touchstart when a new touch begins in the same UIKit batch as another touch ends or cancels

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -243,6 +243,37 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
     return defaultRollAngle;
 }
 
+static bool isBeganTouchPhase(UITouchPhase phase)
+{
+    return phase == UITouchPhaseBegan || phase == UITouchPhaseRegionEntered;
+}
+
+// UIKit can report one touch set where some touches just began while other touches
+// already moved, ended, or cancelled. Keep the existing rule that the final expected
+// event is dispatched once, but first split out a touchstart by preserving only the
+// began-like touches as changed. The final dispatch then suppresses those began-like
+// touches to stationary so they remain active without firing a duplicate touchstart.
+enum class TouchPhaseAdjustment : uint8_t {
+    None,
+    PreserveBeganTouchesOnly,
+    SuppressBeganTouches,
+};
+
+static UITouchPhase adjustedTouchPhase(UITouchPhase phase, TouchPhaseAdjustment adjustment)
+{
+    switch (adjustment) {
+    case TouchPhaseAdjustment::None:
+        return phase;
+    case TouchPhaseAdjustment::PreserveBeganTouchesOnly:
+        return isBeganTouchPhase(phase) ? phase : UITouchPhaseStationary;
+    case TouchPhaseAdjustment::SuppressBeganTouches:
+        return isBeganTouchPhase(phase) ? UITouchPhaseStationary : phase;
+    }
+    return phase;
+}
+
+static NSTimeInterval representativeTimestampForTouches(NSSet<UITouch *> *, WebKit::WKTouchEventType, TouchPhaseAdjustment);
+
 - (WebKit::WKTouchEvent)_touchEventForChildTouch:(UITouch *)touch withParent:(const WebKit::WKTouchPoint&)parentTouchPoint
 {
     auto locationInWindow = [touch locationInView:nil];
@@ -281,7 +312,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
     return event;
 }
 
-- (void)_recordTouches:(NSSet<UITouch *> *)touches ofType:(WebKit::WKTouchEventType)type forEvent:(UIEvent *)event
+- (void)_recordTouches:(NSSet<UITouch *> *)touches ofType:(WebKit::WKTouchEventType)type forEvent:(UIEvent *)event phaseAdjustment:(TouchPhaseAdjustment)phaseAdjustment
 {
     _lastTouchEvent.type = type;
     _lastTouchEvent.inJavaScriptGesture = false;
@@ -301,7 +332,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
     if (_lastTouchEvent.touchPoints.size() != touchCount)
         _lastTouchEvent.touchPoints.resize(touchCount);
 
-    _lastTouchEvent.timestamp = touches.anyObject.timestamp;
+    _lastTouchEvent.timestamp = representativeTimestampForTouches(touches, type, phaseAdjustment);
 
     _lastTouchEvent.coalescedEvents = { };
     _lastTouchEvent.predictedEvents = { };
@@ -312,6 +343,8 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
     [_activeTouchesByIdentifier removeAllObjects];
 
     for (UITouch *touch in touches) {
+        auto touchPhase = adjustedTouchPhase(touch.phase, phaseAdjustment);
+
         // Get the identifier of this touch. Or create one if one did not exist.
         RetainPtr associatedIdentifier = dynamic_objc_cast<NSNumber>(objc_getAssociatedObject(touch, &associatedTouchIdentifierKey));
 
@@ -319,7 +352,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
         // instance persists between trackpad clicks, and there is existing web content that does not expect subsequent
         // clicks to have the same touch identifier (62895732).
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-        if (touch._isPointerTouch && type == WebKit::WKTouchEventType::Begin)
+        if (touch._isPointerTouch && touchPhase == UITouchPhaseBegan)
             associatedIdentifier = nil;
 #endif
 
@@ -340,7 +373,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
         touchPoint.previousLocationInRootViewCoordinates = previousLocationInRootView;
         touchPoint.locationInViewport = mapRootViewToViewport(locationInRootView, contentView.get());
         touchPoint.identifier = [associatedIdentifier unsignedIntValue];
-        touchPoint.phase = touch.phase;
+        touchPoint.phase = touchPhase;
         touchPoint.majorRadiusInWindowCoordinates = touch.majorRadius;
         touchPoint.twist = defaultRollAngle;
 
@@ -371,7 +404,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
 
         ++touchIndex;
 
-        if ((touchPoint.phase == UITouchPhaseEnded) || (touchPoint.phase == UITouchPhaseCancelled)) {
+        if ((touchPhase == UITouchPhaseEnded) || (touchPhase == UITouchPhaseCancelled)) {
             releasedTouchCentroidInWindowCoordinates.x += locationInWindow.x;
             releasedTouchCentroidInWindowCoordinates.y += locationInWindow.y;
             releasedTouchCentroidInRootViewCoordinates.x += locationInRootView.x;
@@ -453,6 +486,27 @@ static WebKit::WKTouchEventType eventTypeForTouchPhase(UITouchPhase phase)
     return WebKit::WKTouchEventType::Change;
 }
 
+static NSTimeInterval representativeTimestampForTouches(NSSet<UITouch *> *touches, WebKit::WKTouchEventType type, TouchPhaseAdjustment phaseAdjustment)
+{
+    switch (phaseAdjustment) {
+    case TouchPhaseAdjustment::PreserveBeganTouchesOnly:
+        for (UITouch *touch in touches) {
+            if (isBeganTouchPhase(touch.phase))
+                return touch.timestamp;
+        }
+        break;
+    case TouchPhaseAdjustment::SuppressBeganTouches:
+        for (UITouch *touch in touches) {
+            if (!isBeganTouchPhase(touch.phase) && eventTypeForTouchPhase(touch.phase) == type)
+                return touch.timestamp;
+        }
+        break;
+    case TouchPhaseAdjustment::None:
+        break;
+    }
+    return touches.anyObject.timestamp;
+}
+
 static WebKit::WKTouchEventType lastExpectedWKEventTypeForTouches(NSSet *touches)
 {
     auto lastPhase = UITouchPhaseBegan;
@@ -461,6 +515,18 @@ static WebKit::WKTouchEventType lastExpectedWKEventTypeForTouches(NSSet *touches
             lastPhase = std::max(lastPhase, touch.phase);
     }
     return eventTypeForTouchPhase(lastPhase);
+}
+
+static bool shouldDispatchBeganTouchesBeforeExpectedEvent(NSSet *touches, WebKit::WKTouchEventType expectedType)
+{
+    if (expectedType == WebKit::WKTouchEventType::Begin)
+        return false;
+
+    for (UITouch *touch in touches) {
+        if (isBeganTouchPhase(touch.phase))
+            return true;
+    }
+    return false;
 }
 
 - (void)performAction
@@ -477,19 +543,9 @@ static WebKit::WKTouchEventType lastExpectedWKEventTypeForTouches(NSSet *touches
     return NO;
 }
 
-- (void)_processTouches:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event type:(WebKit::WKTouchEventType)type
+- (void)_dispatchTouches:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event type:(WebKit::WKTouchEventType)type phaseAdjustment:(TouchPhaseAdjustment)phaseAdjustment
 {
-    // WebCore expects only one event for each distinct set of touches. Gesture recognizer will call
-    // all applicable touchesBegan:, touchesMoved: and so on. If two things happen simultaneously, like this:
-    //     WebKit::WKTouchEventType::Change (UITouchPhaseMoved, UITouchPhaseEnded)
-    //     WebKit::WKTouchEventType::End    (UITouchPhaseMoved, UITouchPhaseEnded)
-    // we should only process and send the last of those into WebCore. Note touches is actually the set returned
-    // by [event touchesForGestureRecognizer:self], not the set of touches passed in to touchesBegan:withEvent:.
-    // See <rdar://8398098> for more detail.
-    if (lastExpectedWKEventTypeForTouches(touches) != type)
-        return;
-
-    [self _recordTouches:touches ofType:type forEvent:event];
+    [self _recordTouches:touches ofType:type forEvent:event phaseAdjustment:phaseAdjustment];
 
     [self performAction];
 
@@ -518,6 +574,30 @@ static WebKit::WKTouchEventType lastExpectedWKEventTypeForTouches(NSSet *touches
         self.state = UIGestureRecognizerStateEnded;
     else if (type == WebKit::WKTouchEventType::Cancel)
         self.state = UIGestureRecognizerStateCancelled;
+}
+
+- (void)_processTouches:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event type:(WebKit::WKTouchEventType)type
+{
+    auto expectedType = lastExpectedWKEventTypeForTouches(touches);
+    bool shouldDispatchBeganTouches = shouldDispatchBeganTouchesBeforeExpectedEvent(touches, expectedType);
+
+    // WebCore expects only one event for each distinct set of touches. Gesture recognizer will call
+    // all applicable touchesBegan:, touchesMoved: and so on. If two things happen simultaneously, like this:
+    //     WebKit::WKTouchEventType::Change (UITouchPhaseMoved, UITouchPhaseEnded)
+    //     WebKit::WKTouchEventType::End    (UITouchPhaseMoved, UITouchPhaseEnded)
+    // we should only process and send the last of those into WebCore. Note touches is actually the set returned
+    // by [event touchesForGestureRecognizer:self], not the set of touches passed in to touchesBegan:withEvent:.
+    // See <rdar://8398098> for more detail.
+    if (expectedType != type && !(type == WebKit::WKTouchEventType::Begin && shouldDispatchBeganTouches))
+        return;
+
+    if (type == WebKit::WKTouchEventType::Begin && shouldDispatchBeganTouches) {
+        [self _dispatchTouches:touches withEvent:event type:type phaseAdjustment:TouchPhaseAdjustment::PreserveBeganTouchesOnly];
+        return;
+    }
+
+    auto phaseAdjustment = expectedType == type && shouldDispatchBeganTouches ? TouchPhaseAdjustment::SuppressBeganTouches : TouchPhaseAdjustment::None;
+    [self _dispatchTouches:touches withEvent:event type:type phaseAdjustment:phaseAdjustment];
 }
 
 - (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TouchEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TouchEventTests.mm
@@ -27,17 +27,136 @@
 
 #if ENABLE(IOS_TOUCH_EVENTS)
 
-#import "InstanceMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestScriptMessageHandler.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "InstanceMethodSwizzler.h"
 #import "UIKitSPIForTesting.h"
 #import "WKTouchEventsGestureRecognizer.h"
+#import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 
 @interface UIView (WKContentView)
 - (void)_touchEventsRecognized;
+@end
+
+@interface WKTouchEventTestTouch : UITouch
+- (instancetype)initWithView:(UIView *)view location:(CGPoint)location;
+- (void)setPhase:(UITouchPhase)phase;
+@end
+
+@implementation WKTouchEventTestTouch {
+    WeakObjCPtr<UIView> _view;
+    CGPoint _location;
+    UITouchPhase _phase;
+}
+
+- (instancetype)initWithView:(UIView *)view location:(CGPoint)location
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    _view = view;
+    _location = location;
+    _phase = UITouchPhaseBegan;
+    return self;
+}
+
+- (UIView *)view
+{
+    return _view.getAutoreleased();
+}
+
+- (NSArray<UIGestureRecognizer *> *)gestureRecognizers
+{
+    return @[];
+}
+
+- (CGPoint)locationInView:(UIView *)view
+{
+    return _location;
+}
+
+- (CGPoint)previousLocationInView:(UIView *)view
+{
+    return _location;
+}
+
+- (void)setPhase:(UITouchPhase)phase
+{
+    _phase = phase;
+}
+
+- (UITouchPhase)phase
+{
+    return _phase;
+}
+
+- (NSTimeInterval)timestamp
+{
+    return MonotonicTime::now().secondsSinceEpoch().value();
+}
+
+- (CGFloat)majorRadius
+{
+    return 1;
+}
+
+- (CGFloat)force
+{
+    return 0;
+}
+
+- (CGFloat)maximumPossibleForce
+{
+    return 1;
+}
+
+- (UITouchType)type
+{
+    return UITouchTypeDirect;
+}
+
+- (BOOL)_isPointerTouch
+{
+    return NO;
+}
+
+@end
+
+@interface WKTouchEventTestUIEvent : UIEvent
+- (void)setActiveTouches:(NSArray<UITouch *> *)touches;
+@end
+
+@implementation WKTouchEventTestUIEvent {
+    RetainPtr<NSSet<UITouch *>> _activeTouches;
+}
+
+- (void)setActiveTouches:(NSArray<UITouch *> *)touches
+{
+    _activeTouches = [NSSet setWithArray:touches];
+}
+
+- (NSSet<UITouch *> *)touchesForGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+{
+    return _activeTouches.get();
+}
+
+- (NSArray<UITouch *> *)coalescedTouchesForTouch:(UITouch *)touch
+{
+    return @[];
+}
+
+- (NSArray<UITouch *> *)predictedTouchesForTouch:(UITouch *)touch
+{
+    return @[];
+}
+
 @end
 
 static WKWebView *globalWebView = nil;
@@ -125,6 +244,88 @@ static const WebKit::WKTouchEvent* simulatedTouchEvent(id, SEL)
     return &globalTouchEvent;
 }
 
+static WKTouchEventsGestureRecognizer *touchEventsGestureRecognizerForWebView(WKWebView *webView)
+{
+    Class touchEventsGestureRecognizerClass = touchEventsGestureRecognizerClassSingleton();
+    for (UIGestureRecognizer *gestureRecognizer in webView.textInputContentView.gestureRecognizers) {
+        if ([gestureRecognizer isKindOfClass:touchEventsGestureRecognizerClass])
+            return static_cast<WKTouchEventsGestureRecognizer *>(gestureRecognizer);
+    }
+    return nil;
+}
+
+static NSArray<NSString *> *touchMessageFields(NSString *message)
+{
+    return [message componentsSeparatedByString:@":"];
+}
+
+static NSString *touchMessageType(NSString *message)
+{
+    return touchMessageFields(message)[0];
+}
+
+static NSString *touchMessageTouches(NSString *message)
+{
+    return touchMessageFields(message)[1];
+}
+
+static NSString *touchMessageTargetTouches(NSString *message)
+{
+    return touchMessageFields(message)[2];
+}
+
+static NSString *touchMessageChangedTouches(NSString *message)
+{
+    return touchMessageFields(message)[3];
+}
+
+static NSInteger onlyTouchIdentifier(NSString *identifiers)
+{
+    EXPECT_FALSE([identifiers containsString:@","]);
+    return identifiers.integerValue;
+}
+
+static void expectTouchMessage(NSString *message, const char* type, NSString *touches, NSString *targetTouches, NSString *changedTouches)
+{
+    EXPECT_WK_STREQ(type, touchMessageType(message));
+    EXPECT_WK_STREQ(touches, touchMessageTouches(message));
+    EXPECT_WK_STREQ(targetTouches, touchMessageTargetTouches(message));
+    EXPECT_WK_STREQ(changedTouches, touchMessageChangedTouches(message));
+}
+
+static RetainPtr<TestWKWebView> createTouchLoggingWebView(RetainPtr<TestScriptMessageHandler>& messageHandler)
+{
+    messageHandler = adoptNS([TestScriptMessageHandler new]);
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:@"<!DOCTYPE html>"
+        @"<html><meta name='viewport' content='width=device-width, initial-scale=1, user-scalable=no'>"
+        @"<body style='margin: 0'><div id='target' style='width: 100vw; height: 100vh'></div>"
+        @"<script>"
+        @"let target = document.getElementById('target');"
+        @"target.addEventListener('touchstart', logTouch);"
+        @"target.addEventListener('touchmove', logTouch);"
+        @"target.addEventListener('touchend', logTouch);"
+        @"target.addEventListener('touchcancel', logTouch);"
+        @"function identifiers(touches) {"
+        @"  return Array.from(touches).map(t => t.identifier).sort((a, b) => a - b).join(',');"
+        @"}"
+        @"function logTouch(event) {"
+        @"  event.preventDefault();"
+        @"  webkit.messageHandlers.testHandler.postMessage(`${event.type}:${identifiers(event.touches)}:${identifiers(event.targetTouches)}:${identifiers(event.changedTouches)}`);"
+        @"}"
+        @"</script></body></html>"];
+    return webView;
+}
+
+static NSString *waitForTouchMessage(TestScriptMessageHandler *messageHandler)
+{
+    return dynamic_objc_cast<NSString>([messageHandler waitForMessage].body);
+}
+
 TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)
 {
     InstanceMethodSwizzler lastTouchEventSwizzler { touchEventsGestureRecognizerClassSingleton(), @selector(lastTouchEvent), reinterpret_cast<IMP>(simulatedTouchEvent) };
@@ -156,6 +357,102 @@ TEST(TouchEventTests, DestroyWebViewWhileHandlingTouchEnd)
         done = true;
     });
     TestWebKitAPI::Util::run(&done);
+}
+
+static void runTouchStartWithConcurrentFinishedTouchTest(UITouchPhase finishedPhase, const char* expectedFinishedEventType)
+{
+    RetainPtr<TestScriptMessageHandler> messageHandler;
+    auto webView = createTouchLoggingWebView(messageHandler);
+    RetainPtr contentView = [webView textInputContentView];
+    RetainPtr recognizer = touchEventsGestureRecognizerForWebView(webView.get());
+    ASSERT_TRUE(recognizer);
+
+    RetainPtr event = adoptNS([WKTouchEventTestUIEvent new]);
+    RetainPtr oldTouch = adoptNS([[WKTouchEventTestTouch alloc] initWithView:contentView.get() location:CGPointMake(80, 100)]);
+    RetainPtr newTouch = adoptNS([[WKTouchEventTestTouch alloc] initWithView:contentView.get() location:CGPointMake(180, 100)]);
+
+    [event setActiveTouches:@[ oldTouch.get() ]];
+    [recognizer touchesBegan:[NSSet setWithObject:oldTouch.get()] withEvent:event.get()];
+    RetainPtr firstStart = waitForTouchMessage(messageHandler.get());
+    EXPECT_WK_STREQ("touchstart", touchMessageType(firstStart.get()));
+    auto oldIdentifier = onlyTouchIdentifier(touchMessageChangedTouches(firstStart.get()));
+    auto oldIdentifierString = [NSString stringWithFormat:@"%ld", static_cast<long>(oldIdentifier)];
+    expectTouchMessage(firstStart.get(), "touchstart", oldIdentifierString, oldIdentifierString, oldIdentifierString);
+
+    [oldTouch setPhase:finishedPhase];
+    [newTouch setPhase:UITouchPhaseBegan];
+    [event setActiveTouches:@[ oldTouch.get(), newTouch.get() ]];
+    [recognizer touchesBegan:[NSSet setWithObject:newTouch.get()] withEvent:event.get()];
+    RetainPtr secondStart = waitForTouchMessage(messageHandler.get());
+    EXPECT_WK_STREQ("touchstart", touchMessageType(secondStart.get()));
+    auto newIdentifier = onlyTouchIdentifier(touchMessageChangedTouches(secondStart.get()));
+    EXPECT_NE(oldIdentifier, newIdentifier);
+    auto newIdentifierString = [NSString stringWithFormat:@"%ld", static_cast<long>(newIdentifier)];
+    auto bothIdentifiersString = [NSString stringWithFormat:@"%@,%@", oldIdentifierString, newIdentifierString];
+    expectTouchMessage(secondStart.get(), "touchstart", bothIdentifiersString, bothIdentifiersString, newIdentifierString);
+
+    if (finishedPhase == UITouchPhaseEnded)
+        [recognizer touchesEnded:[NSSet setWithObject:oldTouch.get()] withEvent:event.get()];
+    else
+        [recognizer touchesCancelled:[NSSet setWithObject:oldTouch.get()] withEvent:event.get()];
+    RetainPtr oldFinished = waitForTouchMessage(messageHandler.get());
+    expectTouchMessage(oldFinished.get(), expectedFinishedEventType, newIdentifierString, newIdentifierString, oldIdentifierString);
+
+    [newTouch setPhase:UITouchPhaseEnded];
+    [event setActiveTouches:@[ newTouch.get() ]];
+    [recognizer touchesEnded:[NSSet setWithObject:newTouch.get()] withEvent:event.get()];
+    RetainPtr newEnd = waitForTouchMessage(messageHandler.get());
+    expectTouchMessage(newEnd.get(), "touchend", @"", @"", newIdentifierString);
+}
+
+TEST(TouchEventTests, DispatchesTouchStartWhenTouchBeginsAsAnotherTouchEnds)
+{
+    runTouchStartWithConcurrentFinishedTouchTest(UITouchPhaseEnded, "touchend");
+}
+
+TEST(TouchEventTests, DispatchesTouchStartWhenTouchBeginsAsAnotherTouchCancels)
+{
+    runTouchStartWithConcurrentFinishedTouchTest(UITouchPhaseCancelled, "touchcancel");
+}
+
+TEST(TouchEventTests, CoalescesMovedAndEndedTouchBatchWithoutDuplicateMove)
+{
+    RetainPtr<TestScriptMessageHandler> messageHandler;
+    auto webView = createTouchLoggingWebView(messageHandler);
+    RetainPtr contentView = [webView textInputContentView];
+    RetainPtr recognizer = touchEventsGestureRecognizerForWebView(webView.get());
+    ASSERT_TRUE(recognizer);
+
+    RetainPtr event = adoptNS([WKTouchEventTestUIEvent new]);
+    RetainPtr movingTouch = adoptNS([[WKTouchEventTestTouch alloc] initWithView:contentView.get() location:CGPointMake(80, 100)]);
+    RetainPtr endingTouch = adoptNS([[WKTouchEventTestTouch alloc] initWithView:contentView.get() location:CGPointMake(180, 100)]);
+
+    [event setActiveTouches:@[ movingTouch.get() ]];
+    [recognizer touchesBegan:[NSSet setWithObject:movingTouch.get()] withEvent:event.get()];
+    RetainPtr movingStart = waitForTouchMessage(messageHandler.get());
+    EXPECT_WK_STREQ("touchstart", touchMessageType(movingStart.get()));
+    auto movingIdentifier = onlyTouchIdentifier(touchMessageChangedTouches(movingStart.get()));
+    auto movingIdentifierString = [NSString stringWithFormat:@"%ld", static_cast<long>(movingIdentifier)];
+    expectTouchMessage(movingStart.get(), "touchstart", movingIdentifierString, movingIdentifierString, movingIdentifierString);
+
+    [movingTouch setPhase:UITouchPhaseStationary];
+    [event setActiveTouches:@[ movingTouch.get(), endingTouch.get() ]];
+    [recognizer touchesBegan:[NSSet setWithObject:endingTouch.get()] withEvent:event.get()];
+    RetainPtr endingStart = waitForTouchMessage(messageHandler.get());
+    EXPECT_WK_STREQ("touchstart", touchMessageType(endingStart.get()));
+    auto endingIdentifier = onlyTouchIdentifier(touchMessageChangedTouches(endingStart.get()));
+    EXPECT_NE(movingIdentifier, endingIdentifier);
+    auto endingIdentifierString = [NSString stringWithFormat:@"%ld", static_cast<long>(endingIdentifier)];
+    auto bothIdentifiersString = [NSString stringWithFormat:@"%@,%@", movingIdentifierString, endingIdentifierString];
+    expectTouchMessage(endingStart.get(), "touchstart", bothIdentifiersString, bothIdentifiersString, endingIdentifierString);
+
+    [movingTouch setPhase:UITouchPhaseMoved];
+    [endingTouch setPhase:UITouchPhaseEnded];
+    [recognizer touchesMoved:[NSSet setWithObject:movingTouch.get()] withEvent:event.get()];
+    [recognizer touchesEnded:[NSSet setWithObject:endingTouch.get()] withEvent:event.get()];
+
+    RetainPtr end = waitForTouchMessage(messageHandler.get());
+    expectTouchMessage(end.get(), "touchend", movingIdentifierString, movingIdentifierString, endingIdentifierString);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
Missing iOS touchstart when a new touch begins in the same UIKit batch as another touch ends or cancels
https://bugs.webkit.org/show_bug.cgi?id=318004

Reviewed by NOBODY (OOPS!).

When UIKit reports an active touch set containing a newly began touch and another touch that has already moved, ended, or cancelled, WKTouchEventsGestureRecognizer used the final expected event type for the whole set. This could cause alternating multi-finger input to dispatch the ending or moving event while the newly began touch was only reported as stationary, so web content never received its touchstart.

This is observable in touch-driven web games on iOS, where players often alternate fingers quickly. In that pattern, a new touch can begin in the same UIKit batch where the previous touch ends or cancels; if the new touchstart is dropped, the page sees missed inputs even though UIKit reported the touch.

Split those mixed-phase batches by dispatching a touchstart first with only began-like touches left changed, then dispatch the final expected event with those began-like touches suppressed to stationary. This preserves the existing coalescing behavior for moved/ended batches that do not contain newly began touches.

Tests: TestWebKitAPI.TouchEventTests.DispatchesTouchStartWhenTouchBeginsAsAnotherTouchEnds
       TestWebKitAPI.TouchEventTests.DispatchesTouchStartWhenTouchBeginsAsAnotherTouchCancels
       TestWebKitAPI.TouchEventTests.CoalescesMovedAndEndedTouchBatchWithoutDuplicateMove

* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(isBeganTouchPhase): Added.
(adjustedTouchPhase): Added.
(-[WKTouchEventsGestureRecognizer _recordTouches:ofType:forEvent:phaseAdjustment:]): Added phase adjustment handling.
(representativeTimestampForTouches): Added.
(shouldDispatchBeganTouchesBeforeExpectedEvent): Added.
(-[WKTouchEventsGestureRecognizer _dispatchTouches:withEvent:type:phaseAdjustment:]): Added.
(-[WKTouchEventsGestureRecognizer _processTouches:withEvent:type:]): Split mixed began/finished touch batches.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TouchEventTests.mm:
(WKTouchEventTestTouch): Added.
(WKTouchEventTestUIEvent): Added.
(touchEventsGestureRecognizerForWebView): Added.
(touchMessageFields): Added.
(touchMessageType): Added.
(touchMessageTouches): Added.
(touchMessageTargetTouches): Added.
(touchMessageChangedTouches): Added.
(onlyTouchIdentifier): Added.
(expectTouchMessage): Added.
(createTouchLoggingWebView): Added.
(waitForTouchMessage): Added.
(runTouchStartWithConcurrentFinishedTouchTest): Added.
(TestWebKitAPI::TouchEventTests_DispatchesTouchStartWhenTouchBeginsAsAnotherTouchEnds_Test::TestBody): Added.
(TestWebKitAPI::TouchEventTests_DispatchesTouchStartWhenTouchBeginsAsAnotherTouchCancels_Test::TestBody): Added.
(TestWebKitAPI::TouchEventTests_CoalescesMovedAndEndedTouchBatchWithoutDuplicateMove_Test::TestBody): Added.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b037682c4c527582874e136737faa85c8046bcf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128287 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172440 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133022 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93814 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113519 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182535 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141480 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44155 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141297 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44844 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29845 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109386 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36564 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116733 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43354 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->