### PR TITLE
[JSC] Add fast path for `RegExp#flags` getter

### DIFF
--- a/JSTests/microbenchmarks/regexp-prototype-flags-getter.js
+++ b/JSTests/microbenchmarks/regexp-prototype-flags-getter.js
@@ -1,0 +1,7 @@
+// Test performance of RegExp.prototype.flags getter.
+var regexps = [/[a-z]+\/\d+/gi, /^\s+|\s+$/g, /(\w+)-(\d+)/, /foo[\s\S]*?bar/m];
+var result = 0;
+for (var i = 0; i < 2e6; ++i)
+    result += regexps[i & 3].flags.length;
+if (result !== 2000000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/stress/regexp-flags-getter-fast-path.js
+++ b/JSTests/stress/regexp-flags-getter-fast-path.js
@@ -1,0 +1,106 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+var flagsGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, "flags").get;
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(/a/.flags, "");
+    shouldBe(/a/g.flags, "g");
+    shouldBe(/a/dgimsy.flags, "dgimsy");
+    shouldBe(/a/giu.flags, "giu");
+    shouldBe(/a/v.flags, "v");
+    shouldBe(new RegExp("a", "yusimgd").flags, "dgimsuy");
+    shouldBe(/a/dgimsy.toString(), "/a/dgimsy");
+}
+
+// lastIndex updates do not affect flags.
+var matched = /a/g;
+matched.lastIndex = 42;
+shouldBe(matched.flags, "g");
+matched.exec("aaa");
+shouldBe(matched.flags, "g");
+
+// Frozen regexp.
+shouldBe(Object.freeze(/a/gi).flags, "gi");
+
+// Own data property shadowing a flag accessor.
+var shadowed = /x/g;
+Object.defineProperty(shadowed, "ignoreCase", { value: true });
+shouldBe(shadowed.flags, "gi");
+
+// Own accessor property shadowing a flag accessor.
+var accessorShadowed = /x/;
+Object.defineProperty(accessorShadowed, "sticky", { get() { return true; } });
+shouldBe(accessorShadowed.flags, "y");
+
+// Own "flags" property shadows the prototype getter entirely.
+var flagsShadowed = /x/g;
+Object.defineProperty(flagsShadowed, "flags", { value: "zzz" });
+shouldBe(flagsShadowed.flags, "zzz");
+
+// Unrelated own property does not change the result.
+var extended = /x/g;
+extended.unrelated = 1;
+shouldBe(extended.flags, "g");
+delete extended.unrelated;
+shouldBe(extended.flags, "g");
+
+// Generic object receiver.
+shouldBe(flagsGetter.call({ global: true, sticky: true, unicode: false }), "gy");
+
+shouldBe(RegExp.prototype.flags, "");
+
+// Proxy receiver: every flag read must remain observable, in spec order.
+var getLog = [];
+var proxied = new Proxy({ global: true, unicode: true }, {
+    get(target, key, receiver) {
+        getLog.push(key);
+        return Reflect.get(target, key, receiver);
+    }
+});
+shouldBe(flagsGetter.call(proxied), "gu");
+shouldBe(getLog.join(","), "hasIndices,global,ignoreCase,multiline,dotAll,unicode,unicodeSets,sticky");
+
+// Prototype replaced with null: flag accessors are no longer reachable.
+var protoNull = /a/g;
+Object.setPrototypeOf(protoNull, null);
+shouldBe(flagsGetter.call(protoNull), "");
+
+// Prototype replaced with a plain object providing its own flag properties.
+var protoSwapped = /a/g;
+Object.setPrototypeOf(protoSwapped, { get global() { return false; }, sticky: true });
+shouldBe(flagsGetter.call(protoSwapped), "y");
+
+// Subclasses.
+class PlainSubclass extends RegExp { }
+shouldBe(new PlainSubclass("a", "gi").flags, "gi");
+
+class OverridingSubclass extends RegExp {
+    get global() { return true; }
+}
+shouldBe(new OverridingSubclass("a", "i").flags, "gi");
+
+// Cross-realm regexp uses its own realm's RegExp.prototype.
+var otherRealm = createGlobalObject();
+var otherRegExp = new otherRealm.RegExp("a", "gi");
+shouldBe(otherRegExp.flags, "gi");
+shouldBe(flagsGetter.call(otherRegExp), "gi");
+Object.defineProperty(otherRealm.RegExp.prototype, "global", { get() { return false; }, configurable: true });
+shouldBe(otherRegExp.flags, "i");
+shouldBe(new otherRealm.RegExp("a", "g").flags, "");
+
+// Deleting a flag accessor must be respected (done in a separate realm).
+var deletionRealm = createGlobalObject();
+var deletionRegExp = new deletionRealm.RegExp("a", "gi");
+shouldBe(deletionRegExp.flags, "gi");
+delete deletionRealm.RegExp.prototype.global;
+shouldBe(deletionRegExp.flags, "i");
+
+// Redefining a flag accessor on RegExp.prototype must be respected. Keep this
+// case last since it invalidates the fast path for the rest of the test.
+Object.defineProperty(RegExp.prototype, "multiline", { get() { return false; }, configurable: true });
+shouldBe(/a/m.flags, "");
+shouldBe(/a/dgimsy.flags, "dgisy");
+shouldBe(/a/giu.flags, "giu");

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -374,6 +374,30 @@ static inline Yarr::FlagsString flagsString(JSGlobalObject* globalObject, JSObje
     return Yarr::flagsString(flags);
 }
 
+static ALWAYS_INLINE bool regExpFlagsWatchpointIsValid(VM& vm, RegExpObject* regExpObject)
+{
+    JSGlobalObject* globalObject = regExpObject->realmMayBeNull();
+    if (!globalObject)
+        return false;
+
+    if (globalObject->regExpPrototype() != regExpObject->getPrototypeDirect())
+        return false;
+
+    if (globalObject->regExpPrimordialPropertiesWatchpointSet().state() != IsWatched)
+        return false;
+
+    if (!regExpObject->hasCustomProperties())
+        return true;
+
+#define JSC_CHECK_REGEXP_FLAG_PROPERTY(key, name, lowerCaseName, index) \
+    if (regExpObject->getDirectOffset(vm, vm.propertyNames->lowerCaseName) != invalidOffset) \
+        return false;
+    JSC_REGEXP_FLAGS(JSC_CHECK_REGEXP_FLAG_PROPERTY)
+#undef JSC_CHECK_REGEXP_FLAG_PROPERTY
+
+    return true;
+}
+
 JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncToString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -544,6 +568,9 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterFlags, (JSGlobalObject* globalObject, 
 
     if (!thisValue.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "The RegExp.prototype.flags getter can only be called on an object"_s);
+
+    if (auto* regExpObject = dynamicDowncast<RegExpObject>(thisValue); regExpObject && regExpFlagsWatchpointIsValid(vm, regExpObject)) [[likely]]
+        return JSValue::encode(jsString(vm, String::fromLatin1(Yarr::flagsString(regExpObject->regExp()->flags()).data())));
 
     auto flags = flagsString(globalObject, asObject(thisValue));
     RETURN_IF_EXCEPTION(scope, encodedJSValue());


### PR DESCRIPTION
#### cab8cdc40a6f3ab6e3943053356f3cd21a2d9e81
<pre>
[JSC] Add fast path for `RegExp#flags` getter
<a href="https://bugs.webkit.org/show_bug.cgi?id=318008">https://bugs.webkit.org/show_bug.cgi?id=318008</a>

Reviewed by Yusuke Suzuki.

Every read of RegExp.prototype.flags performs eight generic property gets on the
receiver, each landing in a host getter on RegExp.prototype, even when nothing is
overridden.

Add a fast path that builds the flags string directly from the RegExp&apos;s flag bits
when the receiver is an unmodified RegExpObject covered by
regExpPrimordialPropertiesWatchpointSet.

                                        Baseline                  Patched

regexp-prototype-flags-getter      328.2361+-8.0599     ^     32.6714+-0.8326        ^ definitely 10.0466x faster

Tests: JSTests/microbenchmarks/regexp-prototype-flags-getter.js
       JSTests/stress/regexp-flags-getter-fast-path.js

* JSTests/microbenchmarks/regexp-prototype-flags-getter.js: Added.
* JSTests/stress/regexp-flags-getter-fast-path.js: Added.
(shouldBe):
(get global):
(PlainSubclass):
(OverridingSubclass.prototype.get global):
(OverridingSubclass):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpFlagsWatchpointIsValid):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/316106@main">https://commits.webkit.org/316106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eae5ca7fcd6a3b5064da2becbd7de1d39bdaf0f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133025 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93817 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33174 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28635 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1878 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182538 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31832 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141483 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44158 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141300 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38179 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44847 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29848 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109389 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36567 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116736 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203256 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43357 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7953 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54426 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42762 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->