### PR TITLE
Fallback font chosen over NotoColorEmoji when U+FE0F emoji variation selector is present

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4891,7 +4891,6 @@ imported/w3c/web-platform-tests/css/css-fonts/font-palette-23b.html [ ImageOnlyF
 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-metrics-override.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-synthesis-position-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-position-04.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-position-05.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -53,6 +53,7 @@
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/CharacterProperties.h>
 #include <wtf/text/TextStream.h>
+#include <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(OPENTYPE_VERTICAL)
 #include "OpenTypeVerticalData.h"
@@ -646,14 +647,28 @@ bool Font::canRenderCombiningCharacterSequence(StringView stringView) const
         ++it;
 
         if (it != end && isVariationSelector(*it)) {
-            if (!platformSupportsCodePoint(codePoint, *it)) {
-                // Try the characters individually.
-                if (!supportsCodePoint(codePoint) || !supportsCodePoint(*it))
+            auto variationSelector = *it;
+            // platformSupportsCodePoint(base, selector) is authoritative when true (e.g. a format 14 cmap entry).
+            if (!platformSupportsCodePoint(codePoint, variationSelector)) {
+                // The selector isn't rendered itself, so don't require a standalone glyph for it (emoji fonts list
+                // U+FE0F only in their format 14 cmap); requiring one wrongly rejects them. The base is enough.
+                if (!supportsCodePoint(codePoint))
+                    return false;
+                // But still honor the requested presentation: VS16 needs a color font, VS15 a text font. Test
+                // font-level color capability, not the base glyph, so substitution-built emoji (keycaps) survive.
+                bool fontHasColorGlyphs = !std::holds_alternative<NoEmojiGlyphs>(m_emojiType);
+                if (variationSelector == emojiVariationSelector && !fontHasColorGlyphs)
+                    return false;
+                if (variationSelector == textVariationSelector && fontHasColorGlyphs)
                     return false;
             }
             ++it;
             continue;
         }
+
+        // Default-ignorable code points (e.g. ZWJ in emoji sequences) drive shaping but aren't rendered themselves.
+        if (isDefaultIgnorableCodePoint(codePoint))
+            continue;
 
         if (!supportsCodePoint(codePoint))
             return false;


### PR DESCRIPTION
#### 0ff7c9b7590f70646a51d1cbe6e4d8825287daf4
<pre>
Fallback font chosen over NotoColorEmoji when U+FE0F emoji variation selector is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=258877">https://bugs.webkit.org/show_bug.cgi?id=258877</a>
<a href="https://rdar.apple.com/112130785">rdar://112130785</a>

Reviewed by NOBODY (OOPS!).

When a combining character sequence ended in an emoji variation selector
(VS16, U+FE0F) or contained a ZWJ (U+200D), Font::canRenderCombiningCharacterSequence
required the font to have a standalone glyph for the selector / joiner. Emoji
fonts list U+FE0F only in their format 14 cmap and never expose it (or ZWJ) as an
independent glyph, so the emoji font was rejected. Font selection then fell through
to a later family in the list, and any font that blanket-maps these code points
(e.g. a &quot;Tofu&quot; missing-glyph fallback) won as a result, rendering .notdef boxes.
This is purely a font-fallback/segmentation issue; it is unrelated to the color
table format (it reproduces with COLR and with SVG-only emoji fonts alike).

Fix canRenderCombiningCharacterSequence to not require a standalone glyph for the
variation selector: the selector is never rendered, so supporting the base
character is sufficient. To keep VS15/VS16 steering the chosen font by the
requested presentation, additionally require the font&apos;s color capability to match
the selector (VS16 -&gt; color font, VS15 -&gt; text font). The capability is tested at
the font level rather than on the base glyph so that emoji assembled by
substitution (e.g. keycaps, whose base glyph is an outline) are not rejected.
Likewise skip default-ignorable code points such as ZWJ, which drive shaping but
are not rendered themselves.

* LayoutTests/TestExpectations: Unskip Progression
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::canRenderCombiningCharacterSequence const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ff7c9b7590f70646a51d1cbe6e4d8825287daf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128291 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ddf758c-4bab-41d6-ae9c-b01d4488c1c6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133026 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93818 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3a8e11c-79d3-4367-ac1c-407781381abb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113523 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77bf5da7-cf0d-44c3-908a-eb6913d9766c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34835 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33175 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182539 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141484 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141301 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44848 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29849 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109396 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36568 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116737 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43358 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7951 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42763 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42894 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->