### PR TITLE
[Selection] getComposedRanges() over-rescopes when a passed shadow root is a descendant of the boundary's shadow tree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/selection/shadow-dom/tentative/Selection-getComposedRanges-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/selection/shadow-dom/tentative/Selection-getComposedRanges-expected.txt
@@ -12,5 +12,5 @@ PASS getComposedRanges a sequence with a static range that crosses shadow bounda
 PASS getComposedRanges returns a sequence with a static range pointing to the outer shadow host when there is a selection in an inner shadow tree and no shadow tree is specified as an argument
 PASS getComposedRanges returns a sequence with a static range pointing to the inner shadow tree when there is a selection in an inner shadow tree and the inner shadow tree is specified as an argument
 PASS getComposedRanges returns a sequence with a static range pointing to the outer shadow tree when there is a selection in an inner shadow tree and the outer shadow tree is specified as an argument
-FAIL getComposedRanges returns a sequence with a static range without rescoping when there is a selection in an outer shadow tree and the inner shadow tree is specified as an argument assert_equals: expected DocumentFragment node with 2 children but got Element node <div id="container">a<div id="outerHost"></div>b</div>
+PASS getComposedRanges returns a sequence with a static range without rescoping when there is a selection in an outer shadow tree and the inner shadow tree is specified as an argument
 

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -374,9 +374,19 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(Variant<Ref<ShadowRoot>
         }
     );
 
+    auto isShadowIncludingInclusiveAncestorOfAnyShadowRoot = [&](ShadowRoot* root) {
+        if (!root)
+            return false;
+        for (auto& shadowRoot : shadowRootSet) {
+            if (root->isShadowIncludingInclusiveAncestorOf(shadowRoot.ptr()))
+                return true;
+        }
+        return false;
+    };
+
     Ref startNode = range->startContainer();
     unsigned startOffset = range->startOffset();
-    while (startNode->isInShadowTree() && !shadowRootSet.contains(startNode->containingShadowRoot())) {
+    while (startNode->isInShadowTree() && !isShadowIncludingInclusiveAncestorOfAnyShadowRoot(startNode->containingShadowRoot())) {
         RefPtr host = startNode->shadowHost();
         ASSERT(host && host->parentNode());
         startNode = *host->parentNode();
@@ -385,7 +395,7 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(Variant<Ref<ShadowRoot>
 
     Ref endNode = range->endContainer();
     unsigned endOffset = range->endOffset();
-    while (endNode->isInShadowTree() && !shadowRootSet.contains(endNode->containingShadowRoot())) {
+    while (endNode->isInShadowTree() && !isShadowIncludingInclusiveAncestorOfAnyShadowRoot(endNode->containingShadowRoot())) {
         RefPtr host = endNode->shadowHost();
         ASSERT(host && host->parentNode());
         endNode = *host->parentNode();


### PR DESCRIPTION
#### 6258fe80af2dd142f5aa056eae347915edf839fb
<pre>
[Selection] getComposedRanges() over-rescopes when a passed shadow root is a descendant of the boundary&apos;s shadow tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=318009">https://bugs.webkit.org/show_bug.cgi?id=318009</a>
<a href="https://rdar.apple.com/180810983">rdar://180810983</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The Selection API&apos;s getComposedRanges() rescoping loop must keep walking a
boundary point out of its shadow tree only while that boundary&apos;s root &quot;is not
a shadow-including inclusive ancestor of any of options[&apos;shadowRoots&apos;]&quot;
(<a href="https://w3c.github.io/selection-api/#dom-selection-getcomposedranges).">https://w3c.github.io/selection-api/#dom-selection-getcomposedranges).</a>

Currently, we instead tested whether the boundary&apos;s containing shadow root was
exactly present in the supplied set. The two agree only when no supplied root
is a descendant of the boundary&apos;s root. When a selection lives in an outer
shadow tree and a nested (descendant) shadow root is passed as an argument,
the spec stops rescoping at the outer root, but we failed the exact-match test
and kept walking up into the host&apos;s parent, returning a node in the wrong
tree.

Fixes the &quot;without rescoping ... the inner shadow tree is specified as an
argument&quot; case in Selection-getComposedRanges.html.

* LayoutTests/imported/w3c/web-platform-tests/selection/shadow-dom/tentative/Selection-getComposedRanges-expected.txt: Progression
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::getComposedRanges):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6258fe80af2dd142f5aa056eae347915edf839fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128292 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf7ed6e7-fdfd-4bf6-b3c7-25676c841ad1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133027 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93820 "2 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f608666-b22c-48fc-a9aa-d27937209875) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/450df3f6-7d14-434a-80d7-77b5f90ba144) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34836 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33176 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28637 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145297 "Found 2 new API test failures: TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess, TestWebKitAPI.WebAuthenticationPanel.PanelHidCtapNoCredentialsFound (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182540 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141485 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44160 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44849 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109397 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36569 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116738 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43359 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42764 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42895 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->