### PR TITLE
MediaContainmentEnabled preference is now dead code.

### DIFF
--- a/LayoutTests/ipc/media-containment-bypass-create-player.html
+++ b/LayoutTests/ipc/media-containment-bypass-create-player.html
@@ -25,11 +25,10 @@ window.onload = function() {
         return;
     }
 
-    // Engines that GPU's RemoteMediaPlayerManagerProxy::createMediaPlayer must reject
-    // when MediaContainmentEnabled is true. AVFoundation (0) and WirelessPlayback (10)
-    // are the only allowed engines; AVFoundationMSE (1) corresponds to
-    // MediaPlayerPrivateMediaSourceAVFObjC, and CocoaWebM (9) corresponds to
-    // MediaPlayerPrivateWebM.
+    // Engines that GPU's RemoteMediaPlayerManagerProxy::createMediaPlayer must reject.
+    // AVFoundation (0) and WirelessPlayback (10) are the only allowed engines;
+    // AVFoundationMSE (1) corresponds to MediaPlayerPrivateMediaSourceAVFObjC,
+    // and CocoaWebM (9) corresponds to MediaPlayerPrivateWebM.
     var blockedEngines = [
         { id: 1, name: 'AVFoundationMSE' },
         { id: 9, name: 'CocoaWebM' },

--- a/LayoutTests/media/media-source/media-managedmse-aac-shared-format.html
+++ b/LayoutTests/media/media-source/media-managedmse-aac-shared-format.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true MediaContainmentEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
 <html>
 <head>
     <title>ManagedMediaSource AAC with shared-format multi-packet CMSampleBuffers</title>
@@ -8,9 +8,9 @@
     // Regression test: ISO-BMFF AAC source from AVStreamDataParser hands the
     // engine multi-sample CMSampleBuffers whose sizes live in the audio stream
     // packet description array (CMSampleBufferGetSampleSizeArray returns
-    // kCMSampleBufferError_BufferHasNoSampleSizes). The MediaContainmentEnabled
-    // IPC encode path used CMSampleBufferCallBlockForEachSample, which can't
-    // subdivide those buffers, and silently shipped 0 packets to the GPU side.
+    // kCMSampleBufferError_BufferHasNoSampleSizes). The IPC encode path used
+    // CMSampleBufferCallBlockForEachSample, which can't subdivide those
+    // buffers, and silently shipped 0 packets to the GPU side.
     // currentTime advanced via the timebase but the audio renderer played
     // silence. The fix in MediaSampleAVFObjC::divide() walks the packet
     // description array directly. Verifying state here (sourceopen, append

--- a/LayoutTests/media/media-source/media-managedmse-adts-aac-remove.html
+++ b/LayoutTests/media/media-source/media-managedmse-adts-aac-remove.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true MediaContainmentEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
 <html>
 <head>
     <title>ManagedMediaSource ADTS-framed AAC partial-sample remove()</title>

--- a/LayoutTests/media/media-source/media-managedmse-adts-aac.html
+++ b/LayoutTests/media/media-source/media-managedmse-adts-aac.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true MediaContainmentEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
 <html>
 <head>
     <title>ManagedMediaSource ADTS-framed AAC</title>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5259,22 +5259,6 @@ MediaContainerTypesAllowedInLockdownMode:
     WebKit:
       default: '"video/mp4,audio/mp4,video/x-m4v,audio/x-m4a,audio/mp3,application/x-mpegURL,application/vnd.apple.mpegURL,video/mp2t,video/iso.segment,audio/aac,audio/mpeg,audio/ac3,audio/eac3,video/mpeg2,text/vtt"_str'
 
-MediaContainmentEnabled:
-  type: bool
-  status: stable
-  category: media
-  humanReadableName: "Media Containment"
-  humanReadableDescription: "Process complex media types in the web process"
-  condition: PLATFORM(COCOA) && ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-  sharedPreferenceForWebProcess: true
-
 MediaContentTypesRequiringHardwareSupport:
   type: String
   status: embedder

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1284,9 +1284,6 @@ ExceptionOr<Ref<SourceBufferPrivate>> MediaSource::createSourceBufferPrivate(con
     RefPtr<SourceBufferPrivate> sourceBufferPrivate;
     MediaSourceConfiguration configuration = {
         .textTracksEnabled = protect(scriptExecutionContext())->settingsValues().textTracksInMSEEnabled,
-#if USE(MEDIAPARSERD)
-        .demuxInProcess = protect(scriptExecutionContext())->settingsValues().mediaContainmentEnabled,
-#endif
 #if ENABLE(MEDIA_RECORDER_WEBM)
         .supportsLimitedMatroska = (document && document->quirks().needsLimitedMatroskaSupport()) || protect(scriptExecutionContext())->settingsValues().limitedMatroskaSupportEnabled
 #endif

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -424,11 +424,10 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
         //       combination of container, media types, robustness and local accumulated configuration in combination
         //       with restrictions:
         MediaEngineSupportParameters parameters { .type = ContentType(contentType->contentType()) };
-        MediaPlayerEngineSelection selection { .scope = hasPlatformStrategies() ? MediaPlayerScope::Playback : MediaPlayerScope::Supports };
-        if (MediaPlayer::supportsType(parameters, selection) == MediaPlayer::SupportsType::IsNotSupported) {
+        if (MediaPlayer::supportsType(parameters) == MediaPlayer::SupportsType::IsNotSupported) {
             // Try with Media Source:
             parameters.platformType = PlatformMediaDecodingType::MediaSource;
-            if (MediaPlayer::supportsType(parameters, selection) == MediaPlayer::SupportsType::IsNotSupported)
+            if (MediaPlayer::supportsType(parameters) == MediaPlayer::SupportsType::IsNotSupported)
                 continue;
         }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -397,6 +397,11 @@ MediaPlayerPrivateInterface* MediaPlayer::playerPrivate()
     return m_private.get();
 }
 
+static MediaPlayerScope effectiveSelectedScope(const MediaPlayerEngineSelection& selection)
+{
+    return selection.scope.value_or(hasPlatformStrategies() ? MediaPlayerScope::Playback : MediaPlayerScope::Supports);
+}
+
 static bool engineScopeMatchesSelection(MediaPlayerScope engineScope, MediaPlayerScope selectionScope)
 {
     if (selectionScope == MediaPlayerScope::Playback)
@@ -414,7 +419,7 @@ const MediaPlayerFactory* MediaPlayer::mediaEngine(const MediaPlayerEngineSelect
     auto& engines = installedMediaEngines();
     auto currentIndex = engines.findIf([&] (auto& engine) {
         return engine->identifier() == *selection.identifier
-            && engineScopeMatchesSelection(engine->supportedScope(selection.mediaContainmentEnabled), selection.scope);
+            && engineScopeMatchesSelection(engine->supportedScope(), effectiveSelectedScope(selection));
     });
 
     if (currentIndex == notFound) {
@@ -443,7 +448,7 @@ static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const Media
     const MediaPlayerFactory* foundEngine = nullptr;
     MediaPlayer::SupportsType supported = MediaPlayer::SupportsType::IsNotSupported;
     for (auto& engine : installedMediaEngines()) {
-        if (!engineScopeMatchesSelection(engine->supportedScope(selection.mediaContainmentEnabled), selection.scope))
+        if (!engineScopeMatchesSelection(engine->supportedScope(), effectiveSelectedScope(selection)))
             continue;
         if (current) {
             if (current == engine.get())

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -131,8 +131,8 @@ struct MediaEngineSupportParameters {
 
 struct MediaPlayerEngineSelection {
     std::optional<MediaPlayerEnums::MediaEngineIdentifier> identifier { };
-    MediaPlayerScope scope { MediaPlayerScope::Playback };
-    MediaContainmentEnabled mediaContainmentEnabled { MediaContainmentEnabled::No };
+    // When unset, resolves to Playback in the WebContent process and Supports in the GPU process.
+    std::optional<MediaPlayerScope> scope { };
 };
 
 struct SeekTarget {
@@ -936,11 +936,9 @@ public:
     virtual void clearMediaCacheForOrigins(const String&, const HashSet<SecurityOriginData>&) const { }
     virtual bool supportsKeySystem(const String& /* keySystem */, const String& /* mimeType */) const { return false; }
 
-    // Describes how this factory may be used. The `mediaContainmentEnabled` context
-    // mirrors the per-WebProcess preference of the same name; in the GPU process it's
-    // sourced from the calling connection. Default is Playback; subclasses override
-    // only if they need to answer differently for some contexts.
-    virtual MediaPlayerScope supportedScope(MediaContainmentEnabled = MediaContainmentEnabled::No) const { return MediaPlayerScope::Playback; }
+    // Describes how this factory may be used. Default is Playback; subclasses
+    // override only if they need to answer differently for some contexts.
+    virtual MediaPlayerScope supportedScope() const { return MediaPlayerScope::Playback; }
 };
 
 using MediaEngineRegistrar = void(std::unique_ptr<MediaPlayerFactory>&&);

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -187,11 +187,6 @@ enum class MediaPlayerScope : uint8_t {
     Supports,
 };
 
-enum class MediaContainmentEnabled : bool {
-    No,
-    Yes,
-};
-
 } // namespace WebCore
 
 

--- a/Source/WebCore/platform/graphics/MediaSourceConfiguration.h
+++ b/Source/WebCore/platform/graphics/MediaSourceConfiguration.h
@@ -31,9 +31,6 @@ namespace WebCore {
 
 struct MediaSourceConfiguration {
     bool textTracksEnabled { false };
-#if USE(MEDIAPARSERD)
-    bool demuxInProcess { false };
-#endif
 #if ENABLE(MEDIA_RECORDER_WEBM)
     bool supportsLimitedMatroska { false };
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -173,7 +173,7 @@ private:
 
     // Only reached when registered locally; registerMediaEngine may instead install
     // a remote proxy for this engine.
-    MediaPlayerScope supportedScope(MediaContainmentEnabled) const final
+    MediaPlayerScope supportedScope() const final
     {
         return hasPlatformStrategies() ? MediaPlayerScope::Playback : MediaPlayerScope::Supports;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -236,7 +236,7 @@ SourceBufferParserAVFObjC::SourceBufferParserAVFObjC(const ContentType& contentT
 
 #if USE(MEDIAPARSERD)
     if ([m_parser.get() respondsToSelector:@selector(setPreferSandboxedParsing:)])
-        [m_parser.get() setPreferSandboxedParsing:!m_configuration.demuxInProcess];
+        [m_parser.get() setPreferSandboxedParsing:NO];
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1757,7 +1757,7 @@ private:
         return MediaPlayerPrivateWebM::supportsType(parameters);
     }
 
-    MediaPlayerScope supportedScope(MediaContainmentEnabled) const final
+    MediaPlayerScope supportedScope() const final
     {
         return hasPlatformStrategies() ? MediaPlayerScope::Playback : MediaPlayerScope::Supports;
     }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -635,14 +635,8 @@ void GPUConnectionToWebProcess::canDecodeExtendedType(PlatformMediaDecodingType 
         .platformType = platformType,
         .type = contentType,
     };
-    auto containment = MediaContainmentEnabled::No;
-#if PLATFORM(COCOA)
-    if (sharedPreferencesForWebProcessValue().mediaContainmentEnabled)
-        containment = MediaContainmentEnabled::Yes;
-#endif
     MediaPlayerEngineSelection selection {
         .scope = MediaPlayerScope::Supports,
-        .mediaContainmentEnabled = containment,
     };
     completionHandler(MediaPlayer::supportsType(parameters, selection) != MediaPlayer::SupportsType::IsNotSupported);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -60,18 +60,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMediaPlayerManagerProxy);
 
 CheckedPtr<const MediaPlayerFactory> RemoteMediaPlayerManagerProxy::playbackEngineForConnection(MediaPlayerEnums::MediaEngineIdentifier engineIdentifier) const
 {
-    auto connection = m_gpuConnectionToWebProcess.get();
-    auto containment = MediaContainmentEnabled::No;
-#if PLATFORM(COCOA)
-    if (connection && connection->sharedPreferencesForWebProcessValue().mediaContainmentEnabled)
-        containment = MediaContainmentEnabled::Yes;
-#else
-    UNUSED_PARAM(connection);
-#endif
     MediaPlayerEngineSelection selection {
         .identifier = engineIdentifier,
         .scope = MediaPlayerScope::Playback,
-        .mediaContainmentEnabled = containment,
     };
     return MediaPlayer::mediaEngine(selection);
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -995,9 +995,6 @@ using WebCore::SourceBufferPrivate::SamplesPromise::Result = Expected<Vector<Str
 header: <WebCore/MediaSourceConfiguration.h>
 struct WebCore::MediaSourceConfiguration {
     bool textTracksEnabled;
-#if USE(MEDIAPARSERD)
-    bool demuxInProcess;
-#endif
 #if ENABLE(MEDIA_RECORDER_WEBM)
     bool supportsLimitedMatroska;
 #endif


### PR DESCRIPTION
#### c76e79654cc0ce12d8995b92b5378bbecd669702
<pre>
MediaContainmentEnabled preference is now dead code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318005">https://bugs.webkit.org/show_bug.cgi?id=318005</a>
<a href="https://rdar.apple.com/180803445">rdar://180803445</a>

Reviewed by Youenn Fablet.

Following 315910@main and 315963@main MediaContainment is now always active,
regardless of the value of the preference and demuxing always occurs in
the content process. We can remove the preference and its use.

Fly-by: clean-up a bit the handling of engine scope selection.

* LayoutTests/ipc/media-containment-bypass-create-player.html:
* LayoutTests/media/media-source/media-managedmse-aac-shared-format.html:
* LayoutTests/media/media-source/media-managedmse-adts-aac-remove.html:
* LayoutTests/media/media-source/media-managedmse-adts-aac.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::createSourceBufferPrivate):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::mediaEngine):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerFactory::supportedScope const):
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebCore/platform/graphics/MediaSourceConfiguration.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::SourceBufferParserAVFObjC):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::canDecodeExtendedType const):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::playbackEngineForConnection const):
* Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316020@main">https://commits.webkit.org/316020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ece8c19a023b4a59fce2dd825de8ba7c9f838fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128303 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a4233b5-8e22-4d23-b735-3f1c2549f894) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133036 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93829 "1 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c527bdf-bc3c-4c24-b7d4-5f0000875875) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113533 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f3a7029-f645-4527-a1ef-7ea094b35d4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34848 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33186 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28648 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1891 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145309 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/32875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182551 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31845 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141494 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38095 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44860 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109409 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36578 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116749 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203269 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43370 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7965 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54428 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42775 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->