### PR TITLE
Support relative length units in <keyframe-selector>

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1210,6 +1210,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/primitives/CSSKeywordList.h
     css/values/primitives/CSSPosition.h
     css/values/primitives/CSSPrimitiveData.h
+    css/values/primitives/CSSPrimitiveNumeric+Forward.h
     css/values/primitives/CSSPrimitiveNumeric.h
     css/values/primitives/CSSPrimitiveNumericCategory.h
     css/values/primitives/CSSPrimitiveNumericConcepts.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		0B9056F90F2685F30095FF6A /* WorkerThreadableLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9056F70F2685F30095FF6A /* WorkerThreadableLoader.h */; settings = {ATTRIBUTES = (); }; };
 		0BCF83F71059C1EB00D999DD /* MathMLFractionElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BCF83F01059C1EB00D999DD /* MathMLFractionElement.h */; };
 		0BE030A20F3112FB003C1A46 /* RenderLineBoxList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BE030A10F3112FB003C1A46 /* RenderLineBoxList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0C0A490A2F9C6DB2963852E1 /* ElementInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EC57482ED01054BFAD1ADBD /* ElementInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0C3F1F5B10C8871200D72CE1 /* WebGLUniformLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C3F1F5810C8871200D72CE1 /* WebGLUniformLocation.h */; };
 		0C45342810CDBBFA00869157 /* JSWebGLUniformLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C45342610CDBBFA00869157 /* JSWebGLUniformLocation.h */; };
 		0C6B52D0EB74C9FC2A56BF0A /* FontInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 59763CF0AFE56B2B76896F18 /* FontInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -590,6 +591,7 @@
 		1A250E0D1CDD632000D0BE63 /* LinkIconType.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A250E0C1CDD632000D0BE63 /* LinkIconType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A299FE81D7F5FA600A60093 /* RenderThemeCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A299FE61D7F5FA600A60093 /* RenderThemeCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A2A68240B5BEDE70002A480 /* ProgressTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A2A68220B5BEDE70002A480 /* ProgressTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1A2B3C4D5E6F708192A3B4C6 /* JSMallocStatisticsCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B4C5 /* JSMallocStatisticsCustom.cpp */; };
 		1A2E6E5A0CC55213004A2062 /* SQLValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A2E6E580CC55213004A2062 /* SQLValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A3586E015264C450022A659 /* RenderMultiColumnFlow.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3586DE15264C450022A659 /* RenderMultiColumnFlow.h */; };
 		1A37636C1A2E68BB009A7EE2 /* StorageNamespaceProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A37636A1A2E68BB009A7EE2 /* StorageNamespaceProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -977,7 +979,6 @@
 		27E3C808257F5E6E00C986AB /* ANGLEHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E3C806257F5E6E00C986AB /* ANGLEHeaders.h */; };
 		27E7CA912D7572C600554A77 /* BoundaryPointInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA902D7572C600554A77 /* BoundaryPointInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E7CA932D7572DE00554A77 /* NodeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA922D7572DE00554A77 /* NodeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E9AC84FF91F6D0B76AF7AEBF /* NodeInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FBEE3DEEB11679A78E3D297 /* NodeInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E7CA952D75731700554A77 /* PositionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA942D75731700554A77 /* PositionInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E7CA972D75735A00554A77 /* RangeBoundaryPointInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA962D75735A00554A77 /* RangeBoundaryPointInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27E7CA9C2D75780500554A77 /* EditingInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 27E7CA9B2D75780500554A77 /* EditingInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1055,7 +1056,6 @@
 		2D0621521DA63AA200A7FB26 /* WebKitMediaKeyNeededEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2D0621471DA63A7900A7FB26 /* WebKitMediaKeyNeededEvent.cpp */; };
 		2D0B4AAB18DA1CCD00434DE1 /* IOSurface.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D0B4AA918DA1CCD00434DE1 /* IOSurface.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D1CE026F32F4DD98F662746 /* JSDOMWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2387F92D88E37E00698102 /* JSDOMWindow.cpp */; };
-		AE9D0D864E151BAC3ECB750E /* JSDOMWindowConstructorAttributes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A02BEA1C4349368FDAA80A0 /* JSDOMWindowConstructorAttributes.cpp */; };
 		2D222D332B03FB3B009F4ADD /* ScrollingStatePluginHostingNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D222D2F2B03FB3A009F4ADD /* ScrollingStatePluginHostingNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D222D352B03FB3B009F4ADD /* ScrollingStatePluginScrollingNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D222D312B03FB3B009F4ADD /* ScrollingStatePluginScrollingNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D222D3A2B03FB6B009F4ADD /* ScrollingTreePluginHostingNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D222D362B03FB69009F4ADD /* ScrollingTreePluginHostingNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2490,7 +2490,6 @@
 		538EC91D1F99B698004D22A8 /* UnifiedSource129.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 538EC9101F99B656004D22A8 /* UnifiedSource129.cpp */; };
 		538EC91E1F99B698004D22A8 /* UnifiedSource130.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 538EC9041F99B64A004D22A8 /* UnifiedSource130.cpp */; };
 		538EC9321F99B9F7004D22A8 /* JSMallocStatistics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7B4EA6814C9348400C8F5BF /* JSMallocStatistics.cpp */; };
-		1A2B3C4D5E6F708192A3B4C6 /* JSMallocStatisticsCustom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B4C5 /* JSMallocStatisticsCustom.cpp */; };
 		538EC9331F99B9F7004D22A8 /* JSMockCDMFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = CDF4B72E1E03CA4A00E235A2 /* JSMockCDMFactory.h */; };
 		538EC9341F99B9F7004D22A8 /* JSMockPageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6F3E931C1F85550061DBD4 /* JSMockPageOverlay.h */; };
 		53B895AF19DC7ED9009CAA93 /* Microtasks.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B895AD19DC7C37009CAA93 /* Microtasks.h */; };
@@ -2649,6 +2648,7 @@
 		5B4C7CA9D949D424F9683D2F /* UnifiedSource41-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FBCE61FFFCC0A29F0D842C51 /* UnifiedSource41-header-RenderStyleGetters.cpp */; };
 		5B602FF31E893171DB3FB4A7 /* UnifiedSource11-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25FAC750F76F755835BE4E86 /* UnifiedSource11-header-RenderStyleGetters.cpp */; };
 		5B92C42D2716E28A00A37CC0 /* ScrollingTreeStickyNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B92C42B2716E23300A37CC0 /* ScrollingTreeStickyNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5B970BEE42D448CC9F33BB6E /* FallbackPopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E27FA0B62374E9BA36143C5 /* FallbackPopupMenu.h */; };
 		5C18AF9F085CE88F6F3BB442 /* UnifiedSource34-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E89B7DB68E9CE297AC2CD6A /* UnifiedSource34-header-RenderStyleGetters.cpp */; };
 		5C1B1D3F26F3978000882DA2 /* ResourceLoaderIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1B1D3D26F3977F00882DA2 /* ResourceLoaderIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C2397D72949288700BB4E10 /* RemoteFrameClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C2397D22949213600BB4E10 /* RemoteFrameClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3651,7 +3651,6 @@
 		8AF4E55611DC5A36000ED3DE /* PerformanceNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AF4E55311DC5A36000ED3DE /* PerformanceNavigation.h */; };
 		8AF4E55C11DC5A63000ED3DE /* PerformanceTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AF4E55911DC5A63000ED3DE /* PerformanceTiming.h */; };
 		8B3C8739E3CFAB0D42937C95 /* SharedTimebase.h in Headers */ = {isa = PBXBuildFile; fileRef = C994659FB046BBF6205518AD /* SharedTimebase.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FED1234567890ABCDEF12347 /* PeriodicSharedTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = FED1234567890ABCDEF12345 /* PeriodicSharedTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8B5216F72DEE4E75003BC21B /* LazyLoadModelObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5216F42DEE4E75003BC21B /* LazyLoadModelObserver.h */; };
 		8D8AB55246EA6D3E46D7E2EF /* UnifiedSource38-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCFF63713748594F7E1BE330 /* UnifiedSource38-header-RenderStyleGetters.cpp */; };
 		8E4C96DD1AD4483500365A50 /* JSFetchResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E4C96D91AD4483500365A50 /* JSFetchResponse.h */; };
@@ -4170,6 +4169,7 @@
 		9BEA6CEE2DD307EC0024B515 /* ScriptExecutionContextInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BEA6CED2DD307EC0024B515 /* ScriptExecutionContextInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9BF9A8811648DD2F001C6B23 /* JSHTMLFormControlsCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BF9A87F1648DD2F001C6B23 /* JSHTMLFormControlsCollection.h */; };
 		9CBFA6F4E27C12C915C9256B /* RenderLayerSVGAdditionsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = B7D4ED519BC985D5E5E97AE2 /* RenderLayerSVGAdditionsInlines.h */; };
+		9D41451DA980438DA186DBDF /* StyleObjectViewBox.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA340CB3EC1453981DF6B56 /* StyleObjectViewBox.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9D6380101AF173220031A15C /* StyleSelfAlignmentData.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D63800F1AF16E160031A15C /* StyleSelfAlignmentData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9DAC7C571AF2CB6400437C44 /* StyleContentAlignmentData.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAC7C561AF2CB6400437C44 /* StyleContentAlignmentData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9E909EADAED4ED0186784634 /* Volume2-RTL.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 1BBDE8612B8CB78D4514D54E /* Volume2-RTL.svg */; platformFilters = (macos, ); };
@@ -4759,6 +4759,7 @@
 		ADDF1AD71257CD9A0003A759 /* LegacyRenderSVGPath.h in Headers */ = {isa = PBXBuildFile; fileRef = ADDF1AD51257CD9A0003A759 /* LegacyRenderSVGPath.h */; };
 		ADEC78F818EE5308001315C2 /* JSElementCustom.h in Headers */ = {isa = PBXBuildFile; fileRef = ADEC78F718EE5308001315C2 /* JSElementCustom.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AE5BDBDD2CA481C600550C8C /* CredentialPropertiesOutput.h in Headers */ = {isa = PBXBuildFile; fileRef = AE5BDBDC2CA481C600550C8C /* CredentialPropertiesOutput.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AE9D0D864E151BAC3ECB750E /* JSDOMWindowConstructorAttributes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A02BEA1C4349368FDAA80A0 /* JSDOMWindowConstructorAttributes.cpp */; };
 		AEBAFFAD2D65D459008311A5 /* UnknownCredentialOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBAFFAC2D65D459008311A5 /* UnknownCredentialOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AEBAFFB02D65D478008311A5 /* AllAcceptedCredentialsOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBAFFAF2D65D478008311A5 /* AllAcceptedCredentialsOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AEBAFFB52D65D537008311A5 /* CurrentUserDetailsOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = AEBAFFB42D65D537008311A5 /* CurrentUserDetailsOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5612,6 +5613,7 @@
 		BCC0F3D62D99BDD90065B859 /* CSSURLValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC0F3D52D99BDD90065B859 /* CSSURLValue.h */; };
 		BCC0F3DA2D99D4860065B859 /* StyleURL.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC0F3D92D99D4860065B859 /* StyleURL.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCC5BE010C0E93110011C2DB /* JSCSSStyleSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC5BDFF0C0E93110011C2DB /* JSCSSStyleSheet.h */; };
+		BCC9ECA92FED9AE0006C8BAD /* CSSPrimitiveNumeric+Forward.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC9ECA82FED9A69006C8BAD /* CSSPrimitiveNumeric+Forward.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCCBAD410C18C14200CE890F /* JSHTMLCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCBAD3F0C18C14200CE890F /* JSHTMLCollection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCCE02912E766AA30028EA38 /* StyleSingleTransitionDelay.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCE02902E766A860028EA38 /* StyleSingleTransitionDelay.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCCE02922E766AAA0028EA38 /* StyleSingleTransitionDuration.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCE028F2E7669A40028EA38 /* StyleSingleTransitionDuration.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5663,7 +5665,6 @@
 		BCD9F13D2E1EE70A00D1C3DF /* CSSGridNamedAreaMap.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD9F13C2E1EE70A00D1C3DF /* CSSGridNamedAreaMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCD9F1682E202E2100D1C3DF /* StyleGridOrderedNamedLinesMap.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD9F1672E202E2100D1C3DF /* StyleGridOrderedNamedLinesMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCD9F1752E203A0200D1C3DF /* StyleObjectPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD9F1742E20384800D1C3DF /* StyleObjectPosition.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		9D41451DA980438DA186DBDF /* StyleObjectViewBox.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA340CB3EC1453981DF6B56 /* StyleObjectViewBox.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCD9F1782E2040DC00D1C3DF /* StylePerspectiveOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD9F1772E2040DC00D1C3DF /* StylePerspectiveOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCD9F17A2E2045C500D1C3DF /* StyleTransformOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD9F1792E2045C500D1C3DF /* StyleTransformOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCD9F1B32E21D62800D1C3DF /* StyleGridTemplateList.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD9F1B22E21D62800D1C3DF /* StyleGridTemplateList.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5931,7 +5932,6 @@
 		CD1F9B42270CED9D00617EB6 /* JSMediaKeyMessageType.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B3F270CED8400617EB6 /* JSMediaKeyMessageType.h */; };
 		CD1F9B43270CED9D00617EB6 /* JSMediaKeyMessageEventInit.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B41270CED8600617EB6 /* JSMediaKeyMessageEventInit.h */; };
 		CD1F9B45270CF1CE00617EB6 /* ElementInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B44270CF1CB00617EB6 /* ElementInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0C0A490A2F9C6DB2963852E1 /* ElementInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EC57482ED01054BFAD1ADBD /* ElementInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD1F9B47270CFC1600617EB6 /* EventOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B46270CFC1600617EB6 /* EventOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD1F9B4D270D03A900617EB6 /* ScrollExtents.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B4C270D03A900617EB6 /* ScrollExtents.h */; };
 		CD1F9B7D270E667800617EB6 /* HTMLAnchorElementInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = CD1F9B7C270E667800617EB6 /* HTMLAnchorElementInlines.h */; };
@@ -6233,7 +6233,6 @@
 		D2042D552EFC45610047B572 /* GraphicsLayerAnimationValue.h in Headers */ = {isa = PBXBuildFile; fileRef = D2042D4C2EFC445A0047B572 /* GraphicsLayerAnimationValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D20E878D2AF44B5E004579F3 /* SwitchMacUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = D20E878C2AF44B5E004579F3 /* SwitchMacUtilities.h */; };
 		D22B85932EB4EF6D000D2DC3 /* HTMLSelectedContentElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D22B85912EB4EF6D000D2DC3 /* HTMLSelectedContentElement.h */; };
-		5B970BEE42D448CC9F33BB6E /* FallbackPopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E27FA0B62374E9BA36143C5 /* FallbackPopupMenu.h */; };
 		D245256B2F22773C000DFFF6 /* SelectFallbackButtonElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D21A65EB2F2276ED004D221F /* SelectFallbackButtonElement.h */; };
 		D245256C2F22773C000DFFF7 /* SelectPopoverElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D21A65ED2F2276ED004D221F /* SelectPopoverElement.h */; };
 		D245B6DD2B679280009AA00E /* HTTPStatusCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = D245B6D02B6791BA009AA00E /* HTTPStatusCodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7117,6 +7116,7 @@
 		E8BF3AE42D56005800E7ED0B /* DummyCredentialRequestCoordinatorClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E8BF3AE12D56003700E7ED0B /* DummyCredentialRequestCoordinatorClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8E7BDE32D94D20E0000A163 /* DigitalCredentialsProtocols.h in Headers */ = {isa = PBXBuildFile; fileRef = E8E7BDE22D94D2020000A163 /* DigitalCredentialsProtocols.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E9066AA4F09A6829ADADE430 /* UnifiedSource42-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C36C2A063D49F0AFB0A20E2 /* UnifiedSource42-header-RenderStyleGetters.cpp */; };
+		E9AC84FF91F6D0B76AF7AEBF /* NodeInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FBEE3DEEB11679A78E3D297 /* NodeInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EAA1A5613998E1BFD9AE7992 /* Ellipsis.svg in Copy Modern Media Controls Images */ = {isa = PBXBuildFile; fileRef = 3F3FBC9A5EE8A4E8D3EDE484 /* Ellipsis.svg */; platformFilters = (ios, maccatalyst, tvos, xros, ); };
 		EB08B45C5495A39E03D5A8B5 /* UnifiedSource20-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1B721B8134C6AE9E9D34A5D7 /* UnifiedSource20-header-RenderStyleGetters.cpp */; };
 		EB0FB708270D0B1000F7810D /* PushEncryptionKeyName.h in Headers */ = {isa = PBXBuildFile; fileRef = EB0FB6FD270D0AE800F7810D /* PushEncryptionKeyName.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7205,8 +7205,8 @@
 		F454C1342BA3B57500871551 /* ElementTargetingTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F454C1322BA3B54C00871551 /* ElementTargetingTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F454C13A2BA3F91100871551 /* ElementTargetingController.h in Headers */ = {isa = PBXBuildFile; fileRef = F454C1382BA3F8FB00871551 /* ElementTargetingController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F457F4C32F156C5D00E97771 /* TextExtraction.h in Headers */ = {isa = PBXBuildFile; fileRef = F457F4BF2F156C5D00E97771 /* TextExtraction.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F457F4D22F156C5D00E97771 /* TextExtractionScriptFiltering.h in Headers */ = {isa = PBXBuildFile; fileRef = F457F4D12F156C5D00E97771 /* TextExtractionScriptFiltering.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F457F4C42F156C5D00E97771 /* TextExtractionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F457F4C12F156C5D00E97771 /* TextExtractionTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F457F4D22F156C5D00E97771 /* TextExtractionScriptFiltering.h in Headers */ = {isa = PBXBuildFile; fileRef = F457F4D12F156C5D00E97771 /* TextExtractionScriptFiltering.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F45EAC7D2A8ADFC4009B986E /* PlatformScreen.serialization.in in Headers */ = {isa = PBXBuildFile; fileRef = F45EAC7B2A8ADE03009B986E /* PlatformScreen.serialization.in */; settings = {ATTRIBUTES = (Private, ); }; };
 		F45EAC822A8AEED2009B986E /* InbandTextTrackPrivate.serialization.in in Headers */ = {isa = PBXBuildFile; fileRef = F45EAC812A8AEED2009B986E /* InbandTextTrackPrivate.serialization.in */; settings = {ATTRIBUTES = (Private, ); }; };
 		F45EAC872A8C1A65009B986E /* LayoutMilestones.serialization.in in Headers */ = {isa = PBXBuildFile; fileRef = F45EAC862A8C1972009B986E /* LayoutMilestones.serialization.in */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7496,6 +7496,7 @@
 		FE8A674816CDD19E00930BF8 /* SQLStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = FE8A674616CDD19E00930BF8 /* SQLStatement.h */; };
 		FE9E89FC16E2DC0500A908F8 /* OriginLock.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9E89FA16E2DC0400A908F8 /* OriginLock.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEB5079D8E50CAD92E49CE04 /* UnifiedSource54-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 73C6E6F635A4B4C36B107EAE /* UnifiedSource54-header-RenderStyleGetters.cpp */; };
+		FED1234567890ABCDEF12347 /* PeriodicSharedTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = FED1234567890ABCDEF12345 /* PeriodicSharedTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FED13D520CEA949700D89466 /* RenderThemeIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = FED13D500CEA949700D89466 /* RenderThemeIOS.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEE1811416C319E800084849 /* SQLTransactionBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = FEE1811216C319E800084849 /* SQLTransactionBackend.h */; };
 		FF6A572B2FA64F1100386D4F /* WorkerSTWParticipation.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6A572A2FA64F1100386D4F /* WorkerSTWParticipation.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8447,7 +8448,6 @@
 		0F580CFA0F12DE9B0051D689 /* RenderLayerCompositor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderLayerCompositor.cpp; sourceTree = "<group>"; };
 		0F580CFB0F12DE9B0051D689 /* RenderLayerBacking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderLayerBacking.h; sourceTree = "<group>"; };
 		0F580CFC0F12DE9B0051D689 /* RenderLayerBacking.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderLayerBacking.cpp; sourceTree = "<group>"; };
-		B5E7A1C20D4F8A2E91C3F6D8 /* RenderLayerBackingSVGAdditions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderLayerBackingSVGAdditions.cpp; sourceTree = "<group>"; };
 		0F580FA11496939100FB5BD8 /* WebTiledBackingLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebTiledBackingLayer.h; sourceTree = "<group>"; };
 		0F580FA21496939100FB5BD8 /* WebTiledBackingLayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebTiledBackingLayer.mm; sourceTree = "<group>"; };
 		0F580FAE149800D400FB5BD8 /* AnimationUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnimationUtilities.h; sourceTree = "<group>"; };
@@ -8807,6 +8807,7 @@
 		1A299FE61D7F5FA600A60093 /* RenderThemeCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderThemeCocoa.h; sourceTree = "<group>"; };
 		1A2A68210B5BEDE70002A480 /* ProgressTracker.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = ProgressTracker.cpp; sourceTree = "<group>"; };
 		1A2A68220B5BEDE70002A480 /* ProgressTracker.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = ProgressTracker.h; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708192A3B4C5 /* JSMallocStatisticsCustom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMallocStatisticsCustom.cpp; sourceTree = "<group>"; };
 		1A2C6671242AFEF7003055EC /* ShareDataReader.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ShareDataReader.cpp; sourceTree = "<group>"; };
 		1A2C6673242AFEF8003055EC /* ShareDataReader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareDataReader.h; sourceTree = "<group>"; };
 		1A2E6E580CC55213004A2062 /* SQLValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQLValue.h; sourceTree = "<group>"; };
@@ -10053,6 +10054,7 @@
 		1DEF06DC233D2E1C00EE228D /* DocumentPictureInPicture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentPictureInPicture.cpp; sourceTree = "<group>"; };
 		1DEF06DD233D2E1C00EE228D /* DocumentPictureInPicture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentPictureInPicture.h; sourceTree = "<group>"; };
 		1DEF06DE233D2E1C00EE228D /* Document+PictureInPicture.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Document+PictureInPicture.idl"; sourceTree = "<group>"; };
+		1EC57482ED01054BFAD1ADBD /* ElementInlinesLight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementInlinesLight.h; sourceTree = "<group>"; };
 		1F36EA9A1E21BA1700621E25 /* WebBackgroundTaskController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackgroundTaskController.h; sourceTree = "<group>"; };
 		1F36EA9B1E21BA1700621E25 /* WebBackgroundTaskController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebBackgroundTaskController.mm; sourceTree = "<group>"; };
 		1F72BF08187FD4270009BCB3 /* TileControllerMemoryHandlerIOS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TileControllerMemoryHandlerIOS.cpp; sourceTree = "<group>"; };
@@ -10139,7 +10141,6 @@
 		27E3C806257F5E6E00C986AB /* ANGLEHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ANGLEHeaders.h; sourceTree = "<group>"; };
 		27E7CA902D7572C600554A77 /* BoundaryPointInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BoundaryPointInlines.h; sourceTree = "<group>"; };
 		27E7CA922D7572DE00554A77 /* NodeInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeInlines.h; sourceTree = "<group>"; };
-		9FBEE3DEEB11679A78E3D297 /* NodeInlinesLight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeInlinesLight.h; sourceTree = "<group>"; };
 		27E7CA942D75731700554A77 /* PositionInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PositionInlines.h; sourceTree = "<group>"; };
 		27E7CA962D75735A00554A77 /* RangeBoundaryPointInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RangeBoundaryPointInlines.h; sourceTree = "<group>"; };
 		27E7CA9B2D75780500554A77 /* EditingInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EditingInlines.h; sourceTree = "<group>"; };
@@ -12363,6 +12364,7 @@
 		49F416EB2ECB878200DBFEEA /* WebGPUXRLayerBacking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUXRLayerBacking.h; sourceTree = "<group>"; };
 		49F416ED2ECB8B5300DBFEEA /* XRLayerBacking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XRLayerBacking.h; sourceTree = "<group>"; };
 		49FC7A4F1444AF5F00A5D864 /* DisplayRefreshMonitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisplayRefreshMonitor.cpp; sourceTree = "<group>"; };
+		4A02BEA1C4349368FDAA80A0 /* JSDOMWindowConstructorAttributes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMWindowConstructorAttributes.cpp; sourceTree = "<group>"; };
 		4A0DA2FC129B241900AB61E1 /* FormListedElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FormListedElement.cpp; sourceTree = "<group>"; };
 		4A0DA2FD129B241900AB61E1 /* FormListedElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FormListedElement.h; sourceTree = "<group>"; };
 		4A0FFA9B1AAF5E6C0062803B /* MockRealtimeMediaSourceCenter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MockRealtimeMediaSourceCenter.cpp; sourceTree = "<group>"; };
@@ -13932,6 +13934,7 @@
 		6E242B29233593D7002CADD4 /* JSWebGLCompressedTextureETC1.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLCompressedTextureETC1.cpp; sourceTree = "<group>"; };
 		6E242B2A233593D8002CADD4 /* JSWebGLCompressedTextureETC1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebGLCompressedTextureETC1.h; sourceTree = "<group>"; };
 		6E27F2422298CE4B00F1F632 /* GraphicsContextGLANGLE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GraphicsContextGLANGLE.cpp; sourceTree = "<group>"; };
+		6E27FA0B62374E9BA36143C5 /* FallbackPopupMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FallbackPopupMenu.h; sourceTree = "<group>"; };
 		6E3FAD3614733F4000E42306 /* JSWebGLCompressedTextureS3TC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLCompressedTextureS3TC.cpp; sourceTree = "<group>"; };
 		6E3FAD3614733F4000E42307 /* JSWebGLDepthTexture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLDepthTexture.cpp; sourceTree = "<group>"; };
 		6E3FAD3614733F4010E42307 /* JSWebGLDebugRendererInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLDebugRendererInfo.cpp; sourceTree = "<group>"; };
@@ -14774,8 +14777,6 @@
 		7A29F57118C69514004D0F81 /* OutOfBandTextTrackPrivateAVF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OutOfBandTextTrackPrivateAVF.h; sourceTree = "<group>"; };
 		7A3EBEAA21BF054C000D043D /* JSSVGViewSpecCustom.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSSVGViewSpecCustom.cpp; sourceTree = "<group>"; };
 		7A41D77F6A607BD50B7B35A6 /* SharedTimebase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedTimebase.cpp; sourceTree = "<group>"; };
-		FED1234567890ABCDEF12345 /* PeriodicSharedTimer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PeriodicSharedTimer.h; sourceTree = "<group>"; };
-		FED1234567890ABCDEF12346 /* PeriodicSharedTimer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PeriodicSharedTimer.mm; sourceTree = "<group>"; };
 		7A4278FF2D8CC06500A60073 /* FontCascadeCocoaInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontCascadeCocoaInlines.h; sourceTree = "<group>"; };
 		7A45032D18DB717200377B34 /* BufferedLineReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BufferedLineReader.cpp; sourceTree = "<group>"; };
 		7A45032E18DB717200377B34 /* BufferedLineReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferedLineReader.h; sourceTree = "<group>"; };
@@ -17058,6 +17059,7 @@
 		9E68A6952DC9406100039106 /* FrameMemoryMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameMemoryMonitor.h; sourceTree = "<group>"; };
 		9E68A6962DC9407300039106 /* FrameMemoryMonitor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameMemoryMonitor.cpp; sourceTree = "<group>"; };
 		9E89B7DB68E9CE297AC2CD6A /* UnifiedSource34-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource34-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
+		9FBEE3DEEB11679A78E3D297 /* NodeInlinesLight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeInlinesLight.h; sourceTree = "<group>"; };
 		A07D3353152B630E001B6393 /* JSWebGLShaderPrecisionFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLShaderPrecisionFormat.cpp; sourceTree = "<group>"; };
 		A07D3354152B630E001B6393 /* JSWebGLShaderPrecisionFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebGLShaderPrecisionFormat.h; sourceTree = "<group>"; };
 		A07D3357152B632D001B6393 /* WebGLShaderPrecisionFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebGLShaderPrecisionFormat.h; sourceTree = "<group>"; };
@@ -17757,7 +17759,6 @@
 		A7A3D55028939156008D683D /* WorkerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkerClient.h; sourceTree = "<group>"; };
 		A7A78CD41532BA62006C21E4 /* ContainerNodeAlgorithms.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContainerNodeAlgorithms.cpp; sourceTree = "<group>"; };
 		A7B4EA6814C9348400C8F5BF /* JSMallocStatistics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMallocStatistics.cpp; sourceTree = "<group>"; };
-		1A2B3C4D5E6F708192A3B4C5 /* JSMallocStatisticsCustom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSMallocStatisticsCustom.cpp; sourceTree = "<group>"; };
 		A7B4EA6914C9348400C8F5BF /* JSMallocStatistics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSMallocStatistics.h; sourceTree = "<group>"; };
 		A7B4EA7814C9348400C8F5BF /* JSInternalSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSInternalSettings.cpp; sourceTree = "<group>"; };
 		A7B4EA7914C9348400C8F5BF /* JSInternalSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSInternalSettings.h; sourceTree = "<group>"; };
@@ -18950,6 +18951,8 @@
 		B5A684230FFABEAA00D24689 /* SQLiteFileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteFileSystem.cpp; sourceTree = "<group>"; };
 		B5B7A16E17C1048000E4AA0A /* ElementData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementData.h; sourceTree = "<group>"; };
 		B5B7A16F17C1080600E4AA0A /* ElementData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ElementData.cpp; sourceTree = "<group>"; };
+		B5E7A1C20D4F8A2E91C3F6D8 /* RenderLayerBackingSVGAdditions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderLayerBackingSVGAdditions.cpp; sourceTree = "<group>"; };
+		B65462106F804C6D97FED16D /* FallbackPopupMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FallbackPopupMenu.cpp; sourceTree = "<group>"; };
 		B656626E120B1227006EA85C /* JSIDBTransaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSIDBTransaction.h; sourceTree = "<group>"; };
 		B658FF9F1522EF3A00DD5595 /* JSRadioNodeList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSRadioNodeList.cpp; sourceTree = "<group>"; };
 		B658FFA01522EF3A00DD5595 /* JSRadioNodeList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSRadioNodeList.h; sourceTree = "<group>"; };
@@ -19229,7 +19232,6 @@
 		BC2387ED2D88E14900698102 /* JSCSSStyleProperties.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSCSSStyleProperties.cpp; sourceTree = "<group>"; };
 		BC2387F82D88E37E00698102 /* JSDOMWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSDOMWindow.h; sourceTree = "<group>"; };
 		BC2387F92D88E37E00698102 /* JSDOMWindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMWindow.cpp; sourceTree = "<group>"; };
-		4A02BEA1C4349368FDAA80A0 /* JSDOMWindowConstructorAttributes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMWindowConstructorAttributes.cpp; sourceTree = "<group>"; };
 		BC23880A2D88EFDA00698102 /* CSSFontFaceDescriptors.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSFontFaceDescriptors.cpp; sourceTree = "<group>"; };
 		BC23880B2D88EFDA00698102 /* CSSFontFaceDescriptors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSFontFaceDescriptors.h; sourceTree = "<group>"; };
 		BC23880C2D88EFDA00698102 /* CSSFontFaceDescriptors.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = CSSFontFaceDescriptors.idl; sourceTree = "<group>"; };
@@ -20349,6 +20351,7 @@
 		BCC5BDFF0C0E93110011C2DB /* JSCSSStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSCSSStyleSheet.h; sourceTree = "<group>"; };
 		BCC6DEE768FF3CAEF219270B /* Airplay-fullscreen.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Airplay-fullscreen.svg"; sourceTree = "<group>"; };
 		BCC8CFCA0986CD2400140BF2 /* ColorData.gperf */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = ColorData.gperf; sourceTree = "<group>"; };
+		BCC9ECA82FED9A69006C8BAD /* CSSPrimitiveNumeric+Forward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPrimitiveNumeric+Forward.h"; sourceTree = "<group>"; };
 		BCCBAD3E0C18C14200CE890F /* JSHTMLCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLCollection.cpp; sourceTree = "<group>"; };
 		BCCBAD3F0C18C14200CE890F /* JSHTMLCollection.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSHTMLCollection.h; sourceTree = "<group>"; };
 		BCCCF06B2EF76F720019EA48 /* StyleComputedStyle+ConstructionInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StyleComputedStyle+ConstructionInlines.h"; sourceTree = "<group>"; };
@@ -20534,8 +20537,6 @@
 		BCD9F1672E202E2100D1C3DF /* StyleGridOrderedNamedLinesMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleGridOrderedNamedLinesMap.h; sourceTree = "<group>"; };
 		BCD9F1692E202E8C00D1C3DF /* StyleGridNamedLinesMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleGridNamedLinesMap.cpp; sourceTree = "<group>"; };
 		BCD9F1742E20384800D1C3DF /* StyleObjectPosition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleObjectPosition.h; sourceTree = "<group>"; };
-		CEA340CB3EC1453981DF6B56 /* StyleObjectViewBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleObjectViewBox.h; sourceTree = "<group>"; };
-		DCD61E9000DE48A88138DCA4 /* StyleObjectViewBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleObjectViewBox.cpp; sourceTree = "<group>"; };
 		BCD9F1772E2040DC00D1C3DF /* StylePerspectiveOrigin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePerspectiveOrigin.h; sourceTree = "<group>"; };
 		BCD9F1792E2045C500D1C3DF /* StyleTransformOrigin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleTransformOrigin.h; sourceTree = "<group>"; };
 		BCD9F1B22E21D62800D1C3DF /* StyleGridTemplateList.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleGridTemplateList.h; sourceTree = "<group>"; };
@@ -21077,7 +21078,6 @@
 		CD1F9B40270CED8500617EB6 /* JSMediaKeyMessageType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSMediaKeyMessageType.cpp; sourceTree = "<group>"; };
 		CD1F9B41270CED8600617EB6 /* JSMediaKeyMessageEventInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSMediaKeyMessageEventInit.h; sourceTree = "<group>"; };
 		CD1F9B44270CF1CB00617EB6 /* ElementInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementInlines.h; sourceTree = "<group>"; };
-		1EC57482ED01054BFAD1ADBD /* ElementInlinesLight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementInlinesLight.h; sourceTree = "<group>"; };
 		CD1F9B46270CFC1600617EB6 /* EventOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EventOptions.h; sourceTree = "<group>"; };
 		CD1F9B4C270D03A900617EB6 /* ScrollExtents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollExtents.h; sourceTree = "<group>"; };
 		CD1F9B70270DFA7F00617EB6 /* MediaKeyMessageEventInit.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = MediaKeyMessageEventInit.idl; sourceTree = "<group>"; };
@@ -21645,6 +21645,7 @@
 		CE7B2DB11586ABAD0098B3FA /* TextAlternativeWithRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextAlternativeWithRange.h; sourceTree = "<group>"; };
 		CE7B2DB21586ABAD0098B3FA /* TextAlternativeWithRange.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TextAlternativeWithRange.mm; sourceTree = "<group>"; };
 		CE7E17821C83A49100AD06AF /* ContentSecurityPolicyHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ContentSecurityPolicyHash.h; path = csp/ContentSecurityPolicyHash.h; sourceTree = "<group>"; };
+		CEA340CB3EC1453981DF6B56 /* StyleObjectViewBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleObjectViewBox.h; sourceTree = "<group>"; };
 		CEA84720212622AD00940809 /* TextCheckingMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextCheckingMac.mm; sourceTree = "<group>"; };
 		CEBB8C3120786DCB00039547 /* FetchIdioms.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FetchIdioms.h; sourceTree = "<group>"; };
 		CEBB8C3220786DCB00039547 /* FetchIdioms.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FetchIdioms.cpp; sourceTree = "<group>"; };
@@ -21704,8 +21705,6 @@
 		D22B85902EB4EF6D000D2DC3 /* HTMLSelectedContentElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLSelectedContentElement.cpp; sourceTree = "<group>"; };
 		D22B85912EB4EF6D000D2DC3 /* HTMLSelectedContentElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTMLSelectedContentElement.h; sourceTree = "<group>"; };
 		D22B85922EB4EF6D000D2DC3 /* HTMLSelectedContentElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HTMLSelectedContentElement.idl; sourceTree = "<group>"; };
-		6E27FA0B62374E9BA36143C5 /* FallbackPopupMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FallbackPopupMenu.h; sourceTree = "<group>"; };
-		B65462106F804C6D97FED16D /* FallbackPopupMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FallbackPopupMenu.cpp; sourceTree = "<group>"; };
 		D245B6D02B6791BA009AA00E /* HTTPStatusCodes.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = HTTPStatusCodes.h; sourceTree = "<group>"; };
 		D26049262EFD23550067D2DA /* GraphicsLayerKeyframeValueList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GraphicsLayerKeyframeValueList.cpp; sourceTree = "<group>"; };
 		D267D41C2EE1B21E00C5E212 /* Origin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Origin.cpp; sourceTree = "<group>"; };
@@ -21800,6 +21799,7 @@
 		DBFCB0EBFF5CD77EBEB3595F /* RenderMathMLPadded.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RenderMathMLPadded.cpp; sourceTree = "<group>"; };
 		DC8EA0C37B0638710AE9B150 /* Play.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Play.svg; sourceTree = "<group>"; };
 		DCA7EDF42C655235000F16C7 /* BoxSides.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BoxSides.h; sourceTree = "<group>"; };
+		DCD61E9000DE48A88138DCA4 /* StyleObjectViewBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleObjectViewBox.cpp; sourceTree = "<group>"; };
 		DD05637C29B6B88100A98258 /* InlineDisplayContent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InlineDisplayContent.h; sourceTree = "<group>"; };
 		DD05FE0B0B8BA3C6009ACDFE /* WebCoreObjCExtras.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = WebCoreObjCExtras.h; sourceTree = "<group>"; };
 		DD17C079286EC51800D60B58 /* README.webkit */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.webkit; sourceTree = "<group>"; };
@@ -23923,6 +23923,8 @@
 		FE8A674616CDD19E00930BF8 /* SQLStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQLStatement.h; sourceTree = "<group>"; };
 		FE9E89F916E2DC0400A908F8 /* OriginLock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginLock.cpp; sourceTree = "<group>"; };
 		FE9E89FA16E2DC0400A908F8 /* OriginLock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginLock.h; sourceTree = "<group>"; };
+		FED1234567890ABCDEF12345 /* PeriodicSharedTimer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PeriodicSharedTimer.h; sourceTree = "<group>"; };
+		FED1234567890ABCDEF12346 /* PeriodicSharedTimer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PeriodicSharedTimer.mm; sourceTree = "<group>"; };
 		FED13D390CEA934600D89466 /* EditorIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EditorIOS.mm; sourceTree = "<group>"; };
 		FED13D3B0CEA936A00D89466 /* FrameIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FrameIOS.mm; sourceTree = "<group>"; };
 		FED13D3F0CEA939400D89466 /* IconIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IconIOS.mm; sourceTree = "<group>"; };
@@ -38945,6 +38947,7 @@
 				BCB271D92CC0142C00265123 /* CSSPosition.cpp */,
 				BCB271D82CC0142C00265123 /* CSSPosition.h */,
 				BC2C0C8E2D32EBCB00FCFBA0 /* CSSPrimitiveData.h */,
+				BCC9ECA82FED9A69006C8BAD /* CSSPrimitiveNumeric+Forward.h */,
 				BC2C0C8F2D32F35000FCFBA0 /* CSSPrimitiveNumeric.h */,
 				BC4630BC2E9D5A5A00EA911F /* CSSPrimitiveNumericCategory.cpp */,
 				BC4630BB2E9D5A5A00EA911F /* CSSPrimitiveNumericCategory.h */,
@@ -44842,6 +44845,7 @@
 				BC3B7A1D2DB55F9B00C7A692 /* CSSPositionValue.h in Headers */,
 				977B3863122883E900B81FF8 /* CSSPreloadScanner.h in Headers */,
 				BC2C0C972D32FCE600FCFBA0 /* CSSPrimitiveData.h in Headers */,
+				BCC9ECA92FED9AE0006C8BAD /* CSSPrimitiveNumeric+Forward.h in Headers */,
 				BC2C0C982D32FCF500FCFBA0 /* CSSPrimitiveNumeric.h in Headers */,
 				BC4630BD2E9D5B7C00EA911F /* CSSPrimitiveNumericCategory.h in Headers */,
 				BCD67C122D1F10BB0079EB9C /* CSSPrimitiveNumericConcepts.h in Headers */,

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -209,7 +209,7 @@ ExceptionOr<void> AnimationEffect::updateTiming(Document& document, const Option
         auto timingFunctionResult = CSSPropertyParserHelpers::parseEasingFunctionDeprecated(timing.easing, parsingContext);
         if (!timingFunctionResult)
             return Exception { ExceptionCode::TypeError };
-        setTimingFunction(WTF::move(timingFunctionResult));
+        setTimingFunction(timingFunctionResult.releaseNonNull());
     }
 
     // 5. Assign each member present in input to the corresponding timing property of effect as follows:

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -132,22 +132,26 @@ void BlendingKeyframes::copyKeyframes(const BlendingKeyframes& other)
 
 static const StyleRuleKeyframe& zeroPercentKeyframe()
 {
+    using namespace CSS::Literals;
+
     static LazyNeverDestroyed<Ref<StyleRuleKeyframe>> rule;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         rule.construct(StyleRuleKeyframe::create(MutableStyleProperties::create()));
-        rule.get()->setKey({ CSSValueNormal, 0 });
+        rule.get()->setKey({ CSSValueNormal, 0_css_percentage });
     });
     return rule.get().get();
 }
 
 static const StyleRuleKeyframe& hundredPercentKeyframe()
 {
+    using namespace CSS::Literals;
+
     static LazyNeverDestroyed<Ref<StyleRuleKeyframe>> rule;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         rule.construct(StyleRuleKeyframe::create(MutableStyleProperties::create()));
-        rule.get()->setKey({ CSSValueNormal, 1 });
+        rule.get()->setKey({ CSSValueNormal, 1_css_percentage });
     });
     return rule.get().get();
 }

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -27,6 +27,7 @@
 #include "CompositeOperation.h"
 #include "KeyframeInterpolation.h"
 #include "StyleComputedStyle.h"
+#include "StyleEasingFunction.h"
 #include "StyleSingleAnimationRangeName.h"
 #include "WebAnimationTypes.h"
 #include <wtf/Vector.h>
@@ -86,8 +87,11 @@ public:
     const Style::ComputedStyle* style() const LIFETIME_BOUND { return m_style.get(); }
     void setStyle(std::unique_ptr<Style::ComputedStyle>&& style) { m_style = WTF::move(style); }
 
-    TimingFunction* timingFunction() const { return m_timingFunction.get(); }
-    void setTimingFunction(const RefPtr<TimingFunction>& timingFunction) { m_timingFunction = timingFunction; }
+    const std::optional<Style::EasingFunction>& easingFunction() const { return m_timingFunction; }
+    void setEasingFunction(Style::EasingFunction&& easingFunction) { m_timingFunction = WTF::move(easingFunction); }
+
+    TimingFunction* timingFunction() const { return m_timingFunction ? m_timingFunction->value.ptr() : nullptr; }
+    void setTimingFunction(Ref<TimingFunction>&& timingFunction) { m_timingFunction = Style::EasingFunction { WTF::move(timingFunction) }; }
 
     void setCompositeOperation(std::optional<CompositeOperation> op) { m_compositeOperation = op; }
 
@@ -101,7 +105,9 @@ private:
     double m_computedOffset { std::numeric_limits<double>::quiet_NaN() };
     HashSet<AnimatableCSSProperty> m_properties; // The properties specified in this keyframe.
     std::unique_ptr<Style::ComputedStyle> m_style;
-    RefPtr<TimingFunction> m_timingFunction;
+    // https://drafts.csswg.org/web-animations-1/#keyframe-specific-easing-function
+    std::optional<Style::EasingFunction> m_timingFunction;
+    // https://drafts.csswg.org/web-animations-1/#keyframe-specific-composite-operation
     std::optional<CompositeOperation> m_compositeOperation;
     bool m_containsDirectionAwareProperty { false };
     bool m_hasPropertiesWithRevertRuleOrLayer { false };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -71,6 +71,7 @@
 #include "StyleExtractor.h"
 #include "StyleInterpolation.h"
 #include "StylePendingResources.h"
+#include "StylePrimitiveNumericTypes+DeprecatedConversions.h"
 #include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
@@ -198,12 +199,15 @@ static std::optional<Variant<double, TimelineRangeOffset>> doubleOrTimelineRange
     if (offsets.size() != 1)
         return { };
 
-    auto [rangeCSSValueID, value] = offsets[0];
-    auto rangeName = Style::convertCSSValueIDToSingleAnimationRangeName(rangeCSSValueID);
-    if (rangeName == Style::SingleAnimationRangeName::Normal)
-        return value;
+    auto [rangeCSSValueID, offsetCSSPercentage] = offsets[0];
 
-    return { TimelineRangeOffset { Style::convertSingleAnimationRangeNameToRangeString(rangeName), CSSNumericFactory::percent(value * 100) } };
+    auto resolvedOffsetPercentage = Style::deprecatedToStyle(offsetCSSPercentage).value;
+    auto rangeName = Style::convertCSSValueIDToSingleAnimationRangeName(rangeCSSValueID);
+
+    if (rangeName == Style::SingleAnimationRangeName::Normal)
+        return { CSS::clampToRange<CSS::ClosedPercentageRange, double>(resolvedOffsetPercentage) / 100 };
+
+    return { TimelineRangeOffset { Style::convertSingleAnimationRangeNameToRangeString(rangeName), CSSNumericFactory::percent(resolvedOffsetPercentage) } };
 }
 
 static std::optional<KeyframeEffect::KeyframeOffset> validateKeyframeOffset(const KeyframeEffect::KeyframeOffset& offset, const Document& document)
@@ -931,7 +935,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
         if (!styleScope)
             return { };
 
-        return protect(styleScope->resolver())->keyframeRulesForName(computedBlendingKeyframes.keyframesName(), backingStyleAnimation.timingFunction().value.ptr());
+        return protect(styleScope->resolver())->keyframeRulesForName(computedBlendingKeyframes.keyframesName(), backingStyleAnimation.timingFunction());
     }();
 
     auto matchingStyleRuleKeyframe = [&](const BlendingKeyframe& keyframe) -> StyleRuleKeyframe* {
@@ -1424,7 +1428,7 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const Style::ComputedS
     if (m_target) {
         Style::Scope::resolveTreeScopedReference(protect(*m_target), *backingStyleAnimationName, [&](const Style::Scope& scope, const AtomString&) {
             ASSERT(scope.resolverIfExists());
-            return protect(scope.resolverIfExists())->keyframeStylesForAnimation(protect(*m_target), unanimatedStyle, resolutionContext, blendingKeyframes, backingStyleAnimation.timingFunction().value.ptr());
+            return protect(scope.resolverIfExists())->keyframeStylesForAnimation(protect(*m_target), unanimatedStyle, resolutionContext, blendingKeyframes, backingStyleAnimation.timingFunction());
         });
 
         // Ensure resource loads for all the frames.

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -27,6 +27,7 @@
 #include "CSSKeyframeRule.h"
 
 #include "CSSKeyframesRule.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPropertyParserConsumer+Animations.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleProperties.h"
@@ -38,23 +39,23 @@
 
 namespace WebCore {
 
-void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
+void StyleRuleKeyframe::Key::writeToString(StringBuilder& builder) const
 {
     if (rangeName == CSSValueContain)
-        str.append("contain "_s);
+        builder.append("contain "_s);
     else if (rangeName == CSSValueCover)
-        str.append("cover "_s);
+        builder.append("cover "_s);
     else if (rangeName == CSSValueEntry)
-        str.append("entry "_s);
+        builder.append("entry "_s);
     else if (rangeName == CSSValueEntryCrossing)
-        str.append("entry-crossing "_s);
+        builder.append("entry-crossing "_s);
     else if (rangeName == CSSValueExit)
-        str.append("exit "_s);
+        builder.append("exit "_s);
     else if (rangeName == CSSValueExitCrossing)
-        str.append("exit-crossing "_s);
+        builder.append("exit-crossing "_s);
     else if (rangeName == CSSValueScroll)
-        str.append("scroll "_s);
-    str.append(offset * 100, '%');
+        builder.append("scroll "_s);
+    CSS::serializationForCSS(builder, CSS::defaultSerializationContext(), offset);
 }
 
 StyleRuleKeyframe::StyleRuleKeyframe(Ref<StyleProperties>&& properties)
@@ -75,7 +76,7 @@ Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Ref<StyleProperties>&& properti
     return adoptRef(*new StyleRuleKeyframe(WTF::move(properties)));
 }
 
-Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Vector<std::pair<CSSValueID, double>>&& keys, Ref<StyleProperties>&& properties)
+Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Vector<std::pair<CSSValueID, CSS::Percentage<>>>&& keys, Ref<StyleProperties>&& properties)
 {
     auto keyStructs = keys.map([](auto& pair) -> Key {
         return { pair.first, pair.second };
@@ -102,7 +103,7 @@ String StyleRuleKeyframe::keyText() const
     }
     return keyText.toString();
 }
-    
+
 bool StyleRuleKeyframe::setKeyText(const String& keyText)
 {
     ASSERT(!keyText.isNull());

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumeric.h"
 #include "CSSRule.h"
 #include "StyleRule.h"
 
@@ -38,14 +39,14 @@ class StyleRuleCSSStyleProperties;
 class StyleRuleKeyframe final : public StyleRuleBase {
 public:
     static Ref<StyleRuleKeyframe> NODELETE create(Ref<StyleProperties>&&);
-    static Ref<StyleRuleKeyframe> create(Vector<std::pair<CSSValueID, double>>&& keys, Ref<StyleProperties>&&);
+    static Ref<StyleRuleKeyframe> create(Vector<std::pair<CSSValueID, CSS::Percentage<>>>&& keys, Ref<StyleProperties>&&);
     ~StyleRuleKeyframe();
 
     Ref<StyleRuleKeyframe> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     struct Key {
         CSSValueID rangeName;
-        double offset;
+        CSS::Percentage<> offset;
 
         void writeToString(StringBuilder&) const;
         bool operator==(const Key&) const = default;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -39,56 +39,41 @@
 #include "CSSPropertyParserConsumer+Timeline.h"
 #include "CSSPropertyParserState.h"
 #include "CSSStringValue.h"
-#include "StylePrimitiveNumericTypes+DeprecatedConversions.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> consumeKeyframeKeyList(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <keyframe-selector> = from | to | <percentage [0,100]> | <timeline-range-name> <percentage>
     // https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
+    //   and extended by
+    // https://drafts.csswg.org/scroll-animations/#named-range-keyframes
 
-    enum class RestrictedToZeroToHundredRange : bool { No, Yes };
-    auto consumeAndConvertPercentage = [&](CSSParserTokenRange& range, RestrictedToZeroToHundredRange restricted) -> std::optional<double> {
-        // FIXME: We use Style::deprecatedToStyle() to deal with calc() and % values.
-        // We will eventually want to return a CSS value that can be kept as-is on a
-        // BlendingKeyframe so that resolution happens when we have the necessary context
-        // when the keyframes are associated with a target element.
-        if (auto percentageValue = MetaConsumer<CSS::Percentage<>>::consume(range, state)) {
-            auto resolvedPercentage = Style::deprecatedToStyle(*percentageValue).value;
-            if (restricted == RestrictedToZeroToHundredRange::No)
-                return resolvedPercentage / 100;
-            if (resolvedPercentage >= 0 && resolvedPercentage <= 100)
-                return resolvedPercentage / 100;
-        }
-        return { };
-    };
-
-    auto timelineRange = [&](CSSParserTokenRange& range, CSSValueID id) -> std::optional<std::pair<CSSValueID, double>> {
+    auto timelineRange = [&](CSSParserTokenRange& range, CSSValueID id) -> std::optional<std::pair<CSSValueID, CSS::Percentage<>>> {
         if (CSSPropertyParserHelpers::isTimelineRangeName(id)) {
-            if (auto convertedPercentage = consumeAndConvertPercentage(range, RestrictedToZeroToHundredRange::No))
-                return { { id, *convertedPercentage } };
+            if (auto percentage = MetaConsumer<CSS::Percentage<>>::consume(range, state))
+                return { { id, WTF::move(*percentage) } };
         }
         return { };
     };
 
-    Vector<std::pair<CSSValueID, double>> result;
+    Vector<std::pair<CSSValueID, CSS::Percentage<>>> result;
     while (true) {
         range.consumeWhitespace();
 
         if (auto tokenValue = consumeIdent(range)) {
             auto valueId = tokenValue->valueID();
             if (valueId == CSSValueFrom)
-                result.append({ CSSValueNormal, 0 });
+                result.append({ CSSValueNormal, CSS::Percentage<> { 0 } });
             else if (valueId == CSSValueTo)
-                result.append({ CSSValueNormal, 1 });
+                result.append({ CSSValueNormal, CSS::Percentage<> { 100 } });
             else if (auto pair = timelineRange(range, valueId))
                 result.append(*pair);
             else
                 return { }; // Parser error, invalid value in keyframe selector
-        } else if (auto convertedPercentage = consumeAndConvertPercentage(range, RestrictedToZeroToHundredRange::Yes))
-            result.append({ CSSValueNormal, *convertedPercentage });
+        } else if (auto percentage = MetaConsumer<CSS::Percentage<CSS::ClosedPercentageRange>>::consume(range, state))
+            result.append({ CSSValueNormal, CSS::rangeExpandingCast<CSS::All>(*percentage) });
         else
             return { }; // Parser error, invalid value in keyframe selector
 
@@ -102,7 +87,7 @@ Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange
     }
 }
 
-Vector<std::pair<CSSValueID, double>> parseKeyframeKeyList(const String& string, const CSSParserContext& context)
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(const String& string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumeric+Forward.h"
 #include <wtf/Forward.h>
 
 namespace WebCore {
@@ -42,11 +43,11 @@ namespace CSSPropertyParserHelpers {
 
 // MARK: <keyframe-selector> consuming
 // https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
-Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange&, CSS::PropertyParserState&);
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> consumeKeyframeKeyList(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <keyframe-selector> parsing
 // https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
-Vector<std::pair<CSSValueID, double>> parseKeyframeKeyList(const String&, const CSSParserContext&);
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(const String&, const CSSParserContext&);
 
 // MARK: <keyframes-name> consuming
 // https://drafts.csswg.org/css-animations/#typedef-keyframes-name

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -152,7 +152,7 @@ std::optional<CSS::GridLine> consumeUnresolvedGridLine(CSSParserTokenRange& rang
         auto name = consumeUnresolvedCustomIdentForGridLine(range, state);
 
         if (consumeIdentRaw<CSSValueSpan>(range).has_value()) {
-            auto rangeCastedIndex = CSS::dynamicRangecast<CSS::Positive>(*index);
+            auto rangeCastedIndex = CSS::dynamicRangeNarrowingCast<CSS::Positive>(*index);
             if (!rangeCastedIndex)
                 return std::nullopt;
 
@@ -181,7 +181,7 @@ std::optional<CSS::GridLine> consumeUnresolvedGridLine(CSSParserTokenRange& rang
 
     if (consumeIdentRaw<CSSValueSpan>(range).has_value()) {
         if (index) {
-            auto rangeCastedIndex = CSS::dynamicRangecast<CSS::Positive>(*index);
+            auto rangeCastedIndex = CSS::dynamicRangeNarrowingCast<CSS::Positive>(*index);
             if (!rangeCastedIndex)
                 return std::nullopt;
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveData.h
@@ -31,6 +31,7 @@
 #include <limits>
 #include <type_traits>
 #include <wtf/EnumTraits.h>
+#include <wtf/Hasher.h>
 
 namespace WebCore {
 namespace CSS {
@@ -211,6 +212,11 @@ template<Numeric N, SpecificKeyword... Ks> struct PrimitiveDataIndex {
 
     constexpr bool operator==(const PrimitiveDataIndex&) const = default;
     constexpr bool operator==(Storage other) const { return storage == other; }
+
+    friend void add(Hasher& hasher, const PrimitiveDataIndex& index)
+    {
+        add(hasher, index.storage);
+    }
 
     Storage storage;
 };
@@ -478,6 +484,15 @@ template<Numeric N, SpecificKeyword... Ks> struct PrimitiveData {
         if (isCalc())
             return f(asCalc());
         return index.visitKeyword(std::forward<F>(f));
+    }
+
+    friend void add(Hasher& hasher, const PrimitiveData& data)
+    {
+        add(hasher, data.index);
+        if (data.isRaw())
+            add(hasher, data.payload.number);
+        else if (data.isCalc())
+            add(hasher, data.payload.calc);
     }
 
     void setAsMovedFrom()

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric+Forward.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric+Forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,24 +24,36 @@
 
 #pragma once
 
-#include "CSSLinearEasingFunction.h"
+#include <WebCore/CSSPrimitiveNumericRange.h>
 
 namespace WebCore {
+namespace CSS {
 
-class CSSToLengthConversionData;
-class LinearTimingFunction;
-class TimingFunction;
+// MARK: Integer Primitive
 
-namespace Style {
+template<Range = All, typename = int> struct Integer;
 
-class BuilderState;
-class ComputedStyle;
+// MARK: Number Primitive
 
-CSS::LinearEasingFunction toCSSLinearEasingFunction(const LinearTimingFunction&, const Style::ComputedStyle&);
+template<Range = All, typename = double> struct Number;
 
-Ref<TimingFunction> createTimingFunction(const BuilderState&, const CSS::LinearEasingFunction&);
-Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData&, const CSS::LinearEasingFunction&);
-Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::LinearEasingFunction&);
+// MARK: Percentage Primitive
 
-} // namespace Style
+template<Range = All, typename = double> struct Percentage;
+
+// MARK: Dimension Primitives
+
+template<Range = All, typename = double> struct Angle;
+template<Range = All, typename = float> struct Length;
+template<Range = All, typename = double> struct Time;
+template<Range = All, typename = double> struct Frequency;
+template<Range = Nonnegative, typename = double> struct Resolution;
+template<Range = All, typename = double> struct Flex;
+
+// MARK: Dimension + Percentage Primitives
+
+template<Range = All, typename = float> struct AnglePercentage;
+template<Range = All, typename = float> struct LengthPercentage;
+
+} // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/CSSPrimitiveData.h>
+#include <WebCore/CSSPrimitiveNumeric+Forward.h>
 #include <WebCore/CSSPrimitiveNumericConcepts.h>
 #include <WebCore/CSSPrimitiveNumericRaw.h>
 #include <WebCore/CSSUnevaluatedCalc.h>
@@ -35,11 +36,6 @@
 
 namespace WebCore {
 namespace CSS {
-
-// MARK: - Forward Declarations
-
-template<NumericRaw> struct PrimitiveNumeric;
-template<Numeric, SpecificKeyword...> struct PrimitiveNumericOrKeyword;
 
 // MARK: - Primitive Numeric (Raw + UnevaluatedCalc)
 
@@ -65,6 +61,11 @@ template<NumericRaw RawType> struct PrimitiveNumeric {
 
     PrimitiveNumeric(Calc calc)
         : m_data { WTF::move(calc) }
+    {
+    }
+
+    PrimitiveNumeric(WTF::HashTableEmptyValueType)
+        : m_data { PrimitiveDataEmptyToken { } }
     {
     }
 
@@ -154,6 +155,11 @@ template<NumericRaw RawType> struct PrimitiveNumeric {
     bool isCalc() const { return m_data.isCalc(); }
     bool isEmpty() const { return m_data.isEmpty(); }
 
+    friend void add(Hasher& hasher, const PrimitiveNumeric& numeric)
+    {
+        add(hasher, numeric.m_data);
+    }
+
 private:
     template<typename> friend struct PrimitiveDataMarkableTraits;
     template<Numeric, SpecificKeyword...> friend struct PrimitiveNumericOrKeyword;
@@ -171,55 +177,55 @@ private:
 
 // MARK: Integer Primitive
 
-template<Range R = All, typename V = int> struct Integer : PrimitiveNumeric<IntegerRaw<R, V>> {
+template<Range R, typename V> struct Integer : PrimitiveNumeric<IntegerRaw<R, V>> {
     using Base = PrimitiveNumeric<IntegerRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Number Primitive
 
-template<Range R = All, typename V = double> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
+template<Range R, typename V> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
     using Base = PrimitiveNumeric<NumberRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Percentage Primitive
 
-template<Range R = All, typename V = double> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
+template<Range R, typename V> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<PercentageRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Dimension Primitives
 
-template<Range R = All, typename V = double> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
+template<Range R, typename V> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
     using Base = PrimitiveNumeric<AngleRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = float> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
+template<Range R, typename V> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
     using Base = PrimitiveNumeric<LengthRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = double> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
+template<Range R, typename V> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
     using Base = PrimitiveNumeric<TimeRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = double> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
+template<Range R, typename V> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
     using Base = PrimitiveNumeric<FrequencyRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
+template<Range R, typename V> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
     using Base = PrimitiveNumeric<ResolutionRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = double> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
+template<Range R, typename V> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
     using Base = PrimitiveNumeric<FlexRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Dimension + Percentage Primitives
 
-template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
+template<Range R, typename V> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<AnglePercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveDataMarkableTraits<AnglePercentage<R, V>>;
@@ -227,7 +233,7 @@ template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNu
     using Dimension = CSS::Angle<R, V>;
     using Percentage = CSS::Percentage<R, V>;
 };
-template<Range R = All, typename V = float> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
+template<Range R, typename V> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<LengthPercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveDataMarkableTraits<LengthPercentage<R, V>>;
@@ -271,13 +277,15 @@ struct ReplacingRangeHelper<LengthPercentage<oldRange, V>, newRange> { using typ
 template<Numeric T, Range newRange>
 using ReplacingRange = typename ReplacingRangeHelper<T, newRange>::type;
 
-// `CSS::dynamicRangecast` converts a `CSS::PrimitiveNumeric` subtype with range `a` to one with range `b`,
-// returning `std::nullopt` if the value stored is a raw value that is not with range `b`. If the
-// value stored is a `calc()` value, the range cast always succeeds, as the range is only evaluated
-// for `calc()` during conversion to its `Style::PrimitiveNumeric` counterpart.
+// `CSS::dynamicRangeNarrowingCast` converts a `CSS::PrimitiveNumeric` subtype with range `a` to one
+// with range `b`, requiring that range `b` be a subrange of range `a`, returning `std::nullopt` if
+// the value stored is a raw value that is not with range `b`. If the value stored is a `calc()` value,
+// the range cast always succeeds, as the range is only evaluated for `calc()` during conversion to its
+// `Style::PrimitiveNumeric` counterpart.
 
 template<auto newRange, Numeric T>
-decltype(auto) dynamicRangecast(const T& value)
+    requires IsSubrange<newRange, T::range>
+auto dynamicRangeNarrowingCast(const T& value) -> std::optional<ReplacingRange<T, newRange>>
 {
     using Replacement = ReplacingRange<T, newRange>;
 
@@ -289,6 +297,59 @@ decltype(auto) dynamicRangecast(const T& value)
         },
         [](const typename T::Calc& calc) -> std::optional<Replacement> {
             return Replacement { typename Replacement::Calc { calc } };
+        }
+    );
+}
+
+template<auto newRange, Numeric T>
+    requires IsSubrange<newRange, T::range>
+auto dynamicRangeNarrowingCast(T&& value) -> std::optional<ReplacingRange<T, newRange>>
+{
+    using Replacement = ReplacingRange<T, newRange>;
+
+    return WTF::switchOn(WTF::move(value),
+        [](typename T::Raw&& raw) -> std::optional<Replacement> {
+            if (!isWithinRange<newRange>(raw.value))
+                return std::nullopt;
+            return Replacement { typename Replacement::Raw { raw.value } };
+        },
+        [](typename T::Calc&& calc) -> std::optional<Replacement> {
+            return Replacement { typename Replacement::Calc { WTF::move(calc) } };
+        }
+    );
+}
+
+// `CSS::rangeExpandingCast` converts a `CSS::PrimitiveNumeric` subtype with narrow range `a` to
+// an encompassing range `b`.
+
+template<auto newRange, Numeric T>
+    requires IsSubrange<T::range, newRange>
+auto rangeExpandingCast(const T& value) -> ReplacingRange<T, newRange>
+{
+    using Replacement = ReplacingRange<T, newRange>;
+
+    return WTF::switchOn(value,
+        [](const typename T::Raw& raw) {
+            return Replacement { typename Replacement::Raw { raw.value } };
+        },
+        [](const typename T::Calc& calc) {
+            return Replacement { typename Replacement::Calc { calc } };
+        }
+    );
+}
+
+template<auto newRange, Numeric T>
+    requires IsSubrange<T::range, newRange>
+auto rangeExpandingCast(T&& value) -> ReplacingRange<T, newRange>
+{
+    using Replacement = ReplacingRange<T, newRange>;
+
+    return WTF::switchOn(WTF::move(value),
+        [](typename T::Raw&& raw) {
+            return Replacement { typename Replacement::Raw { raw.value } };
+        },
+        [](typename T::Calc&& calc) {
+            return Replacement { typename Replacement::Calc { WTF::move(calc) } };
         }
     );
 }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -144,6 +144,20 @@ inline constexpr auto AllLayoutUnitClampedUnzoomed = Range { minValueForCssLengt
 inline constexpr auto NonnegativeLayoutUnitClamped = Range { 0, maxValueForCssLength, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Ignore };
 inline constexpr auto NonnegativeLayoutUnitClampedUnzoomed = Range { 0, maxValueForCssLength, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Ignore, RangeZoomOptions::Unzoomed };
 
+// Returns whether range `a` is equal to or is a subrange of range `b`.
+consteval bool isEqualOrSubrange(Range a, Range b)
+{
+    return a.min >= b.min && a.max <= b.max;
+}
+
+// Returns whether range `a` is a strict subrange of range `b`.
+consteval bool isSubrange(Range a, Range b)
+{
+    return isEqualOrSubrange(a, b) && (a.min != b.min || a.max != b.max);
+}
+
+template<Range a, Range b> concept IsSubrange = isSubrange(a, b);
+
 // Clamps a floating point value to within static `range`.
 template<Range range, std::floating_point T, typename U> constexpr T clampToRange(U value)
 {

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -80,6 +80,7 @@
 #include "StyleEasingFunction.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleKeyword+Mappings.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolveForDocument.h"
@@ -106,20 +107,39 @@
 namespace WTF {
 
 struct StyleRuleKeyframeKeyHash {
-    static unsigned NODELETE hash(const WebCore::StyleRuleKeyframe::Key& p) { return pairIntHash(p.rangeName, p.offset); }
+    static unsigned NODELETE hash(const WebCore::StyleRuleKeyframe::Key& p) { return computeHash(p.rangeName, p.offset); }
     static bool NODELETE equal(const WebCore::StyleRuleKeyframe::Key& a, const WebCore::StyleRuleKeyframe::Key& b) { return a == b; }
     static const bool safeToCompareToEmptyOrDeleted = true;
 };
 template<> struct HashTraits<WebCore::StyleRuleKeyframe::Key> : GenericHashTraits<WebCore::StyleRuleKeyframe::Key> {
-    static WebCore::StyleRuleKeyframe::Key NODELETE emptyValue() { return { WebCore::CSSValueDefault, 0 }; }
+    static WebCore::StyleRuleKeyframe::Key NODELETE emptyValue() { return { WebCore::CSSValueDefault, HashTableEmptyValue }; }
     static bool NODELETE isEmptyValue(const WebCore::StyleRuleKeyframe::Key& value) { return value.rangeName == WebCore::CSSValueDefault; }
 
-    static void NODELETE constructDeletedValue(WebCore::StyleRuleKeyframe::Key& slot) { slot.rangeName = WebCore::CSSValueNone; }
+    template<typename>
+    static void NODELETE constructDeletedValue(WebCore::StyleRuleKeyframe::Key& slot) { slot.rangeName = WebCore::CSSValueNone; slot.offset = HashTableEmptyValue; }
     static bool NODELETE isDeletedValue(const WebCore::StyleRuleKeyframe::Key& slot) { return slot.rangeName == WebCore::CSSValueNone; }
 };
 template<> struct DefaultHash<WebCore::StyleRuleKeyframe::Key> : StyleRuleKeyframeKeyHash { };
 
-}
+struct EasingFunctionHash {
+    static unsigned NODELETE hash(const WebCore::Style::EasingFunction& p) { return computeHash(p.value.ptr()); }
+    static bool NODELETE equal(const WebCore::Style::EasingFunction& a, const WebCore::Style::EasingFunction& b) { return a == b; }
+    static const bool safeToCompareToEmptyOrDeleted = false;
+};
+template<> struct HashTraits<WebCore::Style::EasingFunction> : GenericHashTraits<WebCore::Style::EasingFunction> {
+    static constexpr bool emptyValueIsZero = true;
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static WebCore::Style::EasingFunction NODELETE emptyValue() { return WebCore::Style::EasingFunction { Ref<WebCore::TimingFunction>(HashTableEmptyValue) }; }
+    template<typename>
+    static void NODELETE constructEmptyValue(WebCore::Style::EasingFunction& slot) { new (NotNull, std::addressof(slot)) WebCore::Style::EasingFunction(Ref<WebCore::TimingFunction>(HashTableEmptyValue)); }
+    static bool NODELETE isEmptyValue(const WebCore::Style::EasingFunction& value) { return value.value.isHashTableEmptyValue(); }
+
+    static void constructDeletedValue(WebCore::Style::EasingFunction& slot) { new (NotNull, std::addressof(slot)) WebCore::Style::EasingFunction(Ref<WebCore::TimingFunction>(HashTableDeletedValue)); }
+    static bool NODELETE isDeletedValue(const WebCore::Style::EasingFunction& value) { return value.value.isHashTableDeletedValue(); }
+};
+template<> struct DefaultHash<WebCore::Style::EasingFunction> : EasingFunctionHash { };
+
+} // namespace WTF
 
 namespace WebCore {
 namespace Style {
@@ -442,7 +462,7 @@ bool Resolver::isAnimationNameValid(const AtomString& name) const
         || userAgentKeyframes().find(name) != userAgentKeyframes().end();
 }
 
-Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& animationName, const TimingFunction* defaultTimingFunction) const
+Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& animationName, const EasingFunction& defaultTimingFunction) const
 {
     if (animationName.isEmpty())
         return { };
@@ -465,21 +485,19 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
         return Animation::initialCompositeOperation();
     };
 
-    auto timingFunctionForKeyframe = [&](Ref<StyleRuleKeyframe> keyframe) -> Ref<const TimingFunction> {
+    auto timingFunctionForKeyframe = [&](Ref<StyleRuleKeyframe> keyframe) -> EasingFunction {
         if (RefPtr timingFunctionCSSValue = keyframe->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction)) {
             if (RefPtr timingFunction = createTimingFunctionDeprecated(timingFunctionCSSValue.releaseNonNull()))
-                return timingFunction.releaseNonNull();
+                return EasingFunction { timingFunction.releaseNonNull() };
         }
-        if (defaultTimingFunction)
-            return *defaultTimingFunction;
-        return CubicBezierTimingFunction::defaultTimingFunction();
+        return defaultTimingFunction;
     };
 
-    HashSet<Ref<const TimingFunction>> timingFunctions;
-    auto uniqueTimingFunctionForKeyframe = [&](Ref<StyleRuleKeyframe> keyframe) -> Ref<const TimingFunction> {
-        Ref timingFunction = timingFunctionForKeyframe(keyframe);
+    HashSet<EasingFunction> timingFunctions;
+    auto uniqueTimingFunctionForKeyframe = [&](Ref<StyleRuleKeyframe> keyframe) -> EasingFunction {
+        auto timingFunction = timingFunctionForKeyframe(keyframe);
         for (auto& existingTimingFunction : timingFunctions) {
-            if (arePointingToEqualData(timingFunction.ptr(), existingTimingFunction.ptr()))
+            if (timingFunction == existingTimingFunction)
                 return existingTimingFunction;
         }
         timingFunctions.add(timingFunction);
@@ -489,7 +507,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     Ref keyframesRule = it->value;
     auto* keyframes = &keyframesRule->keyframes();
 
-    using KeyframeUniqueKey = std::tuple<StyleRuleKeyframe::Key, Ref<const TimingFunction>, CompositeOperation>;
+    using KeyframeUniqueKey = std::tuple<StyleRuleKeyframe::Key, EasingFunction, CompositeOperation>;
     auto hasDuplicateKeys = [&]() -> bool {
         HashSet<KeyframeUniqueKey> uniqueKeyframeKeys;
         for (auto& keyframe : *keyframes) {
@@ -513,6 +531,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     for (auto& originalKeyframe : *keyframes) {
         auto compositeOperation = compositeOperationForKeyframe(originalKeyframe);
         auto timingFunction = uniqueTimingFunctionForKeyframe(originalKeyframe);
+
         for (auto key : originalKeyframe->keys()) {
             KeyframeUniqueKey uniqueKey { key, timingFunction, compositeOperation };
             if (RefPtr existingStyleRuleKeyframe = keyframesMap.get(uniqueKey)) {
@@ -536,7 +555,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-bool Resolver::keyframeStylesForAnimation(Element& element, const Style::ComputedStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list, const TimingFunction* defaultTimingFunction) const
+bool Resolver::keyframeStylesForAnimation(Element& element, const Style::ComputedStyle& elementStyle, const ResolutionContext& context, BlendingKeyframes& list, const EasingFunction& defaultTimingFunction) const
 {
     list.clear();
 
@@ -544,22 +563,49 @@ bool Resolver::keyframeStylesForAnimation(Element& element, const Style::Compute
     if (keyframeRules.isEmpty())
         return false;
 
+    auto conversionData = CSSToLengthConversionData {
+        elementStyle,
+        context.documentElementStyle,
+        context.parentStyle ? context.parentStyle : &document().initialStyle(),
+        document().renderView(),
+        &element
+    };
+
     // Construct and populate the style for each keyframe.
     for (auto& keyframeRule : keyframeRules) {
         // Add this keyframe style to all the indicated key times
         for (auto& key : keyframeRule->keys()) {
-            BlendingKeyframe blendingKeyframe({ Style::convertCSSValueIDToSingleAnimationRangeName(key.rangeName), key.offset }, { nullptr });
+            auto offsetPercentage = toStyle(key.offset, conversionData).value;
+            auto offsetRangeName = convertCSSValueIDToSingleAnimationRangeName(key.rangeName);
+
+            if (offsetRangeName == Style::SingleAnimationRangeName::Normal || offsetRangeName == Style::SingleAnimationRangeName::Omitted)
+                offsetPercentage = CSS::clampToRange<CSS::ClosedPercentageRange, double>(offsetPercentage);
+
+            BlendingKeyframe blendingKeyframe({
+                    offsetRangeName,
+                    offsetPercentage / 100.0,
+                },
+                { nullptr }
+            );
+
             blendingKeyframe.setStyle(styleForKeyframe(element, elementStyle, context, keyframeRule.get(), blendingKeyframe));
+
             if (RefPtr timingFunctionCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction))
-                blendingKeyframe.setTimingFunction(createTimingFunctionDeprecated(timingFunctionCSSValue.releaseNonNull()));
+                blendingKeyframe.setEasingFunction(toStyleFromCSSValue<EasingFunction>(conversionData, *timingFunctionCSSValue));
+
             if (RefPtr compositeOperationCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationComposition)) {
-                if (auto compositeOperation = toCompositeOperation(compositeOperationCSSValue.releaseNonNull()))
+                if (auto compositeOperation = toCompositeOperation(*compositeOperationCSSValue))
                     blendingKeyframe.setCompositeOperation(*compositeOperation);
             }
             list.insert(WTF::move(blendingKeyframe));
             list.updatePropertiesMetadata(keyframeRule->properties());
         }
     }
+
+    // FIXME: Do we need to do anything like `styleForKeyframe` does with:
+    //   if (state.style()->usesViewportUnits())
+    //       element.document().setHasStyleWithViewportUnits();
+    // for viewport unit usage by `key.offset` or
 
     return true;
 }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -57,7 +57,6 @@ class StyleRuleKeyframes;
 class StyleRulePage;
 class StyleSheet;
 class StyleSheetList;
-class TimingFunction;
 class ViewportStyleResolver;
 
 enum class RuleMatchingBehavior: uint8_t {
@@ -71,6 +70,7 @@ class ComputedStyle;
 class CustomFunctionRegistry;
 struct BuilderContext;
 struct CachedMatchResult;
+struct EasingFunction;
 struct ResolvedStyle;
 struct SelectorMatchingState;
 struct UnadjustedStyle;
@@ -101,7 +101,7 @@ public:
 
     ResolvedStyle styleForElement(Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    bool keyframeStylesForAnimation(Element&, const Style::ComputedStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&, const TimingFunction*) const;
+    bool keyframeStylesForAnimation(Element&, const ComputedStyle& elementStyle, const ResolutionContext&, BlendingKeyframes&, const EasingFunction& defaultTimingFunction) const;
 
     WEBCORE_EXPORT std::optional<ResolvedStyle> styleForPseudoElement(Element&, const PseudoElementRequest&, const ResolutionContext&);
 
@@ -148,7 +148,7 @@ public:
     static KeyframesRuleMap& NODELETE userAgentKeyframes();
     static void addUserAgentKeyframeStyle(Ref<StyleRuleKeyframes>&&);
     void addKeyframeStyle(Ref<StyleRuleKeyframes>&&);
-    Vector<Ref<StyleRuleKeyframe>> keyframeRulesForName(const AtomString&, const TimingFunction*) const;
+    Vector<Ref<StyleRuleKeyframe>> keyframeRulesForName(const AtomString&, const EasingFunction& defaultTimingFunction) const;
 
     const CustomFunctionRegistry* NODELETE customFunctionRegistry() const;
     CustomFunctionRegistry& ensureCustomFunctionRegistry();

--- a/Source/WebCore/style/values/easing/StyleCubicBezierEasingFunction.cpp
+++ b/Source/WebCore/style/values/easing/StyleCubicBezierEasingFunction.cpp
@@ -60,6 +60,16 @@ Ref<TimingFunction> createTimingFunction(const BuilderState& state, const CSS::C
     );
 }
 
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData& conversionData, const CSS::CubicBezierEasingFunction& function)
+{
+    return CubicBezierTimingFunction::create(
+        toStyle(get<0>(get<0>(function->value)), conversionData).value,
+        toStyle(get<1>(get<0>(function->value)), conversionData).value,
+        toStyle(get<0>(get<1>(function->value)), conversionData).value,
+        toStyle(get<1>(get<1>(function->value)), conversionData).value
+    );
+}
+
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::CubicBezierEasingFunction& function)
 {
     if (!CSS::collectComputedStyleDependencies(function).canResolveDependenciesWithConversionData({ }))

--- a/Source/WebCore/style/values/easing/StyleCubicBezierEasingFunction.h
+++ b/Source/WebCore/style/values/easing/StyleCubicBezierEasingFunction.h
@@ -28,6 +28,7 @@
 
 namespace WebCore {
 
+class CSSToLengthConversionData;
 class CubicBezierTimingFunction;
 class TimingFunction;
 
@@ -39,6 +40,7 @@ class ComputedStyle;
 CSS::CubicBezierEasingFunction toCSSCubicBezierEasingFunction(const CubicBezierTimingFunction&, const Style::ComputedStyle&);
 
 Ref<TimingFunction> createTimingFunction(const BuilderState&, const CSS::CubicBezierEasingFunction&);
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData&, const CSS::CubicBezierEasingFunction&);
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::CubicBezierEasingFunction&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/easing/StyleEasingFunction.cpp
+++ b/Source/WebCore/style/values/easing/StyleEasingFunction.cpp
@@ -74,45 +74,6 @@ static CSS::EasingFunction toCSSEasingFunction(const TimingFunction& function, c
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static Ref<TimingFunction> createTimingFunction(BuilderState& state, const CSS::EasingFunction& function)
-{
-    return WTF::switchOn(function.value,
-        [&](const CSS::Keyword::Linear&) -> Ref<TimingFunction> {
-            return LinearTimingFunction::create();
-        },
-        [&](const CSS::LinearEasingFunction& function) -> Ref<TimingFunction> {
-            return createTimingFunction(state, function);
-        },
-        [&](const CSS::Keyword::Ease&) -> Ref<TimingFunction> {
-            return CubicBezierTimingFunction::create();
-        },
-        [&](const CSS::Keyword::EaseIn&) -> Ref<TimingFunction> {
-            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseIn);
-        },
-        [&](const CSS::Keyword::EaseOut&) -> Ref<TimingFunction> {
-            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseOut);
-        },
-        [&](const CSS::Keyword::EaseInOut&) -> Ref<TimingFunction> {
-            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut);
-        },
-        [&](const CSS::CubicBezierEasingFunction& function) -> Ref<TimingFunction> {
-            return createTimingFunction(state, function);
-        },
-        [&](const CSS::Keyword::StepStart&) -> Ref<TimingFunction> {
-            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::Start);
-        },
-        [&](const CSS::Keyword::StepEnd&) -> Ref<TimingFunction> {
-            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::End);
-        },
-        [&](const CSS::StepsEasingFunction& function) -> Ref<TimingFunction> {
-            return createTimingFunction(state, function);
-        },
-        [&](const CSS::SpringEasingFunction& function) -> Ref<TimingFunction> {
-            return createTimingFunction(state, function);
-        }
-    );
-}
-
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::EasingFunction& function)
 {
     return WTF::switchOn(function.value,
@@ -175,6 +136,29 @@ static Ref<TimingFunction> createTimingFunctionFromValueID(BuilderState& state, 
     }
 }
 
+static Ref<TimingFunction> createTimingFunctionFromValueID(const CSSToLengthConversionData&, CSSValueID valueID)
+{
+    switch (valueID) {
+    case CSSValueLinear:
+        return LinearTimingFunction::create();
+    case CSSValueEase:
+        return CubicBezierTimingFunction::create();
+    case CSSValueEaseIn:
+        return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseIn);
+    case CSSValueEaseOut:
+        return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseOut);
+    case CSSValueEaseInOut:
+        return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut);
+    case CSSValueStepStart:
+        return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::Start);
+    case CSSValueStepEnd:
+        return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::End);
+    default:
+        ASSERT_NOT_REACHED();
+        return LinearTimingFunction::create();
+    }
+}
+
 static RefPtr<TimingFunction> createTimingFunctionFromValueIDDeprecated(CSSValueID valueID)
 {
     switch (valueID) {
@@ -208,14 +192,103 @@ RefPtr<TimingFunction> createTimingFunctionDeprecated(const CSSValue& value)
 
 // MARK: - Conversion
 
+auto ToStyle<CSS::EasingFunction>::operator()(const CSS::EasingFunction& value, const BuilderState& state) -> EasingFunction
+{
+    return EasingFunction { WTF::switchOn(value.value,
+        [&](const CSS::Keyword::Linear&) -> Ref<TimingFunction> {
+            return LinearTimingFunction::create();
+        },
+        [&](const CSS::LinearEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(state, function);
+        },
+        [&](const CSS::Keyword::Ease&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create();
+        },
+        [&](const CSS::Keyword::EaseIn&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseIn);
+        },
+        [&](const CSS::Keyword::EaseOut&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseOut);
+        },
+        [&](const CSS::Keyword::EaseInOut&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut);
+        },
+        [&](const CSS::CubicBezierEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(state, function);
+        },
+        [&](const CSS::Keyword::StepStart&) -> Ref<TimingFunction> {
+            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::Start);
+        },
+        [&](const CSS::Keyword::StepEnd&) -> Ref<TimingFunction> {
+            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::End);
+        },
+        [&](const CSS::StepsEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(state, function);
+        },
+        [&](const CSS::SpringEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(state, function);
+        }
+    ) };
+}
+
+auto ToStyle<CSS::EasingFunction>::operator()(const CSS::EasingFunction& value, const CSSToLengthConversionData& conversionData) -> EasingFunction
+{
+    return EasingFunction { WTF::switchOn(value.value,
+        [&](const CSS::Keyword::Linear&) -> Ref<TimingFunction> {
+            return LinearTimingFunction::create();
+        },
+        [&](const CSS::LinearEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(conversionData, function);
+        },
+        [&](const CSS::Keyword::Ease&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create();
+        },
+        [&](const CSS::Keyword::EaseIn&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseIn);
+        },
+        [&](const CSS::Keyword::EaseOut&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseOut);
+        },
+        [&](const CSS::Keyword::EaseInOut&) -> Ref<TimingFunction> {
+            return CubicBezierTimingFunction::create(CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut);
+        },
+        [&](const CSS::CubicBezierEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(conversionData, function);
+        },
+        [&](const CSS::Keyword::StepStart&) -> Ref<TimingFunction> {
+            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::Start);
+        },
+        [&](const CSS::Keyword::StepEnd&) -> Ref<TimingFunction> {
+            return StepsTimingFunction::create(1, StepsTimingFunction::StepPosition::End);
+        },
+        [&](const CSS::StepsEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(conversionData, function);
+        },
+        [&](const CSS::SpringEasingFunction& function) -> Ref<TimingFunction> {
+            return createTimingFunction(conversionData, function);
+        }
+    ) };
+}
+
 auto CSSValueConversion<EasingFunction>::operator()(BuilderState& state, const CSSValue& value) -> EasingFunction
 {
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value))
         return { createTimingFunctionFromValueID(state, keywordValue->valueID()) };
     if (RefPtr easingFunctionValue = dynamicDowncast<CSSEasingFunctionValue>(value))
-        return { createTimingFunction(state, easingFunctionValue->easingFunction()) };
+        return toStyle(easingFunctionValue->easingFunction(), state);
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
+    return { LinearTimingFunction::create() };
+}
+
+auto CSSValueConversion<EasingFunction>::operator()(const CSSToLengthConversionData& conversionData, const CSSValue& value) -> EasingFunction
+{
+    if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value))
+        return { createTimingFunctionFromValueID(conversionData, keywordValue->valueID()) };
+    if (RefPtr easingFunctionValue = dynamicDowncast<CSSEasingFunctionValue>(value))
+        return toStyle(easingFunctionValue->easingFunction(), conversionData);
+
+    ASSERT_NOT_REACHED();
     return { LinearTimingFunction::create() };
 }
 

--- a/Source/WebCore/style/values/easing/StyleEasingFunction.h
+++ b/Source/WebCore/style/values/easing/StyleEasingFunction.h
@@ -53,7 +53,15 @@ RefPtr<TimingFunction> createTimingFunctionDeprecated(const CSSValue&);
 
 // MARK: - Conversion
 
-template<> struct CSSValueConversion<EasingFunction> { auto operator()(BuilderState&, const CSSValue&) -> EasingFunction; };
+template<> struct ToStyle<CSS::EasingFunction> {
+    auto operator()(const CSS::EasingFunction&, const BuilderState&) -> EasingFunction;
+    auto operator()(const CSS::EasingFunction&, const CSSToLengthConversionData&) -> EasingFunction;
+};
+
+template<> struct CSSValueConversion<EasingFunction> {
+    auto operator()(BuilderState&, const CSSValue&) -> EasingFunction;
+    auto operator()(const CSSToLengthConversionData&, const CSSValue&) -> EasingFunction;
+};
 template<> struct CSSValueCreation<EasingFunction> { Ref<CSSValue> operator()(CSSValuePool&, const Style::ComputedStyle&, const EasingFunction&); };
 
 // MARK: - Serialization

--- a/Source/WebCore/style/values/easing/StyleLinearEasingFunction.cpp
+++ b/Source/WebCore/style/values/easing/StyleLinearEasingFunction.cpp
@@ -163,6 +163,13 @@ Ref<TimingFunction> createTimingFunction(const BuilderState& state, const CSS::L
     });
 }
 
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData& conversionData, const CSS::LinearEasingFunction& function)
+{
+    return createTimingFunctionWithResolver(function, [&](const auto& value) -> double {
+        return toStyle(value, conversionData).value;
+    });
+}
+
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::LinearEasingFunction& function)
 {
     if (!CSS::collectComputedStyleDependencies(function).canResolveDependenciesWithConversionData({ }))

--- a/Source/WebCore/style/values/easing/StyleSpringEasingFunction.cpp
+++ b/Source/WebCore/style/values/easing/StyleSpringEasingFunction.cpp
@@ -54,6 +54,16 @@ Ref<TimingFunction> createTimingFunction(const BuilderState& state, const CSS::S
     );
 }
 
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData& conversionData, const CSS::SpringEasingFunction& function)
+{
+    return SpringTimingFunction::create(
+        toStyle(function->mass, conversionData).value,
+        toStyle(function->stiffness, conversionData).value,
+        toStyle(function->damping, conversionData).value,
+        toStyle(function->initialVelocity, conversionData).value
+    );
+}
+
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::SpringEasingFunction& function)
 {
     if (!CSS::collectComputedStyleDependencies(function).canResolveDependenciesWithConversionData({ }))

--- a/Source/WebCore/style/values/easing/StyleSpringEasingFunction.h
+++ b/Source/WebCore/style/values/easing/StyleSpringEasingFunction.h
@@ -28,6 +28,7 @@
 
 namespace WebCore {
 
+class CSSToLengthConversionData;
 class SpringTimingFunction;
 class TimingFunction;
 
@@ -39,6 +40,7 @@ class ComputedStyle;
 CSS::SpringEasingFunction NODELETE toCSSSpringEasingFunction(const SpringTimingFunction&, const Style::ComputedStyle&);
 
 Ref<TimingFunction> createTimingFunction(const BuilderState&, const CSS::SpringEasingFunction&);
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData&, const CSS::SpringEasingFunction&);
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::SpringEasingFunction&);
 
 } // namespace Style

--- a/Source/WebCore/style/values/easing/StyleStepsEasingFunction.cpp
+++ b/Source/WebCore/style/values/easing/StyleStepsEasingFunction.cpp
@@ -100,6 +100,15 @@ Ref<TimingFunction> createTimingFunction(const BuilderState& state, const CSS::S
     );
 }
 
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData& conversionData, const CSS::StepsEasingFunction& function)
+{
+    return WTF::switchOn(function->value,
+        [&](const auto& value) -> Ref<TimingFunction> {
+            return StepsTimingFunction::create(toStyle(value.steps, conversionData).value, toStepPosition(value.keyword));
+        }
+    );
+}
+
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::StepsEasingFunction& function)
 {
     if (!CSS::collectComputedStyleDependencies(function).canResolveDependenciesWithConversionData({ }))

--- a/Source/WebCore/style/values/easing/StyleStepsEasingFunction.h
+++ b/Source/WebCore/style/values/easing/StyleStepsEasingFunction.h
@@ -28,6 +28,7 @@
 
 namespace WebCore {
 
+class CSSToLengthConversionData;
 class StepsTimingFunction;
 class TimingFunction;
 
@@ -39,6 +40,7 @@ class ComputedStyle;
 CSS::StepsEasingFunction toCSSStepsEasingFunction(const StepsTimingFunction&, const Style::ComputedStyle&);
 
 Ref<TimingFunction> createTimingFunction(const BuilderState&, const CSS::StepsEasingFunction&);
+Ref<TimingFunction> createTimingFunction(const CSSToLengthConversionData&, const CSS::StepsEasingFunction&);
 Ref<TimingFunction> createTimingFunctionDeprecated(const CSS::StepsEasingFunction&);
 
 } // namespace Style


### PR DESCRIPTION
#### 9880c9f831c2abdca853a35d1f840bd9309f2df2
<pre>
Support relative length units in &lt;keyframe-selector&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=318012">https://bugs.webkit.org/show_bug.cgi?id=318012</a>

Reviewed by NOBODY (OOPS!).

WIP - DO NOT REVIEW

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationEffect.cpp:
* Source/WebCore/animation/BlendingKeyframes.cpp:
* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/css/CSSKeyframeRule.cpp:
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
* Source/WebCore/css/values/primitives/CSSPrimitiveData.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric+Forward.h: Added.
* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
* Source/WebCore/style/StyleResolver.cpp:
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/values/easing/StyleCubicBezierEasingFunction.cpp:
* Source/WebCore/style/values/easing/StyleCubicBezierEasingFunction.h:
* Source/WebCore/style/values/easing/StyleEasingFunction.cpp:
* Source/WebCore/style/values/easing/StyleEasingFunction.h:
* Source/WebCore/style/values/easing/StyleLinearEasingFunction.cpp:
* Source/WebCore/style/values/easing/StyleLinearEasingFunction.h:
* Source/WebCore/style/values/easing/StyleSpringEasingFunction.cpp:
* Source/WebCore/style/values/easing/StyleSpringEasingFunction.h:
* Source/WebCore/style/values/easing/StyleStepsEasingFunction.cpp:
* Source/WebCore/style/values/easing/StyleStepsEasingFunction.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9880c9f831c2abdca853a35d1f840bd9309f2df2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170583 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128296 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44142 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133035 "Found 6 new test failures: imported/blink/animations/keyframe-timing-function-unset-crash.html imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html imported/w3c/web-platform-tests/css/css-animations/crashtests/keyframe-easing-var-crash.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93823 "19 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113532 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34839 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-constraint-validation.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33181 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145300 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32871 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182544 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35341 "Found 1 new failure in css/values/primitives/CSSPrimitiveData.h") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37359 "Found 6 new test failures: imported/blink/animations/keyframe-timing-function-unset-crash.html imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html imported/w3c/web-platform-tests/css/css-animations/crashtests/keyframe-easing-var-crash.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141493 "Found 3 new test failures: imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44164 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141310 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44853 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29857 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-animations/KeyframeEffect-getKeyframes.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-hidden-subject.html imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-document-timeline.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109402 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36575 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116742 "Found 1 new failure in css/values/primitives/CSSPrimitiveData.h") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43363 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7961 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->