### PR TITLE
Digital Credentials: Add WebKitTestRunner support for the virtual wallet

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8072,11 +8072,8 @@ webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/create.d
 webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/create-enabled-on-self-origin-by-permissions-policy.https.sub.html [ Skip ]
 webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/allow-attribute-with-create.https.html [ Skip ]
 webkit.org/b/303807 imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html [ Skip ]
-webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html [ Skip ]
-webkit.org/b/306292 http/wpt/identity/formats/ISO18013/valid-roundtrip.https.html [ Skip ]
-webkit.org/b/306292 http/wpt/identity/formats/ISO18013/response-handling.https.html [ Skip ]
+webkit.org/b/317545 imported/w3c/web-platform-tests/digital-credentials/webdriver/get-openid4vp.https.html [ Skip ]
 webkit.org/b/306292 http/wpt/identity/formats/ISO18013/origin-binding.https.html [ Skip ]
-webkit.org/b/306292 imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html [ Skip ]
 webkit.org/b/317545 imported/w3c/web-platform-tests/digital-credentials/protocol-filtering-openid4vp.https.html [ Skip ]
 
 # Hits assert in debug, tracked by https://bugs.webkit.org/show_bug.cgi?id=303414

--- a/LayoutTests/http/wpt/identity/formats/ISO18013/response-handling.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/response-handling.https-expected.txt
@@ -1,0 +1,7 @@
+
+PASS org-iso-mdoc response is passed through with correct protocol and data.
+PASS org-iso-mdoc response with Annex C shaped data preserves the response string.
+PASS Response data is passed through byte-for-byte without modification.
+PASS Empty response string is passed through (validation is the site's responsibility).
+PASS Additional fields in the response object are preserved.
+

--- a/LayoutTests/http/wpt/identity/formats/ISO18013/valid-roundtrip.https-expected.txt
+++ b/LayoutTests/http/wpt/identity/formats/ISO18013/valid-roundtrip.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Valid ISO 18013-7 Annex C request/response round-trip succeeds.
+PASS Valid response contains expected Annex C EncryptedResponse structure prefix.
+PASS Valid org-iso-mdoc request alongside other protocols: wallet response selects org-iso-mdoc.
+PASS Multiple valid org-iso-mdoc requests in a single call: succeeds.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A second get() call while another is pending should reject with NotAllowedError.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://w3c-fedid.github.io/digital-credentials/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
 <body></body>
@@ -12,6 +12,10 @@
   import { makeGetOptions } from "./support/helper.js";
 
   promise_test(async (t) => {
+    // Park the first request ("wait") so the second hits the concurrency guard.
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+
     const abortController = new AbortController();
     const firstOptions = makeGetOptions({ signal: abortController.signal });
     const secondOptions = makeGetOptions();

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS navigator.credentials.get() with respond mode should resolve with the specified data.
+PASS navigator.credentials.get() with complex data response should resolve with structured data.
+PASS navigator.credentials.get() with decline mode should reject with NotAllowedError.
+PASS navigator.credentials.get() with wait mode should reject with the abort reason when aborted.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<title>Digital Credential API: get() webdriver tests for org-iso-mdoc.</title>
+<link rel="help" href="https://wicg.github.io/digital-credentials/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js?feature=bidi"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body></body>
+<script type="module">
+  import { makeGetOptions } from "../support/helper.js";
+
+  promise_test(async (t) => {
+    const responseData = "test-response-data";
+    await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", { "value": responseData });
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "org-iso-mdoc");
+    assert_equals(result.data.value, responseData);
+  }, "navigator.credentials.get() with respond mode should resolve with the specified data.");
+
+  promise_test(async (t) => {
+    const complexData = { "a": 1, "b": [2, 3], "c": { "d": 4 } };
+    await test_driver.set_virtual_wallet_behavior("respond", "org-iso-mdoc", complexData);
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    const result = await navigator.credentials.get(options);
+
+    assert_equals(result.protocol, "org-iso-mdoc");
+    assert_equals(result.data.a, 1);
+    assert_array_equals(result.data.b, [2, 3]);
+    assert_equals(result.data.c.d, 4);
+  }, "navigator.credentials.get() with complex data response should resolve with structured data.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("decline");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const options = makeGetOptions({ protocol: "org-iso-mdoc" });
+    await promise_rejects_dom(t, "NotAllowedError", navigator.credentials.get(options));
+  }, "navigator.credentials.get() with decline mode should reject with NotAllowedError.");
+
+  promise_test(async (t) => {
+    await test_driver.set_virtual_wallet_behavior("wait");
+    t.add_cleanup(() => test_driver.set_virtual_wallet_behavior("clear"));
+    await test_driver.bless("user activation");
+
+    const controller = new AbortController();
+    const options = makeGetOptions({ protocol: "org-iso-mdoc", signal: controller.signal });
+    const promise = navigator.credentials.get(options);
+
+    const reason = new Error("aborted by test");
+    controller.abort(reason);
+    await promise_rejects_exactly(t, reason, promise);
+  }, "navigator.credentials.get() with wait mode should reject with the abort reason when aborted.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-openid4vp.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-openid4vp.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>Digital Credential API: get() webdriver tests.</title>
+<title>Digital Credential API: get() webdriver tests for openid4vp-v1-unsigned.</title>
 <link rel="help" href="https://wicg.github.io/digital-credentials/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -55,10 +55,8 @@
     const options = makeGetOptions({ protocol: "openid4vp-v1-unsigned", signal: controller.signal });
     const promise = navigator.credentials.get(options);
 
-    // Give it some time to make sure it's pending.
-    await new Promise(resolve => t.step_timeout(resolve, 100));
-
-    controller.abort();
-    await promise_rejects_dom(t, "AbortError", promise);
-  }, "navigator.credentials.get() with wait mode should remain pending until aborted.");
+    const reason = new Error("aborted by test");
+    controller.abort(reason);
+    await promise_rejects_exactly(t, reason, promise);
+  }, "navigator.credentials.get() with wait mode should reject with the abort reason when aborted.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/w3c-import.log
@@ -15,4 +15,5 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/create.https.html
-/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https.html
+/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-openid4vp.https.html

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -559,6 +559,15 @@ window.test_driver_internal.set_permission = async function(permission_params)
     }
 };
 
+// Digital Credentials virtual wallet actuation; see webkit.org/b/306292.
+window.test_driver_internal.set_virtual_wallet_behavior = async function(action, protocol = null, response = null, context = null)
+{
+    context = context ?? window;
+    if (!context.testRunner || !context.testRunner.setVirtualWalletBehavior)
+        throw new Error("set_virtual_wallet_behavior is not supported.");
+    context.testRunner.setVirtualWalletBehavior(String(action), protocol != null ? String(protocol) : "", response != null ? JSON.stringify(response) : "");
+};
+
 /**
  *
  * @param {Window?} context

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -200,8 +200,10 @@ void CredentialRequestCoordinator::processCredentialChooserResponse(Expected<Dig
 
     // A parked "wait" reply released during abort/teardown can arrive after the
     // request already left Requesting; it is moot, so return before the guard.
-    if (m_interactionState != InteractionState::Requesting)
+    if (m_interactionState != InteractionState::Requesting) {
+        LOG(DigitalCredentials, "Ignoring credential chooser response received while not in the Requesting state.");
         return;
+    }
 
     InteractionStateGuard guard(*this);
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3241,6 +3241,18 @@ void WKPageSetUseDarkAppearanceForTesting(WKPageRef pageRef, bool useDarkAppeara
     protect(toImpl(pageRef))->setUseDarkAppearanceForTesting(useDarkAppearance);
 }
 
+void WKPageSetVirtualWalletBehaviorForTesting(WKPageRef pageRef, WKStringRef action, WKStringRef protocol, WKStringRef responseJSON)
+{
+#if ENABLE(WEB_AUTHN) && ENABLE(WEBDRIVER_BIDI)
+    protect(toImpl(pageRef))->setVirtualWalletBehaviorForTesting(toWTFString(action), toWTFString(protocol), toWTFString(responseJSON));
+#else
+    UNUSED_PARAM(pageRef);
+    UNUSED_PARAM(action);
+    UNUSED_PARAM(protocol);
+    UNUSED_PARAM(responseJSON);
+#endif
+}
+
 ProcessID WKPageGetProcessIdentifier(WKPageRef page)
 {
     return toImpl(page)->legacyMainFrameProcessID();

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -172,6 +172,9 @@ WK_EXPORT void WKPageSetIgnoresViewportScaleLimits(WKPageRef page, bool ignoresV
 
 WK_EXPORT void WKPageSetUseDarkAppearanceForTesting(WKPageRef pageRef, bool useDarkAppearance);
 
+// Test-only virtual wallet actuation (action: "respond"|"decline"|"wait"|"clear"); webkit.org/b/306292.
+WK_EXPORT void WKPageSetVirtualWalletBehaviorForTesting(WKPageRef page, WKStringRef action, WKStringRef protocol, WKStringRef responseJSON);
+
 WK_EXPORT WKProcessID WKPageGetProcessIdentifier(WKPageRef page);
 WK_EXPORT WKProcessID WKPageGetGPUProcessIdentifier(WKPageRef page);
 

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -241,6 +241,14 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
     return self;
 }
 
+- (void)dealloc
+{
+    if (_completionHandler)
+        _completionHandler(makeUnexpected(WebCore::ExceptionData { ExceptionCode::OperationError, "The digital credential request was interrupted."_s }));
+
+    [super dealloc];
+}
+
 - (id<WKDigitalCredentialsPickerDelegate>)delegate
 {
     return _delegate.getAutoreleased();
@@ -464,6 +472,9 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
 {
     [_presentmentController cancelRequest];
     _presentmentController = nil;
+
+    if (_completionHandler)
+        _completionHandler(makeUnexpected(WebCore::ExceptionData { ExceptionCode::OperationError, "The digital credential request was cancelled."_s }));
 
     if ([self.delegate respondsToSelector:@selector(digitalCredentialsPickerDidDismiss:)])
         [self.delegate digitalCredentialsPickerDidDismiss:self];

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1896,6 +1896,10 @@ void WebPageProxy::close()
 
     m_isClosed = true;
 
+#if ENABLE(WEB_AUTHN) && ENABLE(WEBDRIVER_BIDI)
+    abortPendingDigitalCredentialWaitHandlers("Page closed."_s);
+#endif
+
     // Make sure we do this before we clear the UIClient so that we can ask the UIClient
     // to release the wake locks.
     internals().sleepDisablers.clear();
@@ -11270,6 +11274,29 @@ void WebPageProxy::showContactPicker(IPC::Connection& connection, ContactsReques
         completionHandler(std::nullopt);
 }
 
+#if ENABLE(WEBDRIVER_BIDI) && ENABLE(WEB_AUTHN)
+template<typename StorePendingHandler>
+static bool applyVirtualWalletBehavior(const VirtualWalletBehavior& behavior, DigitalCredentialsPickerCompletionHandler&& completionHandler, NOESCAPE const StorePendingHandler& storePendingHandler)
+{
+    using VirtualWalletAction = Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction;
+    switch (behavior.action) {
+    case VirtualWalletAction::Wait:
+        storePendingHandler(WTF::move(completionHandler));
+        return true;
+    case VirtualWalletAction::Decline:
+        completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "Virtual wallet declined the request."_s }));
+        return true;
+    case VirtualWalletAction::Respond:
+        completionHandler(WebCore::DigitalCredentialsResponseData { behavior.protocol, behavior.responseJSON });
+        return true;
+    case VirtualWalletAction::Clear:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+    return false;
+}
+#endif
+
 #if ENABLE(WEB_AUTHN)
 void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, std::optional<WebCore::FrameIdentifier>&& frameID, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
@@ -11300,29 +11327,29 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, st
                         contextID = automationSession->handleForWebPageProxy(*this);
                     const auto walletBehavior = agent.behaviorForContext(contextID);
                     if (walletBehavior) {
-                        using VirtualWalletAction = Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction;
-                        switch (walletBehavior->action) {
-                        case VirtualWalletAction::Wait:
+                        bool handled = applyVirtualWalletBehavior(*walletBehavior, WTF::move(completionHandler), [&](DigitalCredentialsPickerCompletionHandler&& handler) {
                             // FIXME: A concurrent request from a site-isolated cross-origin iframe (separate
                             // process) can clobber this single slot; only same-process concurrency is
                             // serialized by prepareCredentialRequests (webkit.org/b/318408).
                             ASSERT(!m_pendingDigitalCredentialsWaitContextID);
                             m_pendingDigitalCredentialsWaitContextID = contextID;
-                            agent.holdPendingHandler(contextID, WTF::move(completionHandler));
+                            agent.holdPendingHandler(contextID, WTF::move(handler));
+                        });
+                        if (handled)
                             return;
-                        case VirtualWalletAction::Decline:
-                            completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, "Virtual wallet declined the request."_s }));
-                            return;
-                        case VirtualWalletAction::Respond:
-                            completionHandler(WebCore::DigitalCredentialsResponseData { walletBehavior->protocol, walletBehavior->responseJSON });
-                            return;
-                        case VirtualWalletAction::Clear:
-                            // 'clear' removes the stored behavior in the agent, so it is never a stored action here.
-                            ASSERT_NOT_REACHED();
-                            break;
-                        }
                     }
                 }
+            }
+#endif
+
+#if ENABLE(WEBDRIVER_BIDI)
+            if (const auto& testBehavior = internals().testingVirtualWalletBehavior) {
+                bool handled = applyVirtualWalletBehavior(*testBehavior, WTF::move(completionHandler), [&](DigitalCredentialsPickerCompletionHandler&& handler) {
+                    settlePendingTestingDigitalCredentialHandler("Superseded by a new digital credential request."_s);
+                    internals().testingPendingDigitalCredentialHandler = WTF::move(handler);
+                });
+                if (handled)
+                    return;
             }
 #endif
 
@@ -11340,6 +11367,53 @@ void WebPageProxy::showDigitalCredentialsChooser(IPC::Connection& connection, st
 #endif
     });
 }
+
+#if ENABLE(WEBDRIVER_BIDI)
+void WebPageProxy::settlePendingTestingDigitalCredentialHandler(ASCIILiteral rejectionMessage)
+{
+    if (auto handler = std::exchange(internals().testingPendingDigitalCredentialHandler, nullptr))
+        handler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotAllowedError, rejectionMessage }));
+}
+
+void WebPageProxy::abortPendingDigitalCredentialWaitHandlers(ASCIILiteral rejectionMessage)
+{
+    settlePendingTestingDigitalCredentialHandler(rejectionMessage);
+    if (auto contextID = std::exchange(m_pendingDigitalCredentialsWaitContextID, std::nullopt); contextID) {
+        if (RefPtr automationSession = configuration().processPool().automationSession())
+            automationSession->bidiProcessor().digitalCredentialsAgent().releasePendingHandler(*contextID);
+    }
+}
+
+void WebPageProxy::setVirtualWalletBehaviorForTesting(const String& action, const String& protocol, const String& responseJSON)
+{
+    using VirtualWalletAction = Inspector::Protocol::BidiDigitalCredentials::VirtualWalletAction;
+
+    if (action == "clear"_s) {
+        internals().testingVirtualWalletBehavior = std::nullopt;
+        settlePendingTestingDigitalCredentialHandler("Virtual wallet behavior cleared."_s);
+        return;
+    }
+
+    std::optional<VirtualWalletAction> parsedAction;
+    if (action == "respond"_s)
+        parsedAction = VirtualWalletAction::Respond;
+    else if (action == "decline"_s)
+        parsedAction = VirtualWalletAction::Decline;
+    else if (action == "wait"_s)
+        parsedAction = VirtualWalletAction::Wait;
+
+    if (!parsedAction) {
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Unknown virtual wallet action: %s", action.utf8().data());
+        return;
+    }
+
+    settlePendingTestingDigitalCredentialHandler("Virtual wallet behavior replaced."_s);
+
+    // FIXME: Only org-iso-mdoc is supported, so the requested protocol is ignored (webkit.org/b/317545).
+    UNUSED_PARAM(protocol);
+    internals().testingVirtualWalletBehavior = VirtualWalletBehavior { *parsedAction, WebCore::DigitalCredentialPresentationProtocol::OrgIsoMdoc, responseJSON };
+}
+#endif
 
 void WebPageProxy::fetchRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests)>&& completionHandler)
 {
@@ -11359,10 +11433,7 @@ void WebPageProxy::dismissDigitalCredentialsChooser(IPC::Connection& connection,
     );
 #if ENABLE(WEB_AUTHN)
 #if ENABLE(WEBDRIVER_BIDI)
-    if (auto contextID = std::exchange(m_pendingDigitalCredentialsWaitContextID, std::nullopt)) {
-        if (RefPtr automationSession = configuration().processPool().automationSession())
-            automationSession->bidiProcessor().digitalCredentialsAgent().releasePendingHandler(*contextID);
-    }
+    abortPendingDigitalCredentialWaitHandlers("Digital credential request dismissed."_s);
 #endif
     protect(pageClient())->dismissDigitalCredentialsChooser(WTF::move(completionHandler));
 #else
@@ -13603,6 +13674,10 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     m_focusedFrame = nullptr;
     m_suspendedPageKeptToPreventFlashing = nullptr;
     m_lastSuspendedPage = nullptr;
+
+#if ENABLE(WEB_AUTHN) && ENABLE(WEBDRIVER_BIDI)
+    abortPendingDigitalCredentialWaitHandlers("The page was reset."_s);
+#endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     m_allowedImmersiveElementFrameInfo = nullptr;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2420,6 +2420,12 @@ public:
     void dismissDigitalCredentialsChooser(IPC::Connection&, CompletionHandler<void(bool)>&&);
     void fetchRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests)>&&);
     void showDigitalCredentialsChooser(IPC::Connection&, std::optional<WebCore::FrameIdentifier>&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
+#if ENABLE(WEBDRIVER_BIDI)
+    // Test-only wallet actuation for run-webkit-tests (no automation session); webkit.org/b/306292.
+    void setVirtualWalletBehaviorForTesting(const String& action, const String& protocol, const String& responseJSON);
+    void settlePendingTestingDigitalCredentialHandler(ASCIILiteral rejectionMessage);
+    void abortPendingDigitalCredentialWaitHandlers(ASCIILiteral rejectionMessage);
+#endif
 #endif
 
     using TextManipulationItemCallback = Function<void(const Vector<WebCore::TextManipulationItem>&)>;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#if ENABLE(WEBDRIVER_BIDI)
+#include "BidiDigitalCredentialsAgent.h"
+#endif
 #include "ContextMenuContextData.h"
 #include "EditorState.h"
 #include "EnhancedSecurityTracking.h"
@@ -185,6 +188,11 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 
 public:
     virtual ~Internals();
+
+#if ENABLE(WEB_AUTHN) && ENABLE(WEBDRIVER_BIDI)
+    std::optional<VirtualWalletBehavior> testingVirtualWalletBehavior;
+    CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)> testingPendingDigitalCredentialHandler;
+#endif
 
     uint32_t checkedPtrCount() const { return WebPopupMenuProxy::Client::checkedPtrCount(); }
     uint32_t checkedPtrCountWithoutThreadCheck() const { return WebPopupMenuProxy::Client::checkedPtrCountWithoutThreadCheck(); }

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -188,6 +188,7 @@ interface TestRunner {
     undefined resumeBackgroundFetch(DOMString identifier);
     undefined simulateClickBackgroundFetch(DOMString identifier);
     undefined setBackgroundFetchPermission(boolean value);
+    undefined setVirtualWalletBehavior(DOMString action, DOMString protocol, DOMString responseJSON);
     DOMString lastAddedBackgroundFetchIdentifier();
     DOMString lastRemovedBackgroundFetchIdentifier();
     DOMString lastUpdatedBackgroundFetchIdentifier();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -381,6 +381,15 @@ void TestRunner::setBackgroundFetchPermission(bool enabled)
     postSynchronousPageMessage("SetBackgroundFetchPermission", enabled);
 }
 
+void TestRunner::setVirtualWalletBehavior(JSStringRef action, JSStringRef protocol, JSStringRef responseJSON)
+{
+    postSynchronousPageMessage("SetVirtualWalletBehavior", createWKDictionary({
+        { "Action", toWK(action) },
+        { "Protocol", toWK(protocol) },
+        { "ResponseJSON", toWK(responseJSON) },
+    }));
+}
+
 JSRetainPtr<JSStringRef>  TestRunner::lastAddedBackgroundFetchIdentifier() const
 {
     auto identifier = InjectedBundle::singleton().lastAddedBackgroundFetchIdentifier();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -305,6 +305,7 @@ public:
     void resumeBackgroundFetch(JSStringRef);
     void simulateClickBackgroundFetch(JSStringRef);
     void setBackgroundFetchPermission(bool);
+    void setVirtualWalletBehavior(JSStringRef action, JSStringRef protocol, JSStringRef responseJSON);
     JSRetainPtr<JSStringRef> lastAddedBackgroundFetchIdentifier() const;
     JSRetainPtr<JSStringRef> lastRemovedBackgroundFetchIdentifier() const;
     JSRetainPtr<JSStringRef> lastUpdatedBackgroundFetchIdentifier() const;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2062,6 +2062,12 @@ ASCIILiteral TestController::serviceWorkerProcessName()
 #endif
 }
 
+void TestController::setVirtualWalletBehavior(WKStringRef action, WKStringRef protocol, WKStringRef responseJSON)
+{
+    if (auto* webView = mainWebView())
+        WKPageSetVirtualWalletBehaviorForTesting(webView->page(), action, protocol, responseJSON);
+}
+
 #if !PLATFORM(COCOA)
 
 void TestController::setAllowsAnySSLCertificate(bool allows)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -470,6 +470,7 @@ public:
     void resumeBackgroundFetch(WKStringRef);
     void simulateClickBackgroundFetch(WKStringRef);
     void setBackgroundFetchPermission(bool);
+    void setVirtualWalletBehavior(WKStringRef action, WKStringRef protocol, WKStringRef responseJSON);
     WKRetainPtr<WKStringRef> lastAddedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> lastRemovedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -703,6 +703,15 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "SetVirtualWalletBehavior")) {
+        auto dictionary = dictionaryValue(messageBody);
+        TestController::singleton().setVirtualWalletBehavior(
+            stringValue(dictionary, "Action"),
+            stringValue(dictionary, "Protocol"),
+            stringValue(dictionary, "ResponseJSON"));
+        return nullptr;
+    }
+
     if (WKStringIsEqualToUTF8CString(messageName, "GetBackgroundFetchIdentifier"))
         return TestController::singleton().getBackgroundFetchIdentifier();
 


### PR DESCRIPTION
#### 73c1e36647e4ce1c512d24ebf50c9c4cf2a29fbd
<pre>
Digital Credentials: Add WebKitTestRunner support for the virtual wallet
<a href="https://bugs.webkit.org/show_bug.cgi?id=318290">https://bugs.webkit.org/show_bug.cgi?id=318290</a>
<a href="https://rdar.apple.com/168941907">rdar://168941907</a>

Reviewed by Abrar Rahman Protyasha.

Add a run-webkit-tests path to drive the Digital Credentials virtual
wallet via test_driver.set_virtual_wallet_behavior(), so the WPT
digital-credentials tests can run under WebKitTestRunner and not only
run-webdriver-tests. This is the WebKitTestRunner half of bug 306292 and
builds on the WebDriver BiDi digitalCredentials module.

Also fix WKDigitalCredentialsPicker leaking its completion handler: on
teardown without completion the handler was destroyed unrun, hitting the
CompletionHandler assert. It is now settled with an OperationError,
matching the spec&apos;s &quot;otherwise&quot; platform-error mapping.

Ignore a chooser response that arrives when the coordinator is no longer
in the Requesting state (e.g. after the request was already aborted), so
a late or stale response cannot trip the InteractionStateGuard assertion.

The concurrent-requests test now sets a &quot;wait&quot; virtual wallet behavior so
the first request stays pending, letting the concurrency guard reject the
second request; without a wallet the request fails before the guard runs.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/identity/formats/ISO18013/response-handling.https-expected.txt: Added.
* LayoutTests/http/wpt/identity/formats/ISO18013/valid-roundtrip.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/concurrent-requests.https.html:
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-mdoc.https.html: Copied from LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get-openid4vp.https.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/get.https.html.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/webdriver/w3c-import.log:
* LayoutTests/resources/testdriver-vendor.js:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::processCredentialChooserResponse):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetVirtualWalletBehaviorForTesting):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker dealloc]):
(-[WKDigitalCredentialsPicker dismiss]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::showDigitalCredentialsChooser):
(WebKit::WebPageProxy::settlePendingTestingDigitalCredentialHandler):
(WebKit::WebPageProxy::abortPendingDigitalCredentialWaitHandlers):
(WebKit::WebPageProxy::setVirtualWalletBehaviorForTesting):
(WebKit::WebPageProxy::dismissDigitalCredentialsChooser):
(WebKit::WebPageProxy::resetState):
(WebKit::applyVirtualWalletBehavior):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setVirtualWalletBehavior):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::setVirtualWalletBehavior):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/317196@main">https://commits.webkit.org/317196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4165dd025b960ec216b771e86058c39888bd5690

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132358 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d73c05c9-0111-4628-9873-2829582bc6ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135750 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93203308-9c6e-4b7d-8e28-dbda2b80731d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156548 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12af6361-c0b7-41ff-bb29-22721f108ff0) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36198 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32548 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186493 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35752 "Build is in progress. Recent messages:") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39728 "Found 1028 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144665 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/173890 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38976 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48769 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114365 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39423 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120761 "Found 121 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47276 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11004 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46678 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46909 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46736 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->