### PR TITLE
Digital Credentials: aborting navigator.credentials.get() can leave the document picker stuck on screen

### DIFF
--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
@@ -52,6 +52,12 @@ extension WKIdentityDocumentPresentmentController {
 
         private var performRequestTask: Task<any IdentityDocumentWebPresentmentResponse, any Error>?
 
+        // Single-use: one request per instance, so isCancelled is terminal and never reset.
+        // hasStartedRequest makes reuse fail loudly rather than silently reject as cancelled.
+        private var isCancelled = false
+
+        private var hasStartedRequest = false
+
         weak var delegate: (any WKIdentityDocumentPresentmentDelegate)?
 
         init() {
@@ -61,6 +67,17 @@ extension WKIdentityDocumentPresentmentController {
         }
 
         func perform(request: WKIdentityDocumentPresentmentRequest) async throws -> WKIdentityDocumentPresentmentResponse {
+            if isCancelled {
+                Self.logger.debug("IdentityDocumentPresentmentController perform called after cancellation; not presenting")
+                throw WKIdentityDocumentPresentmentError(.cancelled)
+            }
+
+            if hasStartedRequest {
+                assertionFailure("IdentityDocumentPresentmentController perform called more than once on a single-use controller")
+                throw WKIdentityDocumentPresentmentError(.requestInProgress)
+            }
+            hasStartedRequest = true
+
             do {
                 Self.logger.debug("IdentityDocumentPresentmentController performRequest called with request \(String(describing: request))")
                 let convertedRequests = request.mobileDocumentRequests.map(ISO18013MobileDocumentRequest.init(_:))
@@ -99,12 +116,15 @@ extension WKIdentityDocumentPresentmentController {
                 default:
                     throw WKIdentityDocumentPresentmentError(.unknown, userInfo: userInfo)
                 }
+            } catch is CancellationError {
+                throw WKIdentityDocumentPresentmentError(.cancelled)
             } catch {
                 throw WKIdentityDocumentPresentmentError(.unknown)
             }
         }
 
         func cancelRequest() {
+            isCancelled = true
             performRequestTask?.cancel()
         }
     }


### PR DESCRIPTION
#### bab1bc1f7610146c5ae0ad963cbcd3b743ab0a11
<pre>
Digital Credentials: aborting navigator.credentials.get() can leave the document picker stuck on screen

<a href="https://rdar.apple.com/180812397">rdar://180812397</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318013">https://bugs.webkit.org/show_bug.cgi?id=318013</a>

Reviewed by Abrar Rahman Protyasha.

WKIdentityDocumentPresentmentController.cancelRequest() only cancelled
performRequestTask. When the abort arrived before the asynchronous
perform(request:) had assigned performRequestTask, the optional-chained
cancel was a no-op, so Identity Document Services was never told to dismiss
and the picker stayed on screen.

Track cancellation in an isCancelled flag set by cancelRequest().
perform(request:) throws without presenting when cancellation was already
requested; a cancel that arrives once the request is in flight is delivered
through performRequestTask as before. Map a CancellationError to .cancelled
so the request rejects with AbortError rather than UnknownError.

The controller is single-use: the picker creates a fresh instance per
request and discards it on dismiss, so isCancelled is terminal and never
reset. A hasStartedRequest guard makes that contract explicit, rejecting
reuse with requestInProgress rather than a stale cancelled state.

The repeated get()/abort path is exercised by the &quot;Aborted Digital
Credentials get() requests do not leave a subsequent request stuck in an
invalid state&quot; subtest in get-non-fully-active.https.html; a hermetic
regression test depends on the digital-credentials test automation in
bug 306292.

* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift:
(Base.perform(_:)): Throw before presenting if cancellation was already
requested, reject reuse of a single-use controller, and map a
CancellationError to a cancelled error.
(Base.cancelRequest): Record that cancellation was requested.

Canonical link: <a href="https://commits.webkit.org/316494@main">https://commits.webkit.org/316494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84351637ea09afaebb14ade05bbdef0e1908cdfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181856 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129959 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ce2be3b-af1e-4d41-ba8a-ec579fa52b9d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134090 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c16b327b-401e-4296-95b5-8c467488e43e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114561 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f144724-7179-4042-b45c-3b6cf4128e9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34436 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30460 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184390 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142859 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45993 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38573 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46671 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111399 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37786 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118422 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45188 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9073 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44588 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->