### PR TITLE
[Site Isolation] Per-frame back/forward walk dispatches a duplicate traversal to one live frame, clobbering the iframe navigation

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2885,6 +2885,7 @@ bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromF
         return anySent;
 
     auto& toChildren = toFrame.children();
+    HashSet<WebCore::BackForwardFrameItemIdentifier> pairedFromChildren;
     for (size_t i = 0; i < toChildren.size(); ++i) {
         Ref toChild = toChildren[i];
         auto childFrameID = toChild->frameID();
@@ -2892,9 +2893,12 @@ bool WebPageProxy::dispatchPerFrameTraversals(WebBackForwardListFrameItem& fromF
             continue;
         // Stored frameIDs can disagree across entries after a process swap; fall back to position, which is stable across history.
         RefPtr fromChild = fromFrame.childItemForFrameID(*childFrameID);
-        if (!fromChild)
+        // A duplicated frameID in the to tree can resolve two siblings to the same from child; pairing both
+        // would dispatch a second traversal to the same live frame and clobber the intended navigation. Fall
+        // back to position when the resolved from child is already paired.
+        if (!fromChild || pairedFromChildren.contains(fromChild->identifier()))
             fromChild = fromFrame.childItemAtIndex(i);
-        if (!fromChild)
+        if (!fromChild || !pairedFromChildren.add(fromChild->identifier()).isNewEntry)
             continue;
         if (dispatchPerFrameTraversals(*fromChild, toChild, navigationID, frameLoadType, shouldRestore, publicSuffix))
             anySent = true;


### PR DESCRIPTION
#### 60a8b5a259e838abb0c91565b594acc37dff175b
<pre>
[Site Isolation] Per-frame back/forward walk dispatches a duplicate traversal to one live frame, clobbering the iframe navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=318015">https://bugs.webkit.org/show_bug.cgi?id=318015</a>
<a href="https://rdar.apple.com/180813822">rdar://180813822</a>

Reviewed by Sihui Liu.

Under UseUIProcessForBackForwardItemLoading, WebPageProxy::dispatchPerFrameTraversals walks
the (from, to) back/forward frame trees and pairs each target child frame with a source child
by frameID, falling back to position. When a back/forward entry&apos;s child frame tree carries a
duplicated frameID — an unaffected sibling iframe that inherited the navigated frame&apos;s
frameID — childItemForFrameID resolves two distinct target children to the same source child.
The walk then dispatches a second per-frame GoToBackForwardItem to the same live frame; the
second message (same navigationID) supersedes the first, so the intended iframe navigation is
lost and the back/forward action hangs.

This surfaces as a flaky ~33s timeout in SiteIsolation.NavigateFrameWithSiblingsBackForward on
api-mac / api-mac-debug: navigating one of two sibling iframes and then going back/forward
intermittently records the unaffected sibling with the navigated frame&apos;s frameID, so the
forward traversal dispatches GoToBackForwardItem twice to the same frame and the expected
navigation never completes.

Fix: pair each source child with at most one target child. When the frameID-resolved source
child is already paired, fall back to position to recover the correct sibling, so a duplicated
frameID can no longer route two target frames to the same live frame.

The underlying capture-side bug (a sibling inheriting another frame&apos;s frameID when the
back/forward frame tree is recorded) is a separate, deeper issue in the same area as the
BF-tree frameID staleness work; this change is a defensive guard in the walk.

Covered by existing tests (SiteIsolation.NavigateFrameWithSiblingsBackForward, previously
flaky; 50/50 iterations pass with this change).

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchPerFrameTraversals):

Canonical link: <a href="https://commits.webkit.org/316017@main">https://commits.webkit.org/316017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41e13d05b24ebc6275f34673dd468762f0c01d8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128304 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65558e31-df21-4439-b988-b8905bc33199) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133037 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93828 "2 flakes 16 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4bfeae0-395c-4761-8b9b-ff5c81fe47b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113534 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26746fe5-02a3-49ed-a0b3-05dc4be6bc47) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34846 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33187 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182552 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44172 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141312 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38094 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44861 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29860 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109411 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36579 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116750 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43371 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7964 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42776 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43017 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42907 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->