### PR TITLE
[Text Extraction] Work towards making it possible for clients to target stale node UIDs

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -17,7 +17,7 @@ PASS childScrollerScrollTopAfterScrollToReveal is > 0
 PASS scrollToRevealInPageError is ""
 PASS pageScrollTopAfterScrollToReveal is > 100
 PASS scrollToRevealNotFoundError is "'Nonexistent text' not found inside the target node"
-PASS invalidActionError is "Failed to resolve nodeIdentifier 4294967293"
+PASS invalidActionError is "Failed to resolve stale uid=4294967293"
 PASS clickDisabledError is "Click target is disabled"
 PASS textInputReadonlyError is "Target is readonly"
 PASS selectDisabledMenuItemError is "Select is disabled"

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -189,7 +189,7 @@
         shouldBeEqualToString("scrollToRevealInPageError", "");
         shouldBeGreaterThan("pageScrollTopAfterScrollToReveal", "100");
         shouldBeEqualToString("scrollToRevealNotFoundError", "'Nonexistent text' not found inside the target node");
-        shouldBeEqualToString("invalidActionError", "Failed to resolve nodeIdentifier 4294967293");
+        shouldBeEqualToString("invalidActionError", "Failed to resolve stale uid=4294967293");
         shouldBeEqualToString("clickDisabledError", "Click target is disabled");
         shouldBeEqualToString("textInputReadonlyError", "Target is readonly");
         shouldBeEqualToString("selectDisabledMenuItemError", "Select is disabled");

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1875,7 +1875,7 @@ static String invalidNodeIdentifierDescription(std::optional<NodeIdentifier>&& i
     if (!identifier)
         return "Missing nodeIdentifier"_s;
 
-    return makeString("Failed to resolve nodeIdentifier "_s, identifier->loggingString());
+    return makeString("Failed to resolve stale uid="_s, identifier->loggingString());
 }
 
 static String searchTextNotFoundDescription(const String& searchText)
@@ -1940,12 +1940,15 @@ static Expected<ResolvedMouseTarget, String> resolveMouseTarget(Node& targetNode
         element = targetNode.parentElementInComposedTree();
 
     if (!element || !element->isConnected())
-        return makeUnexpected("Target has been disconnected from the DOM"_s);
+        return makeUnexpected("Target element could not be found; uid may be stale"_s);
+
+    if (!element->document().hasLivingRenderTree())
+        return makeUnexpected("Target belongs to a detached document; uid may be stale"_s);
 
     {
         CheckedPtr renderer = element->renderer();
         if (!renderer)
-            return makeUnexpected("Target is not rendered (possibly display: none)"_s);
+            return makeUnexpected("Target is not rendered (possibly display: none) or uid may be stale"_s);
 
         if (renderer->style().usedVisibility() != Visibility::Visible)
             return makeUnexpected("Target is hidden via CSS visibility"_s);

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -368,6 +368,7 @@ struct TextExtractionLine {
     unsigned enclosingBlockNumber { 0 };
     unsigned superscriptLevel { 0 };
     unsigned visualBlockContainerNumber { 0 };
+    std::optional<String> nodeIdentifier { };
 };
 
 static bool shouldEmitFullStopBetweenLines(const TextExtractionLine& previous, const String& previousText, const TextExtractionLine& line, const String& text)
@@ -410,6 +411,8 @@ static bool shouldEmitExtraSpace(char16_t previousCharacter, char16_t nextCharac
 
 enum class HasAdjacentLinkAfter : bool { No, Yes };
 
+static String lineWithoutNodeIdentifier(const String&, const std::optional<String>&);
+
 class TextExtractionAggregator : public RefCounted<TextExtractionAggregator> {
     WTF_MAKE_NONCOPYABLE(TextExtractionAggregator);
     WTF_MAKE_TZONE_ALLOCATED(TextExtractionAggregator);
@@ -426,8 +429,7 @@ public:
     {
         addNativeMenuItemsIfNeeded();
         addVersionNumberIfNeeded();
-
-        m_completion({ takeResults(), m_filteredOutAnyText, std::exchange(m_shortenedURLStrings, { }), std::exchange(m_textToContainerMap, { }) });
+        m_completion({ takeResults(), m_filteredOutAnyText, std::exchange(m_shortenedURLStrings, { }), std::exchange(m_textToContainerMap, { }), std::exchange(m_lineContents, { }) });
     }
 
     String takeResults()
@@ -463,6 +465,14 @@ public:
         }
 
         if (useTextTreeOutput() || useHTMLOutput()) {
+            if (useTextTreeOutput()) {
+                m_lineContents = m_lines.map([](auto& stringAndLine) {
+                    return TextExtractionLineContent {
+                        lineWithoutNodeIdentifier(stringAndLine.first, stringAndLine.second.nodeIdentifier),
+                        stringAndLine.second.nodeIdentifier
+                    };
+                });
+            }
             return makeStringByJoining(m_lines.map([](auto& stringAndLine) {
                 return stringAndLine.first;
             }), "\n"_s);
@@ -516,7 +526,7 @@ public:
         if (components.isEmpty())
             return;
 
-        auto [lineIndex, indentLevel, enclosingBlockNumber, superscriptLevel, visualBlockContainerNumber] = line;
+        auto [lineIndex, indentLevel, enclosingBlockNumber, superscriptLevel, visualBlockContainerNumber, nodeIdentifier] = line;
         if (lineIndex >= m_lines.size()) {
             ASSERT_NOT_REACHED();
             return;
@@ -833,6 +843,7 @@ private:
 
     const TextExtractionOptions m_options;
     Vector<std::pair<String, TextExtractionLine>> m_lines;
+    Vector<TextExtractionLineContent> m_lineContents;
     Vector<String, 1> m_urlStringStack;
     unsigned m_superscriptLevel { 0 };
     unsigned m_strikethroughLevel { 0 };
@@ -1279,6 +1290,21 @@ static String quoteValue(const String& value, bool conditionalQuoting)
 
 enum class IncludeRectForParentItem : bool { No, Yes };
 
+static String lineWithoutNodeIdentifier(const String& line, const std::optional<String>& identifier)
+{
+    if (!identifier)
+        return line;
+
+    auto token = makeString("uid="_s, *identifier);
+    size_t location = line.find(token);
+    if (location == notFound)
+        return line;
+
+    unsigned start = static_cast<unsigned>(location);
+    unsigned end = start + token.length();
+    return makeString(StringView { line }.left(start), StringView { line }.substring(end));
+}
+
 static Vector<String> partsForItem(const TextExtraction::Item& item, const TextExtractionAggregator& aggregator, IncludeRectForParentItem includeRectForParentItem)
 {
     Vector<String> parts;
@@ -1446,10 +1472,12 @@ static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector
     });
 }
 
-static void addPartsForItem(const TextExtraction::Item& item, std::optional<NodeIdentifier>&& enclosingNode, const TextExtractionLine& line, TextExtractionAggregator& aggregator, IncludeRectForParentItem includeRectForParentItem, HasAdjacentLinkAfter hasAdjacentLinkAfter = HasAdjacentLinkAfter::No)
+static void addPartsForItem(const TextExtraction::Item& item, std::optional<NodeIdentifier>&& enclosingNode, TextExtractionLine line, TextExtractionAggregator& aggregator, IncludeRectForParentItem includeRectForParentItem, HasAdjacentLinkAfter hasAdjacentLinkAfter = HasAdjacentLinkAfter::No)
 {
     Vector<String> parts;
     bool streamlined = aggregator.useTextTreeOutput();
+    if (item.nodeIdentifier)
+        line.nodeIdentifier = aggregator.stringForIdentifiers(item.frameIdentifier, *item.nodeIdentifier);
     WTF::switchOn(item.data,
         [&](const TextExtraction::ContainerType& containerType) {
             auto containerString = containerTypeString(containerType);

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -110,11 +110,17 @@ struct TextExtractionOptions {
     String topHostName;
 };
 
+struct TextExtractionLineContent {
+    String contentWithoutIdentifier;
+    std::optional<String> nodeIdentifier;
+};
+
 struct TextExtractionResult {
     String textContent;
     bool filteredOutAnyText { false };
     Vector<String> shortenedURLStrings;
     HashMap<String, Vector<ExtractedNodeInfo>> textToContainerMap;
+    Vector<TextExtractionLineContent> lineContents;
 };
 
 void convertToText(WebCore::TextExtraction::Item&&, TextExtractionOptions&&, CompletionHandler<void(TextExtractionResult&&)>&&);

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -442,6 +442,7 @@ UIProcess/SpeechRecognitionPermissionManager.cpp
 UIProcess/TextChecker.cpp
 UIProcess/TextCheckerCompletion.cpp
 UIProcess/TextExtractionAssertionScope.cpp
+UIProcess/TextExtractionCache.cpp
 UIProcess/UIProcessLogInitialization.cpp
 UIProcess/UserMediaPermissionCheckProxy.cpp
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp @cost:5

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -67,6 +67,7 @@
 #import "SafeBrowsingUtilities.h"
 #import "SessionStateCoding.h"
 #import "TextExtractionAssertionScope.h"
+#import "TextExtractionCache.h"
 #import "TextExtractionFilter.h"
 #import "TextExtractionToStringConversion.h"
 #import "TextExtractionTokenizer.h"
@@ -7436,7 +7437,11 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
                 return completionHandler(createEmptyTextExtractionResult().get());
 
             RELEASE_LOG(TextExtraction, "<%@: %p> Extraction complete (%.0f ms)", [strongSelf class], strongSelf.get(), (MonotonicTime::now() - startTime).milliseconds());
-            auto [text, filteredOutAnyText, shortenedURLStrings, textToContainerMap] = result;
+            auto [text, filteredOutAnyText, shortenedURLStrings, textToContainerMap, lineContents] = result;
+
+            if (strongSelf->_page)
+                strongSelf->_page->textExtractionCache().add(strongSelf->_page->currentURL(), WTF::move(lineContents));
+
             RetainPtr shortenedURLs = adoptNS([[NSMutableDictionary alloc] initWithCapacity:shortenedURLStrings.size()]);
             for (auto& string : shortenedURLStrings) {
                 if (auto url = urlCache->urlForShortenedString(string); url.isValid()) {

--- a/Source/WebKit/UIProcess/TextExtractionCache.cpp
+++ b/Source/WebKit/UIProcess/TextExtractionCache.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextExtractionCache.h"
+
+#include <optional>
+#include <wtf/StdLibExtras.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+void TextExtractionCache::add(const String& url, Vector<TextExtractionLineContent>&& lineContents)
+{
+    if (lineContents.isEmpty())
+        return;
+
+    Entry entry;
+    entry.url = url;
+    entry.lines = WTF::move(lineContents);
+    for (unsigned index = 0; index < entry.lines.size(); ++index) {
+        if (auto nodeIdentifier = entry.lines[index].nodeIdentifier)
+            entry.lineIndexForUID.add(WTF::move(*nodeIdentifier), index);
+    }
+
+    m_entries.append(WTF::move(entry));
+    if (m_entries.size() > maxEntries)
+        m_entries.removeAt(0, m_entries.size() - maxEntries);
+}
+
+Vector<String> TextExtractionCache::contextWindowBefore(const Vector<TextExtractionLineContent>& lines, unsigned targetIndex)
+{
+    Vector<String> window;
+    window.reserveInitialCapacity(contextLineCount);
+    for (unsigned offset = contextLineCount; offset >= 1; --offset) {
+        if (offset > targetIndex)
+            window.append(emptyString());
+        else
+            window.append(lines[targetIndex - offset].contentWithoutIdentifier);
+    }
+    return window;
+}
+
+Vector<String> TextExtractionCache::contextWindowAfter(const Vector<TextExtractionLineContent>& lines, unsigned targetIndex)
+{
+    unsigned lineCount = lines.size();
+    Vector<String> window;
+    window.reserveInitialCapacity(contextLineCount);
+    for (unsigned offset = 1; offset <= contextLineCount; ++offset) {
+        unsigned index = targetIndex + offset;
+        if (index >= lineCount)
+            window.append(emptyString());
+        else
+            window.append(lines[index].contentWithoutIdentifier);
+    }
+    return window;
+}
+
+auto TextExtractionCache::resolve(const String& identifier) const -> ResolvedNode
+{
+    if (m_entries.isEmpty())
+        return { identifier, NodeResolution::Unknown };
+
+    size_t newestIndex = m_entries.size() - 1;
+    if (m_entries[newestIndex].lineIndexForUID.contains(identifier))
+        return { identifier, NodeResolution::Current };
+
+    std::optional<size_t> sourceEntryIndex;
+    unsigned sourceLineIndex = 0;
+    for (size_t index = 0; index < newestIndex; ++index) {
+        if (auto it = m_entries[index].lineIndexForUID.find(identifier); it != m_entries[index].lineIndexForUID.end()) {
+            sourceEntryIndex = index;
+            sourceLineIndex = it->value;
+        }
+    }
+
+    if (!sourceEntryIndex)
+        return { identifier, NodeResolution::Unknown };
+
+    auto& newestURL = m_entries[newestIndex].url;
+    auto& source = m_entries[*sourceEntryIndex];
+    auto& sourceLineContent = source.lines[sourceLineIndex].contentWithoutIdentifier;
+    auto sourceContextBefore = contextWindowBefore(source.lines, sourceLineIndex);
+    auto sourceContextAfter = contextWindowAfter(source.lines, sourceLineIndex);
+
+    for (size_t entryIndex = newestIndex; entryIndex > *sourceEntryIndex; --entryIndex) {
+        auto& entry = m_entries[entryIndex];
+        if (entry.url != newestURL)
+            continue;
+
+        std::optional<unsigned> uniqueTargetIndex;
+        unsigned matchCount = 0;
+        for (unsigned candidate = 0; candidate < entry.lines.size(); ++candidate) {
+            if (entry.lines[candidate].contentWithoutIdentifier != sourceLineContent)
+                continue;
+
+            bool contextBeforeMatches = contextWindowBefore(entry.lines, candidate) == sourceContextBefore;
+            bool contextAfterMatches = contextWindowAfter(entry.lines, candidate) == sourceContextAfter;
+            if (!contextBeforeMatches && !contextAfterMatches)
+                continue;
+
+            if (++matchCount > 1) {
+                uniqueTargetIndex = { };
+                break;
+            }
+
+            uniqueTargetIndex = candidate;
+        }
+
+        if (!matchCount)
+            continue;
+
+        if (matchCount > 1)
+            return { { }, NodeResolution::Ambiguous };
+
+        if (auto remapped = entry.lines[*uniqueTargetIndex].nodeIdentifier)
+            return { WTF::move(*remapped), NodeResolution::Remapped };
+
+        return { { }, NodeResolution::Stale };
+    }
+
+    return { { }, NodeResolution::Stale };
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/TextExtractionCache.h
+++ b/Source/WebKit/UIProcess/TextExtractionCache.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TextExtractionToStringConversion.h"
+#include <wtf/HashMap.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class TextExtractionCache {
+public:
+    static constexpr auto maxEntries = 4;
+    static constexpr auto contextLineCount = 3;
+
+    enum class NodeResolution : uint8_t {
+        Current,
+        Remapped,
+        Stale,
+        Ambiguous,
+        Unknown,
+    };
+
+    struct ResolvedNode {
+        String identifier;
+        NodeResolution resolution { NodeResolution::Unknown };
+    };
+
+    void add(const String& url, Vector<TextExtractionLineContent>&&);
+    ResolvedNode resolve(const String& identifier) const;
+    void clear() { m_entries.clear(); }
+
+private:
+    struct Entry {
+        String url;
+        Vector<TextExtractionLineContent> lines;
+        HashMap<String, unsigned> lineIndexForUID;
+    };
+
+    static Vector<String> contextWindowBefore(const Vector<TextExtractionLineContent>&, unsigned targetIndex);
+    static Vector<String> contextWindowAfter(const Vector<TextExtractionLineContent>&, unsigned targetIndex);
+
+    Vector<Entry> m_entries;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1596,6 +1596,7 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     m_webPageID = provisionalPage->webPageID();
     if (RefPtr pageClient = this->pageClient())
         pageClient->didChangeWebPageID();
+    internals().textExtractionCache.clear();
     ASSERT(m_legacyMainFrameProcess->websiteDataStore());
     m_websiteDataStore = *m_legacyMainFrameProcess->websiteDataStore();
 #if ENABLE(WEB_ARCHIVE)
@@ -18709,6 +18710,11 @@ void WebPageProxy::updateTextExtractionFilterRules(Vector<WebCore::TextExtractio
 void WebPageProxy::applyTextExtractionFilter(const String& input, CompletionHandler<void(String&&)>&& completion)
 {
     sendWithAsyncReply(Messages::WebPage::ApplyTextExtractionFilter(input), WTF::move(completion));
+}
+
+TextExtractionCache& WebPageProxy::textExtractionCache()
+{
+    return internals().textExtractionCache;
 }
 
 void WebPageProxy::addConsoleMessage(FrameIdentifier frameID, MessageSource messageSource, MessageLevel messageLevel, const String& message, std::optional<ResourceLoaderIdentifier> coreIdentifier)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -550,6 +550,7 @@ class SpeechRecognitionPermissionManager;
 class SuspendedPageProxy;
 class SystemPreviewController;
 class TextExtractionAssertionScope;
+class TextExtractionCache;
 class UserData;
 class UserMediaPermissionRequestManagerProxy;
 class UserMediaPermissionRequestProxy;
@@ -2756,6 +2757,8 @@ public:
     void hasTextExtractionFilterRules(CompletionHandler<void(bool)>&&);
     void updateTextExtractionFilterRules(Vector<WebCore::TextExtraction::FilterRuleData>&&);
     void applyTextExtractionFilter(const String& input, CompletionHandler<void(String&&)>&&);
+
+    TextExtractionCache& textExtractionCache();
 
     void hasVideoInPictureInPictureDidChange(bool);
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -36,6 +36,7 @@
 #include "ProcessActivityGroup.h"
 #include "ProcessThrottler.h"
 #include "ScrollingAccelerationCurve.h"
+#include "TextExtractionCache.h"
 #include "TextManipulationParameters.h"
 #include "VisibleWebPageCounter.h"
 #include "WebColorPicker.h"
@@ -240,6 +241,8 @@ public:
     UserObservablePageCounter::Token pageIsUserObservableCount;
     std::optional<MonotonicTime> pageLoadStart;
     PageLoadState pageLoadState;
+
+    TextExtractionCache textExtractionCache;
     OptionSet<WebCore::ActivityState> potentiallyChangedActivityStateFlags;
     ProcessSuppressionDisabledToken preventProcessSuppressionCount;
     std::optional<PrivateClickMeasurementAndMetadata> privateClickMeasurement;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7258,6 +7258,8 @@
 		7DDEC9D32D4C5DDA000B1353 /* WebExtensionRegisteredScriptsSQLiteStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionRegisteredScriptsSQLiteStore.h; sourceTree = "<group>"; };
 		7DDEC9D42D4C5DDA000B1353 /* WebExtensionRegisteredScriptsSQLiteStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionRegisteredScriptsSQLiteStore.cpp; sourceTree = "<group>"; };
 		7DE4AC4A2E55521C00475DD8 /* WebExtensionDeclarativeNetRequestSQLiteStoreCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionDeclarativeNetRequestSQLiteStoreCocoa.mm; sourceTree = "<group>"; };
+		7E0C1A0E000000000000CAC1 /* TextExtractionCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextExtractionCache.h; sourceTree = "<group>"; };
+		7E0C1A0F000000000000CAC2 /* TextExtractionCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionCache.cpp; sourceTree = "<group>"; };
 		7E0E785501701FB501FB7E04 /* GeneratedSerializersSharedExtensions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializersSharedExtensions.mm; sourceTree = "<group>"; };
 		7E70A07B501701FB501FB523 /* GeneratedSerializersSharedAPI.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializersSharedAPI.mm; sourceTree = "<group>"; };
 		7E70A07B501701FB501FB525 /* GeneratedSerializersSharedCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GeneratedSerializersSharedCocoa.mm; sourceTree = "<group>"; };
@@ -15853,6 +15855,8 @@
 				53CFBBC72224D1B000266546 /* TextCheckerCompletion.h */,
 				F41D73EA2EFF607700FD1ECB /* TextExtractionAssertionScope.cpp */,
 				F41D73E92EFF607700FD1ECB /* TextExtractionAssertionScope.h */,
+				7E0C1A0F000000000000CAC2 /* TextExtractionCache.cpp */,
+				7E0C1A0E000000000000CAC1 /* TextExtractionCache.h */,
 				CD9A64A027C8972C003827C0 /* UIProcessLogInitialization.cpp */,
 				CD9A649F27C8972C003827C0 /* UIProcessLogInitialization.h */,
 				07297F9C1C17BBEA003F0735 /* UserMediaPermissionCheckProxy.cpp */,


### PR DESCRIPTION
#### f9ad94e23bc21d20b48be8c4304e29215b7c9023
<pre>
[Text Extraction] Work towards making it possible for clients to target stale node UIDs
<a href="https://bugs.webkit.org/show_bug.cgi?id=318038">https://bugs.webkit.org/show_bug.cgi?id=318038</a>
<a href="https://rdar.apple.com/180823125">rdar://180823125</a>

Reviewed by Richard Robinson.

It&apos;s possible for agentic text extraction clients to issue clicks over stale unique node `uid`s; for
instance, consider an agent that navigates from one page:

```
…
button uid=2845 haspopup=true label=Menu
button uid=2846 haspopup=true
image uid=2847 src=avatar.svg alt=&apos;Account menu&apos;
&apos;MyChart&apos;
&apos;by Epic&apos;
…
```

…to another page:

```
…
button uid=3004 haspopup=true label=Menu
button uid=3005 haspopup=true
image uid=3006 src=avatar.svg alt=&apos;Account menu&apos;
&apos;MyChart&apos;
&apos;by Epic&apos;
…
```

…and then attempts to issue a click on `uid=2845`. We&apos;ll currently reject the `click` interaction,
communicating in the summary string that the targeted node UID is not rendered. This can end up
confusing or otherwise misaligning a weaker model, which may end up assuming that (in this
particular example) the `Menu` button is simply no longer accessible in the current page, rather
than realizing that it had provided a stale `uid`.

To mitigate this, we work towards a mechanism where:

-   We cache the last few text extraction results.
-   When a `uid` target is stale, we fall back to searching for that `uid` in these cached results.
-   If the context before or after the `uid` is identical (ignoring the `uid`s themselves) to the
    context before or after a `uid` in the latest text extraction results taken from the current
    page, then treat it as if the agent had targeted the new, matching `uid` instead.

This patch only introduces the concept of an text extraction result cache, which we&apos;ll later consult
to resolve stale `uid`s to active `uid`s in the current context, as a fallback.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::invalidNodeIdentifierDescription):
(WebCore::TextExtraction::resolveMouseTarget):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::~TextExtractionAggregator):
(WebKit::TextExtractionAggregator::takeResults):
(WebKit::TextExtractionAggregator::addResult):
(WebKit::lineWithoutNodeIdentifier):
(WebKit::addPartsForItem):

While extracting text, we now also build up a parallel representation of the text extraction
results, where the `uid` is separated out from the rest of the content. This representation allows
us to later efficiently:

1. Check which `uid`s are present in a cached text extraction result.
2. If present, we can easily check the surrounding context around the `uid` to see if it matches.

* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
* Source/WebKit/UIProcess/TextExtractionCache.cpp: Added.
(WebKit::TextExtractionCache::add):
(WebKit::TextExtractionCache::contextWindowBefore):
(WebKit::TextExtractionCache::contextWindowAfter):
(WebKit::TextExtractionCache::resolve const):
* Source/WebKit/UIProcess/TextExtractionCache.h: Added.
(WebKit::TextExtractionCache::clear):

Add a helper class that represents a cached text extraction result, which we use to do the fallback
`uid` lookup above.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::textExtractionCache):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/315981@main">https://commits.webkit.org/315981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2ee9026a0873fa406614786a972cdae3ba6c497

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128351 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/907f3557-177c-4b91-bee4-9fbdfd235ba1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5e4537a-50a5-4dd1-94dc-2606a0daac04) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113567 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06119c73-efe8-442d-870d-4bd5bd27b93b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33218 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28696 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182599 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141528 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38063 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44908 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109493 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36610 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116797 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43418 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42954 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->