### PR TITLE
[YARR] Use StringList optimization when captures are not used

### DIFF
--- a/JSTests/stress/regexp-stringlist-match-only-captures.js
+++ b/JSTests/stress/regexp-stringlist-match-only-captures.js
@@ -1,0 +1,222 @@
+// Coverage for the match-only StringList optimization (capturing fixed-string
+// alternations flattened when captures are not observed) and the
+// terminal-parentheses optimization generalized to match-only patterns.
+//
+// Silent on success; throws on the first discrepancy. Runs the whole battery in
+// a loop so every JIT tier (and, via the -interpreter companion, the Yarr
+// bytecode interpreter) compiles these patterns. The crux of every case: a
+// match-only consumer (test/search) must agree with the spec, AND the very same
+// source used with a capture-observing consumer (exec/match/replace) must still
+// report the correct captures -- proving the flattening never corrupts the
+// capturing compile of the same pattern.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("bad value" + (msg ? " (" + msg + ")" : "") + ": " + actual + " expected " + expected);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null)
+        throw new Error("bad value" + (msg ? " (" + msg + ")" : "") + ": null expected " + JSON.stringify(expected));
+    if (actual.length !== expected.length)
+        throw new Error("bad length" + (msg ? " (" + msg + ")" : "") + ": " + actual.length + " expected " + expected.length);
+    for (let i = 0; i < expected.length; ++i) {
+        if (actual[i] !== expected[i])
+            throw new Error("bad element #" + i + (msg ? " (" + msg + ")" : "") + ": " + actual[i] + " expected " + expected[i]);
+    }
+}
+
+// A 16-bit (non-Latin1) suffix used to force the subject string to be 16-bit so
+// the Char16 matcher paths are exercised too. Patterns that match a prefix can
+// match an ASCII prefix of a 16-bit string.
+const wide = "あ";
+
+function test() {
+    // --- 1. Register-style: each alternative is a single capturing group around a
+    //        literal; anchored ^(...)$; exercised match-only via test()/search(). ---
+    {
+        const re = new RegExp("^((t0)|(t1)|(cfr)|(sp)|(lr)|(pc)|(fr))$");
+        for (const s of ["t0", "t1", "cfr", "sp", "lr", "pc", "fr"])
+            shouldBe(re.test(s), true, "reg member " + s);
+        for (const s of ["", "t", "t2", "zz", "move", "t0x", "xt0", "CFR", "sp ", " sp"])
+            shouldBe(re.test(s), false, "reg non-member " + s);
+        // search() is also match-only.
+        shouldBe(re[Symbol.search]("cfr"), 0, "reg search hit");
+        shouldBe("cfr".search(re), 0, "reg search hit 2");
+        shouldBe("zz".search(re), -1, "reg search miss");
+
+        // Same source, capture-observing: captures must be exact.
+        const m = re.exec("cfr");
+        shouldBeArray(m, ["cfr", "cfr", undefined, undefined, "cfr", undefined, undefined, undefined, undefined], "reg exec cfr");
+        shouldBe(m.index, 0, "reg exec index");
+        shouldBeArray("t1".match(new RegExp("^((t0)|(t1)|(cfr)|(sp)|(lr)|(pc)|(fr))$")),
+            ["t1", "t1", undefined, "t1", undefined, undefined, undefined, undefined, undefined], "reg match t1");
+        shouldBe("fr".replace(re, "$1/$8"), "fr/fr", "reg replace captures");
+    }
+
+    // --- 2. Large generated alternation (like the offlineasm register set). ---
+    {
+        const regs = [];
+        for (let i = 0; i < 6; ++i) regs.push("t" + i, "ft" + i);
+        for (let i = 0; i < 10; ++i) regs.push("csr" + i);
+        regs.push("cfr", "sp", "lr", "pc", "fr", "a0", "a1", "a2", "a3");
+        const re = new RegExp("^((" + regs.join(")|(") + "))$");
+        for (const s of regs)
+            shouldBe(re.test(s), true, "big member " + s);
+        for (const s of ["", "x", "t6", "csr10", "move", "loadi", "storei", "jmp", "bineq"])
+            shouldBe(re.test(s), false, "big non-member " + s);
+        // exec on a member still reports group 1 (the outer group) correctly.
+        const m = re.exec("csr3");
+        shouldBe(m[0], "csr3", "big exec[0]");
+        shouldBe(m[1], "csr3", "big exec[1]");
+    }
+
+    // --- 3. Keyword-style alternation used via test() in a boolean expression. ---
+    {
+        const kw = new RegExp("^((true)|(false)|(if)|(then)|(else)|(end)|(and)|(or)|(not))$");
+        for (const s of ["true", "false", "if", "then", "else", "end", "and", "or", "not"])
+            shouldBe(kw.test(s), true, "kw member " + s);
+        for (const s of ["tru", "trueX", "Xtrue", "iff", "", "macro"])
+            shouldBe(kw.test(s), false, "kw non-member " + s);
+    }
+
+    // --- 4. Mixed alternatives: capturing groups, bare strings, non-capturing. ---
+    {
+        const mix = /^((foo)|bar|(baz)|(?:qux))$/;
+        for (const s of ["foo", "bar", "baz", "qux"])
+            shouldBe(mix.test(s), true, "mix member " + s);
+        for (const s of ["fo", "barX", "quxx", "", "FOO"])
+            shouldBe(mix.test(s), false, "mix non-member " + s);
+        shouldBeArray(mix.exec("baz"), ["baz", "baz", undefined, "baz"], "mix exec baz");
+        shouldBeArray(mix.exec("bar"), ["bar", "bar", undefined, undefined], "mix exec bar");
+        shouldBeArray(mix.exec("qux"), ["qux", "qux", undefined, undefined], "mix exec qux");
+    }
+
+    // --- 5. Non-EOL prefix string list (no trailing $). Exercises 16-bit subjects. ---
+    {
+        const pre = /^((alpha)|(beta)|(gamma)|(delta)|(epsilon)|(zeta)|(eta)|(theta))/;
+        shouldBe(pre.test("alphaXYZ"), true, "prefix alpha");
+        shouldBe(pre.test("thetabeta"), true, "prefix theta");
+        shouldBe(pre.test("zzz"), false, "prefix miss");
+        shouldBe(pre.test("alph"), false, "prefix partial");
+        // 16-bit subject whose ASCII prefix matches.
+        shouldBe(pre.test("gamma" + wide), true, "prefix 16-bit gamma");
+        shouldBe(pre.test(wide + "gamma"), false, "prefix 16-bit leading-wide");
+        shouldBe(pre.exec("delta!")[5], "delta", "prefix exec capture");
+    }
+
+    // --- 6. ignore-case. ---
+    {
+        const ci = new RegExp("^((AA)|(BB)|(CC)|(DD)|(EE)|(FF)|(GG)|(HH))$", "i");
+        shouldBe(ci.test("aa"), true, "ci aa");
+        shouldBe(ci.test("Cc"), true, "ci Cc");
+        shouldBe(ci.test("hh"), true, "ci hh");
+        shouldBe(ci.test("zz"), false, "ci zz");
+        shouldBeArray(ci.exec("dd"), ["dd", "dd", undefined, undefined, undefined, "dd", undefined, undefined, undefined, undefined], "ci exec dd");
+    }
+
+    // --- 7. multiline: ^/$ match at line boundaries; result must stay correct. ---
+    {
+        const ml = new RegExp("^((aa)|(bb)|(cc)|(dd)|(ee)|(ff)|(gg)|(hh))$", "m");
+        shouldBe(ml.test("xx\ncc\nyy"), true, "ml cc");
+        shouldBe(ml.test("xxbbyy"), false, "ml no-boundary");
+        shouldBe(ml.test("zz\nqq"), false, "ml miss");
+        shouldBe(ml.exec("xx\ndd\nyy").index, 3, "ml exec index");
+    }
+
+    // --- 8. Empty alternative in the list (matches empty -> always succeeds). ---
+    {
+        const emptyEOL = /^((aa)|(bb)|()|(cc)|(dd)|(ee)|(ff)|(gg))$/;
+        shouldBe(emptyEOL.test(""), true, "emptyEOL empty");
+        shouldBe(emptyEOL.test("aa"), true, "emptyEOL aa");
+        shouldBe(emptyEOL.test("zz"), false, "emptyEOL zz");
+        const emptyNonEOL = /^((aa)|(bb)|()|(cc)|(dd)|(ee)|(ff)|(gg))/;
+        shouldBe(emptyNonEOL.test("anything"), true, "emptyNonEOL always");
+        shouldBe(emptyNonEOL.test(""), true, "emptyNonEOL empty");
+    }
+
+    // --- 9. Fallback shapes that must NOT be flattened but stay correct. ---
+    {
+        // Backreference -> capture is observable even match-only; no flatten.
+        const br = /^((aa)\2|(bb)|(cc)|(dd)|(ee)|(ff)|(gg)|(hh))$/;
+        shouldBe(br.test("aaaa"), true, "br aaaa");
+        shouldBe(br.test("bb"), true, "br bb");
+        shouldBe(br.test("aa"), false, "br aa-only");
+        shouldBeArray(br.exec("aaaa"), ["aaaa", "aaaa", "aa", undefined, undefined, undefined, undefined, undefined, undefined, undefined], "br exec");
+
+        // Named groups -> no flatten; captures correct.
+        const named = /^((?<x>aa)|(bb)|(cc)|(dd)|(ee)|(ff)|(gg)|(hh))$/;
+        shouldBe(named.test("aa"), true, "named aa");
+        shouldBe(named.test("zz"), false, "named zz");
+        shouldBe(named.exec("aa").groups.x, "aa", "named group x");
+
+        // Quantified inner group -> not a pure fixed string; falls back.
+        const quant = /^((t0)|(t1)?|(cc)|(dd)|(ee)|(ff)|(gg)|(hh))$/;
+        shouldBe(quant.test("t0"), true, "quant t0");
+        shouldBe(quant.test("t1"), true, "quant t1");
+        shouldBe(quant.test(""), true, "quant empty (t1? empty)");
+        shouldBe(quant.test("zz"), false, "quant zz");
+
+        // Deeper nesting inside an alternative -> not unwrappable; falls back.
+        const deep = /^(((ab))|(cd)|(ee)|(ff)|(gg)|(hh)|(ii))$/;
+        shouldBe(deep.test("ab"), true, "deep ab");
+        shouldBe(deep.test("cd"), true, "deep cd");
+        shouldBe(deep.test("zz"), false, "deep zz");
+        shouldBe(deep.exec("ab")[3], "ab", "deep inner capture");
+    }
+
+    // --- 10. Terminal-parentheses optimization in match-only with captures elsewhere. ---
+    {
+        // Trailing greedy non-capturing group; capture (\d+) elsewhere.
+        const t1 = /(\d+)x(?:ab)*/;
+        shouldBe(t1.test("12xababab"), true, "term t1 a");
+        shouldBe(t1.test("7x"), true, "term t1 b");
+        shouldBe(t1.test("nope"), false, "term t1 c");
+        shouldBeArray(t1.exec("12xabab"), ["12xabab", "12"], "term t1 exec");
+
+        // Multi-alternative terminal group.
+        const t2 = /(\w)(?:ab|cd)*/;
+        shouldBe(t2.test("zabcdab"), true, "term t2 a");
+        shouldBe(t2.test("z"), true, "term t2 b");
+        shouldBe(t2.exec("zabcd")[1], "z", "term t2 exec");
+
+        // Terminal candidate that CONTAINS a nested capture: must stay correct
+        // (guard keeps it off the terminal fast path).
+        const t3 = /q(?:(a)b)*/;
+        shouldBe(t3.test("qababab"), true, "term t3 a");
+        shouldBe(t3.test("q"), true, "term t3 b");
+        shouldBeArray(t3.exec("qabab"), ["qabab", "a"], "term t3 exec");
+
+        // Capturing trailing group must not be terminal-marked; captures correct.
+        const t4 = /m(\d)*/;
+        shouldBe(t4.test("m123"), true, "term t4 a");
+        shouldBe(t4.exec("m123")[1], "3", "term t4 exec last iter");
+
+        // No-capture trailing greedy (the originally-supported shape).
+        const t5 = /foo(?:x)*/;
+        shouldBe(t5.test("fooxxxx"), true, "term t5 a");
+        shouldBe(t5.test("bar"), false, "term t5 b");
+    }
+
+    // --- 11. Single-character alternatives (length-1 fixed strings). ---
+    {
+        const ch = /^((a)|(b)|(c)|(d)|(e)|(f)|(g)|(h))$/;
+        for (const s of ["a", "c", "h"])
+            shouldBe(ch.test(s), true, "ch member " + s);
+        for (const s of ["", "z", "ab"])
+            shouldBe(ch.test(s), false, "ch non-member " + s);
+        shouldBeArray(ch.exec("c"), ["c", "c", undefined, undefined, "c", undefined, undefined, undefined, undefined, undefined], "ch exec c");
+    }
+
+    // --- 12. Varying-length EOL alternatives (length-sort path). ---
+    {
+        const vl = /^((a)|(bb)|(ccc)|(dddd)|(ee)|(f)|(gggg)|(hh))$/;
+        for (const s of ["a", "bb", "ccc", "dddd", "ee", "f", "gggg", "hh"])
+            shouldBe(vl.test(s), true, "vl member " + s);
+        for (const s of ["", "aa", "cccc", "ddddd", "z"])
+            shouldBe(vl.test(s), false, "vl non-member " + s);
+    }
+}
+
+for (let i = 0; i < 200; ++i)
+    test();

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -274,7 +274,7 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
         && !pattern.m_containsLookbehinds
         ) {
         auto& jitCode = ensureRegExpJITCode();
-        Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::JITCompileMode::IncludeSubpatterns);
+        Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::ExecutionMode::IncludeSubpatterns);
         if (!jitCode.failureReason()) {
             m_state = JITCode;
             return;
@@ -317,8 +317,8 @@ bool RegExp::matchConcurrently(
 void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<StringView> sampleString)
 {
     Locker locker { cellLock() };
-    
-    Yarr::YarrPattern pattern(m_patternString, m_flags, m_constructionErrorCode);
+
+    Yarr::YarrPattern pattern(m_patternString, m_flags, m_constructionErrorCode, Yarr::ExecutionMode::MatchOnly);
     if (hasError(m_constructionErrorCode)) {
         m_state = ParseError;
         return;
@@ -342,7 +342,7 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
         && !pattern.m_containsLookbehinds
         ) {
         auto& jitCode = ensureRegExpJITCode();
-        Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::JITCompileMode::MatchOnly);
+        Yarr::jitCompile(pattern, m_patternString, charSize, sampleString, vm, jitCode, Yarr::ExecutionMode::MatchOnly);
         if (!jitCode.failureReason()) {
             m_state = JITCode;
             return;
@@ -356,7 +356,16 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
     dataLogLnIf(Options::dumpCompiledRegExpPatterns(), "Can't JIT this regular expression: \"/", m_patternString, "/\"");
 
     m_state = ByteCode;
-    m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);
+    // m_regExpBytecode is shared with capture-observing operations (exec/match) and the Yarr
+    // interpreter has no StringList fast path, so compile it from a capture-complete pattern rather
+    // than the match-only one above, whose capturing fixed-string alternations may have been
+    // flattened (dropping their subpatterns) for the JIT.
+    Yarr::YarrPattern bytecodePattern(m_patternString, m_flags, m_constructionErrorCode, Yarr::ExecutionMode::IncludeSubpatterns);
+    if (hasError(m_constructionErrorCode)) {
+        m_state = ParseError;
+        return;
+    }
+    m_regExpBytecode = byteCodeCompilePattern(vm, bytecodePattern, m_constructionErrorCode);
     if (!m_regExpBytecode) {
         m_state = ParseError;
         return;

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -85,6 +85,12 @@ enum class SpecificPattern : uint8_t {
     Newlines,
 };
 
+enum class ExecutionMode : uint8_t {
+    MatchOnly,
+    IncludeSubpatterns,
+    InlineTest
+};
+
 struct BytecodePattern;
 
 } } // namespace JSC::Yarr

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1574,9 +1574,9 @@ class YarrGenerator final : public YarrJITInfo {
         return MacroAssembler::Address(m_regs.output, offsetForDuplicateNamedGroupId(duplicateNamedGroupId) * sizeof(int));
     }
 
-    static bool NODELETE needsSubpatternRecording(JITCompileMode compileMode, const YarrPattern& pattern)
+    static bool NODELETE needsSubpatternRecording(ExecutionMode executionMode, const YarrPattern& pattern)
     {
-        return compileMode == JITCompileMode::IncludeSubpatterns || (compileMode == JITCompileMode::MatchOnly && pattern.m_containsBackreferences);
+        return executionMode == ExecutionMode::IncludeSubpatterns || (executionMode == ExecutionMode::MatchOnly && pattern.m_containsBackreferences);
     }
 
     static unsigned NODELETE alignCallFrameSizeInBytes(unsigned originalCallFrameSize)
@@ -1596,7 +1596,7 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.move(MacroAssembler::TrustedImm32(0), m_regs.returnRegister2);
 
 #if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
-        if (m_compileMode == JITCompileMode::InlineTest) {
+        if (m_executionMode == ExecutionMode::InlineTest) {
             m_inlinedFailedMatch.append(m_jit.jump());
             return;
         }
@@ -1627,7 +1627,7 @@ class YarrGenerator final : public YarrJITInfo {
         generateReturn();
     }
 
-    // Used to record subpatterns, should be called in JITCompileMode::IncludeSubpatterns　or when m_needsInternalSubpatternOutput is true (MatchOnly with backreferences).
+    // Used to record subpatterns, should be called in ExecutionMode::IncludeSubpatterns　or when m_needsInternalSubpatternOutput is true (MatchOnly with backreferences).
     void setSubpatternStart(MacroAssembler::RegisterID reg, unsigned subpattern)
     {
         ASSERT(subpattern);
@@ -1712,15 +1712,15 @@ class YarrGenerator final : public YarrJITInfo {
 
     bool NODELETE shouldRecordSubpatterns() const
     {
-        return m_compileMode == JITCompileMode::IncludeSubpatterns || m_needsInternalSubpatternOutput;
+        return m_executionMode == ExecutionMode::IncludeSubpatterns || m_needsInternalSubpatternOutput;
     }
 
     // We use one of three different strategies to track the start of the current match,
     // while matching.
     // 1) If the pattern has a fixed size, do nothing! - we calculate the value lazily
-    //    at the end of matching. This is irrespective of m_compileMode, and in this case
+    //    at the end of matching. This is irrespective of m_executionMode, and in this case
     //    these methods should never be called.
-    // 2) If we're compiling JITCompileMode::IncludeSubpatterns, 'm_regs.output' contains a pointer to an output
+    // 2) If we're compiling ExecutionMode::IncludeSubpatterns, 'm_regs.output' contains a pointer to an output
     //    vector, store the match start in the output vector.
     // 3) If we're compiling MatchOnly or InlinedTest, 'm_regs.output' is unused, store the match start directly
     //    in this register.
@@ -6641,7 +6641,7 @@ class YarrGenerator final : public YarrJITInfo {
     void generateReturn()
     {
 #if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
-        if (m_compileMode == JITCompileMode::InlineTest) {
+        if (m_executionMode == ExecutionMode::InlineTest) {
             m_inlinedMatched.append(m_jit.jump());
             return;
         }
@@ -6699,7 +6699,7 @@ class YarrGenerator final : public YarrJITInfo {
     }
 
 public:
-    YarrGenerator(CCallHelpers& jit, VM* vm, YarrCodeBlock* codeBlock, const YarrJITRegs& regs, YarrPattern& pattern, StringView patternString, CharSize charSize, JITCompileMode compileMode, std::optional<StringView> sampleString)
+    YarrGenerator(CCallHelpers& jit, VM* vm, YarrCodeBlock* codeBlock, const YarrJITRegs& regs, YarrPattern& pattern, StringView patternString, CharSize charSize, ExecutionMode executionMode, std::optional<StringView> sampleString)
         : m_jit(jit)
         , m_vm(vm)
         , m_codeBlock(codeBlock)
@@ -6708,14 +6708,14 @@ public:
         , m_pattern(pattern)
         , m_patternString(patternString)
         , m_charSize(charSize)
-        , m_compileMode(compileMode)
+        , m_executionMode(executionMode)
         , m_decodeSurrogatePairs(m_charSize == CharSize::Char16 && m_pattern.eitherUnicode())
         , m_unicodeIgnoreCase(m_pattern.eitherUnicode() && m_pattern.ignoreCase())
         , m_decode16BitForBackreferencesWithCalls(m_charSize == CharSize::Char16 && m_pattern.m_containsBackreferences && (m_pattern.ignoreCase() || m_pattern.m_containsModifiers))
         , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        , m_parenContextSizes(needsSubpatternRecording(compileMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(compileMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
+        , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
 #endif
         , m_sampleString(sampleString)
         , m_sampler(charSize)
@@ -6723,7 +6723,7 @@ public:
         initializeInternalSubpatternStorageIfNeeded();
     }
 
-    YarrGenerator(CCallHelpers& jit, VM* vm, YarrBoyerMooreData* yarrBMData, const YarrJITRegs& regs, YarrPattern& pattern, StringView patternString, CharSize charSize, JITCompileMode compileMode)
+    YarrGenerator(CCallHelpers& jit, VM* vm, YarrBoyerMooreData* yarrBMData, const YarrJITRegs& regs, YarrPattern& pattern, StringView patternString, CharSize charSize, ExecutionMode executionMode)
         : m_jit(jit)
         , m_vm(vm)
         , m_codeBlock(nullptr)
@@ -6732,14 +6732,14 @@ public:
         , m_pattern(pattern)
         , m_patternString(patternString)
         , m_charSize(charSize)
-        , m_compileMode(compileMode)
+        , m_executionMode(executionMode)
         , m_decodeSurrogatePairs(m_charSize == CharSize::Char16 && m_pattern.eitherUnicode())
         , m_unicodeIgnoreCase(m_pattern.eitherUnicode() && m_pattern.ignoreCase())
         , m_decode16BitForBackreferencesWithCalls(m_charSize == CharSize::Char16 && m_pattern.m_containsBackreferences && (m_pattern.ignoreCase() || m_pattern.m_containsModifiers))
         , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        , m_parenContextSizes(needsSubpatternRecording(compileMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(compileMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
+        , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
 #endif
         , m_sampler(charSize)
     {
@@ -6753,7 +6753,7 @@ public:
 #if ENABLE(YARR_JIT_BACKREFERENCES)
         // For MatchOnly mode with backreferences, we need internal storage for subpattern results
         // since m_regs.output is not available for subpattern storage in MatchOnly mode.
-        if (m_compileMode == JITCompileMode::MatchOnly && m_pattern.m_containsBackreferences) {
+        if (m_executionMode == ExecutionMode::MatchOnly && m_pattern.m_containsBackreferences) {
             m_needsInternalSubpatternOutput = true;
             // Store subpattern output after the regular frame data
             m_internalSubpatternOutputOffsetInFrame = m_pattern.m_body->m_callFrameSize;
@@ -6850,7 +6850,7 @@ public:
         }
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        if (m_decodeSurrogatePairs && m_compileMode != JITCompileMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers) {
+        if (m_decodeSurrogatePairs && m_executionMode != ExecutionMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers) {
             ASSERT(m_regs.firstCharacterAdditionalReadSize != InvalidGPRReg);
             m_useFirstNonBMPCharacterOptimization = true;
         }
@@ -6945,7 +6945,7 @@ public:
 
         ptrdiff_t codeSize = MacroAssembler::differenceBetween(startOfMainCode, m_jit.label());
         bool canInline = ([&] -> bool {
-            if (m_compileMode == JITCompileMode::IncludeSubpatterns)
+            if (m_executionMode == ExecutionMode::IncludeSubpatterns)
                 return false;
             if (m_pattern.global())
                 return false;
@@ -6998,7 +6998,7 @@ public:
             return;
         }
 
-        if (m_compileMode == JITCompileMode::MatchOnly) {
+        if (m_executionMode == ExecutionMode::MatchOnly) {
             if (m_charSize == CharSize::Char8) {
                 codeBlock.set8BitCodeMatchOnly(FINALIZE_REGEXP_CODE(linkBuffer, YarrMatchOnly8BitPtrTag, nullptr, "Match-only 8-bit regular expression"), WTF::move(m_bmMaps));
                 codeBlock.set8BitInlineStats(codeSize, m_callFrameSizeInBytes, canInline, m_usesT2);
@@ -7107,7 +7107,7 @@ public:
 
     const char* variant() final
     {
-        if (m_compileMode == JITCompileMode::MatchOnly) {
+        if (m_executionMode == ExecutionMode::MatchOnly) {
             if (m_charSize == CharSize::Char8)
                 return "Match-only 8-bit regular expression";
 
@@ -7384,7 +7384,7 @@ private:
     const StringView m_patternString;
 
     const CharSize m_charSize;
-    const JITCompileMode m_compileMode;
+    const ExecutionMode m_executionMode;
 
     // Used to detect regular expression constructs that are not currently
     // supported in the JIT; fall back to the interpreter when this is detected.
@@ -7576,11 +7576,11 @@ static void dumpCompileFailure(JITFailureReason failure)
     }
 }
 
-void jitCompile(YarrPattern& pattern, StringView patternString, CharSize charSize, std::optional<StringView> sampleString, VM* vm, YarrCodeBlock& codeBlock, JITCompileMode mode)
+void jitCompile(YarrPattern& pattern, StringView patternString, CharSize charSize, std::optional<StringView> sampleString, VM* vm, YarrCodeBlock& codeBlock, ExecutionMode mode)
 {
     CCallHelpers masm;
 
-    ASSERT(mode == JITCompileMode::MatchOnly || mode == JITCompileMode::IncludeSubpatterns);
+    ASSERT(mode == ExecutionMode::MatchOnly || mode == ExecutionMode::IncludeSubpatterns);
 
     YarrJITDefaultRegisters jitRegisters;
     YarrGenerator<YarrJITDefaultRegisters>(masm, vm, &codeBlock, jitRegisters, pattern, patternString, charSize, mode, sampleString).compile(codeBlock);
@@ -7602,7 +7602,7 @@ void jitCompile(YarrPattern& pattern, StringView patternString, CharSize charSiz
 void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringView patternString, OptionSet<Yarr::Flags> flags, CharSize charSize, VM* vm, YarrBoyerMooreData& boyerMooreData, CCallHelpers& jit, YarrJITRegisters& jitRegisters)
 {
     Yarr::ErrorCode errorCode;
-    Yarr::YarrPattern pattern(patternString, flags, errorCode);
+    Yarr::YarrPattern pattern(patternString, flags, errorCode, ExecutionMode::InlineTest);
 
     if (errorCode != Yarr::ErrorCode::NoError) {
         // This path cannot clobber jitRegisters.regT1 as it is needed for the slow path we'll end up in.
@@ -7612,7 +7612,7 @@ void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringVi
 
     jitRegisters.validate();
 
-    YarrGenerator<YarrJITRegisters> yarrGenerator(jit, vm, &boyerMooreData, jitRegisters, pattern, patternString, charSize, JITCompileMode::InlineTest);
+    YarrGenerator<YarrJITRegisters> yarrGenerator(jit, vm, &boyerMooreData, jitRegisters, pattern, patternString, charSize, ExecutionMode::InlineTest);
     yarrGenerator.setStackChecker(m_compilationThreadStackChecker);
     yarrGenerator.compileInline(boyerMooreData);
 }

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -436,12 +436,7 @@ private:
     std::optional<JITFailureReason> m_failureReason;
 };
 
-enum class JITCompileMode : uint8_t {
-    MatchOnly,
-    IncludeSubpatterns,
-    InlineTest
-};
-void jitCompile(YarrPattern&, StringView patternString, CharSize, std::optional<StringView> sampleString, VM*, YarrCodeBlock& jitObject, JITCompileMode);
+void jitCompile(YarrPattern&, StringView patternString, CharSize, std::optional<StringView> sampleString, VM*, YarrCodeBlock& jitObject, ExecutionMode);
 
 #if ENABLE(YARR_JIT_REGEXP_TEST_INLINE)
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2056,9 +2056,17 @@ public:
     //     matching JIT code.
     void checkForTerminalParentheses()
     {
-        // This check is much too crude; should be just checking whether the candidate
-        // node contains nested capturing subpatterns, not the whole expression!
-        if (m_pattern.m_numSubpatterns)
+        // For match-only patterns capture results are never observed, so the string-list optimization
+        // may run even when the pattern declares capturing subpatterns, and a capturing group wrapping
+        // a fixed string (e.g. "(t0)") may be treated as that string. Backreferences and named groups
+        // can still observe captures even in match-only mode, so keep the conservative bail for them.
+        bool ignoreCaptures = m_pattern.m_executionMode != ExecutionMode::IncludeSubpatterns
+            && !m_pattern.m_containsBackreferences
+            && !m_pattern.m_hasNamedCaptureGroups
+            && !m_pattern.m_numDuplicateNamedCaptureGroups
+            && !m_pattern.m_containsLookbehinds;
+
+        if (m_pattern.m_numSubpatterns && !ignoreCaptures)
             return;
 
         Vector<std::unique_ptr<PatternAlternative>>& alternatives = m_pattern.m_body->m_alternatives;
@@ -2074,6 +2082,7 @@ public:
                 && terms[1].type == PatternTerm::Type::ParenthesesSubpattern
                 && terms[1].quantityType == QuantifierType::FixedCount
                 && terms[1].quantityMaxCount == 1
+                && !terms[1].parentheses.isCopy
                 && (terms.size() == 2
                     || (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL))) {
                 // We start assuming this is a string list and then prove the negative.
@@ -2084,20 +2093,71 @@ public:
                 PatternDisjunction* nestedDisjunction = term.parentheses.disjunction;
                 constexpr unsigned emptyAlternativeNotFound = std::numeric_limits<unsigned>::max();
                 unsigned firstEmptyAlternative = emptyAlternativeNotFound;
+
+                auto isPureCharacterSequence = [](const Vector<PatternTerm>& innerTerms) {
+                    for (auto& innerTerm : innerTerms) {
+                        if (innerTerm.type != PatternTerm::Type::PatternCharacter
+                            || innerTerm.quantityType != QuantifierType::FixedCount
+                            || innerTerm.quantityMaxCount != 1)
+                            return false;
+                    }
+                    return true;
+                };
+
+                // When ignoring captures, an alternative that is exactly one once-quantified group
+                // wrapping a pure fixed string (e.g. "(t0)") is equivalent to that string for
+                // matching purposes. Returns the wrapped disjunction so the caller can flatten the
+                // alternative to the group's character terms; nullptr if the shape does not match.
+                auto unwrapSingleGroup = [&](const Vector<PatternTerm>& innerTerms) -> PatternDisjunction* {
+                    if (innerTerms.size() != 1)
+                        return nullptr;
+
+                    const PatternTerm& only = innerTerms[0];
+                    if (only.type != PatternTerm::Type::ParenthesesSubpattern
+                        || only.quantityType != QuantifierType::FixedCount
+                        || only.quantityMinCount != 1
+                        || only.quantityMaxCount != 1
+                        || only.parentheses.isCopy)
+                        return nullptr;
+
+                    PatternDisjunction* inner = only.parentheses.disjunction;
+                    if (inner->m_alternatives.size() != 1)
+                        return nullptr;
+
+                    // Leave an empty capture group (e.g. "()") to the generic path: flattening it to
+                    // an empty sequence would hide it from the empty-alternative bookkeeping below,
+                    // which scans the pre-flattened terms.
+                    if (inner->m_alternatives[0]->m_terms.isEmpty())
+                        return nullptr;
+
+                    if (!isPureCharacterSequence(inner->m_alternatives[0]->m_terms))
+                        return nullptr;
+
+                    return inner;
+                };
+
+                // Pass 1: confirm every alternative is a fixed string (possibly after seeing through a
+                // single wrapping group). Do not mutate the tree yet, so a late non-string alternative
+                // never leaves a half-rewritten tree.
                 for (unsigned alt = 0; isStringList && alt < nestedDisjunction->m_alternatives.size(); ++alt) {
-                    Vector<PatternTerm>& innerTerms = nestedDisjunction->m_alternatives[alt]->m_terms;
+                    const auto& innerTerms = nestedDisjunction->m_alternatives[alt]->m_terms;
 
                     if (innerTerms.isEmpty() && firstEmptyAlternative == emptyAlternativeNotFound)
                         firstEmptyAlternative = alt;
 
-                    for (size_t termIndex = 0; termIndex < innerTerms.size(); ++termIndex) {
-                        PatternTerm& innerTerm = innerTerms[termIndex];
-                        if (innerTerm.type != PatternTerm::Type::PatternCharacter
-                            || innerTerm.quantityType != QuantifierType::FixedCount
-                            || innerTerm.quantityMaxCount != 1) {
-                            isStringList = false;
-                            break;
-                        }
+                    if (isPureCharacterSequence(innerTerms))
+                        continue;
+                    if (ignoreCaptures && unwrapSingleGroup(innerTerms))
+                        continue;
+                    isStringList = false;
+                }
+
+                // Pass 2: now that the whole list is confirmed, flatten any wrapped-group alternatives
+                // by replacing the group term with a copy of its character terms.
+                if (isStringList && ignoreCaptures) {
+                    for (auto& alternative : nestedDisjunction->m_alternatives) {
+                        if (PatternDisjunction* inner = unwrapSingleGroup(alternative->m_terms))
+                            alternative->m_terms = inner->m_alternatives[0]->m_terms;
                     }
                 }
 
@@ -2125,7 +2185,8 @@ public:
                     && term.quantityType == QuantifierType::Greedy
                     && term.quantityMinCount == 0
                     && term.quantityMaxCount == quantifyInfinite
-                    && !term.capture())
+                    && !term.capture()
+                    && !term.containsAnyCaptures())
                     term.parentheses.isTerminal = true;
             }
         }
@@ -2890,7 +2951,7 @@ ErrorCode YarrPattern::compile(StringView patternString)
     return ErrorCode::NoError;
 }
 
-YarrPattern::YarrPattern(StringView pattern, OptionSet<Flags> flags, ErrorCode& error)
+YarrPattern::YarrPattern(StringView pattern, OptionSet<Flags> flags, ErrorCode& error, ExecutionMode executionMode)
     : m_containsBackreferences(false)
     , m_containsBOL(false)
     , m_containsLookbehinds(false)
@@ -2899,6 +2960,7 @@ YarrPattern::YarrPattern(StringView pattern, OptionSet<Flags> flags, ErrorCode& 
     , m_hasCopiedParenSubexpressions(false)
     , m_hasNamedCaptureGroups(false)
     , m_saveInitialStartValue(false)
+    , m_executionMode(executionMode)
     , m_flags(flags)
 {
     ASSERT(m_flags != Flags::DeletedValue);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/Yarr.h>
 #include <JavaScriptCore/YarrErrorCode.h>
 #include <JavaScriptCore/YarrFlags.h>
 #include <JavaScriptCore/YarrUnicodeProperties.h>
@@ -594,7 +595,7 @@ struct TermChain {
 
 
 struct YarrPattern {
-    JS_EXPORT_PRIVATE YarrPattern(StringView pattern, OptionSet<Flags>, ErrorCode&);
+    JS_EXPORT_PRIVATE YarrPattern(StringView pattern, OptionSet<Flags>, ErrorCode&, ExecutionMode = ExecutionMode::IncludeSubpatterns);
 
     void resetForReparsing()
     {
@@ -781,6 +782,7 @@ struct YarrPattern {
     bool m_hasCopiedParenSubexpressions : 1;
     bool m_hasNamedCaptureGroups : 1;
     bool m_saveInitialStartValue : 1;
+    ExecutionMode m_executionMode { ExecutionMode::IncludeSubpatterns };
     OptionSet<Flags> m_flags;
     SpecificPattern m_specificPattern { SpecificPattern::None };
     unsigned m_numSubpatterns { 0 };


### PR DESCRIPTION
#### 5dcf3d0b5d41091683c70d6fbca6940a59fce539
<pre>
[YARR] Use StringList optimization when captures are not used
<a href="https://bugs.webkit.org/show_bug.cgi?id=318041">https://bugs.webkit.org/show_bug.cgi?id=318041</a>
<a href="https://rdar.apple.com/180826671">rdar://180826671</a>

Reviewed by Sosuke Suzuki.

Currently StringList optimization in YarrJIT is disabled when captures
are existing inside it. But if we are using MatchOnly mode &amp;
no-capture-related things exist, then we can still use this optimization
since captures do not matter.

To attach MatchOnly etc. on YarrPattern construction, we move
JITCompileMode to ExecutionMode and use it in YarrPattern too, since
Yarr::CompileMode already exists.

Test: JSTests/stress/regexp-stringlist-match-only-captures.js

* JSTests/stress/regexp-stringlist-match-only-captures.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::jitCompile):
(JSC::Yarr::jitCompileInlinedTest):
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::checkForTerminalParentheses):
(JSC::Yarr::YarrPattern::YarrPattern):
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/315987@main">https://commits.webkit.org/315987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0476e7e15009ab1477bd9927caed99156554b6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128387 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/546a51ea-6aeb-471a-86ae-2f0be43202be) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9e1df75-5a3b-4881-b1aa-9905ff4459af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113598 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4467600-663e-460f-9bda-28c6b2e0b1f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34921 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33253 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28732 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1953 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182635 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31929 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141561 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44255 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141376 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44944 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109578 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36644 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116833 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203353 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43454 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54449 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42859 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->