### PR TITLE
WPT: add [SameObject] identity coverage for SVGSVGElement.currentTranslate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-currentTranslate-SameObject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-currentTranslate-SameObject-expected.txt
@@ -1,0 +1,6 @@
+
+PASS currentTranslate returns the same object on consecutive reads ([SameObject])
+PASS currentTranslate identity is stable across value changes
+PASS mutations through currentTranslate are observable on re-read
+PASS currentTranslate is readonly; assignment does not change the value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-currentTranslate-SameObject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-currentTranslate-SameObject.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVGSVGElement.currentTranslate is [SameObject]</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__currentTranslate">
+<link rel="help" href="https://webidl.spec.whatwg.org/#SameObject">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="100" height="100"></svg>
+<script>
+const svg = document.getElementById("svg");
+
+test(() => {
+  assert_equals(svg.currentTranslate, svg.currentTranslate);
+}, "currentTranslate returns the same object on consecutive reads ([SameObject])");
+
+test(() => {
+  const p = svg.currentTranslate;
+  p.x = 10;
+  assert_equals(svg.currentTranslate, p, "same object after mutating x");
+}, "currentTranslate identity is stable across value changes");
+
+test(() => {
+  svg.currentTranslate.x = 42;
+  assert_equals(svg.currentTranslate.x, 42);
+}, "mutations through currentTranslate are observable on re-read");
+
+test(() => {
+  svg.currentTranslate.x = 7;
+  svg.currentTranslate.y = 9;
+  const replacement = svg.createSVGPoint();
+  replacement.x = 100;
+  replacement.y = 200;
+  // Assignment to a readonly attribute is ignored (silently in non-strict mode).
+  // Asserted on the value, not object identity, so this isolates readonly from
+  // [SameObject]: an engine that fails identity still passes this if it honors readonly.
+  try { svg.currentTranslate = replacement; } catch (e) {}
+  assert_equals(svg.currentTranslate.x, 7, "x value unchanged");
+  assert_equals(svg.currentTranslate.y, 9, "y value unchanged");
+}, "currentTranslate is readonly; assignment does not change the value");
+</script>


### PR DESCRIPTION
#### 391677e4cebdc603c4d9b4ff9ddf540015d1e9a9
<pre>
WPT: add [SameObject] identity coverage for SVGSVGElement.currentTranslate
<a href="https://bugs.webkit.org/show_bug.cgi?id=318044">https://bugs.webkit.org/show_bug.cgi?id=318044</a>
<a href="https://rdar.apple.com/180830216">rdar://180830216</a>

Reviewed by Brent Fulgham.

SVG 2 declares currentTranslate on SVGSVGElement with the WebIDL [SameObject]
extended attribute, which requires the getter to return the same object on
every access. The existing WPT coverage for this corner of the SVG DOM is
reftest-only and visual (svg/struct/reftests/currentScale*); nothing asserts
the JS-observable identity requirement

    svg.currentTranslate === svg.currentTranslate.

WebKit already satisfies this: currentTranslate is backed by a stable
Ref&lt;SVGPoint&gt; member returned by reference, so the same wrapper is observed on
every read. This adds a scripted testharness test that guards that behavior and
exposes the cross-engine divergence upstream.

The test isolates the readonly check on the attribute value rather than object
identity, so an engine that fails [SameObject] still passes the readonly subtest
if it honors readonly. No WebKit code change is required.

* LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-currentTranslate-SameObject-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/SVGSVGElement-currentTranslate-SameObject.html: Added.

Canonical link: <a href="https://commits.webkit.org/316100@main">https://commits.webkit.org/316100@main</a>
</pre>
