### PR TITLE
REGRESSION(313341@main): All gain-map images are decoded into 8-bits per channel pixels

### DIFF
--- a/Source/WebCore/Configurations/AllowedSPI.toml
+++ b/Source/WebCore/Configurations/AllowedSPI.toml
@@ -101,9 +101,16 @@ cleanup = "rdar://175714562"
 symbols = [
     "CGImageApplyHDRGainMap",
     "CGImageSourceCopyAuxiliaryDataInfoAtIndexWithOptions",
+    "CGImageCreateFromIOSurface",
+    "CGImageCreatePixelBufferAttributesForHDRTarget",
+    "CGImageGetHDRGainMapHeadroom",
     "kCGImageAuxiliaryDataInfoPixelBuffer",
     "kCGImageAuxiliaryDataRepresentation",
     "kCGImageAuxiliaryDataRepresentationPixelBuffer",
+    "kCGFlexRangeAlternateColorSpace",
+    "kCGTargetColorSpace",
+    "kCGTargetHeadroom",
+    "kCGTargetPixelFormat",
 ]
 
 [[not-web-essential]]

--- a/Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h
@@ -40,6 +40,14 @@ DECLARE_SYSTEM_HEADER
 
 #else
 
+typedef CF_CLOSED_ENUM(uint32_t, CGImageHDRTarget)
+{
+    kCGImageHDRTargetUndefined = 0,
+    kCGImageHDRTargetSDR, // e.g. HDR -> SDR
+    kCGImageHDRTargetHDR, // e.g. M+ -> HDR
+    kCGImageHDRTargetGainMap, // e.g. HDR -> M+
+};
+
 typedef struct CF_BRIDGED_TYPE(id) __CVBuffer* CVPixelBufferRef;
 
 IMAGEIO_EXTERN const CFStringRef kCGImageAuxiliaryDataInfoColorSpace;
@@ -53,6 +61,10 @@ IMAGEIO_EXTERN const CFStringRef kCGImageSourceShouldPreferRGB32;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceSkipMetadata;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceSubsampleFactor;
 IMAGEIO_EXTERN const CFStringRef kCGImageSourceUseHardwareAcceleration;
+IMAGEIO_EXTERN const CFStringRef kCGTargetPixelFormat;
+IMAGEIO_EXTERN const CFStringRef kCGTargetHeadroom;
+IMAGEIO_EXTERN const CFStringRef kCGTargetColorSpace;
+IMAGEIO_EXTERN const CFStringRef kCGFlexRangeAlternateColorSpace;
 
 WTF_EXTERN_C_BEGIN
 
@@ -67,6 +79,12 @@ IMAGEIO_EXTERN uint16_t CGImageGetContentAverageLightLevelNits(CGImageRef);
 IMAGEIO_EXTERN CFDictionaryRef CGImageSourceCopyAuxiliaryDataInfoAtIndexWithOptions(CGImageSourceRef, size_t index, CFStringRef auxiliaryDataType, CFDictionaryRef options);
 
 IMAGEIO_EXTERN OSStatus CGImageApplyHDRGainMap(CVPixelBufferRef inputImage, CVPixelBufferRef inputGainmap, CVPixelBufferRef outputImage, CFDictionaryRef options);
+
+IMAGEIO_EXTERN CGFloat CGImageGetHDRGainMapHeadroom(CGImageMetadataRef gainMapMetadata, CFDictionaryRef options);
+
+IMAGEIO_EXTERN CGImageRef CGImageCreateFromIOSurface(IOSurfaceRef, CFDictionaryRef options);
+
+IMAGEIO_EXTERN OSStatus CGImageCreatePixelBufferAttributesForHDRTarget(CGImageHDRTarget hdrType, CFDictionaryRef attributes, CFDictionaryRef options, CFDictionaryRef* attributesOut);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CFDictionaryRef attributes, CGColorSpaceRef colorSpace)
+RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CFDictionaryRef attributes, CGColorSpaceRef colorSpace, float headroom)
 {
     CVPixelBufferRef pixelBuffer = nullptr;
     auto status = CVPixelBufferCreate(kCFAllocatorDefault, width, height, pixelFormat, attributes, &pixelBuffer);
@@ -52,6 +52,13 @@ RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned 
 
     if (colorSpace)
         CVBufferSetAttachment(pixelBuffer, kCVImageBufferCGColorSpaceKey, colorSpace, kCVAttachmentMode_ShouldPropagate);
+
+    if (headroom > 1.0) {
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        RetainPtr headroomNumber = adoptCF(CFNumberCreate(nullptr,  kCFNumberFloatType,  &headroom));
+        CVBufferSetAttachment(pixelBuffer, kIOSurfaceContentHeadroom, headroomNumber, kCVAttachmentMode_ShouldPropagate);
+#endif
+    }
 
     return adoptCF(pixelBuffer);
 }

--- a/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class ShareableCVPixelBuffer;
 
-RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CFDictionaryRef = nullptr, CGColorSpaceRef = nullptr);
+RetainPtr<CVPixelBufferRef> createScratchCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CFDictionaryRef = nullptr, CGColorSpaceRef = nullptr, float headroom = 1.0);
 
 RetainPtr<CVPixelBufferRef> createScratchMetalCompatibleCVPixelBuffer(unsigned width, unsigned height, OSType pixelFormat, CGColorSpaceRef = nullptr);
 

--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
@@ -32,7 +32,6 @@
 #include <pal/spi/cg/ImageIOSPI.h>
 
 #include "CoreVideoSoftLink.h"
-#include "VideoToolboxSoftLink.h"
 
 namespace WebCore {
 
@@ -67,12 +66,21 @@ ShareableGainMap::ShareableGainMap(RetainPtr<CFDataRef>&& metadata, Ref<Shareabl
 {
 }
 
+static void setDictionaryValue(CFMutableDictionaryRef theDict, const void *key, unsigned value)
+{
+    RetainPtr number = adoptCF(CFNumberCreate(nullptr,  kCFNumberIntType,  &value));
+    CFDictionarySetValue(theDict, key, number);
+}
+
+static void setDictionaryValue(CFMutableDictionaryRef theDict, const void *key, float value)
+{
+    RetainPtr number = adoptCF(CFNumberCreate(nullptr,  kCFNumberFloatType,  &value));
+    CFDictionarySetValue(theDict, key, number);
+}
+
 PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr basePlatformImage) const
 {
     if (!basePlatformImage)
-        return nullptr;
-
-    if (!canLoad_VideoToolbox_VTCreateCGImageFromCVPixelBuffer())
         return nullptr;
 
     RetainPtr baseImagePixelBuffer = createMetalCompatibleCVPixelBufferFromImage(basePlatformImage);
@@ -87,20 +95,63 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
         return nullptr;
     }
 
-    RetainPtr outputColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ));
-    RetainPtr outputImagePixelBuffer = createScratchMetalCompatibleCVPixelBuffer(baseImagePixelBuffer, outputColorSpace);
-    if (!outputImagePixelBuffer) {
-        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: Failed to create outputImagePixelBuffer", __FUNCTION__);
+    RetainPtr metadata = adoptCF(CGImageMetadataCreateFromXMPData(m_metadata));
+    if (!metadata) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: CGImageMetadataCreateFromXMPData() failed", __FUNCTION__);
         return nullptr;
     }
 
-    RetainPtr metadata = adoptCF(CGImageMetadataCreateFromXMPData(m_metadata));
+    RetainPtr targetColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ));
+    float targetHeadroom = CGImageGetHDRGainMapHeadroom(metadata, nullptr);
 
-    RetainPtr options = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoMetadata, metadata);
-    CFDictionarySetValue(options, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace ? m_colorSpace->platformColorSpace() : nullptr);
+    unsigned width = CVPixelBufferGetWidth(baseImagePixelBuffer);
+    unsigned height = CVPixelBufferGetHeight(baseImagePixelBuffer);
+    unsigned inputPixelFormatType = CVPixelBufferGetPixelFormatType(baseImagePixelBuffer);
+    RetainPtr inputColorSpace = CGImageGetColorSpace(basePlatformImage);
 
-    auto status = CGImageApplyHDRGainMap(baseImagePixelBuffer, gainMapPixelBuffer, outputImagePixelBuffer, options);
+    // MARK: - Get the target CVPixelBuffer attributes.
+    RetainPtr inputAttributes = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    setDictionaryValue(inputAttributes, kCVPixelBufferWidthKey, width);
+    setDictionaryValue(inputAttributes, kCVPixelBufferHeightKey, height);
+    setDictionaryValue(inputAttributes, kCVPixelBufferPixelFormatTypeKey, inputPixelFormatType);
+    CFDictionarySetValue(inputAttributes, kCVImageBufferCGColorSpaceKey, inputColorSpace);
+
+    RetainPtr attributesOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    setDictionaryValue(attributesOptions, kCGTargetPixelFormat, static_cast<unsigned>(kCVPixelFormatType_64RGBAHalf));
+    setDictionaryValue(attributesOptions, kCGTargetHeadroom, targetHeadroom);
+    CFDictionarySetValue(attributesOptions, kCGFlexRangeAlternateColorSpace, targetColorSpace);
+    CFDictionarySetValue(attributesOptions, kCGTargetColorSpace, kCGColorSpaceDisplayP3_PQ);
+
+    CFDictionaryRef outputAttributesRef = nullptr;
+    CGImageCreatePixelBufferAttributesForHDRTarget(kCGImageHDRTargetHDR, inputAttributes, attributesOptions, &outputAttributesRef);
+
+    RetainPtr outputAttributes = outputAttributesRef;
+    if (!outputAttributes) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: CGImageCreatePixelBufferAttributesForHDRTarget() failed", __FUNCTION__);
+        return nullptr;
+    }
+
+    RetainPtr targetAttributes = adoptCF(CFDictionaryCreateMutableCopy(nullptr, 0, outputAttributes));
+    RetainPtr surfaceProperties = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFDictionarySetValue(targetAttributes, kCVPixelBufferIOSurfacePropertiesKey, surfaceProperties);
+    CFDictionarySetValue(targetAttributes, kCVPixelBufferMetalCompatibilityKey, kCFBooleanTrue);
+
+    RetainPtr pixelFormatNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(targetAttributes, kCVPixelBufferPixelFormatTypeKey));
+    OSType targtePixelFormat;
+    CFNumberGetValue(pixelFormatNumber, kCFNumberSInt32Type, &targtePixelFormat);
+
+    // MARK: - Create the target CVPixelBuffer.
+    RetainPtr targetImagePixelBuffer = createScratchCVPixelBuffer(width, height, targtePixelFormat, targetAttributes, targetColorSpace, targetHeadroom);
+    if (!targetImagePixelBuffer) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: Failed to create targetImagePixelBuffer", __FUNCTION__);
+        return nullptr;
+    }
+
+    RetainPtr applyGainMapOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+    CFDictionarySetValue(applyGainMapOptions, kCGImageAuxiliaryDataInfoMetadata, metadata);
+    CFDictionarySetValue(applyGainMapOptions, kCGImageAuxiliaryDataInfoColorSpace, m_colorSpace ? m_colorSpace->platformColorSpace() : nullptr);
+
+    auto status = CGImageApplyHDRGainMap(baseImagePixelBuffer, gainMapPixelBuffer, targetImagePixelBuffer, applyGainMapOptions);
     if (status != kCVReturnSuccess) {
         RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: CGImageApplyHDRGainMap() failed with status=%d", __FUNCTION__, static_cast<int>(status));
         return nullptr;
@@ -109,17 +160,23 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
 #if ENABLE(DUMP_GAIN_MAP_IMAGES)
     CVPixelBufferDumpToFile(baseImagePixelBuffer, "*/base-image.cvpb"_s);
     CVPixelBufferDumpToFile(gainMapPixelBuffer, "*/gainmap-image.cvpb"_s);
-    CVPixelBufferDumpToFile(outputImagePixelBuffer, "*/output-image.cvpb"_s);
+    CVPixelBufferDumpToFile(targetImagePixelBuffer, "*/output-image.cvpb"_s);
 #endif
 
-    CGImageRef outputPlatformImage = nullptr;
-    status = VTCreateCGImageFromCVPixelBuffer(outputImagePixelBuffer, nullptr, &outputPlatformImage);
-    if (status != kCVReturnSuccess) {
-        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: VTCreateCGImageFromCVPixelBuffer() failed with status=%d", __FUNCTION__, static_cast<int>(status));
+    // MARK: - Get a CGImage from the target CVPixelBuffer.
+    RetainPtr surface = CVPixelBufferGetIOSurface(targetImagePixelBuffer);
+    if (!surface) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: CVPixelBufferGetIOSurface() failed", __FUNCTION__);
         return nullptr;
     }
 
-    return adoptCF(outputPlatformImage);
+    RetainPtr targetPlatformImage = adoptCF(CGImageCreateFromIOSurface(surface, nullptr));
+    if (!targetPlatformImage) {
+        RELEASE_LOG_ERROR(Images, "ShareableGainMap::%s: CGImageCreateFromIOSurface() failed", __FUNCTION__);
+        return nullptr;
+    }
+
+    return targetPlatformImage;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### dfcca6f9900ac6564be76443848bf518bf8c4bf2
<pre>
REGRESSION(313341@main): All gain-map images are decoded into 8-bits per channel pixels
<a href="https://bugs.webkit.org/show_bug.cgi?id=318046">https://bugs.webkit.org/show_bug.cgi?id=318046</a>
<a href="https://rdar.apple.com/179152566">rdar://179152566</a>

Reviewed by Mike Wyrzykowski.

CGImageCreatePixelBufferAttributesForHDRTarget() is to get the attributes of the
target CVPixelBuffer. The target pixel format is set explicitly to &apos;RGhA&apos;.

Instead of calling VTCreateCGImageFromCVPixelBuffer(), CVPixelBufferGetIOSurface()
and CGImageCreateFromIOSurface() are used to get a CGImage from the target
CVPixelBuffer.

* Source/WebCore/Configurations/AllowedSPI.toml:
* Source/WebCore/PAL/pal/spi/cg/ImageIOSPI.h:
(CF_CLOSED_ENUM):
* Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.cpp:
(WebCore::createScratchCVPixelBuffer):
* Source/WebCore/platform/graphics/cocoa/CVPixelBufferUtilities.h:
* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp:
(WebCore::setDictionaryValue):
(WebCore::ShareableGainMap::applyGainMapToBaseImage const):

Canonical link: <a href="https://commits.webkit.org/316069@main">https://commits.webkit.org/316069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94011187e00925c0b5fed71d5e31944f688d391b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e09869f7-03e9-4222-bc70-10653603e5a0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133231 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02b2e208-7b1d-47e3-8e70-cc2cc27744d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173770 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5478ec02-a5cd-4f8d-a954-66e55979c7b2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28870 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182776 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141690 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44393 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38145 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45082 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109788 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36775 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116973 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43593 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42997 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43239 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->