### PR TITLE
Cache deviceScaleFactor in BorderPainter::drawBoxSideFromPath

### DIFF
--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -735,6 +735,7 @@ void BorderPainter::drawBoxSideFromPath(const BorderShape& borderShape, const Pa
         return;
 
     auto& graphicsContext = m_paintInfo.context();
+    auto deviceScaleFactor = protect(document())->deviceScaleFactor();
 
     if (borderStyle == BorderStyle::Double && thickness < 3)
         borderStyle = BorderStyle::Solid;
@@ -795,7 +796,7 @@ void BorderPainter::drawBoxSideFromPath(const BorderShape& borderShape, const Pa
             GraphicsContextStateSaver stateSaver(graphicsContext);
 
             auto innerThirdShape = borderShape.shapeWithBorderWidths(innerThirdInsets);
-            innerThirdShape.clipToInnerShape(graphicsContext, protect(document())->deviceScaleFactor()); // FIXME: Cache document().deviceScaleFactor().
+            innerThirdShape.clipToInnerShape(graphicsContext, deviceScaleFactor);
 
             drawBoxSideFromPath(borderShape, borderPath, edges, thickness, drawThickness, side, color, BorderStyle::Solid, bleedAvoidance);
         }
@@ -803,7 +804,7 @@ void BorderPainter::drawBoxSideFromPath(const BorderShape& borderShape, const Pa
         // Draw outer border line
         {
             auto outerThirdShape = borderShape.shapeWithBorderWidths(outerThirdInsets);
-            outerThirdShape.clipOutInnerShape(graphicsContext, protect(document())->deviceScaleFactor());
+            outerThirdShape.clipOutInnerShape(graphicsContext, deviceScaleFactor);
 
             drawBoxSideFromPath(borderShape, borderPath, edges, thickness, drawThickness, side, color, BorderStyle::Solid, bleedAvoidance);
         }
@@ -836,7 +837,7 @@ void BorderPainter::drawBoxSideFromPath(const BorderShape& borderShape, const Pa
         };
 
         auto midBorderShape = borderShape.shapeWithBorderWidths(midWidths);
-        midBorderShape.clipToInnerShape(graphicsContext, protect(document())->deviceScaleFactor());
+        midBorderShape.clipToInnerShape(graphicsContext, deviceScaleFactor);
 
         drawBoxSideFromPath(borderShape, borderPath, edges, thickness, drawThickness, side, color, s2, bleedAvoidance);
         return;
@@ -852,7 +853,7 @@ void BorderPainter::drawBoxSideFromPath(const BorderShape& borderShape, const Pa
     graphicsContext.setStrokeStyle(StrokeStyle::NoStroke);
     graphicsContext.setFillColor(color);
 
-    auto borderRect = borderShape.snappedOuterRect(protect(document())->deviceScaleFactor());
+    auto borderRect = borderShape.snappedOuterRect(deviceScaleFactor);
     graphicsContext.drawRect(borderRect);
 }
 


### PR DESCRIPTION
#### 729d9bb358d1634a1e8fd98b2a824950b0efc441
<pre>
Cache deviceScaleFactor in BorderPainter::drawBoxSideFromPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=318051">https://bugs.webkit.org/show_bug.cgi?id=318051</a>
<a href="https://rdar.apple.com/180836330">rdar://180836330</a>

Reviewed by Alan Baradlay.

drawBoxSideFromPath() re-fetched document().deviceScaleFactor() up to four
times per call (and the function recurses for double/groove/ridge borders),
as flagged by an existing FIXME. Compute it once at the top of the function
and reuse it.

* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::drawBoxSideFromPath const):

Canonical link: <a href="https://commits.webkit.org/315988@main">https://commits.webkit.org/315988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/991e9c1a0370e0957cb0e69c0516496f6c33ec6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128345 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133065 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113562 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33214 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28690 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182593 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141523 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44213 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141340 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38069 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44902 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109487 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36606 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116791 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43412 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7992 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43058 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42948 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->