### PR TITLE
DisplayRefreshMonitorManager::scheduleAnimation marks client scheduled even when scheduling fails

### DIFF
--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
@@ -79,8 +79,9 @@ void DisplayRefreshMonitorManager::clientPreferredFramesPerSecondChanged(Display
 bool DisplayRefreshMonitorManager::scheduleAnimation(DisplayRefreshMonitorClient& client)
 {
     if (RefPtr monitor = monitorForClient(client)) {
-        client.setIsScheduled(true);
-        return monitor->requestRefreshCallback();
+        bool scheduled = monitor->requestRefreshCallback();
+        client.setIsScheduled(scheduled);
+        return scheduled;
     }
     return false;
 }


### PR DESCRIPTION
#### e32bf4ff3f95517d3e6de7312b26b1b8212a29ea
<pre>
DisplayRefreshMonitorManager::scheduleAnimation marks client scheduled even when scheduling fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=318054">https://bugs.webkit.org/show_bug.cgi?id=318054</a>
<a href="https://rdar.apple.com/180837275">rdar://180837275</a>

Reviewed by NOBODY (OOPS!).

scheduleAnimation() called client.setIsScheduled(true) before
requestRefreshCallback(), and never cleared it when that call returned
false. Callers treat a false return as &quot;scheduling failed, fall back&quot;,
but the client was left believing it was scheduled — a stale flag that
windowScreenDidChange() later acts on.

Set the client&apos;s scheduled state to the actual result of
requestRefreshCallback() instead.

* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp:
(WebCore::DisplayRefreshMonitorManager::scheduleAnimation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e32bf4ff3f95517d3e6de7312b26b1b8212a29ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128349 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05c9100a-db5c-4596-ab34-6c18da5f1809) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133067 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93861 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90eedfd1-1b57-471d-a0bf-9e6e1a3ac46a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9c0f916-bf91-46d4-9233-b14c1a35ef8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33216 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28694 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145338 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182597 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141526 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44217 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141343 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44906 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29890 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109491 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36607 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116795 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43416 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7994 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->