### PR TITLE
Drag image of DOM elements with CSS transforms aren't rendered correctly

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -950,7 +950,7 @@ Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotNode(Insp
     if (!localMainFrame)
         return makeUnexpected("Main frame isn't local"_s);
 
-    auto snapshot = WebCore::snapshotNode(*localMainFrame, *node, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() });
+    RefPtr snapshot = WebCore::snapshotNode(*localMainFrame, *node, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() });
     if (!snapshot)
         return makeUnexpected("Could not capture snapshot"_s);
     return encodeDataURL(WTF::move(snapshot), "image/png"_s);
@@ -966,7 +966,7 @@ Inspector::Protocol::ErrorStringOr<String> InspectorPageAgent::snapshotRect(int 
     RefPtr localMainFrame = m_inspectedPage->localMainFrame();
     if (!localMainFrame)
         return makeUnexpected("Main frame isn't local"_s);
-    auto snapshot = snapshotFrameRect(*localMainFrame, rectangle, WTF::move(options));
+    RefPtr snapshot = snapshotFrameRect(*localMainFrame, rectangle, WTF::move(options));
 
     if (!snapshot)
         return makeUnexpected("Could not capture snapshot"_s);

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -214,7 +214,7 @@ static void prepareContextForQRCode(ContextMenuContext& context)
     if (!frame)
         return;
 
-    auto nodeSnapshotImageBuffer = snapshotNode(*frame, *element, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() });
+    RefPtr nodeSnapshotImageBuffer = snapshotNode(*frame, *element, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() });
     RefPtr nodeSnapshotImage = BitmapImage::create(ImageBuffer::sinkIntoNativeImage(WTF::move(nodeSnapshotImageBuffer)));
     context.setPotentialQRCodeNodeSnapshotImage(nodeSnapshotImage.get());
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4852,8 +4852,7 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
         if (RefPtr draggedElement = this->draggedElement(); draggedElement && dragState().type == DragSourceAction::DHTML && !dragState().dataTransfer->hasDragImage()) {
             protect(draggedElement->document())->updateStyleIfNeeded();
             if (CheckedPtr renderer = draggedElement->renderer()) {
-                auto absolutePosition = renderer->localToAbsolute();
-                auto delta = m_mouseDownContentsPosition - roundedIntPoint(absolutePosition);
+                auto delta = m_mouseDownContentsPosition - renderer->absoluteBoundingBoxRect().location();
                 protect(dragState().dataTransfer)->setDragImage(draggedElement.releaseNonNull(), delta.width(), delta.height());
             } else {
                 dispatchEventToDragSourceElement(eventNames().dragendEvent, event.event());

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -167,7 +167,7 @@ RefPtr<ImageBuffer> snapshotSelection(LocalFrame& frame, SnapshotOptions&& optio
     return snapshotFrameRect(frame, enclosingIntRect(selectionBounds), WTF::move(options));
 }
 
-RefPtr<ImageBuffer> snapshotNode(LocalFrame& frame, Node& node, SnapshotOptions&& options)
+RefPtr<ImageBuffer> snapshotNode(LocalFrame& frame, Node& node, SnapshotOptions&& options, IntRect* outPaintingRect, IntRect* outElementRect)
 {
     if (!node.renderer())
         return nullptr;
@@ -176,8 +176,14 @@ RefPtr<ImageBuffer> snapshotNode(LocalFrame& frame, Node& node, SnapshotOptions&
 
     protect(frame.view())->setBaseBackgroundColor(Color::transparentBlack);
 
-    LayoutRect topLevelRect;
-    return snapshotFrameRect(frame, snappedIntRect(node.renderer()->paintingRootRect(topLevelRect)), WTF::move(options), &node);
+    LayoutRect elementRect;
+    auto paintingRect = snappedIntRect(node.renderer()->subtreePaintRootRect(elementRect, RenderObject::RespectTransforms::Yes));
+    if (outPaintingRect)
+        *outPaintingRect = paintingRect;
+    if (outElementRect)
+        *outElementRect = snappedIntRect(elementRect);
+
+    return snapshotFrameRect(frame, paintingRect, WTF::move(options), &node);
 }
 
 static bool styleContainsComplexBackground(const Style::ComputedStyle& style)

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -71,7 +71,7 @@ struct SnapshotOptions {
 
 WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotFrameRect(LocalFrame&, const IntRect&, SnapshotOptions&&, Node* nodeToDraw = nullptr);
 RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame&, const IntRect&, const Vector<FloatRect>& clipRects, SnapshotOptions&&, Node* nodeToDraw = nullptr);
-WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotNode(LocalFrame&, Node&, SnapshotOptions&&);
+WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotNode(LocalFrame&, Node&, SnapshotOptions&&, IntRect* outPaintingRect = nullptr, IntRect* outElementRect = nullptr);
 WEBCORE_EXPORT RefPtr<ImageBuffer> snapshotSelection(LocalFrame&, SnapshotOptions&&);
 
 Color estimatedBackgroundColorForRange(const SimpleRange&, const LocalFrame&);

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -201,23 +201,16 @@ DragImageRef createDragImageForImage(LocalFrame& frame, Node& node, IntRect& ima
 {
     ScopedNodeDragEnabler enableDrag(frame, node);
 
-    CheckedPtr renderer = node.renderer();
-    if (!renderer)
+    if (!node.renderer())
         return nullptr;
-
-    // Calculate image and element metrics for the client, then create drag image.
-    LayoutRect topLevelRect;
-    IntRect paintingRect = snappedIntRect(renderer->paintingRootRect(topLevelRect));
-
-    if (paintingRect.isEmpty())
-        return nullptr;
-
-    elementRect = snappedIntRect(topLevelRect);
-    imageRect = paintingRect;
 
     SnapshotOptions options { { SnapshotFlags::DraggableElement }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() };
 
-    return createDragImageFromSnapshot(snapshotNode(frame, node, WTF::move(options)), &node);
+    RefPtr snapshot = snapshotNode(frame, node, WTF::move(options), &imageRect, &elementRect);
+    if (imageRect.isEmpty())
+        return nullptr;
+
+    return createDragImageFromSnapshot(WTF::move(snapshot), &node);
 }
 
 #if !PLATFORM(IOS_FAMILY) || !ENABLE(DRAG_SUPPORT)

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -858,27 +858,26 @@ void RenderObject::absoluteFocusRingQuads(Vector<FloatQuad>& quads)
     }
 }
 
-void RenderObject::addAbsoluteRectForLayer(LayoutRect& result)
+void RenderObject::addAbsoluteRectForLayer(LayoutRect& result, RespectTransforms respectTransforms)
 {
     if (hasLayer())
-        result.unite(absoluteBoundingBoxRectIgnoringTransforms());
+        result.unite(absoluteBoundingBoxRect(respectTransforms == RespectTransforms::Yes));
 
     auto* renderElement = dynamicDowncast<RenderElement>(*this);
     if (!renderElement)
         return;
 
     for (CheckedRef child : childrenOfType<RenderObject>(*renderElement))
-        child->addAbsoluteRectForLayer(result);
+        child->addAbsoluteRectForLayer(result, respectTransforms);
 }
 
-// FIXME: change this to use the subtreePaint terminology
-LayoutRect RenderObject::paintingRootRect(LayoutRect& topLevelRect)
+LayoutRect RenderObject::subtreePaintRootRect(LayoutRect& topLevelRect, RespectTransforms respectTransforms)
 {
-    LayoutRect result = absoluteBoundingBoxRectIgnoringTransforms();
+    LayoutRect result = absoluteBoundingBoxRect(respectTransforms == RespectTransforms::Yes);
     topLevelRect = result;
     if (auto* renderElement = dynamicDowncast<RenderElement>(*this)) {
         for (CheckedRef child : childrenOfType<RenderObject>(*renderElement))
-            child->addAbsoluteRectForLayer(result);
+            child->addAbsoluteRectForLayer(result, respectTransforms);
     }
     return result;
 }

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -858,8 +858,9 @@ public:
     WEBCORE_EXPORT static Vector<FloatRect> absoluteBorderAndTextRects(const SimpleRange&, OptionSet<BoundingRectBehavior> = { });
     static Vector<FloatRect> clientBorderAndTextRects(const SimpleRange&);
 
-    // the rect that will be painted if this object is passed as the paintingRoot
-    WEBCORE_EXPORT LayoutRect paintingRootRect(LayoutRect& topLevelRect);
+    // the rect that will be painted if this object is passed as the subtree paint root
+    enum class RespectTransforms : bool { No, Yes };
+    WEBCORE_EXPORT LayoutRect subtreePaintRootRect(LayoutRect& topLevelRect, RespectTransforms = RespectTransforms::No);
 
     inline const Style::ComputedStyle& style() const LIFETIME_BOUND; // Defined in RenderObjectStyle.h.
     inline CheckedRef<const Style::ComputedStyle> firstLineStyle() const LIFETIME_BOUND;
@@ -1161,7 +1162,7 @@ private:
 
     virtual RepaintRects localRectsForRepaint(RepaintOutlineBounds) const;
 
-    void addAbsoluteRectForLayer(LayoutRect& result);
+    void addAbsoluteRectForLayer(LayoutRect& result, RespectTransforms = RespectTransforms::No);
     void NODELETE setLayerNeedsFullRepaint();
     void NODELETE setLayerNeedsFullRepaintForOutOfFlowMovementLayout();
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1011,7 +1011,7 @@ static WebCore::IntRect snapshotElementRectForScreenshot(WebPage& page, WebCore:
             return { };
 
         WebCore::LayoutRect topLevelRect;
-        WebCore::IntRect elementRect = WebCore::snappedIntRect(protect(element->renderer())->paintingRootRect(topLevelRect));
+        WebCore::IntRect elementRect = WebCore::snappedIntRect(protect(element->renderer())->subtreePaintRootRect(topLevelRect));
         if (clipToViewport)
             elementRect.intersect(frameView->visibleContentRect());
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -90,7 +90,7 @@ static WebCore::IntRect screenRectOfContents(WebCore::Element& element)
     IntRect contentsRect = renderer->absoluteBoundingBoxRect();
     if (contentsRect.height() <= 1 || contentsRect.width() <= 1) {
         LayoutRect topLevelRect;
-        contentsRect = snappedIntRect(renderer->paintingRootRect(topLevelRect));
+        contentsRect = snappedIntRect(renderer->subtreePaintRootRect(topLevelRect));
     }
 
     if (contentsRect.isEmpty())

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -227,7 +227,7 @@ RefPtr<WebImage> InjectedBundleNodeHandle::renderedImage(SnapshotOptions options
         paintingRect = renderer->absoluteBoundingBoxRectIgnoringTransforms();
     else {
         LayoutRect topLevelRect;
-        paintingRect = snappedIntRect(renderer->paintingRootRect(topLevelRect));
+        paintingRect = snappedIntRect(renderer->subtreePaintRootRect(topLevelRect));
     }
 
     return imageForRect(frameView.get(), m_node.get(), paintingRect, bitmapWidth, options);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3385,7 +3385,7 @@ void WebPage::setFooterBannerHeight(int height)
 RefPtr<ShareableBitmap> WebPage::shareableBitmapSnapshotForNode(Node& node)
 {
     // Ensure that the image contains at most 600K pixels, so that it is not too big.
-    if (auto snapshot = snapshotNode(node, SnapshotOption::Shareable, 600 * 1024))
+    if (RefPtr snapshot = snapshotNode(node, SnapshotOption::Shareable, 600 * 1024))
         return snapshot->bitmap();
     return nullptr;
 }
@@ -3650,7 +3650,7 @@ RefPtr<WebImage> WebPage::snapshotNode(WebCore::Node& node, SnapshotOptions opti
         return nullptr;
 
     LayoutRect topLevelRect;
-    IntRect snapshotRect = snappedIntRect(protect(node.renderer())->paintingRootRect(topLevelRect));
+    IntRect snapshotRect = snappedIntRect(protect(node.renderer())->subtreePaintRootRect(topLevelRect, WebCore::RenderObject::RespectTransforms::Yes));
     if (snapshotRect.isEmpty())
         return nullptr;
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/DataTransfer-setDragImage.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/DataTransfer-setDragImage.html
@@ -35,6 +35,16 @@
         width: 300px;
         height: 100px;
     }
+
+    #rotated {
+        position: absolute;
+        left: 50px;
+        top: 400px;
+        width: 100px;
+        height: 100px;
+        background-color: magenta;
+        transform: translate(100px, 0px) rotate(45deg) scale(1.2);
+    }
 </style>
 </head>
 
@@ -42,7 +52,8 @@
 <div id="green" draggable="true"></div>
 <div id="blue" draggable="true"></div>
 <div id="cyan" draggable="true"></div>
-<img id="icon" src="icon.png"></img>
+<img id="icon" src="icon.png">
+<div id="rotated" draggable="true"></div>
 <div><code>To manually test, attempt to drag each of the colored blocks.</code></div>
 
 <script>
@@ -65,6 +76,11 @@ blue.addEventListener("dragstart", event => {
 
 cyan.addEventListener("dragstart", event => {
     event.dataTransfer.setData("text/plain", "cyan");
+});
+
+// No setDragImage, so the default drag image is a snapshot of this transformed element.
+rotated.addEventListener("dragstart", event => {
+    event.dataTransfer.setData("text/plain", "rotated");
 });
 </script>
 </html>

--- a/Tools/TestWebKitAPI/Resources/cocoa/node-snapshotting.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/node-snapshotting.html
@@ -21,6 +21,33 @@
                 height: 100px;
                 background: red;
             }
+
+            div.translated-box {
+                width: 100px;
+                height: 100px;
+                background: blue;
+                transform: translate(150px, 30px);
+            }
+
+            div.rotated-box {
+                width: 100px;
+                height: 100px;
+                background: lime;
+                transform: rotate(45deg);
+            }
+            
+            .transformed {
+                position: absolute;
+                padding: 20px;
+                border: 1px solid black;
+                transform: translate(120px, 30px) rotate(20deg) scale(1.5);
+            }
+            
+            .child-box {
+                width: 100px;
+                height: 100px;
+                background: cyan;
+            }
         </style>
     </head>
     <body>
@@ -28,5 +55,10 @@
         <br>
         <img src="icon.png" />
         <div class="red-box"></div>
+        <div class="translated-box"></div>
+        <div class="rotated-box"></div>
+        <div class="transformed">
+            <div class="child-box"></div>
+        </div>
     </body>
 </html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
@@ -809,6 +809,54 @@ TEST(WKWebView, SnapshotNodeByJSHandle)
     }
 }
 
+TEST(WKWebView, SnapshotNodeWithTransform)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    [webView synchronouslyLoadTestPageNamed:@"node-snapshotting"];
+
+    RetainPtr worldConfiguration = adoptNS([_WKContentWorldConfiguration new]);
+    [worldConfiguration setAllowJSHandleCreation:YES];
+
+    RetainPtr world = [WKContentWorld _worldWithConfiguration:worldConfiguration.get()];
+    auto querySelector = [&](ASCIILiteral selector) -> RetainPtr<_WKJSHandle> {
+        return [webView querySelector:@(selector.characters()) frame:nil world:world];
+    };
+
+    {
+        auto [image, error] = [webView takeSnapshotOfNode:querySelector(".translated-box"_s).get()];
+        EXPECT_NULL(error);
+
+        CGImagePixelReader reader { Util::convertToCGImage(image.get()).get() };
+        EXPECT_WK_STREQ("rgb(0, 0, 255)", reader.cssColorAt(2, 2));
+        EXPECT_WK_STREQ("rgb(0, 0, 255)", reader.cssColorAt(reader.width() - 2, reader.height() - 2));
+    }
+
+    {
+        auto [image, error] = [webView takeSnapshotOfNode:querySelector(".rotated-box"_s).get()];
+        EXPECT_NULL(error);
+
+        CGImagePixelReader reader { Util::convertToCGImage(image.get()).get() };
+
+        // Image is rotated 45deg.
+        EXPECT_WK_STREQ("rgb(0, 255, 0)", reader.cssColorAt(reader.width() / 2, 10));
+        EXPECT_WK_STREQ("rgb(0, 255, 0)", reader.cssColorAt(10, reader.height() / 2));
+        EXPECT_TRUE(reader.isTransparentBlack(2, 2));
+        EXPECT_TRUE(reader.isTransparentBlack(reader.width() - 2, reader.height() - 2));
+    }
+
+    {
+        auto [image, error] = [webView takeSnapshotOfNode:querySelector(".child-box"_s).get()];
+        EXPECT_NULL(error);
+
+        CGImagePixelReader reader { Util::convertToCGImage(image.get()).get() };
+        // Image is rotated 20deg.
+        EXPECT_WK_STREQ("rgb(0, 255, 255)", reader.cssColorAt(55, 10));
+        EXPECT_WK_STREQ("rgb(0, 255, 255)", reader.cssColorAt(reader.width() - 10, 55));
+        EXPECT_TRUE(reader.isTransparentBlack(2, 2));
+        EXPECT_TRUE(reader.isTransparentBlack(reader.width() - 2, reader.height() - 2));
+    }
+}
+
 // FIXME: Make this test work on iOS.
 #if PLATFORM(MAC)
 static void enableRemoteSnapshotting(WKWebViewConfiguration *configuration)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
@@ -1720,6 +1720,10 @@ TEST(DragAndDropTests, DragLiftPreviewDataTransferSetDragImage)
     // Perform a normal drag on an image.
     [simulator runFrom:CGPointMake(50, 450) to:CGPointMake(250, 450)];
     checkCGRectIsEqualToCGRectWithLogging({{0, 400}, {215, 174}}, [simulator liftPreviews][0].view.frame);
+
+    // Test dragging a transformed element.
+    [simulator runFrom:CGPointMake(200, 450) to:CGPointMake(400, 450)];
+    checkCGRectIsEqualToCGRectWithLogging({{115, 365}, {170, 170}}, [simulator liftPreviews][0].view.frame);
 }
 
 static NSData *testIconImageData()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -548,6 +548,19 @@ TEST(DragAndDropTests, DragPreviewOriginForImage)
     EXPECT_LT(previewOrigin.y, dragStart.y);
 }
 
+TEST(DragAndDropTests, DragPreviewOriginForTransformedElement)
+{
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 600, 600)]);
+    RetainPtr webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"DataTransfer-setDragImage"];
+
+    [simulator runFrom:NSMakePoint(200, 450) to:NSMakePoint(300, 450)];
+
+    CGPoint dragLocation = [simulator initialDragImageLocationInView];
+    EXPECT_NEAR(dragLocation.x, 115, 1);
+    EXPECT_NEAR(dragLocation.y, 365, 1);
+}
+
 TEST(DragAndDropTests, DragEnterAndLeaveRelatedTarget)
 {
     RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 320, 500)]);


### PR DESCRIPTION
#### 0e3ecbee7ab1e0aac1be7f61b27174787a049722
<pre>
Drag image of DOM elements with CSS transforms aren&apos;t rendered correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=318055">https://bugs.webkit.org/show_bug.cgi?id=318055</a>
<a href="https://rdar.apple.com/99614217">rdar://99614217</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

Fix node snapshots to work correctly for elements affected by CSS transforms.

`RenderObject::subtreePaintRootRect()` (renamed from `paintingRootRect`) takes
an argument specifying whether to respect transforms, and uses that to compute
absolute rects as appropriate.

`snapshotNode()` then calls `subtreePaintRootRect(..., RespectTransforms::Yes)`,
but also now returns the paintingRect and elementRect computed taking transforms
into account. This means that `createDragImageForImage()` no longer needs to
compute the rects itself.

The final part of the fix in `EventHandler::handleDrag()` ensures that the offset
of the drag image from the cursor is correct; `absoluteBoundingBoxRect()` respects
transforms.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm

* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::snapshotNode):
(WebCore::InspectorPageAgent::snapshotRect):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::prepareContextForQRCode):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleDrag):
* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::snapshotNode):
* Source/WebCore/page/FrameSnapshotting.h:
* Source/WebCore/platform/DragImage.cpp:
(WebCore::createDragImageForImage):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::addAbsoluteRectForLayer):
(WebCore::RenderObject::subtreePaintRootRect):
(WebCore::RenderObject::paintingRootRect): Deleted.
* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::snapshotElementRectForScreenshot):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::screenRectOfContents):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::renderedImage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::shareableBitmapSnapshotForNode):
(WebKit::WebPage::snapshotNode):
* Tools/TestWebKitAPI/Resources/cocoa/DataTransfer-setDragImage.html:
* Tools/TestWebKitAPI/Resources/cocoa/node-snapshotting.html:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewSnapshot.mm:
(TestWebKitAPI::TEST(WKWebView, SnapshotNodeWithTransform)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::TEST(DragAndDropTests, DragLiftPreviewDataTransferSetDragImage)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, DragPreviewOriginForTransformedElement)):

Canonical link: <a href="https://commits.webkit.org/316077@main">https://commits.webkit.org/316077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88b3749860af86be307922f8248e4a60be978e42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170843 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180223 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a76ac52d-5c0c-499d-8e9e-28a6596ef3ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44404 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b599c54e-c532-4d09-b269-107089256b29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173802 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113749 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70b47f92-44f3-42cd-b1ec-b63a2ca29d8a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28902 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182808 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44425 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141529 "Found 1 new API test failure: TestWTF:WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38142 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45114 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109819 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36800 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43625 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8190 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->