### PR TITLE
[JSC] Optimize AirFixObviousSpills

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
+++ b/Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp
@@ -29,9 +29,12 @@
 #if ENABLE(B3_JIT)
 
 #include "AirArgInlines.h"
+#include "AirCFG.h"
 #include "AirCode.h"
 #include "AirInstInlines.h"
 #include "AirPhaseScope.h"
+#include "Options.h"
+#include <wtf/GraphOrdering.h>
 #include <wtf/IndexMap.h>
 #include <wtf/ListDump.h>
 
@@ -48,8 +51,6 @@ public:
     FixObviousSpills(Code& code)
         : m_code(code)
         , m_atHead(code.size())
-        , m_notBottom(code.size())
-        , m_shouldVisit(code.size())
     {
     }
 
@@ -63,48 +64,61 @@ public:
 private:
     void computeAliases()
     {
-        m_notBottom.quickSet(0);
-        m_shouldVisit.quickSet(0);
-        
-        bool changed = true;
-        while (changed) {
-            changed = false;
-            
-            for (unsigned blockIndex : m_shouldVisit) {
-                m_shouldVisit.quickClear(blockIndex);
-                BasicBlock* block = m_code[blockIndex];
-                ASSERT(m_notBottom.quickGet(blockIndex));
-                m_block = block;
-                m_state = m_atHead[block];
+        Vector<BasicBlock*, 32> reversePostOrder;
+        appendNodesInOrder(m_code.cfg(), GraphOrder::PostOrder, reversePostOrder);
+        reversePostOrder.reverse();
 
-                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "Executing block ", *m_block, ": ", m_state);
-                for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
-                    dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Executing ", m_block->at(m_instIndex), ": ", m_state);
-                    clobberEarlyDefs();
-                    clobberLateDefs();
-                    addInstAliases();
-                }
+        size_t numInOrder = reversePostOrder.size();
+        IndexMap<BasicBlock*, unsigned> rpoNumber(m_code.size());
+        for (size_t i = 0; i < numInOrder; ++i)
+            rpoNumber[reversePostOrder[i]] = i;
 
-                // Before we call merge we must make sure that the two states are sorted.
-                m_state.sort();
+        // shouldVisit is keyed by RPO position here (not block index). Position
+        // 0 is the entry block, which is where the dataflow seeds.
+        BitVector shouldVisit(m_code.size());
+        BitVector notBottom(m_code.size());
+        shouldVisit.quickSet(0);
+        notBottom.quickSet(reversePostOrder[0]->index());
 
-                for (BasicBlock* successor : block->successorBlocks()) {
-                    unsigned successorIndex = successor->index();
-                    State& toState = m_atHead[successor];
-                    if (m_notBottom.quickGet(successorIndex)) {
-                        bool changedAtSuccessorHead = toState.merge(m_state);
-                        if (changedAtSuccessorHead) {
-                            changed = true;
-                            m_shouldVisit.quickSet(successorIndex);
-                        }
-                    } else { // The state at head of successor is bottom
-                        toState = m_state;
-                        changed = true;
-                        m_notBottom.quickSet(successorIndex);
-                        m_shouldVisit.quickSet(successorIndex);
+        unsigned cursor = 0;
+        while ((cursor = shouldVisit.findBit(cursor, true)) < numInOrder) {
+            shouldVisit.quickClear(cursor);
+            BasicBlock* block = reversePostOrder[cursor];
+            ASSERT(notBottom.quickGet(block->index()));
+            m_block = block;
+            m_state = m_atHead[block];
+
+            dataLogLnIf(AirFixObviousSpillsInternal::verbose, "Executing block ", *m_block, ": ", m_state);
+            for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
+                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "    Executing ", m_block->at(m_instIndex), ": ", m_state);
+                clobberAllDefs();
+                addInstAliases();
+            }
+
+            // Before we call merge we must make sure that the two states are sorted.
+            m_state.sort();
+
+            // Default to advancing forward. If a back-edge re-activates an earlier
+            // block, rewind the cursor so findBit picks it up on the next step.
+            unsigned nextCursor = cursor + 1;
+            for (BasicBlock* successor : block->successorBlocks()) {
+                unsigned successorIndex = successor->index();
+                unsigned successorPosition = rpoNumber[successor];
+                State& toState = m_atHead[successor];
+                if (notBottom.quickGet(successorIndex)) {
+                    bool changedAtSuccessorHead = toState.merge(m_state);
+                    if (changedAtSuccessorHead) {
+                        shouldVisit.quickSet(successorPosition);
+                        nextCursor = std::min(nextCursor, successorPosition);
                     }
+                } else { // The state at head of successor is bottom
+                    toState = m_state;
+                    notBottom.quickSet(successorIndex);
+                    shouldVisit.quickSet(successorPosition);
+                    nextCursor = std::min(nextCursor, successorPosition);
                 }
             }
+            cursor = nextCursor;
         }
     }
 
@@ -113,7 +127,6 @@ private:
         for (BasicBlock* block : m_code) {
             m_block = block;
             m_state = m_atHead[block];
-            RELEASE_ASSERT(m_notBottom.quickGet(block->index()));
 
             for (m_instIndex = 0; m_instIndex < block->size(); ++m_instIndex) {
                 clobberEarlyDefs();
@@ -123,7 +136,7 @@ private:
             }
         }
     }
-    
+
     template<typename Func>
     void forAllAliases(const Func& func)
     {
@@ -185,17 +198,38 @@ private:
 
     void clobberDefs(Inst* prevInst, Inst* nextInst)
     {
-        Inst::forEachDefWithExtraClobberedRegs<Reg>(prevInst, nextInst,
-            [&] (const Reg& reg, Arg::Role, Bank, Width, PreservedWidth) {
-                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", reg);
-                m_state.clobber(reg);
+        auto walk = [&] (Inst* inst, auto isWhichDef) {
+            if (!inst)
+                return;
+            inst->forEachArg([&](Arg& arg, Arg::Role role, Bank bank, Width width) {
+                // Only clobber spilled StackSlot since this phase's State only cares spilled StackSlots.
+                if (isWhichDef(role) && arg.isStack() && arg.stackSlot()->isSpill()) {
+                    dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", *arg.stackSlot());
+                    m_state.clobber(arg.stackSlot());
+                }
+                arg.forEachTmp(role, bank, width,
+                    [&](Tmp& tmp, Arg::Role refinedRole, Bank, Width) {
+                        if (isWhichDef(refinedRole) && tmp.isReg()) {
+                            dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", tmp.reg());
+                            m_state.clobber(tmp.reg());
+                        }
+                    });
             });
+        };
+        walk(prevInst, [] (Arg::Role role) { return Arg::isLateDef(role); });
+        walk(nextInst, [] (Arg::Role role) { return Arg::isEarlyDef(role); });
 
-        Inst::forEachDef<StackSlot*>(prevInst, nextInst,
-            [&] (StackSlot* slot, Arg::Role, Bank, Width) {
-                dataLogLnIf(AirFixObviousSpillsInternal::verbose, "        Clobbering ", *slot);
-                m_state.clobber(slot);
-            });
+        // Patch's extra-clobbered registers aren't represented as args. Late
+        // extras live on prevInst, early extras on nextInst — matching
+        // forEachDefWithExtraClobberedRegs.
+        if (prevInst && prevInst->kind.opcode == Patch) [[unlikely]] {
+            prevInst->extraClobberedRegs().forEachWithWidthAndPreserved(
+                [&](Reg reg, Width, PreservedWidth) { m_state.clobber(reg); });
+        }
+        if (nextInst && nextInst->kind.opcode == Patch) [[unlikely]] {
+            nextInst->extraEarlyClobberedRegs().forEachWithWidthAndPreserved(
+                [&](Reg reg, Width, PreservedWidth) { m_state.clobber(reg); });
+        }
     }
 
     void clobberEarlyDefs()
@@ -206,6 +240,28 @@ private:
     void clobberLateDefs()
     {
         clobberDefs(&m_block->at(m_instIndex), nullptr);
+    }
+
+    void clobberAllDefs()
+    {
+        Inst& inst = m_block->at(m_instIndex);
+        inst.forEachArg([&](Arg& arg, Arg::Role role, Bank bank, Width width) {
+            if (Arg::isAnyDef(role) && arg.isStack() && arg.stackSlot()->isSpill())
+                m_state.clobber(arg.stackSlot());
+            arg.forEachTmp(role, bank, width,
+                [&](Tmp& tmp, Arg::Role refinedRole, Bank, Width) {
+                    if (Arg::isAnyDef(refinedRole) && tmp.isReg())
+                        m_state.clobber(tmp.reg());
+                });
+        });
+
+        // Patch ops have extra-clobbered registers that aren't represented as
+        // args. Both early and late extras clobber the same state here.
+        if (inst.kind.opcode == Patch) [[unlikely]] {
+            auto reportReg = [&](Reg reg, Width, PreservedWidth) { m_state.clobber(reg); };
+            inst.extraEarlyClobberedRegs().forEachWithWidthAndPreserved(reportReg);
+            inst.extraClobberedRegs().forEachWithWidthAndPreserved(reportReg);
+        }
     }
 
     void addInstAliases()
@@ -251,11 +307,18 @@ private:
                     uint64_t delta = myValue - otherValue;
                     
                     if (Arg::isValidImmForm(delta)) {
-                        inst.kind = Add64;
-                        inst.args.resize(3);
-                        inst.args[0] = Arg::imm(delta);
-                        inst.args[1] = Tmp(regConst.reg);
-                        inst.args[2] = Tmp(myDest);
+                        if (delta) {
+                            inst.kind = Add64;
+                            inst.args.resize(3);
+                            inst.args[0] = Arg::imm(delta);
+                            inst.args[1] = Tmp(regConst.reg);
+                            inst.args[2] = Tmp(myDest);
+                        } else {
+                            inst.kind = Move;
+                            inst.args.resize(2);
+                            inst.args[0] = Tmp(regConst.reg);
+                            inst.args[1] = Tmp(myDest);
+                        }
                         return;
                     }
                 }
@@ -653,8 +716,6 @@ private:
     Code& m_code;
     IndexMap<BasicBlock*, State> m_atHead;
     State m_state;
-    BitVector m_notBottom;
-    BitVector m_shouldVisit;
     BasicBlock* m_block { nullptr };
     unsigned m_instIndex { 0 };
 };


### PR DESCRIPTION
#### 4bbaa640d0a2f431eab09958b3df0c0938aa640c
<pre>
[JSC] Optimize AirFixObviousSpills
<a href="https://bugs.webkit.org/show_bug.cgi?id=318057">https://bugs.webkit.org/show_bug.cgi?id=318057</a>
<a href="https://rdar.apple.com/180838428">rdar://180838428</a>

Reviewed by Yijia Huang.

This patch speeds up AirFixObviousSpills.

1. Visiting order is changed with RPO and prioritizing RPO ordering.
2. clobberDefs unifies repeated dipatching of forEachArg. Also skip
   non-Spill StackSlot handling as we only care about spilled StackSlots
   for stack locations.
3. clobberAllDefs unifies repeated dispatching as well.
4. If delta=0, use Move instead of `Add %x, $0, %y`.

* Source/JavaScriptCore/b3/air/AirFixObviousSpills.cpp:

Canonical link: <a href="https://commits.webkit.org/315993@main">https://commits.webkit.org/315993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/964bdff6cfe660cdee0ba23a57001f864917cb1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128353 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/413e0bcc-75be-4b7b-8a14-1ac5639ad963) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133073 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba45fba8-500d-4ee1-bd57-0ff6bc14ea5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113570 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54d9ca37-a91f-4684-9901-503d8a240f0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34883 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33221 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28698 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1925 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182601 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31895 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141529 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44221 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141346 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44910 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109496 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26016 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36614 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116799 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203319 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7999 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->