### PR TITLE
[JSC] `Array.from(arguments)` fast path should bail out when length exceeds `MAX_STORAGE_VECTOR_LENGTH`

### DIFF
--- a/JSTests/stress/array-from-cloned-arguments-large-length.js
+++ b/JSTests/stress/array-from-cloned-arguments-large-length.js
@@ -1,0 +1,21 @@
+//@ skip if $addressBits <= 32
+//@ runDefault
+//@ memoryHog!
+
+'use strict';
+
+function target() {
+    arguments.length = 0x10000001;
+    return Array.from(arguments);
+}
+
+try {
+    const result = target(1, 2, 3);
+    if (result.length !== 0x10000001)
+        throw new Error("bad length: " + result.length);
+    if (result[0] !== 1 || result[1] !== 2 || result[2] !== 3)
+        throw new Error("bad elements: " + result[0] + ", " + result[1] + ", " + result[2]);
+} catch (e) {
+    if (!(e instanceof RangeError))
+        throw e;
+}

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -295,6 +295,9 @@ static ALWAYS_INLINE JSArray* tryCreateArrayFromArguments(JSGlobalObject* global
     if (!length)
         RELEASE_AND_RETURN(scope, constructEmptyArray(globalObject, nullptr));
 
+    if (length > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
+        return nullptr;
+
     IndexingType indexingType = IsArray;
     forEachArgumentsElement(globalObject, arguments, length, [&](JSValue value, unsigned) {
         indexingType = leastUpperBoundOfIndexingTypeAndValue(indexingType, value);


### PR DESCRIPTION
#### fc179bd61c6cefb22988f84532515cff802cca0f
<pre>
[JSC] `Array.from(arguments)` fast path should bail out when length exceeds `MAX_STORAGE_VECTOR_LENGTH`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318058">https://bugs.webkit.org/show_bug.cgi?id=318058</a>

Reviewed by Yusuke Suzuki.

The Array.from(arguments) fast path allocates a contiguous butterfly sized from the
arguments&apos; length, but ClonedArguments&apos; length is a writable own data property, so a
user-controlled value above MAX_STORAGE_VECTOR_LENGTH reaches
IndexingHeader::setVectorLength and crashes on its RELEASE_ASSERT. Bail out to the
generic Array.from path instead, as fastFlat already does.

    &apos;use strict&apos;;
    function target() {
        arguments.length = 0x10000001;
        return Array.from(arguments);
    }
    target(1, 2, 3);

Test: JSTests/stress/array-from-cloned-arguments-large-length.js

* JSTests/stress/array-from-cloned-arguments-large-length.js: Added.
(target):
(catch):
* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::tryCreateArrayFromArguments):

Canonical link: <a href="https://commits.webkit.org/316014@main">https://commits.webkit.org/316014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bdd8e37c0f82f305f95bf6f6a4103fdfb25c80e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128357 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133075 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93868 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34889 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33224 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28702 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1928 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182605 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31899 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141533 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44225 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38092 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44914 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109502 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36617 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116803 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203323 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43424 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8002 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54442 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->