### PR TITLE
Element with multiple mask images is not fully repainted when one of the mask images finishes loading

### DIFF
--- a/LayoutTests/fast/repaint/mask-multiple-images-load-expected.txt
+++ b/LayoutTests/fast/repaint/mask-multiple-images-load-expected.txt
@@ -1,0 +1,9 @@
+When the dot mask image finishes loading, the whole masked area should be repainted, not just the dot's rect. bug 241079.
+
+(repaint rects
+  (rect 8 8 100 100)
+  (rect 8 8 100 100)
+  (rect 8 8 100 100)
+  (rect 8 8 100 100)
+)
+

--- a/LayoutTests/fast/repaint/mask-multiple-images-load.html
+++ b/LayoutTests/fast/repaint/mask-multiple-images-load.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Repaint of the whole masked area when one of several mask images finishes loading</title>
+<style>
+#target {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    width: 100px;
+    height: 100px;
+    background: linear-gradient(to bottom, #751fde, #120128);
+    /* Start with a single, immediately-available gradient mask so the element is fully painted. */
+    -webkit-mask-image: linear-gradient(#000, #000);
+    mask-image: linear-gradient(#000, #000);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+}
+</style>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText(false);
+    testRunner.waitUntilDone();
+}
+
+// Two mask layers: a full-box gradient plus a small dot in the bottom-right corner.
+const kMaskImage = "linear-gradient(#000, #000), url(../backgrounds/resources/dot.png)";
+const kMaskPosition = "0 0, bottom right";
+const kMaskRepeat = "no-repeat, no-repeat";
+
+function startTest() {
+    const target = document.getElementById("target");
+
+    // Adding the second mask image is a style change, so flush its repaint *before* we start
+    // tracking. We only want to observe the invalidation issued when the still-loading dot
+    // image finishes loading: the whole masked area must be invalidated (because mask layers
+    // paint as an all-or-nothing group), not just the dot's destination rect. bug 241079.
+    target.style.webkitMaskImage = kMaskImage;
+    target.style.maskImage = kMaskImage;
+    target.style.webkitMaskPosition = kMaskPosition;
+    target.style.maskPosition = kMaskPosition;
+    target.style.webkitMaskRepeat = kMaskRepeat;
+    target.style.maskRepeat = kMaskRepeat;
+
+    document.body.offsetTop; // Force style + layout, flushing the style-change repaint.
+
+    if (!window.internals)
+        return; // Outside the harness, leave the rendered result on screen.
+
+    internals.startTrackingRepaints();
+
+    // The dot shares its CachedImage with this probe; once the probe reports load, the
+    // renderer's imageChanged() has been dispatched in the same notification pass. Defer
+    // the dump a turn so that dispatch (and its repaint) has completed.
+    const probe = new Image();
+    probe.onload = () => setTimeout(finishTest, 0);
+    probe.src = "../backgrounds/resources/dot.png";
+}
+
+function finishTest() {
+    document.body.offsetTop;
+    const rects = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+    const pre = document.createElement("pre");
+    pre.id = "result";
+    pre.textContent = rects;
+    document.body.appendChild(pre);
+    testRunner.notifyDone();
+}
+
+window.addEventListener("load", startTest);
+</script>
+</head>
+<body>
+<p>When the dot mask image finishes loading, the whole masked area should be repainted, not just
+the dot's rect. <a href="https://bugs.webkit.org/show_bug.cgi?id=241079">bug 241079</a>.</p>
+<div id="target"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2186,6 +2186,21 @@ void RenderBox::imageChanged(WrappedImagePtr image, const IntRect*)
 
         if (!didFullRepaint)
             didFullRepaint = repaintLayerRectsForImage(image, style.backgroundLayers(), style.usedZoomForLength(), true);
+
+        // Mask layers paint as a single all-or-nothing group (RenderBox::paintMaskImages), so when
+        // more than one image contributes to the mask we must repaint the whole masked area rather
+        // than just the destination rect of the image that loaded.
+        if (!didFullRepaint) {
+            unsigned maskImageContributors = style.maskBorderSource().tryStyleImage() ? 1 : 0;
+            for (auto& layer : style.maskLayers().usedValues())
+                maskImageContributors += layer.hasImage();
+
+            bool isNonEmpty;
+            if (maskImageContributors > 1 && Style::findLayerUsedImage(style.maskLayers(), image, isNonEmpty)) {
+                repaint();
+                didFullRepaint = true;
+            }
+        }
         if (!didFullRepaint)
             didFullRepaint = repaintLayerRectsForImage(image, style.maskLayers(), style.usedZoomForLength(), false);
     };


### PR DESCRIPTION
#### 226215196553e188a0edd4115e16c3cbb59e47dc
<pre>
Element with multiple mask images is not fully repainted when one of the mask images finishes loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=241079">https://bugs.webkit.org/show_bug.cgi?id=241079</a>
<a href="https://rdar.apple.com/94406306">rdar://94406306</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When an element has more than one mask image (for example a full-box gradient
combined with a smaller SVG/raster image), the mask layers are painted as a
single all-or-nothing group in RenderBox::paintMaskImages(): the entire masked
area is withheld and painted fully transparent until every mask image has
loaded, to avoid a flash of unmasked content.

However, when one of those images finished loading, RenderBox::imageChanged()
only invalidated the destination rect of the image that loaded (via
repaintLayerRectsForImage()). Because the rest of the element had been withheld
by the all-or-nothing group on the previous paint, the regions covered only by
the other, already-loaded mask layers were never re-invalidated and stayed
blank until some unrelated repaint occurred (selecting the element, opening the
inspector, etc.). This is why the gradient region of the reported testcase
remained blank while only the strip covered by the late-loading SVG appeared.

Fix this by repainting the whole masked area, rather than just the loaded
image&apos;s rect, when the changed image belongs to a mask layer and more than one
image contributes to the mask. A single mask image only ever paints within its
own rect, so the cheaper per-rect invalidation is kept for it; this also avoids
over-invalidating animated mask images, whose every frame arrives through this
same path. The full repaint uses the element&apos;s already-zoomed overflow bounds,
so it is correct under CSS zoom and page zoom.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::imageChanged):
* LayoutTests/fast/repaint/mask-multiple-images-load.html: Added.
* LayoutTests/fast/repaint/mask-multiple-images-load-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226215196553e188a0edd4115e16c3cbb59e47dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138818 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137515 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96257 "1 flakes 4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117990 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38024 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37790 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34610 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188565 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146569 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50825 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146379 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41139 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123029 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117102 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49329 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12765 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48731 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48965 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->