### PR TITLE
[JSC] Private field get ICs should fold to megamorphic loads

### DIFF
--- a/JSTests/microbenchmarks/megamorphic-get-private-field.js
+++ b/JSTests/microbenchmarks/megamorphic-get-private-field.js
@@ -1,0 +1,30 @@
+class Base {
+    #state;
+
+    constructor(state) {
+        this.#state = state;
+    }
+
+    getState() {
+        return this.#state;
+    }
+}
+noInline(Base.prototype.getState);
+
+let objects = [];
+for (let i = 0; i < 32; ++i) {
+    class Sub extends Base {
+        constructor(state) {
+            super(state);
+            this["extra" + i] = i;
+        }
+    }
+    objects.push(new Sub(i));
+}
+
+let result = 0;
+for (let i = 0; i < 5e6; ++i)
+    result += objects[i & 31].getState();
+
+if (result !== 77500000)
+    throw new Error("bad result: " + result);

--- a/JSTests/stress/megamorphic-get-private-field-dictionary.js
+++ b/JSTests/stress/megamorphic-get-private-field-dictionary.js
@@ -1,0 +1,55 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+class Base {
+    #state;
+
+    constructor(state) {
+        this.#state = state;
+    }
+
+    getState() {
+        return this.#state;
+    }
+}
+noInline(Base.prototype.getState);
+
+let objects = [];
+for (let i = 0; i < 16; ++i) {
+    class Sub extends Base {
+        constructor(state) {
+            super(state);
+            this['extra' + i] = i;
+        }
+    }
+    objects.push(new Sub(i));
+}
+
+// Warm the IC site up to megamorphic.
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(objects[i & 15].getState(), i & 15);
+
+// Turn some receivers into dictionary structures with heavy property churn, and freeze others.
+for (let i = 0; i < 8; ++i) {
+    let object = objects[i];
+    for (let j = 0; j < 100; ++j)
+        object['churn' + j] = j;
+    for (let j = 0; j < 100; ++j)
+        delete object['churn' + j];
+}
+for (let i = 8; i < 12; ++i)
+    Object.freeze(objects[i]);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(objects[i & 15].getState(), i & 15);
+
+// Keep mutating dictionary receivers between reads so cached offsets must stay coherent.
+for (let i = 0; i < testLoopCount; ++i) {
+    let object = objects[i & 7];
+    object['mutate' + (i & 31)] = i;
+    shouldBe(object.getState(), i & 7);
+    delete object['mutate' + (i & 31)];
+    shouldBe(object.getState(), i & 7);
+}

--- a/JSTests/stress/megamorphic-get-private-field-different-symbols.js
+++ b/JSTests/stress/megamorphic-get-private-field-different-symbols.js
@@ -1,0 +1,54 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function shouldThrowTypeError(func) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof TypeError))
+        throw new Error('expected TypeError but got: ' + error);
+}
+
+// Each evaluation of the class creates a fresh private symbol for #field, but every
+// getField shares the same IC site. With 16 copies the site sees 16 (symbol, structure)
+// pairs and goes megamorphic on the by-val path.
+function makeClass() {
+    class C {
+        #field;
+
+        constructor(value) {
+            this.#field = value;
+        }
+
+        getField() {
+            return this.#field;
+        }
+    }
+    noInline(C.prototype.getField);
+    return C;
+}
+noInline(makeClass);
+
+let classes = [];
+let objects = [];
+for (let i = 0; i < 16; ++i) {
+    let C = makeClass();
+    classes.push(C);
+    objects.push(new C(i));
+}
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let index = i & 15;
+    shouldBe(classes[index].prototype.getField.call(objects[index]), index);
+    if (!(i & 0xff)) {
+        // Another copy's getter looks for a different private symbol, so this must throw
+        // even though the receiver has a private field at the same offset.
+        let other = (index + 1) & 15;
+        shouldThrowTypeError(() => classes[other].prototype.getField.call(objects[index]));
+    }
+}

--- a/JSTests/stress/megamorphic-get-private-field-proxy.js
+++ b/JSTests/stress/megamorphic-get-private-field-proxy.js
@@ -1,0 +1,54 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// Private field reads must not trigger proxy traps, even via the megamorphic paths.
+let traps = 0;
+const handler = {
+    get() { ++traps; return undefined; },
+    getOwnPropertyDescriptor() { ++traps; return undefined; },
+    has() { ++traps; return false; },
+};
+
+class MaybeProxy {
+    constructor(useProxy) {
+        if (useProxy)
+            return new Proxy({}, handler);
+    }
+}
+
+class Base extends MaybeProxy {
+    #state;
+
+    constructor(state, useProxy) {
+        super(useProxy);
+        this.#state = state;
+    }
+
+    getState() {
+        return this.#state;
+    }
+}
+noInline(Base.prototype.getState);
+
+let objects = [];
+for (let i = 0; i < 16; ++i) {
+    class Sub extends Base {
+        constructor(state, useProxy) {
+            super(state, useProxy);
+            if (!useProxy)
+                this['extra' + i] = i;
+        }
+    }
+    // Odd indices get a proxy receiver with the private field stamped directly on the proxy.
+    objects.push(new Sub(i, !!(i & 1)));
+}
+
+// Proxy receivers are not linked to Sub.prototype, so call the getter directly. This keeps
+// the only proxy interaction the private field read itself, which must not hit any trap.
+let getState = Base.prototype.getState;
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(getState.call(objects[i & 15]), i & 15);
+
+shouldBe(traps, 0);

--- a/JSTests/stress/megamorphic-get-private-field.js
+++ b/JSTests/stress/megamorphic-get-private-field.js
@@ -1,0 +1,64 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function shouldThrowTypeError(func) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof TypeError))
+        throw new Error('expected TypeError but got: ' + error);
+}
+
+class Base {
+    #state;
+
+    constructor(state) {
+        this.#state = state;
+    }
+
+    getState() {
+        return this.#state;
+    }
+}
+noInline(Base.prototype.getState);
+
+class Other {
+    #state;
+
+    constructor(state) {
+        this.#state = state;
+    }
+}
+
+let objects = [];
+for (let i = 0; i < 64; ++i) {
+    class Sub extends Base {
+        constructor(state) {
+            super(state);
+            this['extra' + i] = i;
+        }
+    }
+    objects.push(new Sub(i));
+}
+
+let getState = Base.prototype.getState;
+let plainObject = {};
+let otherPrivateField = new Other(42);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(objects[i & 63].getState(), i & 63);
+    if (!(i & 0xff)) {
+        // Reading a private field from an object which does not have it must throw,
+        // even after the IC goes megamorphic.
+        shouldThrowTypeError(() => getState.call(plainObject));
+        shouldThrowTypeError(() => getState.call(otherPrivateField));
+        shouldThrowTypeError(() => getState.call(null));
+        shouldThrowTypeError(() => getState.call(1));
+        shouldThrowTypeError(() => getState.call('string'));
+    }
+}

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -658,6 +658,8 @@ bool GetByStatus::makesCalls() const
 
 GetByStatus GetByStatus::slowVersion() const
 {
+    // FIXME: This discards the Megamorphic state, so a recompile after exits loses the chance
+    // to emit megamorphic load nodes even though the IC already went megamorphic.
     if (observedPropertyInlineCacheSlowPath())
         return GetByStatus(makesCalls() ? ObservedSlowPathAndMakesCalls : ObservedTakesSlowPath, wasSeenInJIT());
     return GetByStatus(makesCalls() ? MakesCalls : LikelyTakesSlowPath, wasSeenInJIT());

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2999,7 +2999,10 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
         slowCases.append(jit.loadCacheableIdentifierImpl(propertyGPR, scratch4GPR, m_propertyCache.propertyIsString, m_propertyCache.propertyIsSymbol));
 
-        slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+        if (m_propertyCache.accessType == AccessType::GetPrivateName)
+            slowCases.append(jit.loadMegamorphicPrivateProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+        else
+            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
@@ -3030,25 +3033,36 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
 
         CCallHelpers::JumpList slowCases;
 
-        jit.move(baseGPR, scratch5GPR);
-        auto isString = jit.branchIfString(scratch5GPR);
-        auto label = jit.label();
-        if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
-            slowCases.append(jit.loadMegamorphicProperty(vm, scratch5GPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
-        } else
-            slowCases.append(jit.loadMegamorphicProperty(vm, scratch5GPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+        if (m_propertyCache.accessType == AccessType::GetPrivateNameById) {
+            if (useHandlerIC()) {
+                jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
+                slowCases.append(jit.loadMegamorphicPrivateProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            } else
+                slowCases.append(jit.loadMegamorphicPrivateProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
 
-        allocator.restoreReusedRegistersByPopping(jit, preservedState);
-        succeed();
+            allocator.restoreReusedRegistersByPopping(jit, preservedState);
+            succeed();
+        } else {
+            jit.move(baseGPR, scratch5GPR);
+            auto isString = jit.branchIfString(scratch5GPR);
+            auto label = jit.label();
+            if (useHandlerIC()) {
+                jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
+                slowCases.append(jit.loadMegamorphicProperty(vm, scratch5GPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            } else
+                slowCases.append(jit.loadMegamorphicProperty(vm, scratch5GPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
 
-        isString.link(jit);
-        if (useHandlerIC()) {
-            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratch5GPR);
-            jit.loadPtr(CCallHelpers::Address(scratch5GPR, JSGlobalObject::offsetOfStringPrototype()), scratch5GPR);
-        } else
-            jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->stringPrototype()), scratch5GPR);
-        jit.jump().linkTo(label, jit);
+            allocator.restoreReusedRegistersByPopping(jit, preservedState);
+            succeed();
+
+            isString.link(jit);
+            if (useHandlerIC()) {
+                jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratch5GPR);
+                jit.loadPtr(CCallHelpers::Address(scratch5GPR, JSGlobalObject::offsetOfStringPrototype()), scratch5GPR);
+            } else
+                jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->stringPrototype()), scratch5GPR);
+            jit.jump().linkTo(label, jit);
+        }
 
         if (allocator.didReuseRegisters()) {
             slowCases.link(&jit);
@@ -4920,6 +4934,25 @@ RefPtr<AccessCase> InlineCacheCompiler::tryFoldToMegamorphic(CodeBlock* codeBloc
                     return nullptr;
             }
 
+            return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicLoad, nullptr);
+        }
+        // FIXME: Private puts (DefinePrivateNameById / SetPrivateNameById), brand checks
+        // (Has/Check/SetPrivateBrand), and HasPrivateName could fold to megamorphic cases similarly.
+        case AccessType::GetPrivateNameById:
+        case AccessType::GetPrivateName: {
+            for (auto& accessCase : cases) {
+                if (accessCase->type() != AccessCase::Load)
+                    return nullptr;
+
+                if (accessCase->viaGlobalProxy())
+                    return nullptr;
+
+                if (accessCase->usesPolyProto())
+                    return nullptr;
+            }
+
+            if (m_propertyCache.accessType == AccessType::GetPrivateNameById)
+                return AccessCase::create(vm(), codeBlock, AccessCase::LoadMegamorphic, useHandlerIC() ? nullptr : m_propertyCache.m_identifier);
             return AccessCase::create(vm(), codeBlock, AccessCase::IndexedMegamorphicLoad, nullptr);
         }
 #endif

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -762,6 +762,12 @@ void repatchGetBy(JSGlobalObject* globalObject, CodeBlock* codeBlock, JSValue ba
         case GetByKind::ByValWithThis:
             repatchSlowPathCall(codeBlock, propertyCache, operationGetByValWithThisMegamorphic);
             break;
+        case GetByKind::PrivateName:
+            repatchSlowPathCall(codeBlock, propertyCache, operationGetPrivateNameMegamorphic);
+            break;
+        case GetByKind::PrivateNameById:
+            repatchSlowPathCall(codeBlock, propertyCache, operationGetPrivateNameByIdMegamorphic);
+            break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -7274,6 +7274,8 @@ void ByteCodeParser::handleGetPrivateNameById(
 
     ASSERT(!getByStatus.isCustomAccessor());
     ASSERT(!getByStatus.makesCalls());
+    // FIXME: When getByStatus.isMegamorphic(), we should emit a megamorphic load node directly
+    // instead of a generic IC node, like handleGetById does with GetByIdMegamorphic.
     if (!getByStatus.isSimple() || !getByStatus.numVariants() || !Options::useAccessInlining()) {
         auto* data = m_graph.m_getByIdData.add(GetByIdData { identifier, CacheType::GetByIdSelf });
         set(destination, addToGraph(GetPrivateNameById, OpInfo(data), OpInfo(prediction), base, nullptr));
@@ -9404,6 +9406,8 @@ void ByteCodeParser::parseBlock(unsigned limit)
             if (compileSingleIdentifier)
                 handleGetPrivateNameById(bytecode.m_dst, prediction, base, identifier, identifierNumber, getByStatus);
             else {
+                // FIXME: When getByStatus.isMegamorphic(), we should emit a megamorphic load node
+                // directly, like get_by_val does with GetByValMegamorphic.
                 Node* node = addToGraph(GetPrivateName, OpInfo(), OpInfo(prediction), base, property);
                 m_exitOK = false;
                 set(bytecode.m_dst, node);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -601,6 +601,19 @@ AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicProperty(VM& vm, GPRRe
     return slowCases;
 }
 
+AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicPrivateProperty(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
+{
+    using Entry = MegamorphicCache::LoadEntry;
+    JumpList slowCases = findMegamorphicCacheEntry<MegamorphicCache::loadCachePrimaryMask, MegamorphicCache::offsetOfLoadCachePrimaryEntries(), MegamorphicCache::loadCacheSecondaryMask, MegamorphicCache::offsetOfLoadCacheSecondaryEntries()>(vm, baseGPR, uidGPR, uid, scratch1GPR, scratch2GPR, scratch3GPR);
+
+    loadPtr(Address(scratch3GPR, Entry::offsetOfHolder()), scratch2GPR);
+    slowCases.append(branchPtr(NotEqual, scratch2GPR, TrustedImmPtr(JSCell::seenMultipleCalleeObjects())));
+    load16(Address(scratch3GPR, Entry::offsetOfOffset()), scratch2GPR);
+    loadProperty(baseGPR, scratch2GPR, JSValueRegs { resultGPR });
+
+    return slowCases;
+}
+
 AssemblyHelpers::JumpList AssemblyHelpers::loadMegamorphicGetterSetter(VM& vm, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl* uid, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR)
 {
     using Entry = MegamorphicCache::GetterEntry;

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -316,6 +316,7 @@ public:
     void storeProperty(JSValueRegs value, GPRReg object, GPRReg offset, GPRReg scratch);
 
     JumpList loadMegamorphicProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
+    JumpList loadMegamorphicPrivateProperty(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
     JumpList loadMegamorphicGetterSetter(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg resultGPR, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);
     template<uint32_t primaryMask, ptrdiff_t primaryEntriesOffset, uint32_t secondaryMask, ptrdiff_t secondaryEntriesOffset>
     JumpList findMegamorphicCacheEntry(VM&, GPRReg baseGPR, GPRReg uidGPR, UniquedStringImpl*, GPRReg scratch1GPR, GPRReg scratch2GPR, GPRReg scratch3GPR);

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -4087,6 +4087,33 @@ ALWAYS_INLINE static JSValue getPrivateName(JSGlobalObject* globalObject, CallFr
     return slot.getValue(globalObject, fieldName);
 }
 
+template<GetByKind kind>
+static ALWAYS_INLINE JSValue getPrivateNameMegamorphic(JSGlobalObject* globalObject, VM& vm, CallFrame* callFrame, PropertyInlineCache* propertyCache, JSValue baseValue, PropertyName fieldName)
+{
+    ASSERT(fieldName.isPrivateName());
+    auto* uid = fieldName.uid();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!baseValue.isObject()) [[unlikely]] {
+        if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
+            repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
+        RELEASE_AND_RETURN(scope, getPrivateName(globalObject, callFrame, baseValue, fieldName));
+    }
+
+    JSObject* baseObject = asObject(baseValue);
+    PropertySlot slot(baseObject, PropertySlot::InternalMethodType::GetOwnProperty);
+    baseObject->getPrivateField(globalObject, fieldName, slot);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    ASSERT(slot.slotBase() == baseObject);
+    if (baseObject->structure()->propertyAccessesAreCacheable() && slot.isCacheableValue() && slot.cachedOffset() <= MegamorphicCache::maxOffset) [[likely]]
+        vm.megamorphicCache()->initAsHit(baseObject->structureID(), uid, baseObject, slot.cachedOffset(), /* ownProperty */ true);
+    else if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
+        repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
+
+    RELEASE_AND_RETURN(scope, slot.getValue(globalObject, fieldName));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameOptimize, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedFieldName, PropertyInlineCache* propertyCache))
 {
     JSGlobalObject* globalObject = propertyCache->globalObject();
@@ -4138,6 +4165,26 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameGaveUp, EncodedJSValue, (Encoded
     JSValue fieldNameValue = JSValue::decode(encodedFieldName);
 
     OPERATION_RETURN(scope, JSValue::encode(getPrivateName(globalObject, callFrame, baseValue, fieldNameValue)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameMegamorphic, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedFieldName, PropertyInlineCache* propertyCache))
+{
+    JSGlobalObject* globalObject = propertyCache->globalObject();
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    ICSlowPathCallFrameTracer tracer(vm, callFrame, propertyCache);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue baseValue = JSValue::decode(encodedBase);
+    JSValue fieldNameValue = JSValue::decode(encodedFieldName);
+    ASSERT(CacheableIdentifier::isCacheableIdentifierCell(fieldNameValue));
+
+    const Identifier fieldName = fieldNameValue.toPropertyKey(globalObject);
+    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    ASSERT(fieldName.isSymbol());
+
+    OPERATION_RETURN(scope, JSValue::encode(getPrivateNameMegamorphic<GetByKind::PrivateName>(globalObject, vm, callFrame, propertyCache, baseValue, fieldName)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameGeneric, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue encodedBase, EncodedJSValue encodedFieldName))
@@ -4204,6 +4251,20 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdOptimize, EncodedJSValue, (E
     }
 
     OPERATION_RETURN(scope, JSValue::encode(getPrivateName(globalObject, callFrame, baseValue, identifier)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdMegamorphic, EncodedJSValue, (EncodedJSValue base, PropertyInlineCache* propertyCache))
+{
+    JSGlobalObject* globalObject = propertyCache->globalObject();
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    ICSlowPathCallFrameTracer tracer(vm, callFrame, propertyCache);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue baseValue = JSValue::decode(base);
+    CacheableIdentifier identifier = propertyCache->identifier();
+
+    OPERATION_RETURN(scope, JSValue::encode(getPrivateNameMegamorphic<GetByKind::PrivateNameById>(globalObject, vm, callFrame, propertyCache, baseValue, identifier)));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdGeneric, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue base, uintptr_t rawCacheableIdentifier))

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -306,10 +306,12 @@ JSC_DECLARE_JIT_OPERATION(operationInstanceOfGeneric, EncodedJSValue, (JSGlobalO
 
 JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameOptimize, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedFieldName, PropertyInlineCache*));
 JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameGaveUp, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedFieldName, PropertyInlineCache*));
+JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameMegamorphic, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedFieldName, PropertyInlineCache*));
 JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedBase, EncodedJSValue encodedFieldName));
 
 JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameByIdOptimize, EncodedJSValue, (EncodedJSValue, PropertyInlineCache*));
 JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameByIdGaveUp, EncodedJSValue, (EncodedJSValue, PropertyInlineCache*));
+JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameByIdMegamorphic, EncodedJSValue, (EncodedJSValue, PropertyInlineCache*));
 JSC_DECLARE_JIT_OPERATION(operationGetPrivateNameByIdGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, uintptr_t));
 
 // End of IC related functions and generic helpers.


### PR DESCRIPTION
#### 8e55959edab5faed8757897ce6d06755d82713eb
<pre>
[JSC] Private field get ICs should fold to megamorphic loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=318059">https://bugs.webkit.org/show_bug.cgi?id=318059</a>

Reviewed by NOBODY (OOPS!).

InlineCacheCompiler::tryFoldToMegamorphic has no case for GetPrivateNameById /
GetPrivateName, so once a private field read sees more than
maxAccessVariantListSize structures, the IC gives up and every read goes
through operationGetPrivateName(ById)GaveUp, a generic C++ lookup. This is
common for a base-class method reading #field across many subclasses that each
add their own properties.

A private field is an own property keyed by a private symbol, and SymbolImpl is
a UniquedStringImpl, so MegamorphicCache can serve it as-is. This change folds
private gets to LoadMegamorphic / IndexedMegamorphicLoad.

The load is emitted by the new loadMegamorphicPrivateProperty, which shares
findMegamorphicCacheEntry with loadMegamorphicProperty and then takes the entry
only when its holder is the own property sentinel. That single comparison
covers both ways a private load differs from a public one: a cached miss holds
a null holder and must throw instead of producing undefined, and a cached hit
whose holder is a prototype cannot describe a private field. Private loads also
skip the string receiver redirection to StringPrototype. The new
operationGetPrivateName(ById)Megamorphic slow paths fill MegamorphicCache on
hits only and never call initAsMiss.

                                        Baseline                  Patched

polymorphic-get-private-field       15.6630+-0.5502           15.3915+-0.7600          might be 1.0176x faster
megamorphic-own-load                19.2887+-0.8041           19.2251+-0.7255
megamorphic-load                     2.6927+-0.1205     ?      2.7266+-0.1050        ? might be 1.0126x slower
class-private-field-polymorphic      1.9503+-0.0641     ?      1.9633+-0.0655        ?
megamorphic-get-private-field       58.8763+-1.2523     ^     30.2560+-0.8053        ^ definitely 1.9459x faster
megamorphic-prototype-load          19.1315+-0.7780     ?     19.5720+-0.5885        ? might be 1.0230x slower
monomorphic-get-private-field        7.7301+-0.3750            7.5668+-0.1481          might be 1.0216x faster
megamorphic-miss                    17.8053+-0.6743     ?     18.2748+-0.4335        ? might be 1.0264x slower
megamorphic-load-get-by-val         23.9476+-0.7004     ?     23.9759+-0.7958        ?

Tests: JSTests/microbenchmarks/megamorphic-get-private-field.js
       JSTests/stress/megamorphic-get-private-field-dictionary.js
       JSTests/stress/megamorphic-get-private-field-different-symbols.js
       JSTests/stress/megamorphic-get-private-field-proxy.js
       JSTests/stress/megamorphic-get-private-field.js

* JSTests/microbenchmarks/megamorphic-get-private-field.js: Added.
(Base):
(Base.prototype.getState):
(i.Sub):
* JSTests/stress/megamorphic-get-private-field-dictionary.js: Added.
(shouldBe):
(Base):
(Base.prototype.getState):
(i.Sub):
* JSTests/stress/megamorphic-get-private-field-different-symbols.js: Added.
(shouldBe):
(shouldThrowTypeError):
(makeClass.C):
(makeClass.C.prototype.getField):
(makeClass):
* JSTests/stress/megamorphic-get-private-field-proxy.js: Added.
(shouldBe):
(MaybeProxy):
(Base):
(Base.prototype.getState):
* JSTests/stress/megamorphic-get-private-field.js: Added.
(shouldBe):
(shouldThrowTypeError):
(Base):
(Base.prototype.getState):
(Other):
(i.Sub):
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::slowVersion const):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::tryFoldToMegamorphic):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::repatchGetBy):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleGetPrivateNameById):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadMegamorphicProperty):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::getPrivateNameMegamorphic):
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e55959edab5faed8757897ce6d06755d82713eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185594 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/138212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137059 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96227 "5 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37547 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6341 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37324 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34063 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37264 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188015 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49600 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146063 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145900 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40688 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122476 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116354 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48787 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12305 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->