### PR TITLE
[AVFoundation] De-duplicate the ARGB color-extraction blocks in processCueAttributes()

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -266,39 +266,29 @@ Ref<InbandGenericCue> InbandTextTrackPrivateAVF::processCueAttributes(CFAttribut
                 continue;
             }
 
-            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_ForegroundColorARGB, 0) == kCFCompareEqualTo) {
+            auto applyColorAttribute = [&](void (InbandGenericCue::*setter)(const Color&)) {
                 RetainPtr arrayValue = dynamic_cf_cast<CFArrayRef>(value.get());
                 if (!arrayValue)
-                    continue;
+                    return;
 
                 auto color = makeSimpleColorFromARGBCFArray(arrayValue.get());
                 if (!color)
-                    continue;
-                cueData->setForegroundColor(*color);
+                    return;
+                (cueData.get().*setter)(*color);
+            };
+
+            if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_ForegroundColorARGB, 0) == kCFCompareEqualTo) {
+                applyColorAttribute(&InbandGenericCue::setForegroundColor);
                 continue;
             }
 
             if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_BackgroundColorARGB, 0) == kCFCompareEqualTo) {
-                RetainPtr arrayValue = dynamic_cf_cast<CFArrayRef>(value.get());
-                if (!arrayValue)
-                    continue;
-
-                auto color = makeSimpleColorFromARGBCFArray(arrayValue.get());
-                if (!color)
-                    continue;
-                cueData->setBackgroundColor(*color);
+                applyColorAttribute(&InbandGenericCue::setBackgroundColor);
                 continue;
             }
 
             if (CFStringCompare(key.get(), PAL::kCMTextMarkupAttribute_CharacterBackgroundColorARGB, 0) == kCFCompareEqualTo) {
-                RetainPtr arrayValue = dynamic_cf_cast<CFArrayRef>(value.get());
-                if (!arrayValue)
-                    continue;
-
-                auto color = makeSimpleColorFromARGBCFArray(arrayValue.get());
-                if (!color)
-                    continue;
-                cueData->setHighlightColor(*color);
+                applyColorAttribute(&InbandGenericCue::setHighlightColor);
                 continue;
             }
         }


### PR DESCRIPTION
#### 012c7fc8787cf44798f92c07ac4efe4a1105aac0
<pre>
[AVFoundation] De-duplicate the ARGB color-extraction blocks in processCueAttributes()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318063">https://bugs.webkit.org/show_bug.cgi?id=318063</a>
<a href="https://rdar.apple.com/180858531">rdar://180858531</a>

Reviewed by Eric Carlson.

The handlers for the ForegroundColorARGB, BackgroundColorARGB, and
CharacterBackgroundColorARGB markup attributes in processCueAttributes()
were byte-identical except for the InbandGenericCue setter they called:
each cast the value to a CFArrayRef, ran it through
makeSimpleColorFromARGBCFArray(), and applied the result.

Extract the shared logic into an applyColorAttribute() lambda that takes
a pointer-to-member setter, collapsing three ~11-line blocks into one
helper plus three one-line dispatches. No change in behavior.

* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processCueAttributes):

Canonical link: <a href="https://commits.webkit.org/315984@main">https://commits.webkit.org/315984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90d2df11736c1b4486ada4cf43ce2d219e973b9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128367 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113580 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33234 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28712 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141542 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44235 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38066 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44924 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36626 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116813 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43434 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->