### PR TITLE
Use WTF::roundUpToMultipleOf in BitVector::OutOfLineBits::create

### DIFF
--- a/Source/WTF/wtf/BitVector.cpp
+++ b/Source/WTF/wtf/BitVector.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <string.h>
 #include <wtf/Assertions.h>
+#include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SIMDHelpers.h>
 
@@ -77,7 +78,7 @@ void BitVector::clearAll()
 
 auto BitVector::OutOfLineBits::create(size_t numBits) -> OutOfLineBits*
 {
-    numBits = (numBits + bitsInPointer() - 1) & ~(static_cast<size_t>(bitsInPointer()) - 1);
+    numBits = roundUpToMultipleOf<bitsInPointer()>(numBits);
     size_t size = sizeof(OutOfLineBits) + sizeof(uintptr_t) * (numBits / bitsInPointer());
     return new (NotNull, BitVectorMalloc::malloc(size)) OutOfLineBits(numBits);
 }

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -403,17 +403,17 @@ private:
     friend class JSC::CachedBitVector;
     friend class FixedBitVector;
 
-    static unsigned bitsInPointer()
+    static constexpr unsigned bitsInPointer()
     {
         return sizeof(void*) << 3;
     }
 
-    static unsigned maxInlineBits()
+    static constexpr unsigned maxInlineBits()
     {
         return bitsInPointer() - 1;
     }
 
-    static size_t byteCount(size_t bitCount)
+    static constexpr size_t byteCount(size_t bitCount)
     {
         return (bitCount + 7) >> 3;
     }


### PR DESCRIPTION
#### 4654057d5187d9ce28ad082559c95838c931cf2f
<pre>
Use WTF::roundUpToMultipleOf in BitVector::OutOfLineBits::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=318065">https://bugs.webkit.org/show_bug.cgi?id=318065</a>
<a href="https://rdar.apple.com/180865497">rdar://180865497</a>

Reviewed by Yusuke Suzuki.

Replace the hand-rolled round-up expression in OutOfLineBits::create()
with WTF::roundUpToMultipleOf(). This is just clearer.

Mark bitsInPointer(), maxInlineBits(), and byteCount() as constexpr so
that the compile-time divisor template form
roundUpToMultipleOf&lt;bitsInPointer()&gt;() can be used.

* Source/WTF/wtf/BitVector.cpp:
(WTF::BitVector::OutOfLineBits::create):
* Source/WTF/wtf/BitVector.h:
(WTF::BitVector::bitsInPointer):
(WTF::BitVector::maxInlineBits):
(WTF::BitVector::byteCount):

Canonical link: <a href="https://commits.webkit.org/315994@main">https://commits.webkit.org/315994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2274c7899a9f6e120d12250331619e6ba38465cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128407 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/871a8057-56b5-4376-b45d-a0bee6c28e91) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133124 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0848deef-fba4-45d7-b9b2-7582fb4db6e7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173653 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113621 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff60dfab-7cbb-4929-925b-b4e07457e2eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33274 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28752 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1977 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182655 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31949 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141582 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44275 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141397 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38074 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44964 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109614 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36666 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116853 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203373 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43474 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8051 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54456 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42879 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43120 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43010 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->