### PR TITLE
SVG SMIL number, integer-optional-integer, number-optional-number and path animations should not apply when from/to/by values fail to parse

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test SVGIntegerOptionalInteger animation with invalid value: String values in from and to attributes. assert_equals: expected 3 but got 0
+PASS Test SVGIntegerOptionalInteger animation with invalid value: String values in from and to attributes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test SVGIntegerOptionalInteger animation with invalid value: String value in by attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>Test SVGIntegerOptionalInteger animation with invalid value: String value in by attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+  <defs>
+    <filter id="effect">
+      <feConvolveMatrix id="matrix" order="3 3" kernelMatrix="0 0 0 0 1 0 0 0 0">
+        <animate attributeName="order" begin="0s" dur="4s" by="A B" />
+      </feConvolveMatrix>
+    </filter>
+  </defs>
+  <rect x="10" y="10" width="80" height="80" fill="blue" filter="url(#effect)" />
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const matrix = document.getElementById("matrix")
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(matrix.orderX.baseVal, 3);
+          assert_equals(matrix.orderY.baseVal, 3);
+          assert_equals(matrix.orderX.animVal, matrix.orderX.baseVal);
+          assert_equals(matrix.orderY.animVal, matrix.orderY.baseVal);
+        }));
+    }));
+  });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test SVGNumber animation with invalid values: String values in from and to attributes. assert_equals: expected 1 but got 0
+PASS Test SVGNumber animation with invalid values: String values in from and to attributes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test SVGNumber animation with invalid values: String value in by attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-2.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<title>Test SVGNumber animation with invalid values: String value in by attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <defs>
+        <filter id="effect">
+            <feComposite id="composite" in="SourceGraphic" in2="SourceAlpha" operator="arithmetic" k1="1">
+                <animate attributeName="k1" begin="0s" dur="4s" by="ERROR" />
+            </feComposite>
+        </filter>
+    </defs>
+    <rect id="rect" x="0" y="0" width="100" height="100" fill="green" filter="url(#effect)" />
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const composite = document.getElementById("composite");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(composite.k1.baseVal, 1);
+          assert_equals(composite.k1.animVal, composite.k1.baseVal);
+        }));
+    }));
+  });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-to-animation-valid-value-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-to-animation-valid-value-1-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test SVGNumber to-animation with a valid value still animates.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-to-animation-valid-value-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-to-animation-valid-value-1.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<title>Test SVGNumber to-animation with a valid value still animates.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <defs>
+        <filter id="effect">
+            <feComposite id="composite" in="SourceGraphic" in2="SourceAlpha" operator="arithmetic" k1="1">
+                <animate attributeName="k1" begin="0s" dur="4s" to="3" />
+            </feComposite>
+        </filter>
+    </defs>
+    <rect id="rect" x="0" y="0" width="100" height="100" fill="green" filter="url(#effect)" />
+</svg>
+
+<script>
+
+// A to-animation has an empty 'from'; the start value comes from the base value at
+// runtime. This guards against the empty-'from' path incorrectly rejecting the animation.
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const composite = document.getElementById("composite");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(composite.k1.baseVal, 1);
+          // Linear interpolation from base (1) to 'to' (3) at the mid-point.
+          assert_equals(composite.k1.animVal, 2);
+        }));
+    }));
+  });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test SVGNumberOptionalNumber animation with invalid values: String values in from and to attributes. assert_equals: expected 5 but got 0
+PASS Test SVGNumberOptionalNumber animation with invalid values: String values in from and to attributes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test SVGNumberOptionalNumber animation with invalid values: String value in by attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Test SVGNumberOptionalNumber animation with invalid values: String value in by attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<svg id="svg">
+    <defs>
+        <filter>
+            <feGaussianBlur id="blur" stdDeviation="5 5">
+                <animate attributeName="stdDeviation" begin="0s" dur="4s" by="A Z" />
+            </feGaussianBlur>
+        </filter>
+    </defs>
+    <rect x="50" y="50" width="100" height="100" fill="green" filter="url(#filter)"></rect>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const feGaussianBlur = document.getElementById("blur");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_equals(feGaussianBlur.stdDeviationX.baseVal, 5);
+          assert_equals(feGaussianBlur.stdDeviationY.baseVal, 5);
+          assert_equals(feGaussianBlur.stdDeviationX.animVal, feGaussianBlur.stdDeviationX.baseVal);
+          assert_equals(feGaussianBlur.stdDeviationY.animVal, feGaussianBlur.stdDeviationY.baseVal);
+        }));
+    }));
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-1-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test SVGPath animation with invalid values: Malformed path in by attribute. assert_in_array: value "" not in array ["M 40.00 40.00 L 60.00 40.00 L 60.00 60.00 L 40.00 60.00 Z"]
+PASS Test SVGPath animation with invalid values: Malformed path in by attribute.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-2-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test SVGPath animation with invalid values: Malformed path in to attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-2.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<title>Test SVGPath animation with invalid values: Malformed path in to attribute.</title>
+<link rel="help" href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#ToAttribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/animated-path-helpers.js"></script>
+
+<svg id="svg">
+  <path id="path" d="M 40 40 L 60 40 L 60 60 L 40 60 z" fill="green">
+    <animate attributeName="d" from="M 0 0 L 10 0 L 10 10 z" to="ERROR" begin="0s" dur="4s" fill="freeze" />
+  </path>
+</svg>
+
+<script>
+
+async_test(t => {
+    const svg = document.getElementById("svg");
+    const path = document.getElementById("path");
+
+    window.addEventListener('load', t.step_func(() => {
+        svg.setCurrentTime(2);
+
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_animated_path_equals(path,
+                               "M 40 40 L 60 40 L 60 60 L 40 60 z");
+        }));
+    }));
+  });
+
+</script>

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -127,6 +127,16 @@ public:
         buildSVGPathByteStreamFromString(string, *this, UnalteredParsing);
     }
 
+    // Returns std::nullopt when the string is not a legal path. An empty string is a legal
+    // (empty) path, so callers that must reject an empty value should check that separately.
+    static std::optional<SVGPathByteStream> create(StringView string)
+    {
+        SVGPathByteStream stream;
+        if (!buildSVGPathByteStreamFromString(string, stream, UnalteredParsing))
+            return std::nullopt;
+        return stream;
+    }
+
     SVGPathByteStream(const SVGPathByteStream& other)
         : CanMakeSingleThreadWeakPtr<SVGPathByteStream>()
         , m_data(other.m_data)

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
@@ -28,6 +28,7 @@
 #include "SVGAnimatedPropertyImpl.h"
 #include "SVGAnimatedPropertyPairAnimator.h"
 #include "SVGMarkerTypes.h"
+#include "SVGPropertyTraits.h"
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
@@ -134,37 +135,44 @@ public:
 private:
     SVGAnimatorType animatorType() const final { return SVGAnimatorType::IntegerPair; }
 
-    bool setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
+    bool setFromAndToValues(SVGElement&, const String& from, const String& to) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, from);
-        auto pairTo = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, to);
+        // In to-animation mode 'from' is empty; the start value is resolved at runtime.
+        auto pairFrom = !from.isEmpty() ? SVGPropertyTraits<std::pair<int, int>>::parse(from) : std::optional<std::pair<int, int>>(std::in_place);
+        auto pairTo = SVGPropertyTraits<std::pair<int, int>>::parse(to);
+        if (!pairFrom || !pairTo)
+            return false;
 
-        m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
-        m_animatedPropertyAnimator1->m_function.m_to = pairTo.first;
+        m_animatedPropertyAnimator1->m_function.m_from = pairFrom->first;
+        m_animatedPropertyAnimator1->m_function.m_to = pairTo->first;
 
-        m_animatedPropertyAnimator2->m_function.m_from = pairFrom.second;
-        m_animatedPropertyAnimator2->m_function.m_to = pairTo.second;
+        m_animatedPropertyAnimator2->m_function.m_from = pairFrom->second;
+        m_animatedPropertyAnimator2->m_function.m_to = pairTo->second;
         return true;
     }
 
-    bool setFromAndByValues(SVGElement& targetElement, const String& from, const String& by) final
+    bool setFromAndByValues(SVGElement&, const String& from, const String& by) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, from);
-        auto pairBy = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, by);
+        auto pairFrom = !from.isEmpty() ? SVGPropertyTraits<std::pair<int, int>>::parse(from) : std::optional<std::pair<int, int>>(std::in_place);
+        auto pairBy = SVGPropertyTraits<std::pair<int, int>>::parse(by);
+        if (!pairFrom || !pairBy)
+            return false;
 
-        m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
-        m_animatedPropertyAnimator1->m_function.m_to = pairFrom.first + pairBy.first;
+        m_animatedPropertyAnimator1->m_function.m_from = pairFrom->first;
+        m_animatedPropertyAnimator1->m_function.m_to = pairFrom->first + pairBy->first;
 
-        m_animatedPropertyAnimator2->m_function.m_from = pairFrom.second;
-        m_animatedPropertyAnimator2->m_function.m_to = pairFrom.second + pairBy.second;
+        m_animatedPropertyAnimator2->m_function.m_from = pairFrom->second;
+        m_animatedPropertyAnimator2->m_function.m_to = pairFrom->second + pairBy->second;
         return true;
     }
 
-    bool setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) final
+    bool setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) final
     {
-        auto pairToAtEndOfDuration = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, toAtEndOfDuration);
-        m_animatedPropertyAnimator1->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.first;
-        m_animatedPropertyAnimator2->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.second;
+        auto pair = SVGPropertyTraits<std::pair<int, int>>::parse(toAtEndOfDuration);
+        if (!pair)
+            return false;
+        m_animatedPropertyAnimator1->m_function.m_toAtEndOfDuration = pair->first;
+        m_animatedPropertyAnimator2->m_function.m_toAtEndOfDuration = pair->second;
         return true;
     }
 };
@@ -183,37 +191,44 @@ public:
 private:
     SVGAnimatorType animatorType() const final { return SVGAnimatorType::NumberPair; }
 
-    bool setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
+    bool setFromAndToValues(SVGElement&, const String& from, const String& to) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, from);
-        auto pairTo = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, to);
-        
-        m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
-        m_animatedPropertyAnimator1->m_function.m_to = pairTo.first;
-        
-        m_animatedPropertyAnimator2->m_function.m_from = pairFrom.second;
-        m_animatedPropertyAnimator2->m_function.m_to = pairTo.second;
+        // In to-animation mode 'from' is empty; the start value is resolved at runtime.
+        auto pairFrom = !from.isEmpty() ? SVGPropertyTraits<std::pair<float, float>>::parse(from) : std::optional<std::pair<float, float>>(std::in_place);
+        auto pairTo = SVGPropertyTraits<std::pair<float, float>>::parse(to);
+        if (!pairFrom || !pairTo)
+            return false;
+
+        m_animatedPropertyAnimator1->m_function.m_from = pairFrom->first;
+        m_animatedPropertyAnimator1->m_function.m_to = pairTo->first;
+
+        m_animatedPropertyAnimator2->m_function.m_from = pairFrom->second;
+        m_animatedPropertyAnimator2->m_function.m_to = pairTo->second;
         return true;
     }
 
-    bool setFromAndByValues(SVGElement& targetElement, const String& from, const String& by) final
+    bool setFromAndByValues(SVGElement&, const String& from, const String& by) final
     {
-        auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, from);
-        auto pairBy = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, by);
-        
-        m_animatedPropertyAnimator1->m_function.m_from = pairFrom.first;
-        m_animatedPropertyAnimator1->m_function.m_to = pairFrom.first + pairBy.first;
-        
-        m_animatedPropertyAnimator2->m_function.m_from = pairFrom.second;
-        m_animatedPropertyAnimator2->m_function.m_to = pairFrom.second + pairBy.second;
+        auto pairFrom = !from.isEmpty() ? SVGPropertyTraits<std::pair<float, float>>::parse(from) : std::optional<std::pair<float, float>>(std::in_place);
+        auto pairBy = SVGPropertyTraits<std::pair<float, float>>::parse(by);
+        if (!pairFrom || !pairBy)
+            return false;
+
+        m_animatedPropertyAnimator1->m_function.m_from = pairFrom->first;
+        m_animatedPropertyAnimator1->m_function.m_to = pairFrom->first + pairBy->first;
+
+        m_animatedPropertyAnimator2->m_function.m_from = pairFrom->second;
+        m_animatedPropertyAnimator2->m_function.m_to = pairFrom->second + pairBy->second;
         return true;
     }
 
-    bool setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) final
+    bool setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) final
     {
-        auto pairToAtEndOfDuration = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, toAtEndOfDuration);
-        m_animatedPropertyAnimator1->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.first;
-        m_animatedPropertyAnimator2->m_function.m_toAtEndOfDuration = pairToAtEndOfDuration.second;
+        auto pair = SVGPropertyTraits<std::pair<float, float>>::parse(toAtEndOfDuration);
+        if (!pair)
+            return false;
+        m_animatedPropertyAnimator1->m_function.m_toAtEndOfDuration = pair->first;
+        m_animatedPropertyAnimator2->m_function.m_toAtEndOfDuration = pair->second;
         return true;
     }
 };

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h
@@ -213,16 +213,24 @@ public:
     using Base = SVGAnimationAdditiveValueFunction<float>;
     using Base::Base;
 
-    bool setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) override
+    bool setFromAndToValues(SVGElement&, const String& from, const String& to) override
     {
-        m_from = SVGPropertyTraits<float>::fromString(targetElement, from);
-        m_to = SVGPropertyTraits<float>::fromString(targetElement, to);
+        // In to-animation mode 'from' is empty; the start value is resolved at runtime.
+        auto fromNumber = !from.isEmpty() ? SVGPropertyTraits<float>::parse(from) : std::optional<float>(0);
+        auto toNumber = SVGPropertyTraits<float>::parse(to);
+        if (!fromNumber || !toNumber)
+            return false;
+        m_from = *fromNumber;
+        m_to = *toNumber;
         return true;
     }
 
-    bool setToAtEndOfDurationValue(SVGElement& targetElement, const String& toAtEndOfDuration) override
+    bool setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
-        m_toAtEndOfDuration = SVGPropertyTraits<float>::fromString(targetElement, toAtEndOfDuration);
+        auto toAtEndOfDurationNumber = SVGPropertyTraits<float>::parse(toAtEndOfDuration);
+        if (!toAtEndOfDurationNumber)
+            return false;
+        m_toAtEndOfDuration = *toAtEndOfDurationNumber;
         return true;
     }
 
@@ -251,14 +259,23 @@ public:
 
     bool setFromAndToValues(SVGElement&, const String& from, const String& to) override
     {
-        m_from = SVGPathByteStream(from);
-        m_to = SVGPathByteStream(to);
+        // An empty string is a legal (empty) path, so it is accepted; only a malformed
+        // path yields std::nullopt and rejects the animation.
+        auto fromStream = SVGPathByteStream::create(from);
+        auto toStream = SVGPathByteStream::create(to);
+        if (!fromStream || !toStream)
+            return false;
+        m_from = WTF::move(*fromStream);
+        m_to = WTF::move(*toStream);
         return true;
     }
 
     bool setToAtEndOfDurationValue(SVGElement&, const String& toAtEndOfDuration) override
     {
-        m_toAtEndOfDuration = SVGPathByteStream(toAtEndOfDuration);
+        auto toAtEndOfDurationStream = SVGPathByteStream::create(toAtEndOfDuration);
+        if (!toAtEndOfDurationStream)
+            return false;
+        m_toAtEndOfDuration = WTF::move(*toAtEndOfDurationStream);
         return true;
     }
 

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.h
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.h
@@ -76,12 +76,15 @@ struct SVGPropertyTraits<std::pair<int, int>> {
     static std::pair<int, int> initialValue() { return { }; }
     static std::pair<int, int> fromString(SVGElement&, const String& string)
     {
+        return parse(string).value_or(initialValue());
+    }
+    static std::optional<std::pair<int, int>> parse(const String& string)
+    {
         auto result = parseNumberOptionalNumber(string);
         if (!result)
-            return { };
+            return std::nullopt;
         return std::make_pair(static_cast<int>(std::round(result->first)), static_cast<int>(std::round(result->second)));
     }
-    static std::optional<std::pair<int, int>> parse(const QualifiedName&, const String&) { ASSERT_NOT_REACHED(); return initialValue(); }
     static String toString(std::pair<int, int>) { ASSERT_NOT_REACHED(); return emptyString(); }
 };
 
@@ -92,9 +95,13 @@ struct SVGPropertyTraits<float> {
     {
         return parseNumber(string).value_or(0);
     }
-    static std::optional<float> parse(const QualifiedName&, const String& string)
+    static std::optional<float> parse(const String& string)
     {
         return parseNumber(string);
+    }
+    static std::optional<float> parse(const QualifiedName&, const String& string)
+    {
+        return parse(string);
     }
     static String toString(float type) { return String::number(type); }
 };
@@ -104,9 +111,12 @@ struct SVGPropertyTraits<std::pair<float, float>> {
     static std::pair<float, float> initialValue() { return { }; }
     static std::pair<float, float> fromString(SVGElement&, const String& string)
     {
-        return valueOrDefault(parseNumberOptionalNumber(string));
+        return parse(string).value_or(initialValue());
     }
-    static std::optional<std::pair<float, float>> parse(const QualifiedName&, const String&) { ASSERT_NOT_REACHED(); return initialValue(); }
+    static std::optional<std::pair<float, float>> parse(const String& string)
+    {
+        return parseNumberOptionalNumber(string);
+    }
     static String toString(std::pair<float, float>) { ASSERT_NOT_REACHED(); return emptyString(); }
 };
 


### PR DESCRIPTION
#### 17c96be1faad0998f6b6acac840ad7f39637d9f1
<pre>
SVG SMIL number, integer-optional-integer, number-optional-number and path animations should not apply when from/to/by values fail to parse
<a href="https://bugs.webkit.org/show_bug.cgi?id=318066">https://bugs.webkit.org/show_bug.cgi?id=318066</a>

Reviewed by Said Abou-Hallawa.

Per the SMIL Animation specification [1]:

    &quot;If any values (i.e., the argument-values for from, to, by or
    values attributes) are not legal, the animation will have no
    effect.&quot;

The bool-returning plumbing through SVGAnimationFunction,
SVGAttributeAnimator and the animator wrappers, which lets a parse
failure propagate up to SVGAnimationElement::m_animationValid and drop
the animation, landed in 315549@main (bug 311817), and rejection of
invalid scalar color/length values followed for SVGAnimateElementBase::
setFromAndToValues(). The remaining scalar animators still coerced an
invalid value to zero (or an empty path) and animated to it, instead of
leaving the underlying value untouched.

This propagates parse validity for the rest of the scalar value
functions, routing the parsing through the property traits and a new
SVGPathByteStream factory so the fallible parse lives in one place:

  - SVGPropertyTraits&lt;float&gt;, SVGPropertyTraits&lt;std::pair&lt;int, int&gt;&gt; and
    SVGPropertyTraits&lt;std::pair&lt;float, float&gt;&gt; gain a parse() overload
    that returns std::nullopt on failure; fromString() is now a thin
    wrapper over parse(). SVGAnimationNumberFunction,
    SVGAnimatedIntegerPairAnimator and SVGAnimatedNumberPairAnimator call
    parse() and reject a &apos;from&apos;/&apos;to&apos;/&apos;by&apos;/toAtEndOfDuration that fails.
  - SVGPathByteStream::create() builds a byte stream and returns
    std::nullopt for a malformed path; SVGAnimationPathSegListFunction
    uses it and rejects a malformed &apos;from&apos;/&apos;to&apos;/toAtEndOfDuration.

An empty string is not handled inside parse()/create(): it is a legal
value in some contexts but not others, so each caller decides. An empty
&apos;from&apos; is accepted for to-animation mode (the start value is resolved at
runtime); a number/integer &apos;to&apos; or &apos;by&apos; must parse, so an empty value is
rejected there because &quot;&quot; is not a legal number. An empty path, by
contrast, is a legal (empty) path, so buildSVGPathByteStreamFromString()
accepting it is correct and the path animator does not reject it; empty
&apos;d&apos; animation behaviour is tracked separately by the tentative
animate-path-*-empty-* tests.

[1] <a href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#AnimFuncValues">https://www.w3.org/TR/2001/REC-smil-animation-20010904/#AnimFuncValues</a>

* Source/WebCore/svg/SVGPathByteStream.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.h:
* Source/WebCore/svg/properties/SVGPropertyTraits.h:
(WebCore::SVGPropertyTraits&lt;float&gt;::parse):

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-1-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-1-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-1-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-1-expected.txt: Ditto

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-animation-invalid-value-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumberoptionalnumber-animation-invalid-value-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgintegeroptionalinteger-animation-invalid-value-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgpath-animation-invalid-value-2-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-to-animation-valid-value-1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/svgnumber-to-animation-valid-value-1-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/316468@main">https://commits.webkit.org/316468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3396e5503baa0718fe47bc51e862dee6d2dbc984

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129885 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05fb2988-018c-4660-b040-b3f2b9433396) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134042 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a81a7d7-4caa-4be6-8064-90895423ccaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114529 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1da6519c-ea14-4707-b668-6df1c5f10c92) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36094 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30386 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184315 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36997 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142809 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142690 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38548 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46597 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111324 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37740 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118348 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45114 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9027 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44514 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->