### PR TITLE
Fix typo in RenderFlexibleBox::performFlexLayout(): last-line item count read from first line

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Flexbox Reference: last baseline of a multi-line flex container comes from its last line</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792@gmail.com">
+<style>
+body { margin: 0; }
+.outer {
+    display: flex;
+    align-items: last baseline;
+    font: 16px/30px monospace;
+}
+.flex {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+}
+.flex > div {
+    width: 45px;
+    height: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if "Ref" shares a baseline with "C" (the bottom row), not "B".</p>
+<div class="outer">
+    <div class="flex">
+        <div>A</div>
+        <div>B</div>
+        <div>C</div>
+    </div>
+    <div>Ref</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Flexbox Reference: last baseline of a multi-line flex container comes from its last line</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792@gmail.com">
+<style>
+body { margin: 0; }
+.outer {
+    display: flex;
+    align-items: last baseline;
+    font: 16px/30px monospace;
+}
+.flex {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+}
+.flex > div {
+    width: 45px;
+    height: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if "Ref" shares a baseline with "C" (the bottom row), not "B".</p>
+<div class="outer">
+    <div class="flex">
+        <div>A</div>
+        <div>B</div>
+        <div>C</div>
+    </div>
+    <div>Ref</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Flexbox: last baseline of a multi-line flex container comes from its last line</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmad.saleem792@gmail.com">
+<link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-baselines">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#baseline-values">
+<link rel="match" href="multiline-last-baseline-item-count-ref.html">
+<meta name="assert" content="When the first and last lines of a wrapping flex container have a different number of items, the container's last baseline is taken from an item on the last line, even if an earlier line has a baseline-aligned item.">
+<style>
+body { margin: 0; }
+.outer {
+    display: flex;
+    align-items: last baseline;
+    font: 16px/30px monospace;
+}
+.flex {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100px;
+}
+.flex > div {
+    width: 45px;
+    height: 30px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if "Ref" shares a baseline with "C" (the bottom row), not "B".</p>
+<div class="outer">
+    <div class="flex">
+        <div>A</div>
+        <div style="align-self: baseline">B</div>
+        <div>C</div>
+    </div>
+    <div>Ref</div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1642,7 +1642,7 @@ void RenderFlexibleBox::performFlexLayout(RelayoutChildren relayoutChildren)
     if (!lineStates.isEmpty()) {
         auto isWrapReverse = this->isWrapReverse();
         auto firstLineItemsCountInOriginalOrder = lineStates.first().flexLayoutItems.size();
-        auto lastLineItemsCountInOriginalOrder = lineStates.first().flexLayoutItems.size();
+        auto lastLineItemsCountInOriginalOrder = lineStates.last().flexLayoutItems.size();
 
         m_numberOfFlexItemsOnFirstLine = !isWrapReverse ? firstLineItemsCountInOriginalOrder : lastLineItemsCountInOriginalOrder;
         m_numberOfFlexItemsOnLastLine = !isWrapReverse ? lastLineItemsCountInOriginalOrder : firstLineItemsCountInOriginalOrder;


### PR DESCRIPTION
#### bcc89c676083459b13d02ccefc82a665613ae626
<pre>
Fix typo in RenderFlexibleBox::performFlexLayout(): last-line item count read from first line
<a href="https://bugs.webkit.org/show_bug.cgi?id=318069">https://bugs.webkit.org/show_bug.cgi?id=318069</a>
<a href="https://rdar.apple.com/180869111">rdar://180869111</a>

Reviewed by Alan Baradlay.

lastLineItemsCountInOriginalOrder was initialized from lineStates.first()
instead of lineStates.last() — a copy/paste typo from the line above. This
patch fixes it.

When the first and last lines of a wrapping flex container have a different
number of items, the count used to locate the container&apos;s last baseline was
wrong, so the baseline was taken from a baseline-aligned item on the first
line instead of an item on the last line. Added a reftest covering this case
(first line: two items, last line: one item); it failed before this change
and matches Chrome and Firefox now.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::performFlexLayout):
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/multiline-last-baseline-item-count.html: Added.

Canonical link: <a href="https://commits.webkit.org/316027@main">https://commits.webkit.org/316027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d12ae5aeb7055505af49d134cddb00e220e6c613

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128448 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94b95311-e6d8-40d1-adbb-f983a1c1eb88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133157 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29e0caac-41a5-49e1-9619-a155009f43e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113654 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22742a9f-b04c-49f2-b229-d387ae75ed6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33309 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28793 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145441 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182696 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141617 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38101 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45005 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109678 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36700 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116894 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43516 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8087 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42920 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43051 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->