### PR TITLE
colorWithTargetLuminance() passes std::clamp() arguments in the wrong order

### DIFF
--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -201,7 +201,7 @@ static Color colorWithTargetLuminance(Color color, float targetLuminance)
 
     const auto [x, y, z, alpha] = color.toColorTypeLossy<XYZA<float, WhitePoint::D65>>().resolved();
 
-    targetLuminance = std::clamp(0.f, targetLuminance, 1.f);
+    targetLuminance = std::clamp(targetLuminance, 0.f, 1.f);
     if (y > 0.0f) {
         const auto scale = targetLuminance / y;
         return Color(XYZA<float, WhitePoint::D65> { x * scale, targetLuminance, z * scale, alpha });


### PR DESCRIPTION
#### 41dcbb4310386635ed1cac662e25346e1f0a0e8e
<pre>
colorWithTargetLuminance() passes std::clamp() arguments in the wrong order
<a href="https://bugs.webkit.org/show_bug.cgi?id=318071">https://bugs.webkit.org/show_bug.cgi?id=318071</a>
<a href="https://rdar.apple.com/180869510">rdar://180869510</a>

Reviewed by Lily Spiniolas.

colorWithTargetLuminance() called std::clamp(0.f, targetLuminance, 1.f),
which clamps the constant 0 into the range [targetLuminance, 1] rather
than clamping targetLuminance into [0, 1]. For a targetLuminance greater
than 1 this violates std::clamp()&apos;s lo &lt;= hi precondition (undefined
behavior) and yields an out-of-range luminance; the only saving grace is
that the sole caller currently passes a fixed 0.5, masking the bug.

Pass the arguments in the correct order so targetLuminance is clamped to
the valid [0, 1] range.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::colorWithTargetLuminance):

Canonical link: <a href="https://commits.webkit.org/316021@main">https://commits.webkit.org/316021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fbb639078f1e65932c946a497112d95c62fd2f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128384 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/264b9833-3176-4e70-9937-7c3d908145db) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133097 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93892 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49ffe042-9987-47ea-a96b-92ce6e262117) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113594 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51423ccc-d4dc-4b54-a5fb-1f193cd8b895) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34920 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33249 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28729 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182632 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141557 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44252 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38098 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44941 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109573 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36641 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116830 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43451 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8026 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42856 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43097 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42987 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->