### PR TITLE
Marked-text highlight pseudo-element fill color is taken from the stroke color

### DIFF
--- a/LayoutTests/fast/css/highlight-pseudo-fill-applies-color-filter-expected.html
+++ b/LayoutTests/fast/css/highlight-pseudo-fill-applies-color-filter-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    p { font: 60px/1.2 monospace; }
+    ::highlight(test) { color: aqua; }
+</style>
+</head>
+<body>
+    <p id="target">PASS</p>
+    <script>
+        var range = new Range();
+        range.selectNodeContents(document.getElementById("target"));
+        CSS.highlights.set("test", new Highlight(range));
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/css/highlight-pseudo-fill-applies-color-filter.html
+++ b/LayoutTests/fast/css/highlight-pseudo-fill-applies-color-filter.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ColorFilterEnabled=true ] -->
+<html>
+<head>
+<style>
+    p { font: 60px/1.2 monospace; }
+    ::highlight(test) { color: red; }
+</style>
+</head>
+<body>
+    <p id="target" style="-apple-color-filter: invert(1)">PASS</p>
+    <script>
+        var range = new Range();
+        range.selectNodeContents(document.getElementById("target"));
+        CSS.highlights.set("test", new Highlight(range));
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Reference: highlight text fill color uses 'color', not 'stroke-color'</title>
+<link rel="stylesheet" href="support/highlights.css">
+<script src="support/selections.js"></script>
+<style>
+    main {
+        font-size: 4em;
+    }
+    main::highlight(example) {
+        color: green;
+    }
+</style>
+<p>Test passes if the word below is green.
+<main class="highlight_reftest" id="target">PASS</main>
+<script>
+    CSS.highlights.set("example", new Highlight(createRangeForTextOnly(target, 0, 4)));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Reference: highlight text fill color uses 'color', not 'stroke-color'</title>
+<link rel="stylesheet" href="support/highlights.css">
+<script src="support/selections.js"></script>
+<style>
+    main {
+        font-size: 4em;
+    }
+    main::highlight(example) {
+        color: green;
+    }
+</style>
+<p>Test passes if the word below is green.
+<main class="highlight_reftest" id="target">PASS</main>
+<script>
+    CSS.highlights.set("example", new Highlight(createRangeForTextOnly(target, 0, 4)));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Pseudo-Elements Test: highlight text fill color uses 'color', not 'stroke-color'</title>
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#highlight-styling">
+<link rel="help" href="https://drafts.fxtf.org/fill-stroke-3/#fill-stroke-paint">
+<link rel="match" href="highlight-fill-color-ignores-stroke-color-ref.html">
+<meta name="assert" content="The text (fill) of a custom highlight is painted using its 'color'. With 'stroke-width: 0' no stroke is painted, so a differing 'stroke-color' must not affect the fill color of the highlighted text.">
+<link rel="stylesheet" href="support/highlights.css">
+<script src="support/selections.js"></script>
+<style>
+    main {
+        font-size: 4em;
+    }
+    main::highlight(example) {
+        color: green;
+        stroke-color: red;
+        stroke-width: 0;
+    }
+</style>
+<p>Test passes if the word below is green.
+<main class="highlight_reftest" id="target">PASS</main>
+<script>
+    CSS.highlights.set("example", new Highlight(createRangeForTextOnly(target, 0, 4)));
+</script>

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -42,7 +42,7 @@ static void computeStyleForPseudoElementStyle(StyledMarkedText::Style& style, co
         return;
 
     style.backgroundColor = pseudoElementStyle->visitedDependentBackgroundColorApplyingColorFilter(paintInfo.paintBehavior);
-    style.textStyles.fillColor = pseudoElementStyle->usedStrokeColor();
+    style.textStyles.fillColor = pseudoElementStyle->visitedDependentTextFillColorApplyingColorFilter(paintInfo.paintBehavior);
     style.textStyles.strokeColor = pseudoElementStyle->usedStrokeColor();
     style.textStyles.hasExplicitlySetFillColor = pseudoElementStyle->hasExplicitlySetColor();
 


### PR DESCRIPTION
#### 27e25ad59abe1829ded805a3b3fc8aac5447077d
<pre>
Marked-text highlight pseudo-element fill color is taken from the stroke color
<a href="https://bugs.webkit.org/show_bug.cgi?id=318073">https://bugs.webkit.org/show_bug.cgi?id=318073</a>
<a href="https://rdar.apple.com/180871490">rdar://180871490</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

computeStyleForPseudoElementStyle() set the text fill color from
usedStrokeColor() — a copy/paste from the strokeColor line below it. As a
result, marked text styled via a highlight pseudo-element (::highlight(),
::target-text, ::spelling-error, ::grammar-error) rendered its glyph fill
using the stroke color rather than the text/fill color, and ignored any
applied color filter.

Set fillColor from visitedDependentTextFillColorApplyingColorFilter(),
matching how the fill color is resolved in TextPaintStyle.cpp.

Tests: fast/css/highlight-pseudo-fill-applies-color-filter.html
       imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-ref.html
       imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color.html

* LayoutTests/fast/css/highlight-pseudo-fill-applies-color-filter-expected.html: Added.
* LayoutTests/fast/css/highlight-pseudo-fill-applies-color-filter.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/highlight-fill-color-ignores-stroke-color.html: Added.
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::computeStyleForPseudoElementStyle):

Canonical link: <a href="https://commits.webkit.org/316156@main">https://commits.webkit.org/316156@main</a>
</pre>
