### PR TITLE
[YARR] Use m_latin1Table in Char16 case & interpreter

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -548,6 +548,9 @@ public:
         if (characterClass->m_table && ch < CharacterClass::tableSize)
             return static_cast<bool>(characterClass->m_table[ch]);
 
+        if (characterClass->m_latin1Table && isLatin1(ch))
+            return static_cast<bool>(characterClass->m_latin1Table->data[ch]);
+
         const size_t thresholdForBinarySearch = 6;
 
         if (!isLatin1(ch)) {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1140,16 +1140,28 @@ class YarrGenerator final : public YarrJITInfo {
             return;
         }
 
-        if (m_charSize == CharSize::Char8 && charClass->m_latin1Table) {
-            const auto* table = m_boyerMooreData->addLatin1Table(*charClass->m_latin1Table);
-            if (matchTargets.hasFailedTarget()) {
+        if (charClass->m_latin1Table) {
+            bool pureLatin1 = charClass->m_matches32.isEmpty() && charClass->m_ranges32.isEmpty();
+            if (m_charSize == CharSize::Char8 || pureLatin1) {
+                const auto* table = m_boyerMooreData->addLatin1Table(*charClass->m_latin1Table);
+                bool needsHighGuard = m_charSize != CharSize::Char8;
+                if (matchTargets.hasFailedTarget()) {
+                    if (needsHighGuard)
+                        matchTargets.appendFailed(m_jit.branch32(MacroAssembler::AboveOrEqual, character, MacroAssembler::TrustedImm32(0x100)));
+                    MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(table));
+                    matchTargets.appendFailed(m_jit.branchTest8(MacroAssembler::Zero, tableEntry));
+                    return;
+                }
+
+                MacroAssembler::Jump isHigh;
+                if (needsHighGuard)
+                    isHigh = m_jit.branch32(MacroAssembler::AboveOrEqual, character, MacroAssembler::TrustedImm32(0x100));
                 MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(table));
-                matchTargets.appendFailed(m_jit.branchTest8(MacroAssembler::Zero, tableEntry));
+                matchTargets.appendSucceeded(m_jit.branchTest8(MacroAssembler::NonZero, tableEntry));
+                if (isHigh.isSet())
+                    isHigh.link(&m_jit);
                 return;
             }
-            MacroAssembler::ExtendedAddress tableEntry(character, reinterpret_cast<intptr_t>(table));
-            matchTargets.appendSucceeded(m_jit.branchTest8(MacroAssembler::NonZero, tableEntry));
-            return;
         }
 
         Vector<char32_t, 32> unifiedMatches;


### PR DESCRIPTION
#### c1d34821e09a47b5e22e73e20ed5fed4b749e30e
<pre>
[YARR] Use m_latin1Table in Char16 case &amp; interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=318079">https://bugs.webkit.org/show_bug.cgi?id=318079</a>
<a href="https://rdar.apple.com/180873581">rdar://180873581</a>

Reviewed by Yijia Huang.

If CharacterClass holds m_latin1Table and no m_matches32 / m_ranges32 exist,
This is latin1 only CharacterClass. So we can use this table even in Char16
case with 0x100 guard. We also add the code using this table in
interpreter too.

* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::testCharacterClass):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/316105@main">https://commits.webkit.org/316105@main</a>
</pre>
