### PR TITLE
[Text Extraction] Make it possible for clients to target elements using stale node UIDs

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2904,7 +2904,13 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
     if ((action == Action::SelectText || action == Action::HighlightText) && interaction.scrollToVisible)
         description.append(makeString(appendedReplaceTextDescription ? " and"_s : ","_s, " scrolling the targeted range into view"_s));
 
-    return { description.toString(), WTF::move(stringsToValidate) };
+    bool didFindTargetNode = true;
+    if (interaction.nodeIdentifier) {
+        RefPtr node = Node::fromIdentifier(*interaction.nodeIdentifier);
+        didFindTargetNode = node && node->isConnected();
+    }
+
+    return { description.toString(), WTF::move(stringsToValidate), didFindTargetNode };
 }
 
 RefPtr<Element> elementForExtractedText(const LocalFrame& frame, ExtractedText&& extractedText)

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -77,6 +77,7 @@ struct ExtractedText {
 struct InteractionDescription {
     String description;
     Vector<String> stringsToValidate;
+    bool didFindTargetNode { true };
 };
 
 enum class EventListenerCategory : uint8_t {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2832,6 +2832,7 @@ header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::InteractionDescription {
     String description;
     Vector<String> stringsToValidate;
+    bool didFindTargetNode;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4169,6 +4169,11 @@ struct WKWebViewData {
 
 #pragma mark -
 
+@interface WKWebView (WKTextExtractionInternal)
+- (void)_performInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame actionType:(_WKTextExtractionAction)actionType nodeIdentifier:(const String&)nodeIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler;
+- (void)_describeInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame nodeIdentifier:(const String&)nodeIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void (^)(NSString *, NSError *))completionHandler;
+@end
+
 @implementation WKWebView (WKPrivate)
 
 #pragma mark - macOS WKPrivate
@@ -7470,7 +7475,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
     }];
 }
 
-- (Expected<std::pair<RefPtr<WebKit::WebFrameProxy>, WebCore::TextExtraction::Interaction>, RetainPtr<NSString>>)_convertToWebCoreInteraction:(_WKTextExtractionInteraction *)wkInteraction
+- (Expected<std::pair<RefPtr<WebKit::WebFrameProxy>, WebCore::TextExtraction::Interaction>, RetainPtr<NSString>>)_convertToWebCoreInteraction:(_WKTextExtractionInteraction *)wkInteraction nodeIdentifier:(const String&)nodeIdentifierString
 {
     std::optional<WebCore::FrameIdentifier> frameIdentifier;
     WebCore::TextExtraction::Interaction interaction;
@@ -7498,7 +7503,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         }
     }();
 
-    if (auto identifiers = WebKit::parseExtractedNodeInfo(String { wkInteraction.nodeIdentifier })) {
+    if (auto identifiers = WebKit::parseExtractedNodeInfo(nodeIdentifierString)) {
         interaction.nodeIdentifier = { WTF::move(identifiers->nodeIdentifier) };
         frameIdentifier = WTF::move(identifiers->frameIdentifier);
     }
@@ -7570,7 +7575,8 @@ static NSString *nameForAction(_WKTextExtractionAction action)
     if (!protect(page->preferences())->textExtractionEnabled())
         return completionHandler(adoptNS([[_WKTextExtractionInteractionResult alloc] initWithErrorDescription:@"Text extraction is unavailable" summary:nil interactedElementBounds:CGRectNull]).get());
 
-    auto conversionResult = [self _convertToWebCoreInteraction:wkInteraction];
+    auto nodeIdentifierString = String { wkInteraction.nodeIdentifier };
+    auto conversionResult = [self _convertToWebCoreInteraction:wkInteraction nodeIdentifier:nodeIdentifierString];
     if (!conversionResult) {
         RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> Interaction conversion failed", [self class], self);
         return completionHandler(adoptNS([[_WKTextExtractionInteractionResult alloc] initWithErrorDescription:conversionResult.error().get() summary:nil interactedElementBounds:CGRectNull]).get());
@@ -7600,22 +7606,60 @@ static NSString *nameForAction(_WKTextExtractionAction action)
     }
 #endif // PLATFORM(MAC)
 
-    UniqueRef assertionScope = _page->createTextExtractionAssertionScope();
+    [self _performInteraction:WTF::move(interaction) inFrame:targetFrame actionType:actionType nodeIdentifier:nodeIdentifierString staleNodeNote:emptyString() shouldResolveStaleNodeIdentifier:YES completionHandler:completionHandler];
+#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+}
+
+- (void)_performInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame actionType:(_WKTextExtractionAction)actionType nodeIdentifier:(const String&)attemptedIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler
+{
+#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+    RefPtr page = _page;
+    if (!page || !targetFrame)
+        return completionHandler(adoptNS([[_WKTextExtractionInteractionResult alloc] initWithErrorDescription:@"Web view is invalid" summary:nil interactedElementBounds:CGRectNull]));
+
+    UniqueRef assertionScope = page->createTextExtractionAssertionScope();
+    auto interactionForRetry = interaction;
     targetFrame->handleTextExtractionInteraction(WTF::move(interaction), [
         weakSelf = WeakObjCPtr<WKWebView>(self),
         weakPage = WeakPtr { *page },
         assertionScope = WTF::move(assertionScope),
         actionType,
+        attemptedIdentifier,
+        staleNodeNote,
+        shouldResolveStaleNodeIdentifier,
+        interaction = WTF::move(interactionForRetry),
         completionHandler = makeBlockPtr(WTF::move(completionHandler))
     ](bool success, String&& description, WebCore::FloatRect interactedElementBounds) mutable {
+        RetainPtr strongSelf = weakSelf.get();
+        RefPtr strongPage = weakPage.get();
+
+        if (!success && shouldResolveStaleNodeIdentifier && strongSelf && strongPage && !attemptedIdentifier.isEmpty()) {
+            auto resolved = strongPage->textExtractionCache().resolve(attemptedIdentifier);
+            if (resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Remapped) {
+                RELEASE_LOG(TextExtraction, "<%@: %p> Interaction failed; re-resolved stale node %" PUBLIC_LOG_STRING " to %" PUBLIC_LOG_STRING " and retrying", [strongSelf class], strongSelf.get(), attemptedIdentifier.utf8().data(), resolved.identifier.utf8().data());
+                auto note = makeString("Note: the targeted node (uid="_s, attemptedIdentifier, ") was stale from an earlier page state and was automatically re-resolved to the current matching element."_s);
+                RefPtr<WebKit::WebFrameProxy> retryFrame;
+                if (auto identifiers = WebKit::parseExtractedNodeInfo(resolved.identifier)) {
+                    interaction.nodeIdentifier = { WTF::move(identifiers->nodeIdentifier) };
+                    retryFrame = WebKit::WebFrameProxy::webFrame(WTF::move(identifiers->frameIdentifier));
+                }
+                if (!retryFrame)
+                    retryFrame = strongPage->mainFrame();
+                [strongSelf _performInteraction:WTF::move(interaction) inFrame:WTF::move(retryFrame) actionType:actionType nodeIdentifier:resolved.identifier staleNodeNote:note shouldResolveStaleNodeIdentifier:NO completionHandler:completionHandler.get()];
+                return;
+            }
+            if (resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Stale || resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Ambiguous)
+                description = makeString(description, " The page changed since this uid was last observed; re-extract the page and retry with a current uid."_s);
+        }
+
         RetainPtr<NSString> errorDescription;
         RetainPtr<NSString> summary;
-        if (success)
+        if (success) {
             summary = description.createNSString();
-        else
+            if (!staleNodeNote.isEmpty())
+                summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeNote.createNSString().get()]);
+        } else
             errorDescription = description.createNSString();
-
-        RetainPtr strongSelf = weakSelf.get();
 
         CGRect bounds = CGRectNull;
         if (!interactedElementBounds.isEmpty()) {
@@ -7635,7 +7679,6 @@ static NSString *nameForAction(_WKTextExtractionAction action)
         else
             RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> %@ failed", [strongSelf class], strongSelf.get(), nameForAction(actionType));
 
-        RefPtr strongPage = weakPage.get();
         if (!strongPage)
             return completionHandler(result.get());
 
@@ -8088,7 +8131,8 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
     if (!protect(page->preferences())->textExtractionEnabled())
         return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]);
 
-    auto conversionResult = [self _convertToWebCoreInteraction:wkInteraction];
+    auto nodeIdentifierString = String { wkInteraction.nodeIdentifier };
+    auto conversionResult = [self _convertToWebCoreInteraction:wkInteraction nodeIdentifier:nodeIdentifierString];
     if (!conversionResult)
         return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSDebugDescriptionErrorKey: conversionResult.error().get() }]);
 
@@ -8101,10 +8145,51 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
         return completionHandler([NSString stringWithFormat:@"Select popup menu item labeled '%s'", interaction.text.utf8().data()], nil);
 #endif
 
-    targetFrame->describeTextExtractionInteraction(WTF::move(interaction), [weakSelf = WeakObjCPtr<WKWebView>(self), weakPage = WeakPtr { *page }, completionHandler = makeBlockPtr(WTF::move(completionHandler))](auto&& result) mutable {
-        auto [description, stringsToValidate] = WTF::move(result);
+    [self _describeInteraction:WTF::move(interaction) inFrame:targetFrame nodeIdentifier:nodeIdentifierString staleNodeNote:emptyString() shouldResolveStaleNodeIdentifier:YES completionHandler:completionHandler];
+#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+}
+
+- (void)_describeInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame nodeIdentifier:(const String&)attemptedIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void (^)(NSString *, NSError *))completionHandler
+{
+#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+    RefPtr page = _page;
+    if (!page || !targetFrame)
+        return completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]);
+
+    auto interactionForRetry = interaction;
+    targetFrame->describeTextExtractionInteraction(WTF::move(interaction), [
+        weakSelf = WeakObjCPtr<WKWebView>(self),
+        weakPage = WeakPtr { *page },
+        attemptedIdentifier,
+        staleNodeNote,
+        shouldResolveStaleNodeIdentifier,
+        interaction = WTF::move(interactionForRetry),
+        completionHandler = makeBlockPtr(WTF::move(completionHandler))
+    ](auto&& result) mutable {
+        RetainPtr strongSelf = weakSelf.get();
+        RefPtr strongPage = weakPage.get();
+
+        if (!result.didFindTargetNode && shouldResolveStaleNodeIdentifier && strongSelf && strongPage && !attemptedIdentifier.isEmpty()) {
+            auto resolved = strongPage->textExtractionCache().resolve(attemptedIdentifier);
+            if (resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Remapped) {
+                RELEASE_LOG(TextExtraction, "<%@: %p> Describe target missing; re-resolved stale node %" PUBLIC_LOG_STRING " to %" PUBLIC_LOG_STRING " and retrying", [strongSelf class], strongSelf.get(), attemptedIdentifier.utf8().data(), resolved.identifier.utf8().data());
+                auto note = makeString("Note: the targeted node (uid="_s, attemptedIdentifier, ") was stale from an earlier page state and was automatically re-resolved to the current matching element."_s);
+                RefPtr<WebKit::WebFrameProxy> retryFrame;
+                if (auto identifiers = WebKit::parseExtractedNodeInfo(resolved.identifier)) {
+                    interaction.nodeIdentifier = { WTF::move(identifiers->nodeIdentifier) };
+                    retryFrame = WebKit::WebFrameProxy::webFrame(WTF::move(identifiers->frameIdentifier));
+                }
+                if (!retryFrame)
+                    retryFrame = strongPage->mainFrame();
+                [strongSelf _describeInteraction:WTF::move(interaction) inFrame:WTF::move(retryFrame) nodeIdentifier:resolved.identifier staleNodeNote:note shouldResolveStaleNodeIdentifier:NO completionHandler:completionHandler.get()];
+                return;
+            }
+        }
+
+        auto description = WTF::move(result.description);
+        auto stringsToValidate = WTF::move(result.stringsToValidate);
         auto valid = Box<bool>::create(true);
-        Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTF::move(completionHandler), description, valid] {
+        Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTF::move(completionHandler), description, valid, staleNodeNote] {
             if (!valid.get()) {
                 completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{
                     NSDebugDescriptionErrorKey: @"One or more strings failed validation."
@@ -8112,11 +8197,13 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
                 return;
             }
 
-            completionHandler(description.createNSString().get(), nil);
+            RetainPtr summary = description.createNSString();
+            if (!staleNodeNote.isEmpty())
+                summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeNote.createNSString().get()]);
+            completionHandler(summary, nil);
         });
 
-        RefPtr page = weakPage.get();
-        if (!page || !protect(page->preferences())->textExtractionFilterEnabled())
+        if (!strongPage || !protect(strongPage->preferences())->textExtractionFilterEnabled())
             return;
 
 #if ENABLE(TEXT_EXTRACTION_FILTER)

--- a/Source/WebKit/UIProcess/TextExtractionCache.cpp
+++ b/Source/WebKit/UIProcess/TextExtractionCache.cpp
@@ -27,6 +27,7 @@
 #include "TextExtractionCache.h"
 
 #include <optional>
+#include <wtf/HashSet.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
 
@@ -44,6 +45,9 @@ void TextExtractionCache::add(const String& url, Vector<TextExtractionLineConten
         if (auto nodeIdentifier = entry.lines[index].nodeIdentifier)
             entry.lineIndexForUID.add(WTF::move(*nodeIdentifier), index);
     }
+
+    if (entry.lineIndexForUID.isEmpty())
+        return;
 
     m_entries.append(WTF::move(entry));
     if (m_entries.size() > maxEntries)
@@ -87,58 +91,53 @@ auto TextExtractionCache::resolve(const String& identifier) const -> ResolvedNod
     if (m_entries[newestIndex].lineIndexForUID.contains(identifier))
         return { identifier, NodeResolution::Current };
 
-    std::optional<size_t> sourceEntryIndex;
-    unsigned sourceLineIndex = 0;
+    Vector<size_t, maxEntries> sourceEntryIndices;
     for (size_t index = 0; index < newestIndex; ++index) {
-        if (auto it = m_entries[index].lineIndexForUID.find(identifier); it != m_entries[index].lineIndexForUID.end()) {
-            sourceEntryIndex = index;
-            sourceLineIndex = it->value;
-        }
+        if (m_entries[index].lineIndexForUID.contains(identifier))
+            sourceEntryIndices.append(index);
     }
 
-    if (!sourceEntryIndex)
+    if (sourceEntryIndices.isEmpty())
         return { identifier, NodeResolution::Unknown };
 
     auto& newestURL = m_entries[newestIndex].url;
-    auto& source = m_entries[*sourceEntryIndex];
-    auto& sourceLineContent = source.lines[sourceLineIndex].contentWithoutIdentifier;
-    auto sourceContextBefore = contextWindowBefore(source.lines, sourceLineIndex);
-    auto sourceContextAfter = contextWindowAfter(source.lines, sourceLineIndex);
-
-    for (size_t entryIndex = newestIndex; entryIndex > *sourceEntryIndex; --entryIndex) {
-        auto& entry = m_entries[entryIndex];
-        if (entry.url != newestURL)
+    for (size_t targetIndex = newestIndex; targetIndex > sourceEntryIndices.first(); --targetIndex) {
+        auto& target = m_entries[targetIndex];
+        if (target.url != newestURL)
             continue;
 
-        std::optional<unsigned> uniqueTargetIndex;
-        unsigned matchCount = 0;
-        for (unsigned candidate = 0; candidate < entry.lines.size(); ++candidate) {
-            if (entry.lines[candidate].contentWithoutIdentifier != sourceLineContent)
-                continue;
-
-            bool contextBeforeMatches = contextWindowBefore(entry.lines, candidate) == sourceContextBefore;
-            bool contextAfterMatches = contextWindowAfter(entry.lines, candidate) == sourceContextAfter;
-            if (!contextBeforeMatches && !contextAfterMatches)
-                continue;
-
-            if (++matchCount > 1) {
-                uniqueTargetIndex = { };
+        HashSet<String> remappedIdentifiers;
+        for (auto sourceIndex : sourceEntryIndices) {
+            if (sourceIndex >= targetIndex)
                 break;
-            }
 
-            uniqueTargetIndex = candidate;
+            auto& source = m_entries[sourceIndex];
+            auto sourceLineIndex = source.lineIndexForUID.get(identifier);
+            auto sourceLineContent = source.lines[sourceLineIndex].contentWithoutIdentifier;
+            auto sourceContextBefore = contextWindowBefore(source.lines, sourceLineIndex);
+            auto sourceContextAfter = contextWindowAfter(source.lines, sourceLineIndex);
+
+            for (unsigned candidate = 0; candidate < target.lines.size(); ++candidate) {
+                if (target.lines[candidate].contentWithoutIdentifier != sourceLineContent)
+                    continue;
+
+                bool contextBeforeMatches = contextWindowBefore(target.lines, candidate) == sourceContextBefore;
+                bool contextAfterMatches = contextWindowAfter(target.lines, candidate) == sourceContextAfter;
+                if (!contextBeforeMatches && !contextAfterMatches)
+                    continue;
+
+                if (auto& remapped = target.lines[candidate].nodeIdentifier)
+                    remappedIdentifiers.add(*remapped);
+            }
         }
 
-        if (!matchCount)
+        if (remappedIdentifiers.isEmpty())
             continue;
 
-        if (matchCount > 1)
+        if (remappedIdentifiers.size() > 1)
             return { { }, NodeResolution::Ambiguous };
 
-        if (auto remapped = entry.lines[*uniqueTargetIndex].nodeIdentifier)
-            return { WTF::move(*remapped), NodeResolution::Remapped };
-
-        return { { }, NodeResolution::Stale };
+        return { *remappedIdentifiers.begin(), NodeResolution::Remapped };
     }
 
     return { { }, NodeResolution::Stale };

--- a/Source/WebKit/UIProcess/TextExtractionCache.h
+++ b/Source/WebKit/UIProcess/TextExtractionCache.h
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class TextExtractionCache {
 public:
-    static constexpr auto maxEntries = 4;
+    static constexpr auto maxEntries = 6;
     static constexpr auto contextLineCount = 3;
 
     enum class NodeResolution : uint8_t {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1789,7 +1789,7 @@ void WebFrame::describeTextExtractionInteraction(TextExtraction::Interaction&& i
 {
     RefPtr frame = coreLocalFrame();
     if (!frame)
-        return completion({ });
+        return completion({ { }, { }, false });
 
     completion(TextExtraction::interactionDescription(interaction, *frame));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -437,6 +437,46 @@ TEST(TextExtractionTests, InteractionResultSummary)
     }
 }
 
+TEST(TextExtractionTests, InteractionRemapsStaleNodeIdentifier)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+
+    auto makeDebugTextConfiguration = [] {
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        return configuration;
+    };
+
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+    RetainPtr staleIdentifier = extractNodeIdentifier([webView synchronouslyGetDebugText:makeDebugTextConfiguration()], @"Test");
+    EXPECT_NOT_NULL(staleIdentifier);
+
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+    RetainPtr currentIdentifier = extractNodeIdentifier([webView synchronouslyGetDebugText:makeDebugTextConfiguration()], @"Test");
+    EXPECT_NOT_NULL(currentIdentifier);
+    EXPECT_FALSE([staleIdentifier isEqualToString:currentIdentifier]);
+
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [interaction setNodeIdentifier:staleIdentifier];
+
+    NSError *error = nil;
+    RetainPtr description = [interaction debugDescriptionInWebView:webView.get() error:&error];
+    EXPECT_NULL(error);
+    EXPECT_NOT_NULL(description);
+    EXPECT_TRUE([description containsString:@"Click Me"]);
+
+    RetainPtr result = [webView synchronouslyPerformInteraction:interaction];
+    EXPECT_NULL([result error]);
+    RetainPtr summary = [result summary];
+    EXPECT_TRUE([summary containsString:@"Click Me"]);
+    EXPECT_TRUE([summary containsString:@"stale"]);
+    EXPECT_TRUE([summary containsString:@"re-resolved"]);
+    EXPECT_EQ(1, [[webView objectByEvaluatingJavaScript:@"document.querySelector('.click-count').textContent"] intValue]);
+}
+
 TEST(TextExtractionTests, TargetNodeAndClientAttributes)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{


### PR DESCRIPTION
#### c7b96b676c378ff2df1de077acbd349d74a809b6
<pre>
[Text Extraction] Make it possible for clients to target elements using stale node UIDs
<a href="https://bugs.webkit.org/show_bug.cgi?id=318078">https://bugs.webkit.org/show_bug.cgi?id=318078</a>
<a href="https://rdar.apple.com/180873603">rdar://180873603</a>

Reviewed by Abrar Rahman Protyasha.

Build on top of the changes in 315981@main, to complete the heuristic and map stale element `uid`s
to elements in the current DOM. See below for more details.

Test: TextExtractionTests.InteractionRemapsStaleNodeIdentifier

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::interactionDescription):

See changes in `_describeInteraction` below.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _convertToWebCoreInteraction:nodeIdentifier:]):
(-[WKWebView _performInteraction:completionHandler:]):

When performing an interaction, if the interaction fails due to the element being disconnected or
otherwise stale, try to resolve the `uid` against older cached extraction results and remap it to a
newer `uid` if the context in and around that newer `uid` matches the context in and around the
stale `uid`.

(-[WKWebView _performInteraction:inFrame:actionType:nodeIdentifier:staleNodeNote:shouldResolveStaleNodeIdentifier:completionHandler:]):
(-[WKWebView _describeInteraction:completionHandler:]):
(-[WKWebView _describeInteraction:inFrame:nodeIdentifier:staleNodeNote:shouldResolveStaleNodeIdentifier:completionHandler:]):

Similar to the above; this time, we additionally add a flag to the `interactionDescription` result
that indicates whether the element being described is disconnected from the DOM; if so, then we fall
back to re-resolving it.

(-[WKWebView _convertToWebCoreInteraction:]): Deleted.
* Source/WebKit/UIProcess/TextExtractionCache.cpp:
(WebKit::TextExtractionCache::add):
(WebKit::TextExtractionCache::resolve const):

Search for stale node UIDs that appear in any cached results, not just the oldest one. This ensures
that even if the stale element appears in different contexts, we&apos;ll still be able to resolve it as
long as any of the contexts are similar enough to the latest extraction result.

* Source/WebKit/UIProcess/TextExtractionCache.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionRemapsStaleNodeIdentifier)):

Canonical link: <a href="https://commits.webkit.org/316094@main">https://commits.webkit.org/316094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2753b2a9d83c93b5c51b791948d33a0fea1b4626

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128582 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d150f992-c0ae-45b5-957d-f305ba95e086) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133272 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc036a98-e0fd-4767-844f-95b0d4fc95e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113757 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5320e4de-b5ef-4bc6-9966-5abb023c2185) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28926 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182831 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35626 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141731 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44448 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38161 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45137 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109842 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36815 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117028 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43648 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8207 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43052 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->