### PR TITLE
[AppKit Gestures] Clicking on select controls causes the menu to immediately disappear

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -606,6 +606,19 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     case NSGestureRecognizerStateChanged: {
         if (!_mouseTrackingHasSentMouseDown) {
+            // Either the synthetic single-click path or this mouse-tracking path delivers a mouse
+            // down for a given interaction, but never both. An event that stays within the single-click
+            // gesture's allowable movement is a click: that gesture stays alive and, when it ends, the
+            // synthetic click path delivers the mouse down, mouse up, and click (plus pointer events).
+            // Only once the event moves past that threshold — at which point the single-click gesture
+            // cancels and this becomes a drag — does mouse tracking take over event delivery. Sending a
+            // mouse down here for a stationary click would deliver a second mouse down to the content,
+            // which should be avoided.
+            auto movementInWindow = locationInWindow - _mouseTrackingStartLocationInWindow;
+            auto allowableMovement = [_singleClickGestureRecognizer allowableMovement];
+            if (std::abs(movementInWindow.width()) <= allowableMovement && std::abs(movementInWindow.height()) <= allowableMovement)
+                break;
+
             RetainPtr mouseDown = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
                 location:_mouseTrackingStartLocationInWindow
                 modifierFlags:modifierFlags

--- a/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
@@ -248,3 +248,27 @@ nonisolated(nonsending) public func withSwizzledObjectiveCClassMethod<Result, Fa
 
     return try await body()
 }
+
+/// Creates a tuple of a statically known type from some arbitrary sequence at runtime.
+///
+/// It is invalid to create a tuple from a sequence with a differing number of elements, or if the type of the elements do not match those of the tuple.
+///
+/// - Parameters:
+///   - type: The type of the tuple.
+///   - sequence: The sequence to create the tuple from.
+/// - Returns: A tuple whose elements are equal to those of the sequence and whose type is equal to `type`.
+public func createTuple<S, each T>(of type: (repeat each T).Type, from sequence: S) -> (repeat each T) where S: Sequence {
+    var iterator = sequence.makeIterator()
+
+    func extract<Element>(_: Element.Type, iterator: inout S.Iterator) -> Element {
+        guard let element = iterator.next() else {
+            preconditionFailure("The sequence has fewer elements than the type of the tuple.")
+        }
+        guard let typed = element as? Element else {
+            preconditionFailure("Invalid type (expected: \(Element.self))")
+        }
+        return typed
+    }
+
+    return (repeat extract((each T).self, iterator: &iterator))
+}

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
@@ -168,6 +168,37 @@ extension WebPage {
     ///   - script: The JavaScript string to use as the function body.
     /// - Returns: The result of the script evaluation. If the type of the result is not the type of `returnType`, an error is thrown.
     /// - Throws: A `JavaScriptEvaluationError` error if there was a problem evaluating the script, or if a serialization failure occurred.
+    public func callJavaScript<First, each Rest, Last>(
+        returning returnType: (First, repeat each Rest, Last).Type,
+        arguments: [String: Any] = [:],
+        script: () -> String
+    ) async throws(JavaScriptEvaluationError) -> (First, repeat each Rest, Last) {
+        let result: Any?
+        do {
+            result = try await callJavaScript(script(), arguments: arguments)
+        } catch {
+            throw .scriptError(underlyingError: error)
+        }
+
+        guard let result else {
+            throw .noResult
+        }
+
+        guard let array = result as? [Any] else {
+            throw .mismatchedType(expected: [Any].self, actual: type(of: result))
+        }
+
+        return createTuple(of: returnType, from: array)
+    }
+
+    /// Executes the specified string as an async JavaScript function.
+    ///
+    /// - Parameters:
+    ///   - returnType: The type the expression returns.
+    ///   - arguments: A dictionary of the arguments to pass to the function call.
+    ///   - script: The JavaScript string to use as the function body.
+    /// - Returns: The result of the script evaluation. If the type of the result is not the type of `returnType`, an error is thrown.
+    /// - Throws: A `JavaScriptEvaluationError` error if there was a problem evaluating the script, or if a serialization failure occurred.
     public func callJavaScript<Result>(
         returning returnType: Result?.Type,
         arguments: [String: Any] = [:],

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -758,6 +758,63 @@ extension AppKitGesturesTests.Basic {
         #expect(page.url == initialURL)
     }
 
+    @Test
+    func clickingOnSelectControlsKeepsMenuOpen() async throws {
+        let html = """
+            <select name="pets" id="select">
+                <option value="">--Please choose an option--</option>
+                <option value="dog">Dog</option>
+                <option value="cat">Cat</option>
+                <option value="goose">Goose</option>
+            </select>
+            """
+
+        try await page.load(html: html).wait()
+
+        // This is a proxy for "keeping the menu open" since if there are two mousedown events,
+        // then it toggles the menu back to being closed.
+
+        try await page.callJavaScript {
+            """
+            window.mousedownCount = 0;
+            window.clickCount = 0;
+
+            document.addEventListener("mousedown", event => {
+                window.mousedownCount++;
+                event.preventDefault();
+            }, { capture: true });
+
+            document.addEventListener("click", () => {
+                window.clickCount++;
+            }, { capture: true });
+            """
+        }
+
+        let bounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "select"))
+        let convertedBounds = screenBounds(ofRectInViewportCoordinates: bounds)
+
+        await page.waitForNextPresentationUpdate()
+
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(at: convertedBounds.center, for: .seconds(0.1))
+        }
+
+        // Hard-coded delay to give the test a chance for multiple events to happen, in the failure case.
+        try await Task.sleep(for: .seconds(0.5))
+
+        let (mouseDownCount, clickCount) = try await page.callJavaScript(returning: (Int, Int).self) {
+            """
+            return [window.mousedownCount, window.clickCount];
+            """
+        }
+        #expect(mouseDownCount == 1)
+        #expect(clickCount == 1)
+    }
+
     // MARK: - Drag Press Disambiguation Tests
 
     @Test(arguments: [true, false])


### PR DESCRIPTION
#### a79d5611d4612d1cb8172e173cc4d510b07577bd
<pre>
[AppKit Gestures] Clicking on select controls causes the menu to immediately disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=318080">https://bugs.webkit.org/show_bug.cgi?id=318080</a>
<a href="https://rdar.apple.com/177199226">rdar://177199226</a>

Reviewed by NOBODY (OOPS!).

For a single click, WKAppKitGestureRecognizer recognizes its single-click
and mouse-tracking gesture recognizers simultaneously. The mouse-tracking
recognizer synthesizes a real mouse down/up pair as soon as the event
registers movement, while the single-click recognizer drives the deferred
synthetic click that ends in WebPage::completeSyntheticClick. Both paths
delivered a mouse down for the same event.

Because HTMLSelectElement::menuListDefaultEventHandler toggles the menu on
every mouse down — opening it when hidden and hiding it when shown — the
first mouse down opened the popup and the second toggled it shut, sending a
HidePopupMenu message back to the UI process.

The intended contract (<a href="https://commits.webkit.org/309295@main">309295@main</a>) is that either the mouse-tracking
path or the synthetic click path delivers a mouse down for a given
interaction, but never both. That contract was not enforced for a stationary
event.

Restore the invariant in the mouse-tracking recognizer: while the event
stays within the single-click recognizer&apos;s allowable movement it is a
click, so defer to the synthetic click path and do not synthesize a mouse
down (nor the mouse dragged that follows it). Only once movement exceeds
that threshold — at which point the single-click recognizer cancels and
the interaction becomes a drag — does mouse tracking take over event
delivery. Using the single-click recognizer&apos;s own allowable movement as
the boundary keeps the hand-off aligned with the point at which that
recognizer cancels, so exactly one path delivers a mouse down for any
interaction. The synthetic click path continues to produce the DOM
pointer and click events for a mouse event.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController mouseTrackingGestureRecognized:]):

The actual fix

* Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift:
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift:

Testing infra support

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

The test
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a79d5611d4612d1cb8172e173cc4d510b07577bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/171004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/172870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/46202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/173963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/46202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/46202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/46202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/44565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/44586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26043 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/43786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/38349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->