### PR TITLE
[SVG] Remove redundant duplicate condition in SVGRenderingContext::prepareToRenderSVGContent

### DIFF
--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -128,18 +128,15 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
             FloatRect repaintRect = m_renderer->repaintRectInLocalCoordinates();
             m_paintInfo->context().clip(repaintRect);
 
-            if (opacity < 1 || hasBlendMode || isolateMaskForBlending || hasIsolation) {
+            if (hasBlendMode)
+                m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), style.blendMode());
 
-                if (hasBlendMode)
-                    m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), style.blendMode());
+            m_paintInfo->context().beginTransparencyLayer(opacity);
 
-                m_paintInfo->context().beginTransparencyLayer(opacity);
+            if (hasBlendMode)
+                m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), BlendMode::Normal);
 
-                if (hasBlendMode)
-                    m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), BlendMode::Normal);
-
-                m_renderingFlags |= EndOpacityLayer;
-            }
+            m_renderingFlags |= EndOpacityLayer;
         }
     }
 


### PR DESCRIPTION
#### 13a6b1ddfcb06175ad207b80ce914ea76963901d
<pre>
[SVG] Remove redundant duplicate condition in SVGRenderingContext::prepareToRenderSVGContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=318082">https://bugs.webkit.org/show_bug.cgi?id=318082</a>
<a href="https://rdar.apple.com/180876883">rdar://180876883</a>

Reviewed by Rob Buis.

In prepareToRenderSVGContent() the inner `if` guarding the transparency
layer setup tested the exact same condition as the enclosing `if`
(opacity &lt; 1 || hasBlendMode || isolateMaskForBlending || hasIsolation).
The inner check can never be false when reached, so it was dead code.

Remove the redundant nested condition. No behavior change.

* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):

Canonical link: <a href="https://commits.webkit.org/316004@main">https://commits.webkit.org/316004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1200780ef27534369f1de971b79be0a6f17236f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128401 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6fdbacd-d044-45c6-8d58-ea0fb1e30847) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ef41aef-000b-4b25-9f4b-d6bd64cac785) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113616 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3270fd4d-465e-49a9-9857-e7683186ad12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33267 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182649 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141575 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44269 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38085 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109604 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36659 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116847 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43468 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8044 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42873 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43114 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43004 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->