### PR TITLE
LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters mutates m_anchorScrollAdjusters while iterating it

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -1075,10 +1075,15 @@ void LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters(const 
     if (!renderView() || renderView()->renderTreeBeingDestroyed())
         m_anchorScrollAdjusters.clear();
     else {
+        // Collect the anchored boxes to unregister first: unregisterAnchorScrollAdjusterFor()
+        // mutates m_anchorScrollAdjusters, which would invalidate this iteration.
+        Vector<CheckedPtr<RenderBox>> anchoredToUnregister;
         for (auto& adjuster : m_anchorScrollAdjusters) {
             if (adjuster.invalidateForScroller(scroller))
-                unregisterAnchorScrollAdjusterFor(*adjuster.anchored());
+                anchoredToUnregister.append(adjuster.anchored());
         }
+        for (auto& anchored : anchoredToUnregister)
+            unregisterAnchorScrollAdjusterFor(*anchored);
     }
 }
 


### PR DESCRIPTION
#### e535d5008b4ad0faac481857b3c2fc0dc936d849
<pre>
LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters mutates m_anchorScrollAdjusters while iterating it
<a href="https://bugs.webkit.org/show_bug.cgi?id=318083">https://bugs.webkit.org/show_bug.cgi?id=318083</a>

Reviewed by Alan Baradlay.

removeScrollerFromAnchorScrollAdjusters() range-iterates m_anchorScrollAdjusters
and, for each adjuster invalidated by the scroller, calls
unregisterAnchorScrollAdjusterFor(), which in turn calls removeFirstMatching()
on that same Vector. This was not safe.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters):

Canonical link: <a href="https://commits.webkit.org/316000@main">https://commits.webkit.org/316000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c8aa1e749e88f5c989366d539e7ee3760d860b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128409 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9272e4d4-f009-402f-b281-316ce9d07e48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133121 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0be0980b-f6b7-419f-a0ce-e629982af43d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113618 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a7acd12-735f-43b8-9cd6-60fb2107ca78) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33273 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28754 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145399 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.DoesNotTransformColorsOfLightContent (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182657 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141581 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44277 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38078 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44966 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109619 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36663 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116855 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43476 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8050 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42881 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43122 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43012 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->