### PR TITLE
UserAgentStringParser stores the Safari product version into the wrong field

### DIFF
--- a/Source/WebCore/page/UserAgentStringParser.cpp
+++ b/Source/WebCore/page/UserAgentStringParser.cpp
@@ -259,7 +259,7 @@ void UserAgentStringParser::populateUserAgentData()
                 return;
             }
             if (p.name == "Safari") {
-                browsersSeen.firefoxVersion = p.version;
+                browsersSeen.safariVersion = p.version;
                 browsersSeen.safari = true;
                 return;
             }

--- a/Source/WebCore/page/UserAgentStringParser.h
+++ b/Source/WebCore/page/UserAgentStringParser.h
@@ -24,6 +24,7 @@
  */
 
 #pragma once
+#include <WebCore/PlatformExportMacros.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Variant.h>
@@ -37,8 +38,8 @@ struct UserAgentStringData;
  */
 class UserAgentStringParser : public RefCountedAndCanMakeWeakPtr<UserAgentStringParser> {
 public:
-    static Ref<UserAgentStringParser> create(const String& userAgentString);
-    std::optional<Ref<UserAgentStringData>> parse();
+    WEBCORE_EXPORT static Ref<UserAgentStringParser> create(const String& userAgentString);
+    WEBCORE_EXPORT std::optional<Ref<UserAgentStringData>> parse();
 
 private:
     UserAgentStringParser(const String& userAgentString);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -782,6 +782,7 @@
 				WebCore/TransformationMatrix.cpp,
 				WebCore/U2fCommandConstructorTest.cpp,
 				WebCore/URLParserTextEncoding.cpp,
+				WebCore/UserAgentStringParser.cpp,
 				WebCore/WritingModeTests.cpp,
 				WebCore/XRCompositionLayer.cpp,
 				WebCore/YouTubePluginReplacement.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentStringParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentStringParser.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Helpers/PlatformUtilities.h"
+#include <WebCore/UserAgentStringData.h>
+#include <WebCore/UserAgentStringParser.h>
+#include <wtf/MainThread.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+class UserAgentStringParserTest : public testing::Test {
+public:
+    void SetUp() final
+    {
+        WTF::initializeMainThread();
+    }
+};
+
+static Ref<UserAgentStringData> parse(const String& userAgent)
+{
+    auto data = UserAgentStringParser::create(userAgent)->parse();
+    RELEASE_ASSERT(data);
+    return WTF::move(*data);
+}
+
+TEST_F(UserAgentStringParserTest, SafariBrowserVersionIsReported)
+{
+    auto data = parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"_s);
+    EXPECT_WK_STREQ("Safari", data->browserName);
+    EXPECT_WK_STREQ("605.1.15", data->browserVersion);
+}
+
+TEST_F(UserAgentStringParserTest, FirefoxVersionNotClobberedByTrailingSafariToken)
+{
+    auto data = parse("Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0 Safari/605.1.15"_s);
+    EXPECT_WK_STREQ("Firefox", data->browserName);
+    EXPECT_WK_STREQ("120.0", data->browserVersion);
+}
+
+TEST_F(UserAgentStringParserTest, ChromeBrowserVersionIsReported)
+{
+    auto data = parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"_s);
+    EXPECT_WK_STREQ("Google Chrome", data->browserName);
+    EXPECT_WK_STREQ("120.0.0.0", data->browserVersion);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### bf4754390235b77cec6b3423764529a29eb4a252
<pre>
UserAgentStringParser stores the Safari product version into the wrong field
<a href="https://bugs.webkit.org/show_bug.cgi?id=318084">https://bugs.webkit.org/show_bug.cgi?id=318084</a>

Reviewed by Anne van Kesteren.

When the user-agent parser encountered the &quot;Safari&quot; product token, it assigned the
parsed version to BrowsersSeen::firefoxVersion instead of BrowsersSeen::safariVersion.
The safariVersion member was therefore never written, and was read back as the empty
string when the result was determined to be Safari, so navigator.userAgentData reported
Safari with an empty browser version. As a secondary effect, a user-agent string listing
both Firefox and Safari products had its real Firefox version clobbered by the Safari
product version.

Test: Tools/TestWebKitAPI/Tests/WebCore/UserAgentStringParser.cpp

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/UserAgentStringParser.cpp:
(WebCore::UserAgentStringParser::populateUserAgentData):
* Source/WebCore/page/UserAgentStringParser.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/UserAgentStringParser.cpp: Added.
(TestWebKitAPI::parse):
(TestWebKitAPI::TEST_F(UserAgentStringParserTest, SafariBrowserVersionIsReported)):
(TestWebKitAPI::TEST_F(UserAgentStringParserTest, FirefoxVersionNotClobberedByTrailingSafariToken)):
(TestWebKitAPI::TEST_F(UserAgentStringParserTest, ChromeBrowserVersionIsReported)):

Canonical link: <a href="https://commits.webkit.org/315999@main">https://commits.webkit.org/315999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c61fe76934a3875a4665d83959a1f77455635782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128412 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d72a246c-ff9e-4192-b4dd-ba7659ddcb8a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133125 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a593f96-9ecc-4b47-90c1-1b86ff988e31) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0975c47c-a5cf-470b-a710-5f51408d20a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34945 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33277 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28757 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182660 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141585 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44280 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38082 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44969 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109624 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36669 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116858 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43480 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8052 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->