### PR TITLE
[JSC] Support space argument in `FastStringifier`

### DIFF
--- a/JSTests/microbenchmarks/json-stringify-pretty-tab.js
+++ b/JSTests/microbenchmarks/json-stringify-pretty-tab.js
@@ -1,0 +1,16 @@
+const objs = [];
+for (let j = 0; j < 16; j++) {
+    objs.push({
+        id: j,
+        name: 'user' + j,
+        tags: ['alpha', 'beta', 'gamma'],
+        nested: { active: true, score: j * 1.5, items: [1, 2, 3, j] },
+    });
+}
+
+let result = 0;
+for (let i = 0; i < 2e6; ++i) {
+    const o = objs[i & 15];
+    o.id = i;
+    result += JSON.stringify(o, null, '\t').length;
+}

--- a/JSTests/microbenchmarks/json-stringify-pretty.js
+++ b/JSTests/microbenchmarks/json-stringify-pretty.js
@@ -1,0 +1,16 @@
+const objs = [];
+for (let j = 0; j < 16; j++) {
+    objs.push({
+        id: j,
+        name: 'user' + j,
+        tags: ['alpha', 'beta', 'gamma'],
+        nested: { active: true, score: j * 1.5, items: [1, 2, 3, j] },
+    });
+}
+
+let result = 0;
+for (let i = 0; i < 2e6; ++i) {
+    const o = objs[i & 15];
+    o.id = i;
+    result += JSON.stringify(o, null, 2).length;
+}

--- a/JSTests/stress/json-stringify-space-fast-path.js
+++ b/JSTests/stress/json-stringify-space-fast-path.js
@@ -1,0 +1,109 @@
+// Differential test: fast path JSON.stringify(v, null, space) must match the
+// general Stringifier, which we force via an identity callable replacer.
+let failures = 0;
+
+const values = [
+    {},
+    [],
+    { a: 1 },
+    [1, 2, 3],
+    [[]],
+    [{}],
+    { a: {} },
+    { a: [] },
+    { a: { b: { c: [1, [2, [3, {}]]] } } },
+    { id: 1, name: 'user1', tags: ['alpha', 'beta'], nested: { active: true, score: 1.5, items: [1, 2, 3] } },
+    { s: 'esc"ape\\\n\t', t: 'plain' },
+    { u: undefined, v: 1 },
+    { u: undefined },
+    [undefined, null, true, false],
+    [function () {}, Symbol('x'), undefined],
+    { f: function () {}, sym: Symbol('x'), ok: 1 },
+    'top-level string',
+    42,
+    1.25,
+    -0,
+    NaN,
+    Infinity,
+    true,
+    null,
+    [1e21, 1e-7, 0.1, -2147483648, 2147483647],
+    { 'k"ey': 1 },
+    { '': 2 },
+    { 'ユニコード': 'マルチバイト文字列' },
+    ['16bit→string', { a: '€' }],
+    [[[[[[[[[[1]]]]]]]]]],
+    new Date(0),
+    { d: new Date(0) },
+    [0.5, [0.25, { x: 0.125 }]],
+];
+
+const spaces = [
+    undefined, null, 2, 0, -1, 1, 10, 11, 100, 2.7, 0.5, -2.5, NaN, Infinity, -Infinity,
+    '\t', '  ', 'ab', '', '0123456789ABC', '', '€', 'あ',
+    true, false, {}, [], new Number(3), new String('xy'), Symbol('s'), 10n, 3n,
+];
+
+function show(x) {
+    if (typeof x === 'symbol') return 'Symbol';
+    if (typeof x === 'bigint') return x + 'n';
+    try { return JSON.stringify(x) ?? String(x); } catch { return String(x); }
+}
+
+for (const space of spaces) {
+    for (const value of values) {
+        let fast, slow;
+        let fastErr, slowErr;
+        try { fast = JSON.stringify(value, null, space); } catch (e) { fastErr = String(e); }
+        try { slow = JSON.stringify(value, (k, x) => x, space); } catch (e) { slowErr = String(e); }
+        if (fast !== slow || fastErr !== slowErr) {
+            failures++;
+            print('MISMATCH space=' + show(space) + ' value=' + show(value));
+            print('  fast: ' + (fastErr ?? JSON.stringify(fast)));
+            print('  slow: ' + (slowErr ?? JSON.stringify(slow)));
+        }
+    }
+}
+
+// Large outputs: force StaticBuffer overflow into DynamicBuffer with gap.
+{
+    const big = [];
+    for (let i = 0; i < 2000; i++)
+        big.push({ idx: i, name: 'n' + i, vals: [i, i + 1, i + 2], deep: { x: i * 0.5 } });
+    for (const space of [2, '\t', 10]) {
+        const fast = JSON.stringify(big, null, space);
+        const slow = JSON.stringify(big, (k, x) => x, space);
+        if (fast !== slow) {
+            failures++;
+            print('MISMATCH big space=' + show(space) + ' lens ' + fast.length + ' vs ' + slow.length);
+        }
+    }
+}
+
+// 16-bit content with gap (char16_t fast path).
+{
+    const v = { 'キー': ['値', { nested: '🎉 emoji', n: 1 }] };
+    for (const space of [2, '\t', 4]) {
+        const fast = JSON.stringify(v, null, space);
+        const slow = JSON.stringify(v, (k, x) => x, space);
+        if (fast !== slow) {
+            failures++;
+            print('MISMATCH 16bit space=' + show(space));
+            print('  fast: ' + fast);
+            print('  slow: ' + slow);
+        }
+    }
+}
+
+// Deep nesting with gap.
+{
+    let v = 1;
+    for (let i = 0; i < 200; i++) v = [v];
+    const fast = JSON.stringify(v, null, 2);
+    const slow = JSON.stringify(v, (k, x) => x, 2);
+    if (fast !== slow) { failures++; print('MISMATCH deep nesting'); }
+}
+
+if (failures)
+    throw new Error('FAILED: ' + failures + ' mismatches');
+print('all ok');

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -179,27 +179,21 @@ static inline JSValue unwrapBoxedPrimitive(JSGlobalObject* globalObject, JSValue
     return value.isObject() ? unwrapBoxedPrimitive(globalObject, asObject(value)) : value;
 }
 
+static constexpr unsigned maxGapLength = 10;
+
 static inline String gap(JSGlobalObject* globalObject, JSValue space)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    constexpr unsigned maxGapLength = 10;
     space = unwrapBoxedPrimitive(globalObject, space);
     RETURN_IF_EXCEPTION(scope, { });
 
     // If the space value is a number, create a gap string with that number of spaces.
     if (space.isNumber()) {
-        double spaceCount = space.asNumber();
-        size_t count;
-        if (spaceCount > maxGapLength)
-            count = maxGapLength;
-        else if (!(spaceCount > 0))
-            count = 0;
-        else
-            count = static_cast<size_t>(spaceCount);
+        unsigned count = clampTo<unsigned>(space.asNumber(), 0, maxGapLength);
         char spaces[maxGapLength];
-        for (size_t i = 0; i < count; ++i)
+        for (unsigned i = 0; i < count; ++i)
             spaces[i] = ' ';
         return String(std::span { spaces }.first(count));
     }
@@ -692,6 +686,8 @@ enum class BufferMode : uint8_t {
     DynamicBuffer,
 };
 
+enum class HasGap : bool { No, Yes };
+
 enum class FailureReason : uint8_t {
     BufferFull,
     Found16BitEarly,
@@ -711,9 +707,9 @@ public:
 
 private:
     explicit FastStringifier(JSGlobalObject&);
-    void append(JSValue);
+    template<HasGap hasGap> void append(JSValue);
     void appendInt32(int32_t);
-    void appendInt32Array(JSArray&);
+    template<HasGap hasGap> void appendInt32Array(JSArray&);
     String result();
 
     static constexpr unsigned maxInt32StringLength = ("-2147483648"_s).length();
@@ -721,6 +717,9 @@ private:
     // FIXME These should probably just take an ASCIILiteral.
     void append(char, char, char, char);
     void append(char, char, char, char, char);
+    bool setGap(JSValue space);
+    unsigned newLineAndIndentSize() const;
+    void appendNewLineAndIndentUnchecked();
     template<typename T> void recordFailure(FailureReason, T&& reason);
     template<typename T> void NODELETE recordFailure(T&& reason)
     {
@@ -747,6 +746,9 @@ private:
     VM& m_vm;
     unsigned m_length { 0 }; // length of content already filled into m_buffer.
     unsigned m_capacity { 0 };
+    unsigned m_depth { 0 };
+    unsigned m_gapLength { 0 };
+    std::array<Latin1Character, maxGapLength> m_gap;
     bool m_checkedObjectPrototype { false };
     bool m_checkedArrayPrototype { false };
     std::optional<FailureReason> m_failureReason;
@@ -1080,6 +1082,55 @@ inline void FastStringifier<CharType, bufferMode>::append(char a, char b, char c
     m_length += 5;
 }
 
+// Resolves the space argument into a gap string, mirroring the gap() helper above.
+// Returns false for the cases left to the general Stringifier: boxed primitives
+// (observable unwrap), 16-bit gap strings, and other cells.
+template<typename CharType, BufferMode bufferMode>
+inline bool FastStringifier<CharType, bufferMode>::setGap(JSValue space)
+{
+    ASSERT(!space.isUndefined());
+    if (space.isNumber()) {
+        m_gapLength = clampTo<unsigned>(space.asNumber(), 0, maxGapLength);
+        m_gap.fill(' ');
+        return true;
+    }
+    if (space.isString()) {
+        auto string = asString(space)->tryGetValue();
+        if (string.data.isNull() || !string.data.is8Bit()) [[unlikely]]
+            return false;
+        auto span = string.data.span8();
+        unsigned count = std::min<unsigned>(span.size(), maxGapLength);
+        memcpySpan(std::span { m_gap }.first(count), span.first(count));
+        m_gapLength = count;
+        return true;
+    }
+    if (space.isCell())
+        return false;
+    // Other primitives (booleans, null) mean no gap.
+    m_gapLength = 0;
+    return true;
+}
+
+template<typename CharType, BufferMode bufferMode>
+ALWAYS_INLINE unsigned FastStringifier<CharType, bufferMode>::newLineAndIndentSize() const
+{
+    ASSERT(m_gapLength);
+    return 1 + m_depth * m_gapLength;
+}
+
+template<typename CharType, BufferMode bufferMode>
+ALWAYS_INLINE void FastStringifier<CharType, bufferMode>::appendNewLineAndIndentUnchecked()
+{
+    ASSERT(m_gapLength);
+    auto* cursor = buffer() + m_length;
+    *cursor++ = '\n';
+    for (unsigned i = 0; i < m_depth; ++i) {
+        for (unsigned j = 0; j < m_gapLength; ++j)
+            *cursor++ = m_gap[j];
+    }
+    m_length += 1 + m_depth * m_gapLength;
+}
+
 template<typename CharType, BufferMode bufferMode>
 ALWAYS_INLINE void FastStringifier<CharType, bufferMode>::appendInt32(int32_t number)
 {
@@ -1197,6 +1248,7 @@ static ALWAYS_INLINE bool stringCopyUpconvert(std::span<const Latin1Character> s
 }
 
 template<typename CharType, BufferMode bufferMode>
+template<HasGap hasGap>
 void FastStringifier<CharType, bufferMode>::append(JSValue value)
 {
     if constexpr (bufferMode == BufferMode::DynamicBuffer) {
@@ -1368,6 +1420,9 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             recordFastPropertyEnumerationFailure(object);
             return;
         }
+        if constexpr (hasGap == HasGap::Yes)
+            ++m_depth;
+        const unsigned newLineAndIndent = hasGap == HasGap::Yes ? newLineAndIndentSize() : 0;
         structure.forEachProperty(m_vm, [&](const auto& entry) -> bool {
             if (entry.attributes() & PropertyAttribute::DontEnum)
                 return true;
@@ -1396,12 +1451,14 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 return true;
 
             bool needComma = buffer()[m_length - 1] != '{';
-            if (!hasRemainingCapacity(needComma + 1 + span.size() + 2)) [[unlikely]] {
+            if (!hasRemainingCapacity(needComma + newLineAndIndent + 1 + span.size() + 2 + (hasGap == HasGap::Yes))) [[unlikely]] {
                 recordBufferFull();
                 return false;
             }
             if (needComma)
                 buffer()[m_length++] = ',';
+            if constexpr (hasGap == HasGap::Yes)
+                appendNewLineAndIndentUnchecked();
             buffer()[m_length] = '"';
 
             if constexpr (std::same_as<CharType, char16_t>) {
@@ -1419,6 +1476,8 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             buffer()[m_length + 1 + span.size()] = '"';
             buffer()[m_length + 1 + span.size() + 1] = ':';
             m_length += 1 + span.size() + 2;
+            if constexpr (hasGap == HasGap::Yes)
+                buffer()[m_length++] = ' ';
 
             if constexpr (std::same_as<CharType, Latin1Character>) {
                 // Inlining String case here since it is too common.
@@ -1450,15 +1509,20 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 return true;
             }
 
-            append(value);
+            append<hasGap>(value);
             return !haveFailure();
         });
         if (haveFailure()) [[unlikely]]
             return;
-        if (!hasRemainingCapacity()) [[unlikely]] {
+        if constexpr (hasGap == HasGap::Yes)
+            --m_depth;
+        bool needNewLine = hasGap == HasGap::Yes && buffer()[m_length - 1] != '{';
+        if (!hasRemainingCapacity(needNewLine ? 1 + newLineAndIndentSize() : 1)) [[unlikely]] {
             recordBufferFull();
             return;
         }
+        if (needNewLine)
+            appendNewLineAndIndentUnchecked();
         buffer()[m_length++] = '}';
         return;
     }
@@ -1489,17 +1553,28 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             return;
         }
         buffer()[m_length++] = '[';
+        if constexpr (hasGap == HasGap::Yes)
+            ++m_depth;
 
-        IndexingType indexingType = array.indexingType();
-        if (hasInt32(indexingType)) {
-            appendInt32Array(array);
-            if (haveFailure()) [[unlikely]]
-                return;
-            if (!hasRemainingCapacity()) [[unlikely]] {
+        auto closeArray = [&] {
+            if constexpr (hasGap == HasGap::Yes)
+                --m_depth;
+            bool needNewLine = hasGap == HasGap::Yes && buffer()[m_length - 1] != '[';
+            if (!hasRemainingCapacity(needNewLine ? 1 + newLineAndIndentSize() : 1)) [[unlikely]] {
                 recordBufferFull();
                 return;
             }
+            if (needNewLine)
+                appendNewLineAndIndentUnchecked();
             buffer()[m_length++] = ']';
+        };
+
+        IndexingType indexingType = array.indexingType();
+        if (hasInt32(indexingType)) {
+            appendInt32Array<hasGap>(array);
+            if (haveFailure()) [[unlikely]]
+                return;
+            closeArray();
             return;
         }
 
@@ -1511,51 +1586,51 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
                 return;
             }
             auto data = butterfly->contiguous();
+            const unsigned newLineAndIndent = hasGap == HasGap::Yes ? newLineAndIndentSize() : 0;
             for (unsigned i = 0; i < length; ++i) {
-                if (i) {
-                    if (!hasRemainingCapacity()) [[unlikely]] {
+                if (i || hasGap == HasGap::Yes) {
+                    if (!hasRemainingCapacity(!!i + newLineAndIndent)) [[unlikely]] {
                         recordBufferFull();
                         return;
                     }
-                    buffer()[m_length++] = ',';
+                    if (i)
+                        buffer()[m_length++] = ',';
+                    if constexpr (hasGap == HasGap::Yes)
+                        appendNewLineAndIndentUnchecked();
                 }
                 JSValue element = data.at(&array, i).get();
                 if (!element) [[unlikely]] {
                     recordFailure("!canGetIndexQuickly"_s);
                     return;
                 }
-                append(element);
+                append<hasGap>(element);
                 if (haveFailure()) [[unlikely]]
                     return;
             }
-            if (!hasRemainingCapacity()) [[unlikely]] {
-                recordBufferFull();
-                return;
-            }
-            buffer()[m_length++] = ']';
+            closeArray();
             return;
         }
+        const unsigned newLineAndIndent = hasGap == HasGap::Yes ? newLineAndIndentSize() : 0;
         for (unsigned i = 0, length = array.length(); i < length; ++i) {
-            if (i) {
-                if (!hasRemainingCapacity()) [[unlikely]] {
+            if (i || hasGap == HasGap::Yes) {
+                if (!hasRemainingCapacity(!!i + newLineAndIndent)) [[unlikely]] {
                     recordBufferFull();
                     return;
                 }
-                buffer()[m_length++] = ',';
+                if (i)
+                    buffer()[m_length++] = ',';
+                if constexpr (hasGap == HasGap::Yes)
+                    appendNewLineAndIndentUnchecked();
             }
             if (!array.canGetIndexQuickly(i)) [[unlikely]] {
                 recordFailure("!canGetIndexQuickly"_s);
                 return;
             }
-            append(array.getIndexQuickly(i));
+            append<hasGap>(array.getIndexQuickly(i));
             if (haveFailure()) [[unlikely]]
                 return;
         }
-        if (!hasRemainingCapacity()) [[unlikely]] {
-            recordBufferFull();
-            return;
-        }
-        buffer()[m_length++] = ']';
+        closeArray();
         return;
     }
 
@@ -1569,6 +1644,7 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
 }
 
 template<typename CharType, BufferMode bufferMode>
+template<HasGap hasGap>
 NEVER_INLINE void FastStringifier<CharType, bufferMode>::appendInt32Array(JSArray& array)
 {
     auto* butterfly = array.butterfly();
@@ -1578,18 +1654,21 @@ NEVER_INLINE void FastStringifier<CharType, bufferMode>::appendInt32Array(JSArra
         return;
     }
     auto data = butterfly->contiguousInt32();
+    const unsigned newLineAndIndent = hasGap == HasGap::Yes ? newLineAndIndentSize() : 0;
     for (unsigned i = 0; i < length; ++i) {
         JSValue element = data.at(&array, i).get();
         if (!element) [[unlikely]] {
             recordFailure("!canGetIndexQuickly"_s);
             return;
         }
-        if (!hasRemainingCapacity(1 + maxInt32StringLength)) [[unlikely]] {
+        if (!hasRemainingCapacity(1 + newLineAndIndent + maxInt32StringLength)) [[unlikely]] {
             recordBufferFull();
             return;
         }
         if (i)
             buffer()[m_length++] = ',';
+        if constexpr (hasGap == HasGap::Yes)
+            appendNewLineAndIndentUnchecked();
         appendInt32(element.asInt32());
     }
 }
@@ -1601,12 +1680,17 @@ inline String FastStringifier<CharType, bufferMode>::stringify(JSGlobalObject& g
         logOutcome("replacer"_s);
         return { };
     }
-    if (!space.isUndefined()) {
-        logOutcome("space"_s);
-        return { };
-    }
     FastStringifier stringifier(globalObject);
-    stringifier.append(value);
+    if (!space.isUndefined()) {
+        if (!stringifier.setGap(space)) [[unlikely]] {
+            logOutcome("space"_s);
+            return { };
+        }
+    }
+    if (stringifier.m_gapLength)
+        stringifier.append<HasGap::Yes>(value);
+    else
+        stringifier.append<HasGap::No>(value);
     failureReason = stringifier.m_failureReason;
     return stringifier.result();
 }


### PR DESCRIPTION
#### 7658c6d1236fe89d94477d91983f8db321bde587
<pre>
[JSC] Support space argument in `FastStringifier`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318086">https://bugs.webkit.org/show_bug.cgi?id=318086</a>

Reviewed by Yusuke Suzuki.

FastStringifier bails out whenever the space argument is not undefined,
so common pretty-printing calls like JSON.stringify(value, null, 2)
always run the general Stringifier, which is several times slower than
the fast path on typical config / logging shaped objects.

This patch resolves the gap inside FastStringifier and writes the
newline plus depth * gap indentation directly into the flat buffer.
Numbers and 8-bit string spaces are handled; boxed primitives keep
falling back since unwrapping them is observable, and so do 16-bit gap
strings since the gap is stored as Latin-1. append() is templatized on
HasGap so that the no-space instantiation compiles to the same code as
before; a runtime-checked version regressed json-stringify-int32-array
by 1.78x.

                                              baseline                  patched

json-stringify-int32-array                18.9412+-0.8168     ?     19.1482+-0.7348        ? might be 1.0109x slower
json-stringify-many-objects              144.2817+-1.2609     ?    145.7997+-0.7796        ? might be 1.0105x slower
json-stringify-empty-array                20.6268+-0.8005           20.2796+-0.3744          might be 1.0171x faster
json-stringify-pretty-tab               1128.9899+-15.1355    ^    274.4653+-3.0505        ^ definitely 4.1134x faster
json-stringify-array-replacer             13.6181+-0.1381     ?     13.7487+-0.2907        ?
json-stringify-pretty                   1191.4510+-7.5572     ^    301.6980+-4.2533        ^ definitely 3.9492x faster
json-stringify-many-objects-to-json       89.9216+-0.4452     ?     90.5576+-1.0200        ?
vanilla-todomvc-json-stringify            40.9058+-0.6199     ^     38.5172+-0.8057        ^ definitely 1.0620x faster

Tests: JSTests/microbenchmarks/json-stringify-pretty-tab.js
       JSTests/microbenchmarks/json-stringify-pretty.js
       JSTests/stress/json-stringify-space-fast-path.js

* JSTests/microbenchmarks/json-stringify-pretty-tab.js: Added.
* JSTests/microbenchmarks/json-stringify-pretty.js: Added.
* JSTests/stress/json-stringify-space-fast-path.js: Added.
(f):
(new.Date):
(show):
(const.space.of.spaces.const.value.of.values.catch):
(print.string_appeared_here.slowErr.JSON.stringify):
(print):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::gap):
(JSC::bufferMode&gt;::setGap):
(JSC::bufferMode&gt;::newLineAndIndentSize const):
(JSC::bufferMode&gt;::appendNewLineAndIndentUnchecked):
(JSC::bufferMode&gt;::append):
(JSC::bufferMode&gt;::appendInt32Array):
(JSC::bufferMode&gt;::stringify):

Canonical link: <a href="https://commits.webkit.org/316108@main">https://commits.webkit.org/316108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01abea1f1d02fc97b2bab37f01ba19c59986f2cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128413 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133126 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93926 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33278 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28758 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1980 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182661 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31955 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141586 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44281 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141402 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38181 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44970 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109625 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36668 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116859 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203379 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43481 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8054 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54458 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42885 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->