### PR TITLE
[WTF] `Int128` should fall back to `Int128Impl` when the standard library does not support `__int128_t`

### DIFF
--- a/JSTests/stress/temporal-int128-alignment-and-limits.js
+++ b/JSTests/stress/temporal-int128-alignment-and-limits.js
@@ -1,0 +1,26 @@
+//@ requireOptions("--useTemporal=1")
+
+// On Windows, WTF::Int128 used to crash Duration rounding and reject negative
+// durations. See webkit.org/b/318085.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected "${expected}" but got "${actual}"`);
+}
+
+// Used to crash: round with relativeTo (splitTimeDuration).
+shouldBe(Temporal.Duration.from({ months: 1 }).round({ largestUnit: "month", relativeTo: "2023-01-01" }).toString(), "P1M");
+shouldBe(Temporal.Duration.from({ months: 17, days: 14 }).round({ largestUnit: "month", relativeTo: "2023-01-01" }).toString(), "P17M14D");
+shouldBe(Temporal.Duration.from({ days: 40 }).round({ largestUnit: "month", relativeTo: "2023-01-01" }).toString(), "P1M9D");
+shouldBe(Temporal.Duration.from({ hours: 36, minutes: 30 }).round({ largestUnit: "day", relativeTo: "2023-01-01" }).toString(), "P1DT12H30M");
+
+// Used to crash: wall-clock-time rounding (roundTime).
+shouldBe(Temporal.PlainDateTime.from("2023-01-01T12:34:56.789").round({ smallestUnit: "minute" }).toString(), "2023-01-01T12:35:00");
+shouldBe(Temporal.PlainTime.from("12:34:56.789").round({ smallestUnit: "second" }).toString(), "12:34:57");
+
+// Used to be RangeErrors: negative durations through Checked<Int128>.
+shouldBe(Temporal.Duration.from("-P1D").toString(), "-P1D");
+shouldBe(new Temporal.Duration(0, 0, 0, -1).toString(), "-P1D");
+shouldBe(Temporal.Duration.from({ hours: -3, minutes: -30 }).toString(), "-PT3H30M");
+shouldBe(Temporal.PlainDate.from("2024-06-15").since("2023-01-01", { largestUnit: "month" }).toString(), "P17M14D");
+shouldBe(Temporal.Instant.from("2020-01-01T00:00:00Z").subtract({ hours: 1 }).toString(), "2019-12-31T23:00:00Z");

--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -1231,13 +1231,8 @@ constexpr Int128Impl operator>>(Int128Impl lhs, int amount) {
 }
 
 #if HAVE(INT128_T)
-#if COMPILER(MSVC) // Workaround for a clang-cl bug <https://webkit.org/b/274765>
-typedef __uint128_t UInt128 __attribute__((aligned(16)));
-typedef __int128_t Int128 __attribute__((aligned(16)));
-#else
 using UInt128 = __uint128_t;
 using Int128 = __int128_t;
-#endif
 #else
 using UInt128 = UInt128Impl;
 using Int128 = Int128Impl;

--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -344,10 +344,20 @@ if (NOT APPLE)
     WEBKIT_CHECK_HAVE_STRUCT(HAVE_TM_ZONE "struct tm" tm_zone time.h)
 
     # Check for int types
-    check_type_size("__int128_t" INT128_VALUE)
+    # Some standard libraries (e.g. the Microsoft STL) do not support __int128_t.
+    set(INT128_TEST_SOURCE "
+        #include <limits>
+        #include <utility>
+        static_assert(std::numeric_limits<__int128_t>::is_specialized);
+        static_assert(std::numeric_limits<__int128_t>::is_signed);
+        static_assert(std::numeric_limits<__uint128_t>::is_specialized);
+        static_assert(alignof(std::pair<long long, __int128_t>) == alignof(__int128_t));
+        int main() { return 0; }
+    ")
+    check_cxx_source_compiles("${INT128_TEST_SOURCE}" INT128_IS_USABLE)
 
-    if (HAVE_INT128_VALUE)
-      SET_AND_EXPOSE_TO_BUILD(HAVE_INT128_T INT128_VALUE)
+    if (INT128_IS_USABLE)
+      SET_AND_EXPOSE_TO_BUILD(HAVE_INT128_T TRUE)
     endif ()
 
     # Check which filesystem implementation is available if any

--- a/Tools/TestWebKitAPI/Tests/WTF/Int128.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Int128.cpp
@@ -28,6 +28,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <wtf/CheckedArithmetic.h>
 
 namespace TestWebKitAPI {
 
@@ -1362,5 +1363,42 @@ TEST(WTF_Int128, VsNativeInt128)
 }
 
 #endif
+
+static_assert(sizeof(Int128) == 16);
+static_assert(sizeof(UInt128) == 16);
+static_assert(std::is_trivially_copyable_v<Int128>);
+static_assert(std::is_trivially_copyable_v<UInt128>);
+
+static_assert(alignof(std::pair<int64_t, Int128>) == alignof(Int128));
+static_assert(alignof(std::pair<Int128, Int128>) == alignof(Int128));
+static_assert(alignof(std::pair<UInt128, UInt128>) == alignof(UInt128));
+
+static_assert(std::numeric_limits<Int128>::is_specialized);
+static_assert(std::numeric_limits<Int128>::is_signed);
+static_assert(std::numeric_limits<Int128>::is_integer);
+static_assert(std::numeric_limits<Int128>::digits == 127);
+static_assert(std::numeric_limits<UInt128>::is_specialized);
+static_assert(!std::numeric_limits<UInt128>::is_signed);
+static_assert(std::numeric_limits<UInt128>::digits == 128);
+
+TEST(WTF_Int128, ActiveTypeBoundsChecks)
+{
+    EXPECT_TRUE(WTF::isInBounds<Int128>(static_cast<int64_t>(-1)));
+    EXPECT_TRUE(WTF::isInBounds<Int128>(std::numeric_limits<int64_t>::min()));
+    EXPECT_TRUE(WTF::isInBounds<Int128>(std::numeric_limits<int64_t>::max()));
+    EXPECT_FALSE(WTF::isInBounds<int64_t>(std::numeric_limits<Int128>::max()));
+
+    Checked<Int128, RecordOverflow> negative = static_cast<int64_t>(-86400);
+    EXPECT_FALSE(negative.hasOverflowed());
+    EXPECT_TRUE(negative.value() == Int128 { -86400 });
+
+    Checked<Int128, RecordOverflow> sum = std::numeric_limits<Int128>::max();
+    sum += Int128 { 1 };
+    EXPECT_TRUE(sum.hasOverflowed());
+
+    Checked<Int128, RecordOverflow> product = std::numeric_limits<Int128>::max();
+    product *= Int128 { 2 };
+    EXPECT_TRUE(product.hasOverflowed());
+}
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### be7d4ca66743f064939eb9ed5f02b8d57661b517
<pre>
[WTF] `Int128` should fall back to `Int128Impl` when the standard library does not support `__int128_t`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318085">https://bugs.webkit.org/show_bug.cgi?id=318085</a>

Reviewed by Yusuke Suzuki.

Some C++ standard libraries do not know that __int128_t exists. Under the
Microsoft STL, std::numeric_limits&lt;__int128_t&gt; falls through to the primary
template (is_signed == false, max() == 0), so CheckedArithmetic rejected
negative values fed into a Checked&lt;Int128&gt;; and the STL&apos;s #pragma pack(push, 8)
under-aligned __int128_t members inside library templates, so e.g.
std::pair&lt;int64_t, Int128&gt; placed its second member at offset 8 while
std::get() handed out a fully aligned reference, and the 16-byte-aligned loads
emitted through it faulted. In practice, every negative Temporal duration was
a RangeError, and Duration.prototype.round with relativeTo crashed. The
PlayStation ports&apos; standard library has the same numeric_limits gap. The
aligned(16) typedef workaround from webkit.org/b/274765 does not help inside
templates, because template arguments are canonicalized.

Instead of teaching those configurations about __int128_t, stop using it
there: extend the CMake __int128_t check to require a functional
std::numeric_limits&lt;__int128_t&gt;, so HAVE(INT128_T) is unset under the
Microsoft and PlayStation STLs and WTF::Int128 falls back to the software
[U]Int128Impl, which has proper numeric_limits specializations, no alignment
assumptions the STL cannot honor, and is already exercised by other
configurations (e.g. watchOS). This also makes the clang-cl aligned-typedef
workaround dead, so remove it.

* JSTests/stress/temporal-int128-alignment-and-limits.js: Added.
* Source/WTF/wtf/Int128.h:
* Source/cmake/OptionsCommon.cmake:
* Tools/TestWebKitAPI/Tests/WTF/Int128.cpp:

Canonical link: <a href="https://commits.webkit.org/316358@main">https://commits.webkit.org/316358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16040a7d67ac8681a4598d69ff329e4887d593ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38535 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180570 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133470 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94160 "21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113932 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35333 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33596 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29250 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2320 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183155 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32447 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37790 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141935 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44772 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38461 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45461 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30251 "Too many flaky failures: http/tests/contentextensions/test-jump-table-bytecode-generation.html, http/tests/media/now-playing-info-default-artwork-favicon.html, http/tests/misc/percent-sign-in-form-field-name.html, http/tests/navigation/page-cache-xhr-in-loading-iframe.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/canvas-remote-read-remote-image-blocked-then-allowed.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/navigate-self-to-data-url.html, http/tests/security/mixedContent/redirect-https-to-http-iframe-in-main-frame.html, http/tests/site-isolation/frame-index.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110166 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36994 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117324 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203869 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43972 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8347 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54539 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43376 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43507 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->