### PR TITLE
ResourceUsageThread reads m_collectionMode off-thread without holding its lock

### DIFF
--- a/Source/WebCore/page/ResourceUsageThread.cpp
+++ b/Source/WebCore/page/ResourceUsageThread.cpp
@@ -103,10 +103,12 @@ void ResourceUsageThread::notifyObservers(ResourceUsageData&& data)
 
 void ResourceUsageThread::recomputeCollectionMode()
 {
-    m_collectionMode = None;
+    ResourceUsageCollectionMode mode = None;
 
     for (auto& pair : m_observers.values())
-        m_collectionMode = static_cast<ResourceUsageCollectionMode>(m_collectionMode | pair.first);
+        mode = static_cast<ResourceUsageCollectionMode>(mode | pair.first);
+
+    m_collectionMode = mode;
 }
 
 void ResourceUsageThread::createThreadIfNeeded()
@@ -132,7 +134,11 @@ void ResourceUsageThread::createThreadIfNeeded()
         auto start = WallTime::now();
 
         ResourceUsageData data;
-        ResourceUsageCollectionMode mode = m_collectionMode;
+        ResourceUsageCollectionMode mode;
+        {
+            Locker locker { m_observersLock };
+            mode = m_collectionMode;
+        }
         if (mode & CPU)
             platformCollectCPUData(m_vm, data);
         if (mode & Memory)

--- a/Source/WebCore/page/ResourceUsageThread.h
+++ b/Source/WebCore/page/ResourceUsageThread.h
@@ -82,7 +82,7 @@ private:
     Lock m_observersLock;
     Condition m_condition;
     HashMap<void*, std::pair<ResourceUsageCollectionMode, std::function<void(const ResourceUsageData&)>>> m_observers WTF_GUARDED_BY_LOCK(m_observersLock);
-    ResourceUsageCollectionMode m_collectionMode { None };
+    ResourceUsageCollectionMode m_collectionMode WTF_GUARDED_BY_LOCK(m_observersLock) { None };
 
     // Platforms may need to access some data from the common VM.
     // They should ensure their use of the VM is thread safe.


### PR DESCRIPTION
#### ccf04bde47571298cd62d79f0bcd83c2cd3a3db0
<pre>
ResourceUsageThread reads m_collectionMode off-thread without holding its lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=318087">https://bugs.webkit.org/show_bug.cgi?id=318087</a>

Reviewed by Darin Adler.

m_collectionMode is written by recomputeCollectionMode() while holding m_observersLock
(from addObserver()/removeObserver() on the main thread), but the dedicated resource-usage
sampling thread read it in threadBody() without acquiring the lock. waitUntilObservers()
releases the lock before threadBody() reaches the read, so the locked main-thread write and
the unlocked background-thread read could run concurrently on a non-atomic variable, which is
a data race / undefined behavior. The field was also not annotated, so Clang&apos;s thread-safety
analysis could not catch the unguarded access.

Synchronize m_collectionMode with the same lock that already guards the m_observers set it is
derived from: annotate it WTF_GUARDED_BY_LOCK(m_observersLock) so unguarded accesses become a
build error, and read it under a short Locker scope in threadBody() (without holding the lock
across the platformCollect* calls). recomputeCollectionMode() now accumulates into a local and
performs a single store, which it already does under the lock.

* Source/WebCore/page/ResourceUsageThread.cpp:
(WebCore::ResourceUsageThread::recomputeCollectionMode):
(WebCore::ResourceUsageThread::threadBody):
* Source/WebCore/page/ResourceUsageThread.h:
(WebCore::ResourceUsageThread::WTF_GUARDED_BY_LOCK):

Canonical link: <a href="https://commits.webkit.org/316090@main">https://commits.webkit.org/316090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a97743bb96544bd337c933e038cbf5031d156cd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128416 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2d44c97-e011-4b1c-8be5-4a4549497da7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133127 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93927 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cfbefe1-9d46-4c23-90d9-fcafe1b12754) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0d39085-d63e-410b-a261-1dd8752f3803) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34948 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33279 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28761 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182664 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37455 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141587 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44284 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38157 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44973 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109630 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36670 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116862 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43484 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8055 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42888 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43019 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->