### PR TITLE
Assert RunLoop::Timer is stopped and destroyed on its own run loop's thread

### DIFF
--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -95,9 +95,11 @@ public:
         // If the timeout for AsyncWaiter is infinity, we won't dispatch any timer.
         if (!m_timer)
             return;
-        m_timer->stop();
-        // The AsyncWaiter's timer holds the waiter's reference. This
-        // releases the strong reference to the Waiter in the timer.
+        // Don't stop the timer here: clearTimer() can run on a different thread than the one whose run
+        // loop owns the timer (e.g. from Atomics.notify on another agent), and stopping a RunLoop timer
+        // off its run loop's thread is unsafe. The dispatchAfter() timer keeps itself alive, fires once
+        // on its own thread, and tears itself down there; the timeout handler is idempotent because the
+        // waiter's ticket has already been cleared, so a late fire is a no-op. Just drop our reference.
         m_timer = nullptr;
     }
 

--- a/Source/WTF/wtf/FunctionDispatcher.h
+++ b/Source/WTF/wtf/FunctionDispatcher.h
@@ -56,10 +56,8 @@ class GuaranteedSerialFunctionDispatcher : public SerialFunctionDispatcher {
 
 inline void assertIsCurrent(const SerialFunctionDispatcher& queue) WTF_ASSERTS_ACQUIRED_CAPABILITY(queue)
 {
-    ASSERT(queue.isCurrent());
-#if !ASSERT_ENABLED
     UNUSED_PARAM(queue);
-#endif
+    ASSERT_WITH_SECURITY_IMPLICATION(queue.isCurrent());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -152,16 +152,27 @@ public:
     static void registerRunLoopMessageWindowClass();
 #endif
 
+    // A RunLoop::Timer is owned by the thread whose run loop it is constructed with: it fires on that
+    // run loop's thread, and stop() and the destructor must run on that thread. Stopping or destroying
+    // a timer from another thread races with an in-flight callback and is a use-after-free; both assert
+    // RunLoop::isCurrent() in debug builds (see assertIsCurrent()). Starting/re-arming a timer from
+    // another thread is allowed -- it only schedules onto the run loop and never frees the timer -- which
+    // is how RunLoop::dispatch()/dispatchAfter() and cross-thread timer schedulers (e.g. JSRunLoopTimer)
+    // work.
     class TimerBase {
         friend class RunLoop;
     public:
         WTF_EXPORT_PRIVATE explicit TimerBase(Ref<RunLoop>&&, ASCIILiteral description);
+        // Must run on the run loop's thread if the timer is active (asserted in debug); see class comment.
         WTF_EXPORT_PRIVATE virtual ~TimerBase();
 
+        // May be called from any thread; (re)schedules the timer onto its run loop's thread.
         void startRepeating(Seconds interval) { start(std::max(interval, 0_s), true); }
         void startOneShot(Seconds interval) { start(std::max(interval, 0_s), false); }
 
+        // Must be called on the run loop's thread when the timer is active (asserted in debug).
         WTF_EXPORT_PRIVATE void stop();
+
         WTF_EXPORT_PRIVATE bool isActive() const;
         WTF_EXPORT_PRIVATE Seconds secondsUntilFire() const;
 
@@ -399,7 +410,8 @@ private:
 
 inline void assertIsCurrent(const RunLoop& runLoop) WTF_ASSERTS_ACQUIRED_CAPABILITY(runLoop)
 {
-    ASSERT_UNUSED(runLoop, runLoop.isCurrent());
+    UNUSED_PARAM(runLoop);
+    ASSERT_WITH_SECURITY_IMPLICATION(runLoop.isCurrent());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -121,7 +121,13 @@ void RunLoop::TimerBase::start(Seconds interval, bool repeat)
             return;
         }
 
-        stop();
+        // Re-arm the timer by invalidating the old CFRunLoopTimer in place. Unlike stop(), this does
+        // NOT assert run-loop affinity: start() may legitimately be called from another thread to (re)arm
+        // a timer -- e.g. JSRunLoopTimer::Manager arms its per-VM timer from GC and Wasm compiler threads.
+        // This does not free the TimerBase, so it cannot cause the cross-thread use-after-free that stop()
+        // and the destructor guard against.
+        CFRunLoopTimerInvalidate(m_timer.get());
+        m_timer = nullptr;
     }
 
     m_timer = createTimer(interval, repeat, [] (CFRunLoopTimerRef cfTimer, void* context) {
@@ -141,7 +147,14 @@ void RunLoop::TimerBase::stop()
 {
     if (!m_timer)
         return;
-    
+
+    // An active timer must be stopped (and destroyed) on its run loop's thread: the CFRunLoopTimer
+    // holds a raw pointer to this TimerBase as its callback context, and CFRunLoopTimerInvalidate()
+    // does not synchronize with a callback already dispatching on the run loop's thread, so invalidating
+    // from another thread races with the in-flight callback and can leave it reading freed memory.
+    // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
+    // schedule work onto another run loop.)
+    assertIsCurrent(m_runLoop);
     CFRunLoopTimerInvalidate(m_timer.get());
     m_timer = nullptr;
 }

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -307,6 +307,13 @@ RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop, ASCIILiteral description)
 
 RunLoop::TimerBase::~TimerBase()
 {
+    // An active timer must be stopped/destroyed on its run loop's thread: fired() runs the timer's
+    // callback on that thread without holding m_loopLock, and the TimerBase is not ref-counted, so
+    // tearing it down from another thread races with the in-flight callback and risks a use-after-free.
+    // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
+    // schedule work onto another run loop.)
+    if (m_scheduledTask->isActive())
+        assertIsCurrent(m_runLoop);
     Locker locker { m_runLoop->m_loopLock };
     stopWithLock();
 }
@@ -329,6 +336,8 @@ void RunLoop::TimerBase::stopWithLock()
 void RunLoop::TimerBase::stop()
 {
     Locker locker { m_runLoop->m_loopLock };
+    if (m_scheduledTask->isActive())
+        assertIsCurrent(m_runLoop);
     stopWithLock();
 }
 

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -335,6 +335,13 @@ RunLoop::TimerBase::TimerBase(Ref<RunLoop>&& runLoop, ASCIILiteral description)
 
 RunLoop::TimerBase::~TimerBase()
 {
+    // An active timer must be stopped/destroyed on its run loop's thread: the GSource holds a raw
+    // pointer to this TimerBase as its callback user data and runs fired() on that thread, so tearing
+    // it down from another thread races with the in-flight callback and risks a use-after-free.
+    // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
+    // schedule work onto another run loop.)
+    if (isActive())
+        assertIsCurrent(m_runLoop);
     g_source_destroy(m_source.get());
 }
 
@@ -378,6 +385,8 @@ void RunLoop::TimerBase::start(Seconds interval, bool repeat)
 
 void RunLoop::TimerBase::stop()
 {
+    if (isActive())
+        assertIsCurrent(m_runLoop);
     g_source_set_ready_time(m_source.get(), -1);
     m_interval = { };
     m_isRepeating = false;

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -261,6 +261,12 @@ void RunLoop::TimerBase::stop()
     if (!isActiveWithLock())
         return;
 
+    // An active timer must be stopped/destroyed on its run loop's thread: timerFired() runs the timer's
+    // callback on that thread after releasing m_loopLock and the TimerBase is not ref-counted, so
+    // tearing it down from another thread races with the in-flight callback and risks a use-after-free.
+    // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
+    // schedule work onto another run loop.)
+    assertIsCurrent(m_runLoop);
     m_isActive = false;
     m_nextFireDate = MonotonicTime::infinity();
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -30,6 +30,7 @@
 
 #include "ScrollExtents.h"
 #include "ScrollingStateScrollingNode.h"
+#include "ScrollingThread.h"
 #include "ScrollingTree.h"
 #include "ScrollingTreeFrameScrollingNode.h"
 #include "ScrollingTreeScrollingNode.h"
@@ -101,6 +102,16 @@ std::unique_ptr<ScrollingEffectsControllerTimer> ThreadedScrollingTreeScrollingN
         Locker locker { scrollingNode->scrollingTree()->treeLock() };
         function();
     });
+}
+
+void ThreadedScrollingTreeScrollingNodeDelegate::destroyTimer(std::unique_ptr<ScrollingEffectsControllerTimer> timer)
+{
+    // Snap timers are created against the scrolling thread's run loop (see createTimer), so they must
+    // be destroyed there to avoid racing CFRunLoopTimerInvalidate() against an in-flight callback when
+    // the node is torn down on the main thread (e.g. from commitTreeState()). The timer's callback
+    // holds a Ref to the scrolling node, so the node and this delegate stay alive until the timer is
+    // gone, keeping a late-firing callback safe.
+    ScrollingThread::dispatch([timer = WTF::move(timer)] { });
 }
 
 void ThreadedScrollingTreeScrollingNodeDelegate::startAnimationCallback(ScrollingEffectsController&)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
@@ -60,6 +60,7 @@ protected:
 
     // ScrollingEffectsControllerClient.
     std::unique_ptr<ScrollingEffectsControllerTimer> createTimer(Function<void()>&&) override;
+    void destroyTimer(std::unique_ptr<ScrollingEffectsControllerTimer>) override;
     void startAnimationCallback(ScrollingEffectsController&) override;
     void stopAnimationCallback(ScrollingEffectsController&) override;
 

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -79,6 +79,12 @@ public:
     // Only used for non-animation timers.
     virtual std::unique_ptr<ScrollingEffectsControllerTimer> createTimer(Function<void()>&&) = 0;
 
+    // Destroys a timer returned by createTimer() on the thread that owns its run loop. A timer may
+    // fire on a different thread than the one tearing the controller down (e.g. the scrolling thread),
+    // so it must not be stopped or destroyed from the wrong thread. The default destroys it inline,
+    // which is correct for clients whose timers run on the calling thread.
+    virtual void destroyTimer(std::unique_ptr<ScrollingEffectsControllerTimer>) { }
+
     virtual void startAnimationCallback(ScrollingEffectsController&) = 0;
     virtual void stopAnimationCallback(ScrollingEffectsController&) = 0;
 

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -133,8 +133,16 @@ private:
     void scheduleScratchBufferPurge()
     {
         ASSERT(lock().isHeld());
-        const Seconds scratchBufferPurgeInterval { 2_s };
-        m_purgeTimer.startOneShot(scratchBufferPurgeInterval);
+        static constexpr Seconds scratchBufferPurgeInterval { 2_s };
+
+        // m_purgeTimer fires on the main run loop and so must be started/restarted there: getScratchBuffer()
+        // runs on a paint worker thread in the GPU process, and restarting an active timer off its run
+        // loop's thread races with an in-flight callback. The ScratchBuffer singleton is NeverDestroyed,
+        // so capturing it across the hop is safe, and m_purgeTimer is then only ever touched on the main
+        // run loop.
+        ensureOnMainRunLoop([checkedThis = CheckedRef { *this }] {
+            checkedThis->m_purgeTimer.startOneShot(scratchBufferPurgeInterval);
+        });
     }
 
     void purgeTimerFired()

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -349,6 +349,22 @@ void IOSurfacePool::scheduleCollectionTimer()
         m_collectionTimer.startRepeating(collectionInterval);
 }
 
+void IOSurfacePool::stopCollectionTimer()
+{
+    if (RunLoop::isMain()) {
+        m_collectionTimer.stop();
+        return;
+    }
+
+    // m_collectionTimer fires on the main run loop, so it must be stopped there to avoid racing an
+    // in-flight callback. The pool can be discarded from other threads (e.g. when an ImageBuffer
+    // backend is destroyed in the GPU process).
+    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }] {
+        Locker locker { protectedThis->m_lock };
+        protectedThis->m_collectionTimer.stop();
+    });
+}
+
 void IOSurfacePool::discardAllSurfaces()
 {
     Locker locker { m_lock };
@@ -363,7 +379,7 @@ void IOSurfacePool::discardAllSurfacesInternal()
     m_cachedSurfaces.clear();
     m_inUseSurfaces.clear();
     m_sizesInPruneOrder.clear();
-    m_collectionTimer.stop();
+    stopCollectionTimer();
     platformGarbageCollectNow();
 }
 

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -106,6 +106,7 @@ private:
     void tryEvictOldestCachedSurface() WTF_REQUIRES_LOCK(m_lock);
 
     void scheduleCollectionTimer() WTF_REQUIRES_LOCK(m_lock);
+    void stopCollectionTimer() WTF_REQUIRES_LOCK(m_lock);
     void collectionTimerFired();
     void collectInUseSurfaces() WTF_REQUIRES_LOCK(m_lock);
     bool markOlderSurfacesPurgeable() WTF_REQUIRES_LOCK(m_lock);

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -74,13 +74,16 @@ ScrollingEffectsController::~ScrollingEffectsController()
 
 void ScrollingEffectsController::stopAllTimers()
 {
+    // Hand the timers to the client for destruction rather than stopping them here: they may fire on
+    // another thread (e.g. the scrolling thread) than the one tearing down the controller, and stopping
+    // or destroying a timer off its run loop's thread races with an in-flight callback.
     if (m_discreteSnapTransitionTimer) {
-        m_discreteSnapTransitionTimer->stop();
+        m_client.destroyTimer(WTF::move(m_discreteSnapTransitionTimer));
         m_client.didStopScrollSnapAnimation();
     }
 
     if (m_discreteScrollendTimer)
-        m_discreteScrollendTimer->stop();
+        m_client.destroyTimer(WTF::move(m_discreteScrollendTimer));
 
 #if ASSERT_ENABLED
     m_timersWereStopped = true;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -405,7 +405,7 @@ void MockRealtimeVideoSource::applyFrameRateAndZoomWithPreset(double frameRate, 
     if (m_preset)
         setIntrinsicSize(m_preset->size());
     if (isProducingData())
-        m_emitFrameTimer->startRepeating(1_s / frameRate);
+        startCaptureTimer(frameRate);
 }
 
 IntSize MockRealtimeVideoSource::captureSize() const
@@ -450,7 +450,24 @@ void MockRealtimeVideoSource::settingsDidChange(OptionSet<RealtimeMediaSourceSet
 
 void MockRealtimeVideoSource::startCaptureTimer()
 {
-    m_emitFrameTimer->startRepeating(1_s / frameRate());
+    startCaptureTimer(frameRate());
+}
+
+void MockRealtimeVideoSource::startCaptureTimer(double frameRate)
+{
+    // m_emitFrameTimer fires on m_runLoop's thread, so it must be started and stopped there to avoid
+    // racing CFRunLoopTimerInvalidate() against an in-flight callback. Marshal both onto m_runLoop so
+    // they also stay ordered relative to each other.
+    m_runLoop->dispatch([this, protectedThis = Ref { *this }, interval = 1_s / frameRate] {
+        m_emitFrameTimer->startRepeating(interval);
+    });
+}
+
+void MockRealtimeVideoSource::stopCaptureTimer()
+{
+    m_runLoop->dispatch([this, protectedThis = Ref { *this }] {
+        m_emitFrameTimer->stop();
+    });
 }
 
 void MockRealtimeVideoSource::startProducingData()
@@ -467,7 +484,7 @@ void MockRealtimeVideoSource::startProducingData()
 
 void MockRealtimeVideoSource::stopProducingData()
 {
-    m_emitFrameTimer->stop();
+    stopCaptureTimer();
     m_elapsedTime += MonotonicTime::now() - m_startTime;
     m_startTime = MonotonicTime::nan();
 }
@@ -793,7 +810,7 @@ void MockRealtimeVideoSource::setIsInterrupted(bool isInterrupted)
         if (!source->isProducingData())
             continue;
         if (isInterrupted)
-            source->m_emitFrameTimer->stop();
+            source->stopCaptureTimer();
         else
             source->startCaptureTimer();
         source->notifyMutedChange(isInterrupted);

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -105,6 +105,8 @@ private:
     void generateFrame();
     RefPtr<ImageBuffer> generateFrameInternal();
     void startCaptureTimer();
+    void startCaptureTimer(double frameRate);
+    void stopCaptureTimer();
     RefPtr<ImageBuffer> generatePhoto();
 
     void delaySamples(Seconds) final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -78,7 +78,7 @@ class WebProcessPool;
 // This class exists to act as a threadsafe DisplayLink::Client client, allowing RemoteScrollingCoordinatorProxyMac to
 // be main-thread only. It's the UI-process analogue of WebPage/EventDispatcher.
 class RemoteLayerTreeEventDispatcher
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteLayerTreeEventDispatcher>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteLayerTreeEventDispatcher, WTF::DestructionThread::MainRunLoop>
     , public MomentumEventDispatcher::Client {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeEventDispatcher);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeEventDispatcher);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -122,23 +122,41 @@ RemoteLayerTreeEventDispatcher::RemoteLayerTreeEventDispatcher(RemoteScrollingCo
 
 RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher()
 {
+    ASSERT(!m_displayRefreshObserverID);
+    ASSERT(!m_delayedRenderingUpdateDetectionTimer);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     ASSERT(!m_momentumEventDispatcher);
 #endif
-    ASSERT(!m_displayRefreshObserverID);
 }
 
 // This must be called to break the cycle between RemoteLayerTreeEventDispatcherDisplayLinkClient and this.
 void RemoteLayerTreeEventDispatcher::invalidate()
 {
+    ASSERT(isMainRunLoop());
+
     protect(m_displayLinkClient)->invalidate();
 
     removeDisplayLinkClient();
+
+    // Stop m_wheelEventActivityHysteresis here, on the main run loop, so its (main run loop) timer
+    // does not fire a spurious state change while we tear down. Its timer is safe to destroy because
+    // this object is destroyed on the main run loop (see DestructionThread::MainRunLoop).
+    m_wheelEventActivityHysteresis.cancel();
 
     {
         Locker locker { m_scrollingTreeLock };
         m_scrollingTree = nullptr;
     }
+
+    // m_delayedRenderingUpdateDetectionTimer is created on the scrolling thread and fires on the
+    // scrolling thread's run loop, so it must be destroyed there to avoid racing with an in-flight
+    // CFRunLoopTimer callback that holds a raw pointer to it. The dispatcher itself is destroyed on the
+    // main run loop (DestructionThread::MainRunLoop), so dropping the last reference on the scrolling
+    // thread here hops the destructor back to the main run loop, where the main-run-loop timers are torn
+    // down safely.
+    ScrollingThread::dispatch([protectedThis = Ref { *this }] {
+        protectedThis->m_delayedRenderingUpdateDetectionTimer = nullptr;
+    });
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     m_momentumEventDispatcher = nullptr;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -929,15 +929,25 @@ void AcceleratedSurface::visibilityDidChange(bool isVisible)
         return;
 
     m_isVisible = isVisible;
-    if (!m_releaseUnusedBuffersTimer)
+
+    // m_releaseUnusedBuffersTimer is owned by, and fires on, the compositing run loop; it must be
+    // started/stopped there. visibilityDidChange() is called on the main thread (from
+    // ThreadedCompositor::suspend()/resume()), so hop to the compositing run loop.
+    RefPtr compositingRunLoop = m_compositingRunLoop;
+    if (!compositingRunLoop)
         return;
 
-    if (m_isVisible)
-        m_releaseUnusedBuffersTimer->stop();
-    else {
-        static const Seconds releaseUnusedBuffersDelay = 10_s;
-        m_releaseUnusedBuffersTimer->startOneShot(releaseUnusedBuffersDelay);
-    }
+    compositingRunLoop->dispatch([protectedThis = Ref { *this }, isVisible] {
+        auto& timer = protectedThis->m_releaseUnusedBuffersTimer;
+        if (!timer)
+            return;
+        if (isVisible)
+            timer->stop();
+        else {
+            static const Seconds releaseUnusedBuffersDelay = 10_s;
+            timer->startOneShot(releaseUnusedBuffersDelay);
+        }
+    });
 }
 
 void AcceleratedSurface::backgroundColorDidChange()
@@ -972,6 +982,7 @@ void AcceleratedSurface::didCreateCompositingRunLoop(RunLoop& runLoop)
         return;
 #endif
 
+    m_compositingRunLoop = &runLoop;
     m_releaseUnusedBuffersTimer = makeUnique<RunLoop::Timer>(runLoop, "AcceleratedSurface::ReleaseUnusedBuffersTimer"_s, this, &AcceleratedSurface::releaseUnusedBuffersTimerFired);
 #if USE(GLIB_EVENT_LOOP)
     m_releaseUnusedBuffersTimer->setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
@@ -990,7 +1001,13 @@ void AcceleratedSurface::willDestroyCompositingRunLoop()
         return;
 #endif
 
-    m_releaseUnusedBuffersTimer = nullptr;
+    // m_releaseUnusedBuffersTimer is owned by the compositing run loop and its destructor stops it, so
+    // destroy it on that run loop's thread rather than here on the main thread.
+    if (RefPtr compositingRunLoop = std::exchange(m_compositingRunLoop, nullptr)) {
+        compositingRunLoop->dispatch([protectedThis = Ref { *this }] {
+            protectedThis->m_releaseUnusedBuffersTimer = nullptr;
+        });
+    }
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     WebProcess::singleton().parentProcessConnection()->removeMessageReceiver(Messages::AcceleratedSurface::messageReceiverName(), m_id);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -453,6 +453,7 @@ private:
     bool m_isVisible { false };
     bool m_useExplicitSync { false };
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
+    RefPtr<WTF::RunLoop> m_compositingRunLoop;
 #if ENABLE(DAMAGE_TRACKING)
     SwapChainDamageTracker m_damageTracker;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -180,14 +180,37 @@ void ThreadedCompositor::startRenderTimer()
     ASSERT(m_state.lock.isHeld());
     ASSERT(!m_state.isRenderTimerActive);
     m_state.isRenderTimerActive = true;
-    m_renderTimer.startOneShot(0_s);
+    updateRenderTimer();
 }
 
 void ThreadedCompositor::stopRenderTimer()
 {
     ASSERT(m_state.lock.isHeld());
     m_state.isRenderTimerActive = false;
-    m_renderTimer.stop();
+    updateRenderTimer();
+}
+
+void ThreadedCompositor::updateRenderTimer()
+{
+    ASSERT(m_state.lock.isHeld());
+
+    // m_renderTimer is bound to the compositor thread's run loop (m_workQueue), so it must be started
+    // and stopped there. The render timer's desired state is tracked synchronously under m_state.lock by
+    // m_state.isRenderTimerActive and may be changed from the main thread (e.g. from suspend()/resume()/
+    // invalidate()), so hop to the compositor thread to bring the timer in line with that state.
+    if (!m_workQueue->runLoop().isCurrent()) {
+        m_workQueue->dispatch([protectedThis = Ref { *this }] {
+            Locker locker { protectedThis->m_state.lock };
+            protectedThis->updateRenderTimer();
+        });
+        return;
+    }
+
+    if (m_state.isRenderTimerActive) {
+        if (!m_renderTimer.isActive())
+            m_renderTimer.startOneShot(0_s);
+    } else
+        m_renderTimer.stop();
 }
 
 bool ThreadedCompositor::isOnlyRenderingUpdatePendingAndWaitingForTiles() const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -116,6 +116,7 @@ private:
 
     void startRenderTimer();
     void stopRenderTimer();
+    void updateRenderTimer();
     bool isOnlyRenderingUpdatePendingAndWaitingForTiles() const;
 
     void scheduleUpdateLocked();


### PR DESCRIPTION
#### f53d1f284bc24887cb00783ef8aee9e35809b8bc
<pre>
Assert RunLoop::Timer is stopped and destroyed on its own run loop&apos;s thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=318088">https://bugs.webkit.org/show_bug.cgi?id=318088</a>

Reviewed by Darin Adler.

Assert RunLoop::Timer is stopped and destroyed on its own run loop&apos;s thread
to help find thread safety bugs. Use ASSERT_WITH_SECURITY_IMPLICATION
to help the fuzzers find such bugs.

Starting (and re-arming) a timer from another thread is safe and supported (that is
how dispatch()/dispatchAfter() and cross-thread schedulers like JSRunLoopTimer work),
so only assert thread affinity on stop() and destruction, and only when the timer is
active (tearing down a never-started or already-stopped timer off-thread is harmless).
On Cocoa, start() re-arms an already-fired one-shot by invalidating the old
CFRunLoopTimer in place; this does so without the affinity assert (it does not free the
TimerBase, so it cannot cause the cross-thread use-after-free stop()/the destructor
guard against).

This immediately caught a real teardown race in MockRealtimeVideoSource,
whose m_emitFrameTimer fires on a dedicated &quot;generateFrame&quot; run loop but
was being stopped directly from the main thread (in stopProducingData()
and setIsInterrupted()), racing CFRunLoopTimerInvalidate() against an
in-flight timer callback. Fix it by marshaling the timer start and stop
onto m_runLoop (matching what the destructor already does), routing both
through startCaptureTimer()/stopCaptureTimer() so they stay correctly
ordered relative to each other.

It also caught a bug in RemoteLayerTreeEventDispatcher, which owns timers on two
different run loops: m_delayedRenderingUpdateDetectionTimer fires on the scrolling
thread, while m_wheelEventActivityHysteresis&apos;s timer fires on the main run loop.
The object is ThreadSafeRefCounted and was destroyed on whichever thread dropped
the last reference, so one of the two timers was always torn down off its run
loop&apos;s thread. Fix it by (a) destroying m_delayedRenderingUpdateDetectionTimer on
the scrolling thread from invalidate(), after m_scrollingTree has been cleared so
any in-flight didRefreshDisplay() returns early and cannot recreate it, and (b)
making the dispatcher DestructionThread::MainRunLoop so it (and its main-run-loop
timers) is always destroyed on the main run loop, even when invalidate()&apos;s
scrolling-thread dispatch drops the last reference. invalidate() also cancels the
hysteresis so its timer does not fire a spurious state change during teardown.

It caught IOSurfacePool, whose m_collectionTimer fires on the main run loop but
whose discardAllSurfaces() can run on another thread when an ImageBuffer backend
is destroyed in the GPU process. Stop the timer on the main run loop in that case.

It also caught the scroll-snap timers in ScrollingEffectsController, which are
created against the scrolling thread&apos;s run loop (ThreadedScrollingTreeScrollingNodeDelegate::createTimer)
but were stopped on the main thread from stopAllTimers() during commitTreeState().
Hand those timers to the client for destruction instead of stopping them inline,
and have the threaded delegate destroy them on the scrolling thread. The timer&apos;s
callback holds a Ref to the scrolling node (and ScrollerPairMac already releases
its main-thread resources via ensureOnMainThread()), so the node stays alive until
the timer is gone and a late-firing callback remains safe.

It also caught ScratchBuffer (ShadowBlur), whose m_purgeTimer fires on the main
run loop but was restarted from scheduleScratchBufferPurge() on a paint worker thread
(RemoteGraphicsContext in the GPU process). Restarting an active timer off-thread is
unsafe because start() invalidates the existing CFRunLoopTimer; schedule the purge on
the main run loop via ensureOnMainRunLoop() so m_purgeTimer is only ever touched there.

The assertions are not Cocoa-specific: every RunLoop backend (CF, GLib, generic,
Windows) reaches the TimerBase via the run loop&apos;s own thread, so they all assert.
On GTK this caught ThreadedCompositor::m_renderTimer, which is bound to the compositor
thread&apos;s run loop (m_workQueue) but whose start/stop was driven from the main thread
via suspend()/resume()/invalidate(). Route the render-timer start/stop through a new
updateRenderTimer() that hops to the compositor thread; the desired state stays tracked
synchronously under m_state.lock by m_state.isRenderTimerActive. The same suspend()/
resume() path also reaches AcceleratedSurface::m_releaseUnusedBuffersTimer (via
visibilityDidChange()) and AcceleratedSurface tears it down in willDestroyCompositingRunLoop();
that timer is likewise bound to the compositing run loop, so confine its start/stop and
destruction to that run loop too.

It also caught JSC&apos;s Atomics.waitAsync timeout timer (WaiterListManager): the timeout
is a RunLoop::dispatchAfter() timer created on the waiting agent&apos;s thread, but
Waiter::clearTimer() stop()s it from the notifying agent&apos;s thread (Atomics.notify) or a
GC thread. A dispatchAfter() timer is fire-and-forget -- its callback holds a self-
reference, so it stays alive, fires once on its own thread, and tears itself down there;
stopping it early both raced cross-thread and leaked it (the self-reference was never
consumed). Since the timeout handler is idempotent (the waiter&apos;s ticket is already
cleared), clearTimer() now just drops the waiter&apos;s reference and lets the timer fire
harmlessly on its own thread.

* Source/JavaScriptCore/runtime/WaiterListManager.h:
* Source/WTF/wtf/FunctionDispatcher.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/RunLoop.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::TimerBase::start):
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
(WTF::RunLoop::TimerBase::~TimerBase):
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::TimerBase::~TimerBase):
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::TimerBase::stop):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::destroyTimer):
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/platform/ScrollingEffectsController.h:
(WebCore::ScrollingEffectsControllerClient::destroyTimer):
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::stopCollectionTimer):
(WebCore::IOSurfacePool::discardAllSurfacesInternal):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::stopAllTimers):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::applyFrameRateAndZoomWithPreset):
(WebCore::MockRealtimeVideoSource::startCaptureTimer):
(WebCore::MockRealtimeVideoSource::stopCaptureTimer):
(WebCore::MockRealtimeVideoSource::stopProducingData):
(WebCore::MockRealtimeVideoSource::setIsInterrupted):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher):
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::startRenderTimer):
(WebKit::ThreadedCompositor::stopRenderTimer):
(WebKit::ThreadedCompositor::updateRenderTimer):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::visibilityDidChange):
(WebKit::AcceleratedSurface::didCreateCompositingRunLoop):
(WebKit::AcceleratedSurface::willDestroyCompositingRunLoop):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/316457@main">https://commits.webkit.org/316457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63b6b4b35d3a0697e5f2ce3e54d34d10b53bb7f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171318 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128991 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94dba771-c5eb-450c-9114-65ec560b5972) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133547 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94202 "1 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cef3269b-1159-4c4d-bc53-86fd49da92b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114010 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6da945b-a3b4-40e8-a8fe-a4eaa431dc49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35388 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33651 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29378 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2416 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145812 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.MultipleAccounts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183287 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32575 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142042 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44900 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141860 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38539 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30301 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110294 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37098 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117388 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203997 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44100 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8397 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54561 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43504 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->