### PR TITLE
[JSC] Add missing exit-profile bails to some DFG nodes

### DIFF
--- a/JSTests/stress/promise-prototype-catch-on-non-promise.js
+++ b/JSTests/stress/promise-prototype-catch-on-non-promise.js
@@ -1,0 +1,24 @@
+//@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
+
+// PromisePrototypeCatchIntrinsic guards the receiver with Check(PromiseObjectUse),
+// which fails with a BadType exit when the receiver is not a JSPromise. The
+// recompile must not re-inline the intrinsic and loop, and must keep producing
+// the spec result via the runtime path.
+
+function callCatch(promise, onRejected)
+{
+    return promise.catch(onRejected);
+}
+noInline(callCatch);
+
+var fake = Object.create(Promise.prototype);
+fake.then = function(onFulfilled, onRejected) { return "ok"; };
+
+for (var i = 0; i < 1e5; ++i) {
+    var result = callCatch(fake, function() {});
+    if (result !== "ok")
+        throw new Error("bad result at " + i + ": " + result);
+}
+
+if (numberOfDFGCompiles(callCatch) > 2)
+    throw new Error("too many recompiles: " + numberOfDFGCompiles(callCatch));

--- a/JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js
+++ b/JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js
@@ -1,0 +1,25 @@
+//@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
+
+// RegExpSearchIntrinsic guards the receiver with Check(RegExpObjectUse), which
+// fails with a BadType exit when the receiver is not a RegExpObject. The
+// recompile must not re-inline the intrinsic and loop, and must keep producing
+// the spec result via the runtime path.
+
+function search(regexp, string)
+{
+    return regexp[Symbol.search](string);
+}
+noInline(search);
+
+var fake = Object.create(RegExp.prototype);
+fake.exec = function() { return null; };
+fake.lastIndex = 0;
+
+for (var i = 0; i < 1e5; ++i) {
+    var result = search(fake, "abc");
+    if (result !== -1)
+        throw new Error("bad result at " + i + ": " + result);
+}
+
+if (numberOfDFGCompiles(search) > 2)
+    throw new Error("too many recompiles: " + numberOfDFGCompiles(search));

--- a/JSTests/stress/regexp-prototype-test-on-non-regexp.js
+++ b/JSTests/stress/regexp-prototype-test-on-non-regexp.js
@@ -1,0 +1,25 @@
+//@ runDefault("--validateOptions=true", "--useConcurrentJIT=0")
+
+// RegExpTestIntrinsic guards the receiver with Check(RegExpObjectUse), which
+// fails with a BadType exit when the receiver is not a RegExpObject. The
+// recompile must not re-inline the intrinsic and loop, and must keep producing
+// the spec result via the runtime path.
+
+function test(regexp, string)
+{
+    return regexp.test(string);
+}
+noInline(test);
+
+var fake = Object.create(RegExp.prototype);
+fake.exec = function() { return null; };
+fake.lastIndex = 0;
+
+for (var i = 0; i < 1e5; ++i) {
+    var result = test(fake, "abc");
+    if (result !== false)
+        throw new Error("bad result at " + i + ": " + result);
+}
+
+if (numberOfDFGCompiles(test) > 2)
+    throw new Error("too many recompiles: " + numberOfDFGCompiles(test));

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3643,6 +3643,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
 
             // Don't inline intrinsic if we exited due to one of the primordial RegExp checks failing.
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
                 return CallOptimizationResult::DidNothing;
 
@@ -3691,6 +3694,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
 
             // Don't inline intrinsic if we exited due to one of the primordial RegExp checks failing.
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
                 return CallOptimizationResult::DidNothing;
 
@@ -5581,7 +5587,11 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (argumentCountIncludingThis < 1)
                 return CallOptimizationResult::DidNothing;
 
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache))
                 return CallOptimizationResult::DidNothing;
 
             JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();


### PR DESCRIPTION
#### bf1915b95bd382bc5c1b714b78e9c9ab24ffb0b5
<pre>
[JSC] Add missing exit-profile bails to some DFG nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318089">https://bugs.webkit.org/show_bug.cgi?id=318089</a>

Reviewed by Yusuke Suzuki.

RegExpSearchIntrinsic, RegExpTestIntrinsic, and PromisePrototypeCatchIntrinsic
guard the receiver with Check(RegExpObjectUse / PromiseObjectUse) but never
consult the BadType exit profile, unlike their siblings (RegExpMatchIntrinsic,
RegExpSplitIntrinsic, PromisePrototypeThenIntrinsic).

Tests: JSTests/stress/promise-prototype-catch-on-non-promise.js
       JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js
       JSTests/stress/regexp-prototype-test-on-non-regexp.js

* JSTests/stress/promise-prototype-catch-on-non-promise.js: Added.
(callCatch):
(fake.then):
* JSTests/stress/regexp-prototype-symbol-search-on-non-regexp.js: Added.
(search):
(fake.exec):
* JSTests/stress/regexp-prototype-test-on-non-regexp.js: Added.
(test):
(fake.exec):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):

Canonical link: <a href="https://commits.webkit.org/316013@main">https://commits.webkit.org/316013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51ab2739f839b065f7703f49950ff46933773374

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128418 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133128 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113625 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34949 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33281 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28763 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1984 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182666 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31960 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141589 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44286 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38093 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44975 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109634 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36672 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116864 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203384 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43486 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8058 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54461 "Found 3 new JSC stress test failures: stress/promise-prototype-catch-on-non-promise.js.default, stress/regexp-prototype-symbol-search-on-non-regexp.js.default, stress/regexp-prototype-test-on-non-regexp.js.default (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->