### PR TITLE
Extend svg/historical.html removed Members list to include setCurrentScale, setCurrentTranslate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt
@@ -54,6 +54,8 @@ PASS SVGSVGElement.prototype.pixelUnitToMillimeterX must be removed
 PASS SVGSVGElement.prototype.pixelUnitToMillimeterY must be removed
 PASS SVGSVGElement.prototype.screenPixelToMillimeterX must be removed
 PASS SVGSVGElement.prototype.screenPixelToMillimeterY must be removed
+PASS SVGSVGElement.prototype.setCurrentScale must be removed
+PASS SVGSVGElement.prototype.setCurrentTranslate must be removed
 FAIL SVGSVGElement.prototype.useCurrentView must be removed assert_false: expected false got true
 PASS SVGSVGElement.prototype.viewport must be removed
 PASS SVGViewElement.prototype.viewTarget must be removed

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/historical.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/historical.html
@@ -82,6 +82,8 @@ var removedMembers = {
     "pixelUnitToMillimeterY",
     "screenPixelToMillimeterX",
     "screenPixelToMillimeterY",
+    "setCurrentScale",
+    "setCurrentTranslate",
     "useCurrentView",
     "viewport"
   ],


### PR DESCRIPTION
#### b15d6bf67a4dfacb6a02064216c63fa094bbcd3e
<pre>
Extend svg/historical.html removed Members list to include setCurrentScale, setCurrentTranslate
<a href="https://bugs.webkit.org/show_bug.cgi?id=318007">https://bugs.webkit.org/show_bug.cgi?id=318007</a>
<a href="https://rdar.apple.com/180885531">rdar://180885531</a>

Reviewed by Brent Fulgham.

setCurrentScale and setCurrentTranslate were SVGSVGElement methods in
SVG Tiny 1.2. SVG 2 dropped them in favor of the currentScale attribute
and the currentTranslate readonly attribute; no engine exposes them as
WebIDL methods, so they are undefined on SVGSVGElement.prototype in
WebKit, Gecko, and Blink. WebKit retains setCurrentScale() and
setCurrentTranslate() as C++ helpers (the latter is used to pan), routed
through the attribute setters at the bindings layer rather than bound.

Add both to the SVGSVGElement removedMembers list so the historical
removals stay covered.

* LayoutTests/imported/w3c/web-platform-tests/svg/historical-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/historical.html:

Canonical link: <a href="https://commits.webkit.org/316099@main">https://commits.webkit.org/316099@main</a>
</pre>
