### PR TITLE
CSP: nonce-source and hash-source must reject trailing characters after the closing quote

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A nonce-source with trailing characters after the closing quote ('nonce-abc'X) is invalid, so a script carrying that nonce must be blocked.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+    A nonce-source must match the grammar  "'nonce-" base64-value "'"  in its
+    entirety. A token such as  'nonce-abc'X  has trailing characters after the
+    closing quote, so it is not a valid source expression and must be ignored
+    when parsing the source list. Consequently the nonce "abc" is never
+    registered, and a <script nonce="abc"> must be blocked.
+
+    The valid 'nonce-driver' source is only used to bootstrap testharness.js and
+    the test driver so the test can run (and report) under a policy that would
+    otherwise block all inline script.
+-->
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-driver' 'nonce-abc'X">
+<script src="/resources/testharness.js" nonce="driver"></script>
+<script src="/resources/testharnessreport.js" nonce="driver"></script>
+<script nonce="driver">
+    var t = async_test("A nonce-source with trailing characters after the closing quote ('nonce-abc'X) is invalid, so a script carrying that nonce must be blocked.");
+
+    document.addEventListener('securitypolicyviolation', t.step_func(e => {
+        assert_equals(e.blockedURI, "inline", "The inline script should be reported as blocked.");
+        t.done();
+    }));
+</script>
+<script nonce="abc">
+    t.unreached_func("A script whose nonce matches the malformed 'nonce-abc'X source must not execute.")();
+</script>

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -592,10 +592,15 @@ template<typename CharacterType> bool ContentSecurityPolicySourceList::parseNonc
 
     auto beginNonceValue = buffer.span();
     skipWhile<isNonceCharacter>(buffer);
-    if (buffer.atEnd() || buffer.position() == beginNonceValue.data() || *buffer != '\'')
+    if (buffer.position() == beginNonceValue.data())
+        return false;
+    auto nonceValue = beginNonceValue.first(buffer.position() - beginNonceValue.data());
+    // The closing quote must be the last character of the source expression;
+    // any trailing characters make this an invalid nonce-source.
+    if (!skipExactly(buffer, '\'') || !buffer.atEnd())
         return false;
     if (extensionModeAllowsKeywordsForDirective(m_contentSecurityPolicyModeForExtension, m_directiveName))
-        m_nonces.add(beginNonceValue.first(buffer.position() - beginNonceValue.data()));
+        m_nonces.add(nonceValue);
     return true;
 }
 
@@ -614,7 +619,9 @@ template<typename CharacterType> bool ContentSecurityPolicySourceList::parseHash
     if (!digest)
         return false;
 
-    if (buffer.atEnd() || *buffer != '\'')
+    // The closing quote must be the last character of the source expression;
+    // any trailing characters make this an invalid hash-source.
+    if (!skipExactly(buffer, '\'') || !buffer.atEnd())
         return false;
 
     if (digest->value.size() > ContentSecurityPolicyHash::maximumDigestLength)


### PR DESCRIPTION
#### 3df73f1f9e3a5a8c5ed3891b5a4c35c8a2c95d4e
<pre>
CSP: nonce-source and hash-source must reject trailing characters after the closing quote
<a href="https://bugs.webkit.org/show_bug.cgi?id=318098">https://bugs.webkit.org/show_bug.cgi?id=318098</a>

Reviewed by Anne van Kesteren.

ContentSecurityPolicySourceList::parseNonceSource() and parseHashSource()
verified that the byte at the current position was the closing quote, but never
verified that the quote was the *last* character of the source expression. Both
take their StringParsingBuffer by value, and the caller discards the buffer on a
true return, so any trailing characters were silently ignored. As a result a
malformed token such as
```
      script-src &apos;nonce-abc&apos;X
      script-src &apos;sha256-&lt;base64&gt;=&apos;X
```
was accepted as the valid nonce/hash &apos;nonce-abc&apos; / &apos;sha256-&lt;base64&gt;=&apos;, instead
of being treated as an invalid source expression and dropped.

Per the CSP3 grammar, nonce-source (&quot;&apos;nonce-&quot; base64-value &quot;&apos;&quot;) and hash-source
(&quot;&apos;&quot; hash-algorithm &quot;-&quot; base64-value &quot;&apos;&quot;) must match a source-expression token
in its entirety; a token with characters after the closing quote is invalid and
must be ignored during parsing. The non-quoted host/scheme/port/path path
already enforces this by requiring buffer.atEnd(), so the laxity was unique to
the quoted forms.

This aligns WebKit with Blink and Gecko, both of which reject these malformed
tokens.

Consume the closing quote with skipExactly() and require buffer.atEnd()
afterwards, rejecting the source expression if any characters remain.

Test: imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/nonce-with-trailing-characters-blocked.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parseNonceSource):
(WebCore::ContentSecurityPolicySourceList::parseHashSource):

Canonical link: <a href="https://commits.webkit.org/316008@main">https://commits.webkit.org/316008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44356374cc750f8cd9932f61c60478a9a265fb36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180097 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128432 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba01a9be-aa06-44c2-9e29-51f358878893) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133142 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/154b8a2c-9cce-4ade-8d64-2f7875203a73) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113639 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b271e0ad-43c7-4546-831e-f36887c84df7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28777 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32978 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182680 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37471 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141603 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44300 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38088 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44989 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109652 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36684 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116878 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43500 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8068 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42904 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->