### PR TITLE
SVGSVGElement.currentScale is a no-op on non-document-root outermost <svg>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS currentScale round-trips on an HTML-body-child outermost svg element
+PASS currentScale round-trips on an outermost svg element inside a foreignObject
+PASS currentScale is inert on a non-outermost (nested) svg element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVGSVGElement.currentScale on outermost vs non-outermost svg</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__currentScale">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- An <svg> whose parent is not in the SVG namespace is an outermost svg element
+     (SVG 2, "Definitions": the terms "SVG document fragment" / "outermost svg element"). currentScale must
+     round-trip on such elements even when they are not the document root. -->
+<svg id="bodyChild"><rect width="50" height="50" fill="green"/></svg>
+
+<svg id="outer">
+  <foreignObject width="100" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <svg id="foInner"><rect width="50" height="50" fill="green"/></svg>
+    </div>
+  </foreignObject>
+</svg>
+
+<!-- An <svg> nested directly inside another <svg> is NOT an outermost svg element. -->
+<svg id="container"><svg id="nested"><rect width="50" height="50" fill="green"/></svg></svg>
+
+<script>
+test(() => {
+  const svg = document.getElementById("bodyChild");
+  svg.currentScale = 2;
+  assert_equals(svg.currentScale, 2);
+}, "currentScale round-trips on an HTML-body-child outermost svg element");
+
+test(() => {
+  const svg = document.getElementById("foInner");
+  svg.currentScale = 3;
+  assert_equals(svg.currentScale, 3);
+}, "currentScale round-trips on an outermost svg element inside a foreignObject");
+
+test(() => {
+  const svg = document.getElementById("nested");
+  assert_equals(svg.currentScale, 1, "getter returns 1 on a non-outermost svg element");
+  svg.currentScale = 5;
+  assert_equals(svg.currentScale, 1, "setter is a no-op on a non-outermost svg element");
+}, "currentScale is inert on a non-outermost (nested) svg element");
+</script>

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -130,17 +130,24 @@ RefPtr<LocalFrame> SVGSVGElement::frameForCurrentScale() const
 
 float SVGSVGElement::currentScale() const
 {
-    // When asking from inside an embedded SVG document, a scale value of 1 seems reasonable, as it doesn't
-    // know anything about the parent scale.
-    auto frame = frameForCurrentScale();
-    return frame ? frame->pageZoomFactor() : 1;
+    // Only an outermost svg element has a currentScale (SVG 2, "Interface SVGSVGElement").
+    if (!isOutermostSVGSVGElement())
+        return 1;
+    if (RefPtr frame = frameForCurrentScale())
+        return frame->pageZoomFactor();
+    return m_currentScale;
 }
 
 void SVGSVGElement::setCurrentScale(float scale)
 {
     ASSERT(std::isfinite(scale));
-    if (auto frame = frameForCurrentScale())
+    if (!isOutermostSVGSVGElement())
+        return;
+    if (RefPtr frame = frameForCurrentScale()) {
         frame->setPageZoomFactor(scale);
+        return;
+    }
+    m_currentScale = scale;
 }
 
 void SVGSVGElement::setCurrentTranslate(const FloatPoint& translation)

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -165,6 +165,8 @@ private:
 
     mutable std::optional<FloatSize> m_cachedViewportSizeExcludingZoom;
 
+    float m_currentScale { 1 };
+
     const Ref<SVGAnimatedLength> m_x { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
     const Ref<SVGAnimatedLength> m_y { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
     const Ref<SVGAnimatedLength> m_width { SVGAnimatedLength::create(this, SVGLengthMode::Width, "100%"_s) };


### PR DESCRIPTION
#### c6bd8acdac1fdbc4f3836f5841a207e24cb2bc46
<pre>
SVGSVGElement.currentScale is a no-op on non-document-root outermost &lt;svg&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=318096">https://bugs.webkit.org/show_bug.cgi?id=318096</a>
<a href="https://rdar.apple.com/180889449">rdar://180889449</a>

Reviewed by Nikolas Zimmermann.

currentScale was implemented purely as the main frame&apos;s page zoom,
gated on the &lt;svg&gt; being the document root (frameForCurrentScale() requires
document().documentElement() == this).

As a result, setting currentScale on an outermost &lt;svg&gt; embedded in HTML
(inline, or inside a foreignObject) was silently discarded. The getter
returned 1, whereas SVG 2 (&quot;Interface SVGSVGElement&quot;) only mandates that
behavior for non-outermost svg elements. Chrome and Firefox both
round-trip the value; WebKit was the outlier.

Store the assigned value in a new SVGSVGElement::m_currentScale member
and return it for an outermost svg element that is not the document root.
The document root continues to map currentScale to page zoom, so its
rendering is unchanged.

As with Gecko, the stored value is not reflected into rendering for
non-root outermost elements (only Blink does that; the existing
currentScale-change-repaint.html reftest indicate that area is
underspecified), so this change is limited to the web-observable
getter/setter round-trip. We need more discussions in the SVG WG.

Test: imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost.html

* LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/struct/scripted/currentScale-outermost.html: Added.
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::currentScale const):
(WebCore::SVGSVGElement::setCurrentScale):
* Source/WebCore/svg/SVGSVGElement.h:

Canonical link: <a href="https://commits.webkit.org/318762@main">https://commits.webkit.org/318762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc26cf715892d24a07249428cace39384fe351ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/189000 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b4e650d4-03ee-4019-b67d-6a58f7ee29e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/181032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139720 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7fc70072-5978-473f-b953-5c6e9faa6764) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120169 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2eb80f94-5ec6-476e-8181-662fbe89b463) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41982 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40327 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39977 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/306 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191218 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148961 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39986 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53458 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148707 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43385 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125729 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120576 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51976 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14957 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51361 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51602 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51422 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->