### PR TITLE
CSP: trusted-types expressions must reject trailing characters after keywords and the wildcard

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A trusted-types wildcard with trailing characters ('*X') is an invalid expression and must not enable the wildcard, so createPolicy() is blocked.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<!--
+    tt-wildcard must be exactly "*". A token such as "*X" has trailing
+    characters after the wildcard, so it is neither a valid tt-wildcard nor a
+    valid tt-policy-name (the "*" is not a policy-name character). It is therefore
+    an invalid tt-expression and must be ignored when parsing the directive.
+
+    With no valid tt-expression in the directive value, the trusted-types list is
+    empty and the wildcard is not enabled (equivalent to 'none'), so
+    trustedTypes.createPolicy() must throw a TypeError. Both Blink and Gecko
+    reject "*X" as a wildcard.
+-->
+<meta http-equiv="Content-Security-Policy" content="trusted-types *X">
+<link rel="help" href="https://w3c.github.io/trusted-types/dist/spec/#trusted-types-csp-directive">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    test(() => {
+        assert_throws_js(TypeError, () => {
+            trustedTypes.createPolicy("policy");
+        });
+    }, "A trusted-types wildcard with trailing characters ('*X') is an invalid expression and must not enable the wildcard, so createPolicy() is blocked.");
+</script>

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -98,32 +98,33 @@ void ContentSecurityPolicyTrustedTypesDirective::parse(const String& value)
             if (buffer.atEnd())
                 return;
 
-            auto beginPolicy = buffer.position();
+            auto beginPolicy = buffer.span();
             skipWhile<isTrustedTypeCharacter>(buffer);
 
-            StringParsingBuffer policyBuffer(std::span(beginPolicy, buffer.position()));
+            StringView policy(beginPolicy.first(buffer.position() - beginPolicy.data()));
 
-            if (skipExactlyIgnoringASCIICase(policyBuffer, "'allow-duplicates'"_s)) {
+            // Each tt-expression must match a keyword, the wildcard, or a
+            // tt-policy-name in its entirety; a token with trailing characters
+            // (e.g. "*X" or "'allow-duplicates'X") is an invalid expression.
+            if (equalIgnoringASCIICase(policy, "'allow-duplicates'"_s)) {
                 m_allowDuplicates = true;
                 continue;
             }
 
-            if (skipExactlyIgnoringASCIICase(policyBuffer, "'none'"_s)) {
+            if (equalIgnoringASCIICase(policy, "'none'"_s)) {
                 directiveList().policy().reportInvalidTrustedTypesNoneKeyword();
                 continue;
             }
 
-            if (skipExactly(policyBuffer, '*')) {
+            if (policy == "*"_s) {
                 m_allowAny = true;
                 continue;
             }
 
-            if (skipExactly<isPolicyNameCharacter>(policyBuffer)) {
-                auto policy = String({ beginPolicy, buffer.position() });
-                m_list.add(policy);
-            } else {
-                auto policy = String({ beginPolicy, buffer.position() });
-                directiveList().policy().reportInvalidTrustedTypesPolicy(policy);
+            if (!policy.isEmpty() && policy.containsOnly<isPolicyNameCharacter<char16_t>>())
+                m_list.add(policy.toString());
+            else {
+                directiveList().policy().reportInvalidTrustedTypesPolicy(policy.toString());
                 return;
             }
 


### PR DESCRIPTION
#### 99a1610c70e2740d684e6d024775a2f3e2755e80
<pre>
CSP: trusted-types expressions must reject trailing characters after keywords and the wildcard
<a href="https://bugs.webkit.org/show_bug.cgi?id=318099">https://bugs.webkit.org/show_bug.cgi?id=318099</a>

Reviewed by Darin Adler and Anne van Kesteren.

ContentSecurityPolicyTrustedTypesDirective::parse() classified each whitespace-
delimited tt-expression by matching only a *prefix* of the token: it used
skipExactly()/skipExactlyIgnoringASCIICase() for the wildcard and the
&apos;allow-duplicates&apos;/&apos;none&apos; keywords, and skipExactly&lt;isPolicyNameCharacter&gt;()
(which advances a single character) for tt-policy-name, then stored the whole
token without checking that nothing followed the matched prefix. As a result a
token with trailing characters was misclassified. Most visibly,
```
      trusted-types *X
```
was treated as the wildcard &quot;*&quot; and set m_allowAny, so trustedTypes.createPolicy()
was allowed for any name, even though &quot;*X&quot; is not a valid tt-expression. The
keyword forms (&apos;allow-duplicates&apos;X, &apos;none&apos;X) and tt-policy-name validation (only
the first character was checked) had the same prefix-matching flaw.

Per the Trusted Types spec, each tt-expression must match a tt-keyword, the
tt-wildcard (&quot;*&quot;), or a tt-policy-name in its entirety; tt-wildcard is exactly
&quot;*&quot; and tt-policy-name is 1*( ALPHA / DIGIT / &quot;-&quot; / &quot;#&quot; / &quot;=&quot; / &quot;_&quot; / &quot;/&quot; / &quot;@&quot;
/ &quot;.&quot; / &quot;%&quot; ). A token with any trailing character matches none of these and is
an invalid expression that must be ignored.

Classify each whole token instead of a prefix: compare the full token against
the keyword and wildcard literals, and accept a tt-policy-name only when every
character is a policy-name character. &quot;*X&quot; and similar malformed tokens are now
rejected, so trusted-types with no other valid expression blocks policy creation.

This aligns WebKit with Blink and Gecko, both of which require the wildcard token
to be exactly &quot;*&quot; and validate the entire policy-name token.

Test: imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters.html

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-wildcard-with-trailing-characters.html: Added.
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::parse):

Canonical link: <a href="https://commits.webkit.org/316089@main">https://commits.webkit.org/316089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e3f1899fbf173d62b6ae2f30b78b49963603585

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128451 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3d7a6ef-29f7-40cf-93e1-63d362efca60) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133160 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b1cb004-a31b-41f1-a587-f7a5b7f11ce0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36369 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153611 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113657 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d0e0811-4f8d-445e-ada4-fea95e5c9232) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34987 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33312 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28796 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182699 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37488 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141622 "Found 1 new test failure: compositing/geometry/abs-position-inside-opacity.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141438 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109682 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36708 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116897 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43519 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8092 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42923 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->