### PR TITLE
[Debug] UI process sometimes crashes after scroll to refresh (ScrollingThread::isCurrentThread() assert under RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged())

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -190,8 +190,6 @@ void RemoteScrollingTreeMac::startPendingScrollAnimations()
 
 void RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAnimatedScroll)
 {
-    ASSERT(ScrollingThread::isCurrentThread());
-
     RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, hasNodeWithAnimatedScroll] {
         if (CheckedPtr scrollingCoordinatorProxy = protectedThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);


### PR DESCRIPTION
#### 6c93b8ced48c62e201b957d849faf08cfc73ea91
<pre>
[Debug] UI process sometimes crashes after scroll to refresh (ScrollingThread::isCurrentThread() assert under RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged())
<a href="https://bugs.webkit.org/show_bug.cgi?id=318100">https://bugs.webkit.org/show_bug.cgi?id=318100</a>
<a href="https://rdar.apple.com/179514078">rdar://179514078</a>

Reviewed by Simon Fraser and Abrar Rahman Protyasha.

RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged() asserted that it was
running on the scrolling thread, but it can also legitimately be reached on the
main thread. After a scroll-to-refresh driven reload, the scrolling tree is
committed on the main thread, and ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode()
restores the saved rubber-band state by synchronously starting a rubber-band animation.
That calls setScrollAnimationInProgress(true), which toggles
ScrollingTree::m_treeState.nodesWithActiveScrollAnimations from empty to non-empty and
invokes hasNodeWithAnimatedScrollChanged() — on the main thread, tripping
ASSERT(ScrollingThread::isCurrentThread()) in debug builds.

The assertion was overly strict. The mutated state is guarded by m_treeStateLock,
which is held across the mutation regardless of the calling thread, and the
override body only does a RunLoop::mainSingleton().dispatch(), which is safe from
any thread; the main-thread caller was therefore always correct.

Fix by removing the assertion.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged):

Canonical link: <a href="https://commits.webkit.org/316068@main">https://commits.webkit.org/316068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/530285ce5af663cae53a12d32c8856abedfc41a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128436 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45912 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44282 "Hash 530285ce for PR 68079 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133147 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113644 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34971 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/44282 "Hash 530285ce for PR 68079 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28781 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182684 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35481 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/44282 "Hash 530285ce for PR 68079 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141607 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44304 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141423 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109658 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26033 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36691 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116882 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43504 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8075 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43149 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->