### PR TITLE
[TimeRanges] Add API test coverage for TimeRanges::nearest()

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
@@ -288,6 +288,21 @@ TEST(TimeRanges, IntersectWith_Gaps3)
     ASSERT_RANGE("{ [1,5) [6,9) }", rangesB);
 }
 
+TEST(TimeRanges, Nearest)
+{
+    RefPtr<TimeRanges> ranges = TimeRanges::create();
+    ranges->add(0, 2);
+    ranges->add(5, 7);
+
+    EXPECT_EQ(0, ranges->nearest(0));
+    EXPECT_EQ(1, ranges->nearest(1));
+    EXPECT_EQ(2, ranges->nearest(2));
+    EXPECT_EQ(2, ranges->nearest(3));
+    EXPECT_EQ(5, ranges->nearest(4));
+    EXPECT_EQ(5, ranges->nearest(5));
+    EXPECT_EQ(7, ranges->nearest(8));
+}
+
 TEST(TimeRanges, Add_SmallGaps)
 {
     RefPtr<TimeRanges> ranges = TimeRanges::create();


### PR DESCRIPTION
#### f7278b91b3b05920dc1002d9abb5e5ba48f50151
<pre>
[TimeRanges] Add API test coverage for TimeRanges::nearest()
<a href="https://bugs.webkit.org/show_bug.cgi?id=273346">https://bugs.webkit.org/show_bug.cgi?id=273346</a>
<a href="https://rdar.apple.com/127517211">rdar://127517211</a>

Reviewed by Eric Carlson.

Merge (Test Only): <a href="https://chromium.googlesource.com/chromium/src.git/+/ca7a61971dd87991e2b923eb66448bdd8129284c">https://chromium.googlesource.com/chromium/src.git/+/ca7a61971dd87991e2b923eb66448bdd8129284c</a>

Add a direct API test, ported from Blink&apos;s TimeRangesTest.Nearest, to cover
the single-argument nearest() behavior including exact start/end boundary
inputs.

* Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp:
(TestWebKitAPI::TEST(TimeRanges, Nearest)):

Canonical link: <a href="https://commits.webkit.org/316026@main">https://commits.webkit.org/316026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76b4666d3a04d01a5cf9c5c2b530c24c3a666236

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128439 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/382259b5-5bac-45d8-aba7-5c6c4789c24f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133150 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d2289f9-4440-4306-b9b6-4ef7ecf21e9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113647 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0875d543-3e9e-4433-bb9d-6d185e8dcd43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33301 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28784 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182687 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141610 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44307 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38100 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44996 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109665 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36694 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43507 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8078 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42911 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43152 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43042 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->