### PR TITLE
Deduplicate the multi-line nine-piece image strip computation in InlineBoxPainter

### DIFF
--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -128,6 +128,30 @@ static LayoutRect clipRectForNinePieceImageStrip(const InlineIterator::InlineBox
     return clipRect;
 }
 
+LayoutRect InlineBoxPainter::computeNinePieceImageStrip(const LayoutPoint& adjustedPaintOffset, const LayoutRect& localRect) const
+{
+    // We have a border/mask image that spans multiple lines.
+    // We need to adjust tx and ty by the width of all previous lines.
+    // Think of border image painting on inlines as though you had one long line, a single continuous
+    // strip. Even though that strip has been broken up across multiple lines, you still paint it
+    // as though you had one single line. This means each line has to pick up the image where
+    // the previous line left off.
+    // FIXME: What the heck do we do with RTL here? The math we're using is obviously not right,
+    // but it isn't even clear how this should work at all.
+    LayoutUnit logicalOffsetOnLine;
+    for (auto box = m_inlineBox.nextInlineBoxLineLeftward(); box; box.traverseInlineBoxLineLeftward())
+        logicalOffsetOnLine += box->logicalWidth();
+    LayoutUnit totalLogicalWidth = logicalOffsetOnLine;
+    for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineRightward())
+        totalLogicalWidth += box->logicalWidth();
+
+    LayoutUnit stripX = adjustedPaintOffset.x() - (isHorizontal() ? logicalOffsetOnLine : 0_lu);
+    LayoutUnit stripY = adjustedPaintOffset.y() - (isHorizontal() ? 0_lu : logicalOffsetOnLine);
+    LayoutUnit stripWidth = isHorizontal() ? totalLogicalWidth : localRect.width();
+    LayoutUnit stripHeight = isHorizontal() ? localRect.height() : totalLogicalWidth;
+    return { stripX, stripY, stripWidth, stripHeight };
+}
+
 void InlineBoxPainter::paintMask()
 {
     if (!m_paintInfo.shouldPaintWithinRoot(renderer()) || renderer().style().usedVisibility() != Visibility::Visible || m_paintInfo.phase != PaintPhase::Mask)
@@ -174,22 +198,11 @@ void InlineBoxPainter::paintMask()
         borderPainter.paintNinePieceImage(LayoutRect(adjustedPaintOffset, localRect.size()), renderer().style(), maskBorder, compositeOp);
     else {
         // We have a mask image that spans multiple lines.
-        // We need to adjust _tx and _ty by the width of all previous lines.
-        LayoutUnit logicalOffsetOnLine;
-        for (auto box = m_inlineBox.nextInlineBoxLineLeftward(); box; box.traverseInlineBoxLineLeftward())
-            logicalOffsetOnLine += box->logicalWidth();
-        LayoutUnit totalLogicalWidth = logicalOffsetOnLine;
-        for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineRightward())
-            totalLogicalWidth += box->logicalWidth();
-        LayoutUnit stripX = adjustedPaintOffset.x() - (isHorizontal() ? logicalOffsetOnLine : 0_lu);
-        LayoutUnit stripY = adjustedPaintOffset.y() - (isHorizontal() ? 0_lu : logicalOffsetOnLine);
-        LayoutUnit stripWidth = isHorizontal() ? totalLogicalWidth : localRect.width();
-        LayoutUnit stripHeight = isHorizontal() ? localRect.height() : totalLogicalWidth;
-
+        LayoutRect imageStrip = computeNinePieceImageStrip(adjustedPaintOffset, localRect);
         LayoutRect clipRect = clipRectForNinePieceImageStrip(m_inlineBox, maskBorder, paintRect);
         GraphicsContextStateSaver stateSaver(m_paintInfo.context());
         m_paintInfo.context().clip(clipRect);
-        borderPainter.paintNinePieceImage(LayoutRect(stripX, stripY, stripWidth, stripHeight), renderer().style(), maskBorder, compositeOp);
+        borderPainter.paintNinePieceImage(imageStrip, renderer().style(), maskBorder, compositeOp);
     }
 
     if (pushTransparencyLayer)
@@ -248,29 +261,11 @@ void InlineBoxPainter::paintDecorations()
     }
 
     // We have a border image that spans multiple lines.
-    // We need to adjust tx and ty by the width of all previous lines.
-    // Think of border image painting on inlines as though you had one long line, a single continuous
-    // strip. Even though that strip has been broken up across multiple lines, you still paint it
-    // as though you had one single line. This means each line has to pick up the image where
-    // the previous line left off.
-    // FIXME: What the heck do we do with RTL here? The math we're using is obviously not right,
-    // but it isn't even clear how this should work at all.
-    LayoutUnit logicalOffsetOnLine;
-    for (auto box = m_inlineBox.nextInlineBoxLineLeftward(); box; box.traverseInlineBoxLineLeftward())
-        logicalOffsetOnLine += box->logicalWidth();
-    LayoutUnit totalLogicalWidth = logicalOffsetOnLine;
-    for (auto box = m_inlineBox.iterator(); box; box.traverseInlineBoxLineRightward())
-        totalLogicalWidth += box->logicalWidth();
-
-    LayoutUnit stripX = adjustedPaintoffset.x() - (isHorizontal() ? logicalOffsetOnLine : 0_lu);
-    LayoutUnit stripY = adjustedPaintoffset.y() - (isHorizontal() ? 0_lu : logicalOffsetOnLine);
-    LayoutUnit stripWidth = isHorizontal() ? totalLogicalWidth : localRect.width();
-    LayoutUnit stripHeight = isHorizontal() ? localRect.height() : totalLogicalWidth;
-
+    LayoutRect imageStrip = computeNinePieceImageStrip(adjustedPaintoffset, localRect);
     LayoutRect clipRect = clipRectForNinePieceImageStrip(m_inlineBox, borderImage, paintRect);
     GraphicsContextStateSaver stateSaver(context);
     context.clip(clipRect);
-    borderPainter.paintBorder(LayoutRect(stripX, stripY, stripWidth, stripHeight), style);
+    borderPainter.paintBorder(imageStrip, style);
 }
 
 template<typename Layers> void InlineBoxPainter::paintFillLayers(const Color& color, const Layers& fillLayers, Style::ZoomFactor zoom, const LayoutRect& rect, CompositeOperator op)

--- a/Source/WebCore/rendering/InlineBoxPainter.h
+++ b/Source/WebCore/rendering/InlineBoxPainter.h
@@ -56,6 +56,9 @@ private:
 
     void paintMask();
     void paintDecorations();
+    // Computes the rect into which a nine-piece border/mask image is painted for an inline box that
+    // has been split across multiple lines, treating the fragments as one continuous strip.
+    LayoutRect computeNinePieceImageStrip(const LayoutPoint& adjustedPaintOffset, const LayoutRect& localRect) const;
     template<typename Layers> void paintFillLayers(const Color&, const Layers&, Style::ZoomFactor, const LayoutRect& paintRect, CompositeOperator);
     template<typename Layer> void paintFillLayer(const Color&, const FillLayerToPaint<Layer>&, const LayoutRect& paintRect, CompositeOperator);
     void paintBoxShadow(Style::ShadowStyle, const LayoutRect& paintRect);


### PR DESCRIPTION
#### ec4c328ee08b66cae29d2c266b6c1cd7b2972c8d
<pre>
Deduplicate the multi-line nine-piece image strip computation in InlineBoxPainter
<a href="https://bugs.webkit.org/show_bug.cgi?id=318104">https://bugs.webkit.org/show_bug.cgi?id=318104</a>
<a href="https://rdar.apple.com/180896838">rdar://180896838</a>

Reviewed by Simon Fraser.

InlineBoxPainter::paintMask() and InlineBoxPainter::paintDecorations() each
contained an identical copy of the math that lays out a border/mask nine-piece
image as one continuous strip across the fragments of an inline box that has
been split over multiple lines (the line-leftward/rightward width accumulation
plus the stripX/stripY/stripWidth/stripHeight derivation).

Extract that shared computation into a new helper,
InlineBoxPainter::computeNinePieceImageStrip(), and call it from both sites.
This is a pure refactor with no behavior change: the helper preserves the
existing math verbatim (including the pre-existing RTL FIXME), and each caller
keeps its own clip-rect setup since those differ (mask vs. border image,
different graphics contexts).

* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::computeNinePieceImageStrip const):
(WebCore::InlineBoxPainter::paintMask):
(WebCore::InlineBoxPainter::paintDecorations):
* Source/WebCore/rendering/InlineBoxPainter.h:

Canonical link: <a href="https://commits.webkit.org/316045@main">https://commits.webkit.org/316045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf0fb23cb9f1c798f0a2e5180458dc927f27e339

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128440 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0901eb83-2c9d-4929-a58e-dac2bf324b1f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133151 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83189552-737b-4fe7-b2f5-56fceaf01607) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113648 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1b86f34-be64-401e-bb84-222f76f64a6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33302 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28785 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182688 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141611 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44308 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141427 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38126 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44997 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109666 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36696 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116886 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43508 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8081 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42912 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43153 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->