### PR TITLE
Combining marks on SVG <textPath> render as dotted circles

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG text: combining marks on a textPath shape as one typographic character (reference)</title>
+
+<body style="margin:20px">
+
+<!-- Precomposed U+00E9 (LATIN SMALL LETTER E WITH ACUTE), same straight horizontal path. -->
+<svg width="600" height="100">
+  <path id="hline" d="M 50 50 L 550 50" fill="none"/>
+  <text font-size="40px">
+    <textPath href="#hline">caf&#x00e9; expos&#x00e9;</textPath>
+  </text>
+</svg>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<title>SVG text: combining marks on a textPath shape as one typographic character (reference)</title>
+
+<body style="margin:20px">
+
+<!-- Precomposed U+00E9 (LATIN SMALL LETTER E WITH ACUTE), same straight horizontal path. -->
+<svg width="600" height="100">
+  <path id="hline" d="M 50 50 L 550 50" fill="none"/>
+  <text font-size="40px">
+    <textPath href="#hline">caf&#x00e9; expos&#x00e9;</textPath>
+  </text>
+</svg>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<link rel="match" href="textpath-combining-marks-ref.html">
+<title>SVG text: combining marks on a textPath shape as one typographic character</title>
+<link rel="help" href="https://w3c.github.io/svgwg/master/text.html#TextLayoutIntroduction">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=266832">
+<meta name="assert" content="A base letter followed by a combining mark (e + U+0301) placed on a textPath must be shaped together as one typographic character, rendering an accented letter — not a base glyph and a dotted-circle for the lone mark.">
+
+<body style="margin:20px">
+
+<!-- e + U+0301 (COMBINING ACUTE ACCENT): the mark must join its base, not become its own
+     isolated single-code-point fragment. Straight horizontal path so layout matches the
+     precomposed reference exactly. -->
+<svg width="600" height="100">
+  <path id="hline" d="M 50 50 L 550 50" fill="none"/>
+  <text font-size="40px">
+    <textPath href="#hline">cafe&#x0301; expose&#x0301;</textPath>
+  </text>
+</svg>
+
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -33,6 +33,8 @@
 #include "SVGTextLayoutEngineBaseline.h"
 #include "SVGTextLayoutEngineSpacing.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include <unicode/ubrk.h>
+#include <wtf/text/TextBreakIterator.h>
 
 // Set to a value > 0 to dump the text fragments
 #define DUMP_SVG_TEXT_LAYOUT_FRAGMENTS 0
@@ -434,6 +436,9 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
     float baselineShift = baselineLayout.calculateBaselineShift(style);
     baselineShift -= baselineLayout.calculateAlignmentBaselineShift(m_isVerticalText, text);
 
+    // Grapheme-cluster boundaries, keyed by the same code-unit offset the loop walks (m_visualCharacterOffset).
+    NonSharedCharacterBreakIterator clusterIterator(StringView(text.text()));
+
     // Main layout algorithm.
     while (true) {
         // Find the start of the current text box in this list, respecting ligatures.
@@ -629,9 +634,12 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
             m_lastChunkHasTextLength = definesTextLength;
         }
 
+        // Only a cluster start may open a new fragment, so a combining mark stays with its base rather than being shaped alone (dotted circle). Bug 266832.
+        bool isClusterStart = ubrk_isBoundary(clusterIterator, m_visualCharacterOffset);
+
         // Determine whether we have to start a new fragment.
-        bool shouldStartNewFragment = hasXOrY || m_dx || m_dy || m_isVerticalText || m_inPathLayout || angle || angle != lastAngle
-            || orientationAngle || applySpacingToNextCharacter || definesTextLength;
+        bool shouldStartNewFragment = isClusterStart && (hasXOrY || m_dx || m_dy || m_isVerticalText || m_inPathLayout || angle || angle != lastAngle
+            || orientationAngle || applySpacingToNextCharacter || definesTextLength);
 
         // If we already started a fragment, close it now.
         if (didStartTextFragment && shouldStartNewFragment) {


### PR DESCRIPTION
#### ef2bac73ff9346238a2821c222980d38f9aaad97
<pre>
Combining marks on SVG &lt;textPath&gt; render as dotted circles
<a href="https://bugs.webkit.org/show_bug.cgi?id=266832">https://bugs.webkit.org/show_bug.cgi?id=266832</a>
<a href="https://rdar.apple.com/120284006">rdar://120284006</a>

Reviewed by Elika Etemad.

SVG text on a path (and any per-character-positioned text) was laid out one
Unicode code point at a time: SVGTextLayoutEngine opened a fresh
single-code-point fragment for every code point whenever a per-character
condition fired (text on a path, an explicit rotate, vertical text, …),
and SVGTextBoxPainter then shaped each fragment&apos;s substring in isolation. A lone
combining mark shaped on its own (e.g. U+0301, or the Devanagari virama U+094D)
makes the font emit a dotted circle.

SVG 2 section 11 addresses the text-positioning attributes (x/y/dx/dy/rotate)
per Unicode code point, but it also defines a &quot;typographic character&quot;

    a UAX #29 grapheme cluster such as a base letter plus its
    combining marks, or a Devanagari syllable

as an indivisible unit whose internal glyph arrangement is &quot;not user
controllable&quot;. So code points are addressed, but typographic characters
are positioned and shaped. WebKit placed code points.

Compute grapheme-cluster boundaries over the renderer text with an ICU
character-break iterator, keyed by the same code-unit offset the layout loop
walks, and only let a cluster-start code point open a new fragment. A
continuation code point (a combining mark, a Devanagari continuation, the
second regional indicator of a flag) now joins the current fragment, so the
painter hands base + marks to the shaper together. This is font-independent, so
it groups base + mark even when the font has no composed glyph -- precisely the
dotted-circle case. Per-code-point metrics, character-data lookups, and the
getNumberOfChars / query contract are unchanged; the fragment simply spans
multiple metrics entries, which recordTextFragment already sums.

Matches Gecko and Blink, which both treat the typographic character as the
positioning unit. For pure ASCII / precomposed Latin-1 text every code point is
a grapheme boundary, so behavior is unchanged there.

Tests: imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-ref.html
       imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks.html

* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textpath-combining-marks.html: Added.
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):

Canonical link: <a href="https://commits.webkit.org/316144@main">https://commits.webkit.org/316144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeb1e5a9dd6ebd6136e9a21de3dbaf19fa3f804b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128616 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6f9280b-a2c6-491f-9f87-6854962a060c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133300 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6193b87-32b0-4770-94a2-4a2b967f1bf5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113781 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6062e92-9f81-47e2-af2f-c21db0e59e0a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35139 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33458 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28960 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145597 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.PanelHidCtapNoCredentialsFound (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182865 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141759 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141569 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45171 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30119 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109876 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36830 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117062 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43682 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43086 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43328 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->