### PR TITLE
[LBSE] Adjust test expectations after 315946@main

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt
@@ -23,7 +23,7 @@ PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline 
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().height, <foreignObject> inline style but "display: none"
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> initial
-FAIL SVG Geometry Properties: getComputedStyle().height, <svg> presentation attribute assert_equals: presentation attribute expected "auto" but got "200px"
+PASS SVG Geometry Properties: getComputedStyle().height, <svg> presentation attribute
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().height, <svg> inline style (percentage)
@@ -34,7 +34,7 @@ PASS SVG Geometry Properties: getComputedStyle().height, <g> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().height, <g> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().height, <g> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().height, <text> initial
-FAIL SVG Geometry Properties: getComputedStyle().height, <text> initial (with dummy attribute) assert_equals: initial (with dummy attribute) expected "auto" but got "42px"
+PASS SVG Geometry Properties: getComputedStyle().height, <text> initial (with dummy attribute)
 PASS SVG Geometry Properties: getComputedStyle().height, <text> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().height, <text> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().height, <text> inline style (percentage)

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt
@@ -23,7 +23,7 @@ PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline s
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().width, <foreignObject> inline style but "display: none"
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> initial
-FAIL SVG Geometry Properties: getComputedStyle().width, <svg> presentation attribute assert_equals: presentation attribute expected "auto" but got "100px"
+PASS SVG Geometry Properties: getComputedStyle().width, <svg> presentation attribute
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().width, <svg> inline style (percentage)
@@ -34,7 +34,7 @@ PASS SVG Geometry Properties: getComputedStyle().width, <g> inline style (percen
 PASS SVG Geometry Properties: getComputedStyle().width, <g> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().width, <g> inline style (pixels)
 PASS SVG Geometry Properties: getComputedStyle().width, <text> initial
-FAIL SVG Geometry Properties: getComputedStyle().width, <text> initial (with dummy attribute) assert_equals: initial (with dummy attribute) expected "auto" but got "100px"
+PASS SVG Geometry Properties: getComputedStyle().width, <text> initial (with dummy attribute)
 PASS SVG Geometry Properties: getComputedStyle().width, <text> inline style (percentage)
 PASS SVG Geometry Properties: getComputedStyle().width, <text> inline style (auto)
 PASS SVG Geometry Properties: getComputedStyle().width, <text> inline style (pixels)


### PR DESCRIPTION
#### 8be3ba5c9f04cadf8636e69450309fa1c6eeedb1
<pre>
[LBSE] Adjust test expectations after 315946@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=318106">https://bugs.webkit.org/show_bug.cgi?id=318106</a>

Reviewed by Nikolas Zimmermann.

Adjust test expectations after 315946@main, this is a progression.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/height-computed-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/geometry/parsing/width-computed-expected.txt:

Canonical link: <a href="https://commits.webkit.org/316542@main">https://commits.webkit.org/316542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d6c073eb2c13a1a5d7735f7d7759fb170b2bcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128452 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133164 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93964 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113661 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34988 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33313 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182700 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141623 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44320 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141439 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38610 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45009 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109683 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36706 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43520 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8089 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42924 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->