### PR TITLE
Cherry-pick 315809@main (b74c6193c14d). https://bugs.webkit.org/show_bug.cgi?id=317782

### DIFF
--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -103,9 +103,18 @@ SoupNetworkSession::SoupNetworkSession(PAL::SessionID sessionID)
     static const int maxConnections = 256;
     static const int maxConnectionsPerHost = 6;
 
+    // libsoup's default idle-timeout is 60s. Raise it to 115s, matching
+    // Firefox's network.http.keep-alive.timeout default, to keep connections
+    // warm for same-origin renavigation within a browsing session.
+    // Firefox flags a problem with IIS7 servers' default timeout of 120s, so
+    // the timeout chosen is a little shorter to keep a reserve for cases
+    // when the packet is lost or delayed on the route.
+    static const int idleTimeout = 115;
+
     m_soupSession = adoptGRef(soup_session_new_with_options(
         "max-conns", maxConnections,
         "max-conns-per-host", maxConnectionsPerHost,
+        "idle-timeout", idleTimeout,
         "timeout", 0,
         nullptr));
 

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -116,8 +116,10 @@ void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, const GRe
         certificatesData.insert(0, WTF::move(certificateData));
     }
 
-    if (certificatesData.isEmpty())
+    if (certificatesData.isEmpty()) {
+        encoder << Vector<std::span<const uint8_t>> { };
         return;
+    }
 
     encoder << certificatesData;
 

--- a/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
+++ b/Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp
@@ -32,6 +32,8 @@
 #include "APISerializedScriptValue.h"
 #include <jsc/JSCContextPrivate.h>
 #include <jsc/JSCValuePrivate.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
 
 namespace WebKit {
 
@@ -63,17 +65,16 @@ auto JavaScriptEvaluationResult::GLibExtractor::toValue(GVariant* variant) -> Va
 {
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE("a{sv}"))) {
         ObjectMap objectMap;
-        GVariantIter iter;
-        g_variant_iter_init(&iter, variant);
+        GUniquePtr<GVariantIter> iter(g_variant_iter_new(variant));
         const char* key;
-        GVariant* value;
-        while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
+        GRefPtr<GVariant> value;
+        while (g_variant_iter_next(iter.get(), "{&sv}", &key, &value.outPtr())) {
             if (!key || !value)
                 continue;
             auto keyID = JSObjectID::generate();
             m_map.add(keyID, String::fromUTF8(key));
             auto valueID = JSObjectID::generate();
-            m_map.add(valueID, toValue(value));
+            m_map.add(valueID, toValue(value.get()));
             objectMap.add(keyID, valueID);
         }
         return { WTF::move(objectMap) };
@@ -116,12 +117,11 @@ static bool isSerializable(GVariant* variant)
         return true;
 
     if (g_variant_is_of_type(variant, G_VARIANT_TYPE("a{sv}"))) {
-        GVariantIter iter;
-        g_variant_iter_init(&iter, variant);
+        GUniquePtr<GVariantIter> iter(g_variant_iter_new(variant));
         const char* key;
-        GVariant* value;
-        while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
-            if (!key || !isSerializable(value))
+        GRefPtr<GVariant> value;
+        while (g_variant_iter_next(iter.get(), "{&sv}", &key, &value.outPtr())) {
+            if (!key || !isSerializable(value.get()))
                 return false;
         }
         return true;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -90,7 +90,9 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
+#include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GSpanExtras.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CStringView.h>
 #include <wtf/text/StringBuilder.h>
@@ -4468,15 +4470,14 @@ static Vector<std::pair<String, JavaScriptEvaluationResult>> parseAsyncFunctionA
 
     Vector<std::pair<String, JavaScriptEvaluationResult>> argumentsVector;
 
-    GVariantIter iter;
-    g_variant_iter_init(&iter, arguments);
+    GUniquePtr<GVariantIter> iter(g_variant_iter_new(arguments));
     const char* key;
-    GVariant* value;
-    while (g_variant_iter_loop(&iter, "{&sv}", &key, &value)) {
+    GRefPtr<GVariant> value;
+    while (g_variant_iter_next(iter.get(), "{&sv}", &key, &value.outPtr())) {
         if (!key)
             continue;
 
-        auto parameter = JavaScriptEvaluationResult::extract(value);
+        auto parameter = JavaScriptEvaluationResult::extract(value.get());
         if (!parameter) {
             *error = g_error_new(WEBKIT_JAVASCRIPT_ERROR, WEBKIT_JAVASCRIPT_ERROR_INVALID_PARAMETER, "Invalid parameter %s passed as argument of async function call", key);
             return argumentsVector;

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -26,6 +26,7 @@
 #include "cmakeconfig.h"
 
 #include "BuildRevision.h"
+#include <glib-unix.h>
 #include <memory>
 #include <wpe/webkit.h>
 #include <wtf/Compiler.h>
@@ -798,6 +799,12 @@ int main(int argc, char *argv[])
 #else
     g_signal_connect(application, "activate", G_CALLBACK(activate), nullptr);
 #endif
+    GSourceFunc quitOnSignal = [](gpointer app) -> gboolean {
+        g_application_quit(G_APPLICATION(app));
+        return G_SOURCE_REMOVE;
+    };
+    g_unix_signal_add(SIGINT, quitOnSignal, application);
+    g_unix_signal_add(SIGTERM, quitOnSignal, application);
     g_application_run(application, 0, nullptr);
     g_object_unref(application);
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2758,6 +2758,12 @@ sub shouldRemoveCMakeCache(@)
         }
     }
 
+    # A new wkdev SDK image can ship a different toolchain, so re-run cmake.
+    my $wkdevSdkVersionFile = File::Spec->catfile(sourceDir(), ".wkdev-sdk-version");
+    if (-e $wkdevSdkVersionFile && $cacheFileModifiedTime < stat($wkdevSdkVersionFile)->mtime) {
+        return 1;
+    }
+
     # FIXME: This probably does not work as expected, or the next block to
     # delete the images subdirectory would not be here. Directory mtime does not
     # percolate upwards when files are added or removed from subdirectories.


### PR DESCRIPTION
#### 087748fb24107905a790a2d5b90a617582947fb8
<pre>
Cherry-pick 315809@main (b74c6193c14d). <a href="https://bugs.webkit.org/show_bug.cgi?id=317782">https://bugs.webkit.org/show_bug.cgi?id=317782</a>

    [GTK][WPE] Regenerate CMake cache when .wkdev-sdk-version changes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317782">https://bugs.webkit.org/show_bug.cgi?id=317782</a>

    Reviewed by Adrian Perez de Castro.

    A new wkdev-sdk image can ship a different toolchain and dependencies,
    which can influence the generated CMake cache. Invalidate the cache in
    shouldRemoveCMakeCache() when .wkdev-sdk-version is newer than
    CMakeCache.txt, mirroring the existing mtime-based check for *.cmake
    files under Source/cmake.

    * Tools/Scripts/webkitdirs.pm:
    (shouldRemoveCMakeCache):

    Canonical link: <a href="https://commits.webkit.org/315809@main">https://commits.webkit.org/315809@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.800@webkitglib/2.52">https://commits.webkit.org/305877.800@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### bd214b43c980d69eec6c00ffd19699f430de9563
<pre>
Cherry-pick 315741@main (db4d5fc97b32). <a href="https://bugs.webkit.org/show_bug.cgi?id=316990">https://bugs.webkit.org/show_bug.cgi?id=316990</a>

    [GTK][WPE] Increase the libsoup idle connection timeout to 115 seconds
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316990">https://bugs.webkit.org/show_bug.cgi?id=316990</a>

    Reviewed by Patrick Griffis.

    Raise the libsoup session idle-connection timeout from the 60s default
    to 115s. Keeping idle connections in the pool longer avoids a full
    TCP+TLS reconnect when navigating back to a recently-used origin within
    a browsing session. This matches Firefox&apos;s default
    (network.http.keep-alive.timeout = 115); Chrome keeps used idle sockets
    for 300s.

    No new tests, behavior change is a timeout tuning value.

    * Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
    (WebCore::SoupNetworkSession::SoupNetworkSession):

    Canonical link: <a href="https://commits.webkit.org/315741@main">https://commits.webkit.org/315741@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.799@webkitglib/2.52">https://commits.webkit.org/305877.799@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c067e9ff28d1d1d9c9bc7463d0ef68308000df82
<pre>
Cherry-pick 315630@main (449035bdfe62). <a href="https://bugs.webkit.org/show_bug.cgi?id=298066">https://bugs.webkit.org/show_bug.cgi?id=298066</a>

    [WPE][GTK] Fix leaks when using g_variant_iter_loop()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=298066">https://bugs.webkit.org/show_bug.cgi?id=298066</a>

    Reviewed by Patrick Griffis.

    Milan pointed out that if we break out of a g_variant_iter_loop() loop,
    then it cannot free the key or value for us. In these cases, we have to
    free it manually.

    The easiest solution is to just not use g_variant_iter_loop() in these
    cases, to ensure we cannot mess up. g_variant_iter_next() is basically
    the same thing, except it requires that we handle the ownership.

    * Source/WebKit/Shared/glib/JavaScriptEvaluationResultGLib.cpp:
    (WebKit::JavaScriptEvaluationResult::GLibExtractor::toValue):
    (WebKit::isSerializable):
    * Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
    (parseAsyncFunctionArguments):

    Canonical link: <a href="https://commits.webkit.org/315630@main">https://commits.webkit.org/315630@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.798@webkitglib/2.52">https://commits.webkit.org/305877.798@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6f0310c3848c0264644c5f66b6fa92aa0feb7c97
<pre>
Cherry-pick 315631@main (e81367bfcb6f). <a href="https://bugs.webkit.org/show_bug.cgi?id=317567">https://bugs.webkit.org/show_bug.cgi?id=317567</a>

    [WPE] Make MiniBrowser exit cleanly on SIGTERM and SIGINT
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317567">https://bugs.webkit.org/show_bug.cgi?id=317567</a>

    Reviewed by Carlos Garcia Campos.

    Instrumenting with `-fprofile-generate` dump the collected data through
    atexit handlers. Currently, MiniBrowser do not install any handler on
    the catchable signals SIGTERM/SIGINT to exit its mainloop, making it
    hard to properly instrument it.

    * Tools/MiniBrowser/wpe/main.cpp:
    (main):

    Canonical link: <a href="https://commits.webkit.org/315631@main">https://commits.webkit.org/315631@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.797@webkitglib/2.52">https://commits.webkit.org/305877.797@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 77c629c048ea6b430a7bebdb675dec803b313208
<pre>
Cherry-pick 315892@main (ac70e863fb9d). <a href="https://bugs.webkit.org/show_bug.cgi?id=317922">https://bugs.webkit.org/show_bug.cgi?id=317922</a>

    Regression(278316@main): [GLIB] IPC encoder desyncs on certificate extraction failure
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317922">https://bugs.webkit.org/show_bug.cgi?id=317922</a>

    Reviewed by Claudio Saavedra.

    ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode() unconditionally reads
    a vector of cert data as its first field. The encoder, however, fails to
    write anything if the certificate fails to produce its DER data. This
    means that the decoder will go out of sync, reading subsequent elements
    as if they were the certificate, which in turn can cause intermittent
    crashes afterwards.

    This is a regression from 278316@main. Before its refactoring, the
    certificate size was unconditionally written, and when 0 the decoder
    would handle it appropriately. After the refactoring, empty certificates
    are skipped, and the 0 size is not communicated. This ensures an empty
    vector is encoded on the failure path, so that decoder and encoder are
    kept in sync.

    No new tests: this would probably require IPC API tests to run for GLib
    platforms.

    * Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
    (IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::encode):

    Canonical link: <a href="https://commits.webkit.org/315892@main">https://commits.webkit.org/315892@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.796@webkitglib/2.52">https://commits.webkit.org/305877.796@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89d8743b506de7e066db29d71a9cf96dab084489

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170747 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44672 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180125 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128460 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172613 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45940 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44306 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133169 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128460 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173706 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/45940 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113666 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45940 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44306 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28805 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/45940 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182708 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/32002 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35505 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/44306 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141630 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/44328 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141446 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45017 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109696 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26020 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45017 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116906 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203426 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/43528 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/38090 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54475 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42932 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43173 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43063 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->