### PR TITLE
3 Performance tests are failing on GTK-Linux-64-bit-Release-Perf bot.

### DIFF
--- a/PerformanceTests/Skipped
+++ b/PerformanceTests/Skipped
@@ -152,6 +152,9 @@ MediaTime/
 # Bug 167616 - Performance test IndexedDB/large-binary-keys.html creates a DB of more than 6GB and takes more than 10 minutes to run.
 [GTK] IndexedDB/stress/large-binary-keys.html
 
+# WTR doesn't load any content-extension rules, so it can't benchmark meaningfully here. Run manually.
+Bindings/insert-img-with-src.html
+
 # Skip timeouts.
 [Win] IndexedDB/basic/index-cursor-delete-2.html
 [Win] IndexedDB/basic/index-cursor-delete.html

--- a/Tools/Scripts/webkitpy/performance_tests/perftest.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftest.py
@@ -242,6 +242,8 @@ class PerfTest(object):
 
     _lines_to_ignore = [
         re.compile(r"^\s+$"),
+        # PerformanceTests/CSS/WhereIs*Indexing.html print lot of lines containing "x" or "xx"
+        re.compile(r"^x+$"),
         # Following are for handle existing test like Dromaeo
         re.compile(re.escape("""main frame - has 1 onunload handler(s)""")),
         re.compile('frame \"[^"]+\" - has \\d+ onunload handler\\(s\\)'),


### PR DESCRIPTION
#### 02ce2969afb1e2ddc9361ff0f837a7ec3e2febee
<pre>
3 Performance tests are failing on GTK-Linux-64-bit-Release-Perf bot.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318110">https://bugs.webkit.org/show_bug.cgi?id=318110</a>

Unreviewed gardening.

The test Bindings/insert-img-with-src.html fails because it prints
to stdout an error related to not beeing able to access an external
URL. In this case we simply skip the test instead of filtering that
message beacause this test can&apos;t be benchmarked with the current
run-perf-test/WTR infrastructure because it needs to load some
content filter rules to be able to meaningfully run the benchmark,
and that is currently not supported.

The other two tests CSS/WhereIs*RuleIndexing.html test are generating
lot of elements with the text &quot;x&quot; that later is dumped to stdout when
the test runner executes testRunner.dumpAsText(); and that confuses
the python tooling. In this case the fix chosen is to simply filter
out lines containing only &quot;x&quot; as character (which is clearly garbage
and not an indication of any error). Instead of doing that it was
tested to remove the &quot;el.textContent = &apos;x&apos;;&quot; line from the tests,
but then the test gives different benchmark results, so to not
invalidate previous benchmark data results it is preferred to not
touch the test.

* PerformanceTests/Skipped:
* Tools/Scripts/webkitpy/performance_tests/perftest.py:
(PerfTest):

Canonical link: <a href="https://commits.webkit.org/316016@main">https://commits.webkit.org/316016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0aa837898eeb02361745af7cb07c4a63893331cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44677 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173711 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170073 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28810 "Failed to checkout and rebase branch from PR 68091") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182715 "Failed to checkout and rebase branch from PR 68091") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/182715 "Failed to checkout and rebase branch from PR 68091") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44333 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/182715 "Failed to checkout and rebase branch from PR 68091") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45022 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109703 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26019 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/36719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43533 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->