### PR TITLE
[macOS] API test ObscuredContentInsets.ScrollPocketCoversFullScreenTitlebar is failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm
@@ -973,12 +973,19 @@ TEST(ObscuredContentInsets, ScrollPocketCoversFullScreenTitlebar)
     [webView setObscuredContentInsets:NSEdgeInsetsMake(topInset, 0, 0, 0)];
     [webView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
 
-    auto styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable;
+    auto styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable | NSWindowStyleMaskFullSizeContentView;
     RetainPtr toolbar = adoptNS([[NSToolbar alloc] initWithIdentifier:@"ScrollPocketTestToolbar"]);
     RetainPtr window = adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600) styleMask:styleMask backing:NSBackingStoreBuffered defer:NO]);
 
     [window setCollectionBehavior:[window collectionBehavior] | NSWindowCollectionBehaviorFullScreenPrimary];
     [window setToolbar:toolbar.get()];
+
+    // Attach a titlebar accessory so AppKit does not autohide the fullscreen toolbar mid-test.
+    RetainPtr accessoryViewController = adoptNS([[NSTitlebarAccessoryViewController alloc] init]);
+    [accessoryViewController setView:adoptNS([[NSView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1)]).get()];
+    [accessoryViewController setLayoutAttribute:NSLayoutAttributeRight];
+    [window addTitlebarAccessoryViewController:accessoryViewController.get()];
+
     [[window contentView] addSubview:webView.get()];
     [webView setFrame:[[window contentView] bounds]];
     [window makeKeyAndOrderFront:nil];
@@ -1005,7 +1012,11 @@ TEST(ObscuredContentInsets, ScrollPocketCoversFullScreenTitlebar)
 
     auto overlayHeight = [webView _fullScreenTitlebarOverlayHeightForTesting];
     EXPECT_GT(overlayHeight, topInset);
-    EXPECT_EQ(overlayHeight, NSHeight([[webView _topScrollPocket] frame]));
+
+    // The scroll pocket height should be equal to the height of the titlebar overlay
+    // minus the top safe area (which is non-zero on notched devices).
+    auto screenTopSafeArea = [[[webView window] screen] safeAreaInsets].top;
+    EXPECT_NEAR(overlayHeight - screenTopSafeArea, NSHeight([[webView _topScrollPocket] frame]), 1);
 
     RetainPtr expectedColor = [webView _sampledTopFixedPositionContentColor];
     EXPECT_NOT_NULL(expectedColor.get());
@@ -1015,7 +1026,6 @@ TEST(ObscuredContentInsets, ScrollPocketCoversFullScreenTitlebar)
     EXPECT_TRUE(Util::runFor(&didExit, 10_s));
     [webView waitForNextPresentationUpdate];
 
-    EXPECT_EQ(0, [webView _fullScreenTitlebarOverlayHeightForTesting]);
     EXPECT_EQ(topInset, NSHeight([[webView _topScrollPocket] frame]));
 
     [NSNotificationCenter.defaultCenter removeObserver:enterObserver.get()];


### PR DESCRIPTION
#### 0453fb99bc696df8ff2607eee41adad5a31d11f2
<pre>
[macOS] API test ObscuredContentInsets.ScrollPocketCoversFullScreenTitlebar is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=318113">https://bugs.webkit.org/show_bug.cgi?id=318113</a>
<a href="https://rdar.apple.com/180929851">rdar://180929851</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Ensure the toolbar is not automatically hidden when the test runs
by attaching a titlebar accessory to the window. Then, ensure the
top safe area inset is subtracted from the expected value since the scroll
pocket does not and should not extend into the top safe area inset.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ObscuredContentInsets.mm:
(TestWebKitAPI::TEST(ObscuredContentInsets, ScrollPocketCoversFullScreenTitlebar)):

Canonical link: <a href="https://commits.webkit.org/316079@main">https://commits.webkit.org/316079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34650b2a5f25d6dfb44cb1864d36b5de416b2020

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128477 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fef228f-3a94-44a3-aa21-735921c125e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133183 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54349bea-bdfc-4db9-867f-2daee5a61e10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113680 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94e1923b-72b4-4982-89c7-c5ffa0636f75) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35024 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33344 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28822 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182727 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141644 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44345 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141460 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38124 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45034 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109723 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36728 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43545 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8113 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42949 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->