### PR TITLE
[MediaStreams] Add tests for untested areas of the MediaCapture-Main and Extensions specifications

### DIFF
--- a/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
@@ -9,12 +9,14 @@ PASS navigator.mediaDevices.getSupportedConstraints is an instance of Function
 supportedConstraints = navigator.mediaDevices.getSupportedConstraints()
 
 PASS supportedConstraints.aspectRatio is true
+PASS supportedConstraints.backgroundBlur is true
 PASS supportedConstraints.deviceId is true
 PASS supportedConstraints.echoCancellation is true
 PASS supportedConstraints.facingMode is true
 PASS supportedConstraints.frameRate is true
 PASS supportedConstraints.groupId is true
 PASS supportedConstraints.height is true
+PASS supportedConstraints.powerEfficient is true
 PASS supportedConstraints.sampleRate is true
 PASS supportedConstraints.sampleSize is true
 PASS supportedConstraints.volume is true

--- a/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints.html
+++ b/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints.html
@@ -19,12 +19,14 @@
             evalAndLog("supportedConstraints = navigator.mediaDevices.getSupportedConstraints()");
             debug("");
             shouldBeTrue("supportedConstraints.aspectRatio");
+            shouldBeTrue("supportedConstraints.backgroundBlur");
             shouldBeTrue("supportedConstraints.deviceId");
             shouldBeTrue("supportedConstraints.echoCancellation");
             shouldBeTrue("supportedConstraints.facingMode");
             shouldBeTrue("supportedConstraints.frameRate");
             shouldBeTrue("supportedConstraints.groupId");
             shouldBeTrue("supportedConstraints.height");
+            shouldBeTrue("supportedConstraints.powerEfficient");
             shouldBeTrue("supportedConstraints.sampleRate");
             shouldBeTrue("supportedConstraints.sampleSize");
             shouldBeTrue("supportedConstraints.volume");

--- a/LayoutTests/fast/mediastream/VideoFacingModeEnum-values-expected.txt
+++ b/LayoutTests/fast/mediastream/VideoFacingModeEnum-values-expected.txt
@@ -1,0 +1,3 @@
+
+PASS VideoFacingModeEnum: returned settings/capabilities values are in the spec enum domain
+

--- a/LayoutTests/fast/mediastream/VideoFacingModeEnum-values.html
+++ b/LayoutTests/fast/mediastream/VideoFacingModeEnum-values.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>VideoFacingModeEnum: returned values are in the spec enum domain</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// MediaCapture-Main §"VideoFacingModeEnum":
+//   https://w3c.github.io/mediacapture-main/#dom-videofacingmodeenum
+//
+//   enum VideoFacingModeEnum {
+//     "user",
+//     "environment",
+//     "left",
+//     "right"
+//   };
+//
+// Exhaustive enum-completeness testing would require multi-facing-mode
+// hardware (or mock-device infrastructure that honors the facingMode
+// option through to getSettings — WebKit's addMockCameraDevice
+// currently does not). What we can verify is the narrower
+// spec-conformance claim: any value WebKit returns through
+// getSettings().facingMode or getCapabilities().facingMode entries must
+// be one of the four enum values. A value outside this set would be a
+// spec violation regardless of which subset WebKit's mocks expose.
+//
+// TODO: when mock cameras honor the facingMode constructor arg through
+// to getSettings(), extend this test to verify all four values
+// round-trip through the IDL binding.
+
+const VALID = ["user", "environment", "left", "right"];
+
+if (window.testRunner)
+    testRunner.setCameraPermission(true);
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    const settings = track.getSettings();
+    if ("facingMode" in settings) {
+        assert_in_array(settings.facingMode, VALID,
+            "getSettings().facingMode is a value from VideoFacingModeEnum");
+    }
+
+    const caps = track.getCapabilities();
+    if ("facingMode" in caps) {
+        assert_true(Array.isArray(caps.facingMode),
+            "capabilities.facingMode is a sequence");
+        for (const entry of caps.facingMode) {
+            assert_in_array(entry, VALID,
+                `capability entry "${entry}" is a value from VideoFacingModeEnum`);
+        }
+    }
+}, "VideoFacingModeEnum: returned settings/capabilities values are in the spec enum domain");
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/fast/mediastream/configurationchange-defer-and-abort-expected.txt
+++ b/LayoutTests/fast/mediastream/configurationchange-defer-and-abort-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL configurationchange task is deferred until track is no longer muted promise_test: Unhandled rejection with value: object "Error: timeout waiting for configurationchange after deferred unmute"
+PASS configurationchange task aborts if track readyState is 'ended'
+

--- a/LayoutTests/fast/mediastream/configurationchange-defer-and-abort.html
+++ b/LayoutTests/fast/mediastream/configurationchange-defer-and-abort.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>configurationchange: waits for unmuted/live state and aborts on ended track</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<video id="video" playsInline autoplay></video>
+<script>
+// MediaCapture Extensions §"configurationchange":
+//   https://w3c.github.io/mediacapture-extensions/#change-track-configuration
+//
+// Spec algorithm for queuing a configurationchange task:
+//   - Waits for muted to become false (i.e. the task isn't queued while
+//     the track is muted; it's deferred until the track is live again),
+//     OR for readyState to become "ended" (in which case it's abandoned).
+//   - Aborts (no task queued) if the track's readyState is already "ended"
+//     when the trigger fires, or if the new capabilities/settings already
+//     match the current source state.
+
+if (window.testRunner) {
+    testRunner.setMicrophonePermission(true);
+    testRunner.setCameraPermission(true);
+}
+
+function waitFor(eventTarget, eventName, timeoutMs = 3000, label = eventName) {
+    return new Promise((resolve, reject) => {
+        eventTarget.addEventListener(eventName, resolve, { once: true });
+        setTimeout(() => {
+            reject(new Error(`timeout waiting for ${label}`));
+        }, timeoutMs);
+    });
+}
+
+// Spec step 1: configurationchange firing waits for muted to become
+// false (or readyState to become "ended") before queueing the task.
+//
+// Scenario: get a video track, verify initial backgroundBlur=false,
+// mute the track (interrupt), trigger a backgroundBlur change while
+// muted, then unmute. After the unmute, configurationchange must fire
+// (the deferred task wakes up) and backgroundBlur must reflect the
+// new state.
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    document.getElementById("video").srcObject = stream;
+    await document.getElementById("video").play();
+
+    assert_false(track.getSettings().backgroundBlur,
+        "initial backgroundBlur is false");
+
+    // Mute the track first.
+    const muted = waitFor(track, "mute", 5000);
+    testRunner.setMockCaptureDevicesInterrupted(true, false);
+    await muted;
+    assert_true(track.muted, "track is muted after interrupt");
+
+    // Trigger a config change while muted (this is the spec-mandated
+    // "deferred" scenario). The configurationchange event must NOT
+    // fire while muted; the task is queued only once muted is false.
+    let firedWhileMuted = false;
+    track.onconfigurationchange = () => {
+        if (track.muted)
+            firedWhileMuted = true;
+    };
+    testRunner.triggerMockCaptureConfigurationChange(true, false, false);
+
+    await new Promise(r => test.step_timeout(r, 200));
+    assert_false(firedWhileMuted,
+        "configurationchange did not fire while track was muted");
+
+    // Now unmute. Per spec step 1 (wait for muted=false), the deferred
+    // task wakes up and fires configurationchange. Per spec step 3
+    // (abort if settings/caps already match source), the task only
+    // fires if the source-side state genuinely changed — which it did
+    // here (backgroundBlur went false -> true).
+    const unmute = waitFor(track, "unmute", 5000);
+    const config = waitFor(track, "configurationchange", 5000,
+        "configurationchange after deferred unmute");
+    testRunner.setMockCaptureDevicesInterrupted(false, false);
+    await unmute;
+    await config;
+
+    assert_false(track.muted,
+        "track is unmuted by the time configurationchange fires");
+    assert_true(track.getSettings().backgroundBlur,
+        "backgroundBlur change applied after deferred configurationchange");
+}, "configurationchange task is deferred until track is no longer muted");
+
+// Spec step 2.1: configurationchange task aborts if readyState is
+// "ended" before the trigger fires (no event queued).
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    document.getElementById("video").srcObject = stream;
+    await document.getElementById("video").play();
+
+    // Stop the track BEFORE triggering a config change.
+    track.stop();
+    assert_equals(track.readyState, "ended");
+
+    // Trigger a config change. Since the track is already "ended", no
+    // task should be queued and no event should fire.
+    let fired = false;
+    track.onconfigurationchange = () => { fired = true; };
+    testRunner.triggerMockCaptureConfigurationChange(true, false, false);
+
+    await new Promise(r => test.step_timeout(r, 500));
+    assert_false(fired,
+        "configurationchange does not fire on a track whose readyState " +
+        "is already 'ended' when the source-side change is signalled");
+}, "configurationchange task aborts if track readyState is 'ended'");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/mediastream/constrainable-dictionary-shapes-expected.txt
+++ b/LayoutTests/fast/mediastream/constrainable-dictionary-shapes-expected.txt
@@ -1,0 +1,6 @@
+
+PASS DoubleRange/ULongRange capability values have spec-mandated shapes
+PASS ConstrainDoubleRange/ConstrainULongRange round-trip exact/ideal members
+PASS ConstrainDOMStringParameters: exact/ideal accept DOMString or sequence<DOMString>
+PASS ConstrainBooleanOrDOMStringParameters: exact/ideal accept boolean or DOMString
+

--- a/LayoutTests/fast/mediastream/constrainable-dictionary-shapes.html
+++ b/LayoutTests/fast/mediastream/constrainable-dictionary-shapes.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Constrainable dictionary shapes (DoubleRange, ULongRange, ConstrainXxxParameters)</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// MediaCapture-Main §"Constrainable Properties" dictionary definitions:
+//   https://w3c.github.io/mediacapture-main/#constrainable-interface
+//
+// IDL shapes asserted:
+//   DoubleRange.{min, max}                              — double
+//   ULongRange.{min, max}                               — [Clamp] unsigned long
+//   ConstrainDoubleRange.{exact, ideal}                 — double required/target
+//   ConstrainULongRange.{exact, ideal}                  — [Clamp] unsigned long
+//   ConstrainDOMStringParameters.{exact, ideal}         — DOMString or sequence<DOMString>
+//   ConstrainBooleanOrDOMStringParameters.{exact, ideal} — boolean or DOMString
+//
+// DoubleRange / ULongRange are *returned* via track.getCapabilities() —
+// we observe their shape directly. ConstrainXxxParameters are *input*
+// types — we verify them by applyConstraints round-trip (apply, then
+// inspect via getConstraints).
+
+if (window.testRunner) {
+    testRunner.setMicrophonePermission(true);
+    testRunner.setCameraPermission(true);
+}
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const caps = stream.getVideoTracks()[0].getCapabilities();
+
+    // ULongRange for width/height. Members are integers (the [Clamp]
+    // attribute means values out of range are clamped, but the type
+    // is still unsigned long -> JS Number that is_integer).
+    if ("width" in caps) {
+        assert_equals(typeof caps.width.min, "number", "width.min is a number");
+        assert_equals(typeof caps.width.max, "number", "width.max is a number");
+        assert_true(Number.isInteger(caps.width.min), "width.min is an integer (ULongRange)");
+        assert_true(Number.isInteger(caps.width.max), "width.max is an integer (ULongRange)");
+        assert_greater_than_equal(caps.width.min, 0, "width.min is non-negative");
+        assert_greater_than_equal(caps.width.max, caps.width.min, "width.max >= width.min");
+    }
+    if ("height" in caps) {
+        assert_equals(typeof caps.height.min, "number", "height.min is a number");
+        assert_equals(typeof caps.height.max, "number", "height.max is a number");
+        assert_true(Number.isInteger(caps.height.min), "height.min is an integer (ULongRange)");
+        assert_true(Number.isInteger(caps.height.max), "height.max is an integer (ULongRange)");
+        assert_greater_than_equal(caps.height.min, 0, "height.min is non-negative");
+        assert_greater_than_equal(caps.height.max, caps.height.min, "height.max >= height.min");
+    }
+
+    // DoubleRange for frameRate / aspectRatio. Members are doubles
+    // (not necessarily integers).
+    if ("frameRate" in caps) {
+        assert_equals(typeof caps.frameRate.min, "number", "frameRate.min is a number");
+        assert_equals(typeof caps.frameRate.max, "number", "frameRate.max is a number");
+        assert_greater_than(caps.frameRate.min, 0, "frameRate.min > 0");
+        assert_greater_than_equal(caps.frameRate.max, caps.frameRate.min, "frameRate.max >= min");
+    }
+    if ("aspectRatio" in caps) {
+        assert_equals(typeof caps.aspectRatio.min, "number", "aspectRatio.min is a number");
+        assert_equals(typeof caps.aspectRatio.max, "number", "aspectRatio.max is a number");
+    }
+}, "DoubleRange/ULongRange capability values have spec-mandated shapes");
+
+promise_test(async test => {
+    // ConstrainDoubleRange.exact / .ideal — double required/target.
+    // ConstrainULongRange.exact / .ideal — unsigned long required/target.
+    // Verified by round-trip: apply, then getConstraints returns the same shape.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    // ConstrainDoubleRange.ideal
+    await track.applyConstraints({ frameRate: { ideal: 30 } });
+    let c = track.getConstraints();
+    assert_equals(typeof c.frameRate, "object",
+        "frameRate constraint round-trips as an object (ConstrainDoubleRange)");
+    assert_equals(c.frameRate.ideal, 30,
+        "ConstrainDoubleRange.ideal round-trips as the applied value");
+
+    // ConstrainULongRange.ideal
+    await track.applyConstraints({ width: { ideal: 640 } });
+    c = track.getConstraints();
+    assert_equals(typeof c.width, "object",
+        "width constraint round-trips as an object (ConstrainULongRange)");
+    assert_equals(c.width.ideal, 640,
+        "ConstrainULongRange.ideal round-trips as the applied value");
+    assert_true(Number.isInteger(c.width.ideal),
+        "ConstrainULongRange.ideal round-trips an integer (ULongRange)");
+    // ConstrainULongRange.exact (using a value the track can actually
+    // satisfy — apply the device's current width back).
+    const currentWidth = track.getSettings().width;
+    await track.applyConstraints({ width: { exact: currentWidth } });
+    c = track.getConstraints();
+    assert_equals(c.width.exact, currentWidth,
+        "ConstrainULongRange.exact round-trips as the applied value");
+    assert_true(Number.isInteger(c.width.exact),
+        "ConstrainULongRange.exact round-trips an integer (ULongRange)");
+}, "ConstrainDoubleRange/ConstrainULongRange round-trip exact/ideal members");
+
+promise_test(async test => {
+    // ConstrainDOMStringParameters.exact / .ideal — DOMString OR
+    // sequence<DOMString>. Tested via facingMode, which uses
+    // ConstrainDOMString.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    // Single DOMString form. Use ideal so an OverconstrainedError doesn't
+    // fire if the device doesn't satisfy.
+    await track.applyConstraints({ facingMode: { ideal: "user" } });
+    let c = track.getConstraints();
+    assert_equals(c.facingMode.ideal, "user",
+        "ConstrainDOMStringParameters.ideal accepts a single DOMString");
+
+    // Sequence<DOMString> form.
+    await track.applyConstraints({ facingMode: { ideal: ["user", "environment"] } });
+    c = track.getConstraints();
+    assert_true(Array.isArray(c.facingMode.ideal),
+        "ConstrainDOMStringParameters.ideal accepts a sequence<DOMString>");
+    assert_array_equals(c.facingMode.ideal, ["user", "environment"],
+        "sequence<DOMString> ideal round-trips with original order");
+}, "ConstrainDOMStringParameters: exact/ideal accept DOMString or sequence<DOMString>");
+
+promise_test(async test => {
+    // ConstrainBooleanOrDOMStringParameters — exact/ideal can be
+    // boolean OR DOMString. echoCancellation uses ConstrainBooleanOrDOMString.
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getAudioTracks()[0];
+
+    // Boolean form
+    await track.applyConstraints({ echoCancellation: { ideal: true } });
+    let c = track.getConstraints();
+    assert_equals(c.echoCancellation.ideal, true,
+        "ConstrainBooleanOrDOMStringParameters.ideal accepts a boolean");
+
+    // String form — the type allows DOMString even if no specific
+    // string value is required to be accepted by the implementation.
+    // We use applyConstraints + ideal so unknown string values don't
+    // throw OverconstrainedError; the assertion is that no TypeError
+    // fires (the IDL accepts the union arm).
+    try {
+        await track.applyConstraints({ echoCancellation: { ideal: "always" } });
+        c = track.getConstraints();
+        // If it round-tripped, great — exercising the string arm.
+        if (typeof c.echoCancellation === "object" && "ideal" in c.echoCancellation) {
+            assert_true(typeof c.echoCancellation.ideal === "string"
+                        || typeof c.echoCancellation.ideal === "boolean",
+                "ConstrainBooleanOrDOMStringParameters.ideal round-trips as boolean or string");
+        }
+    } catch (e) {
+        // Non-TypeError rejection is acceptable (e.g. the implementation
+        // doesn't recognize "always" as a value). A TypeError would
+        // mean the IDL union doesn't accept the DOMString arm.
+        assert_false(e instanceof TypeError,
+            "echoCancellation.ideal = string must not throw TypeError " +
+            "(ConstrainBooleanOrDOMString union accepts DOMString arm)");
+    }
+}, "ConstrainBooleanOrDOMStringParameters: exact/ideal accept boolean or DOMString");
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/fast/mediastream/constrainable-pattern-getters-expected.txt
+++ b/LayoutTests/fast/mediastream/constrainable-pattern-getters-expected.txt
@@ -1,0 +1,5 @@
+
+PASS getCapabilities returns the [[Capabilities]] internal slot as a plain object
+PASS getConstraints returns the [[Constraints]] internal slot (most recent successfully applied)
+PASS getSettings returns the [[Settings]] internal slot as a plain object
+

--- a/LayoutTests/fast/mediastream/constrainable-pattern-getters.html
+++ b/LayoutTests/fast/mediastream/constrainable-pattern-getters.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>ConstrainablePattern getCapabilities/getConstraints/getSettings return the internal slots</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// MediaCapture-Main §"ConstrainablePattern":
+//   https://w3c.github.io/mediacapture-main/#constrainable-interface
+//
+// MediaStreamTrack implements ConstrainablePattern, which exposes three
+// getter-style methods:
+//
+//   getCapabilities() — returns the [[Capabilities]] internal slot
+//                       (the device's full range of values for each
+//                       constrainable property)
+//   getConstraints()  — returns the [[Constraints]] internal slot (the
+//                       most recently applied constraints, or {} if none
+//                       have been applied)
+//   getSettings()     — returns the [[Settings]] internal slot (the
+//                       current actual settings the track is operating
+//                       under)
+//
+// All three return plain dictionaries (per IDL, the IDL records are
+// stringified to JS objects). Across multiple calls without an
+// intervening mutation, each must return equivalent data.
+
+if (window.testRunner) {
+    testRunner.setMicrophonePermission(true);
+    testRunner.setCameraPermission(true);
+}
+
+promise_test(async test => {
+    // getCapabilities returns the [[Capabilities]] internal slot.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    const caps = track.getCapabilities();
+    assert_equals(typeof caps, "object", "getCapabilities returns an object");
+    assert_not_equals(caps, null, "getCapabilities returns non-null");
+
+    // Idempotent: a second call yields the same content (no per-call
+    // mutation of [[Capabilities]]).
+    const caps2 = track.getCapabilities();
+    assert_object_equals(caps, caps2,
+        "two getCapabilities calls return equivalent content");
+
+    // Per spec, capability values for constrainable properties of the
+    // device should include at least the kind-applicable members. For a
+    // video track this includes width/height or facingMode.
+    const hasAtLeastOneCap = "width" in caps || "height" in caps
+        || "facingMode" in caps || "deviceId" in caps;
+    assert_true(hasAtLeastOneCap,
+        "video track getCapabilities exposes at least one constrainable property");
+}, "getCapabilities returns the [[Capabilities]] internal slot as a plain object");
+
+promise_test(async test => {
+    // getConstraints returns the [[Constraints]] internal slot —
+    // the most recently *successfully applied* constraints.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    // Before any explicit applyConstraints, [[Constraints]] reflects
+    // whatever getUserMedia was called with — for our setup, no constraints.
+    let c = track.getConstraints();
+    assert_equals(typeof c, "object", "getConstraints returns an object");
+
+    // After applyConstraints with a successful constraint, getConstraints
+    // returns the applied set verbatim.
+    await track.applyConstraints({ frameRate: { ideal: 24 } });
+    c = track.getConstraints();
+    assert_object_equals(c, { frameRate: { ideal: 24 } },
+        "getConstraints returns the most recently applied constraints");
+
+    // A second applyConstraints replaces (not merges) [[Constraints]].
+    await track.applyConstraints({ width: { ideal: 320 } });
+    c = track.getConstraints();
+    assert_object_equals(c, { width: { ideal: 320 } },
+        "getConstraints reflects only the most recent applyConstraints input " +
+        "(replaces prior constraints, not merges)");
+    assert_false("frameRate" in c,
+        "prior frameRate constraint cleared by second applyConstraints");
+}, "getConstraints returns the [[Constraints]] internal slot (most recent successfully applied)");
+
+promise_test(async test => {
+    // getSettings returns the [[Settings]] internal slot —
+    // the actual current operating values for each constrainable property.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    const settings = track.getSettings();
+    assert_equals(typeof settings, "object", "getSettings returns an object");
+
+    // Settings must include a deviceId (the spec marks it as inherent
+    // constrainable property for every track).
+    assert_true("deviceId" in settings, "getSettings includes deviceId");
+    assert_equals(typeof settings.deviceId, "string", "deviceId is a string");
+
+    // Idempotent: two calls without mutation return equivalent content.
+    const settings2 = track.getSettings();
+    assert_object_equals(settings, settings2,
+        "two getSettings calls return equivalent content");
+}, "getSettings returns the [[Settings]] internal slot as a plain object");
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/fast/mediastream/enumerateDevices-truncation-expected.txt
+++ b/LayoutTests/fast/mediastream/enumerateDevices-truncation-expected.txt
@@ -1,0 +1,6 @@
+
+PASS precondition: mock environment exposes multiple microphones and cameras
+FAIL enumerateDevices truncates microphone list when microphone permission is denied assert_less_than_equal: microphone list is truncated to at most 1 entry when microphone permission is denied expected a number less than or equal to 1 but got 4
+FAIL enumerateDevices truncates camera list when camera permission is denied assert_less_than_equal: camera list is truncated to at most 1 entry when camera permission is denied expected a number less than or equal to 1 but got 2
+PASS enumerateDevices returns full device lists when both permissions are granted
+

--- a/LayoutTests/fast/mediastream/enumerateDevices-truncation.html
+++ b/LayoutTests/fast/mediastream/enumerateDevices-truncation.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>enumerateDevices truncates microphone/camera lists when permission is not granted</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// MediaCapture-Main §"Device enumeration" — enumerateDevices algorithm,
+// device information exposure rules:
+//   https://w3c.github.io/mediacapture-main/#dom-mediadevices-enumeratedevices
+//   https://w3c.github.io/mediacapture-main/#microphone-information-can-be-exposed
+//
+// When the permission to access a device kind has not been granted, the
+// UA truncates that kind's device list returned by enumerateDevices() to
+// at most a single device. This prevents fingerprinting via device count
+// before the user grants permission. After permission is granted, the
+// full device list is returned with non-empty labels.
+//
+// To verify the truncation rule we need an environment with > 1 device
+// of each kind. The WebKit test runner ships multiple mock cameras and
+// microphones by default.
+
+async function countByKind(devices) {
+    return devices.reduce((acc, d) => {
+        acc[d.kind] = (acc[d.kind] || 0) + 1;
+        return acc;
+    }, {});
+}
+
+promise_test(async test => {
+    // Start fresh: no permissions yet.
+    if (window.testRunner) {
+        testRunner.resetUserMediaPermission();
+        testRunner.setMicrophonePermission(false);
+        testRunner.setCameraPermission(false);
+    }
+
+    // First, prove the test environment actually has > 1 device of each
+    // kind so the truncation rule has something to truncate. Grant both
+    // permissions briefly to observe the underlying device counts.
+    if (window.testRunner) {
+        testRunner.setMicrophonePermission(true);
+        testRunner.setCameraPermission(true);
+    }
+    const full = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => full.getTracks().forEach(t => t.stop()));
+    const fullDevices = await navigator.mediaDevices.enumerateDevices();
+    const fullCounts = await countByKind(fullDevices);
+    full.getTracks().forEach(t => t.stop());
+
+    // Sanity-precondition: the mock environment must expose > 1 microphone
+    // and > 1 camera, otherwise we can't tell whether truncation occurred.
+    assert_greater_than(fullCounts.audioinput || 0, 1,
+        "test precondition: mock environment exposes > 1 microphone");
+    assert_greater_than(fullCounts.videoinput || 0, 1,
+        "test precondition: mock environment exposes > 1 camera");
+}, "precondition: mock environment exposes multiple microphones and cameras");
+
+promise_test(async test => {
+    // When microphone info cannot be exposed (permission denied / prompt),
+    // the microphone list in enumerateDevices() is truncated to at most
+    // one entry.
+    if (window.testRunner) {
+        testRunner.resetUserMediaPermission();
+        testRunner.setMicrophonePermission(false);
+        testRunner.setCameraPermission(true);
+    }
+
+    // Need an active capture to expose ANY devices, per WebKit's existing
+    // privacy posture: use video so we trigger the enumeration path while
+    // microphone permission stays denied.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const counts = await countByKind(devices);
+    assert_less_than_equal(counts.audioinput || 0, 1,
+        "microphone list is truncated to at most 1 entry when " +
+        "microphone permission is denied");
+}, "enumerateDevices truncates microphone list when microphone permission is denied");
+
+promise_test(async test => {
+    // Same rule applied to cameras.
+    if (window.testRunner) {
+        testRunner.resetUserMediaPermission();
+        testRunner.setMicrophonePermission(true);
+        testRunner.setCameraPermission(false);
+    }
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const counts = await countByKind(devices);
+    assert_less_than_equal(counts.videoinput || 0, 1,
+        "camera list is truncated to at most 1 entry when " +
+        "camera permission is denied");
+}, "enumerateDevices truncates camera list when camera permission is denied");
+
+promise_test(async test => {
+    // Sanity check: after both permissions are granted, the full device
+    // list is returned without truncation.
+    if (window.testRunner) {
+        testRunner.resetUserMediaPermission();
+        testRunner.setMicrophonePermission(true);
+        testRunner.setCameraPermission(true);
+    }
+
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const counts = await countByKind(devices);
+    assert_greater_than(counts.audioinput || 0, 1,
+        "microphone list is NOT truncated when permission is granted");
+    assert_greater_than(counts.videoinput || 0, 1,
+        "camera list is NOT truncated when permission is granted");
+}, "enumerateDevices returns full device lists when both permissions are granted");
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code-expected.txt
@@ -1,0 +1,6 @@
+
+PASS MediaStream.onaddtrack and onremovetrack IDL attributes (existence + default)
+PASS MediaStream.onaddtrack: addtrack event payload (when fired by UA or by script addTrack)
+FAIL OverconstrainedError.code is 0 (no legacy DOMException code mapping) assert_true: OverconstrainedError inherits from DOMException expected true got false
+FAIL OverconstrainedError raised by applyConstraints also has code 0 assert_equals: UA-raised OverconstrainedError.code is also 0 expected (number) 0 but got (undefined) undefined
+

--- a/LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code.html
+++ b/LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MediaStream.onaddtrack IDL handler + OverconstrainedError.code is 0</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// MediaCapture-Main §"MediaStream" and §"OverconstrainedError":
+//   https://w3c.github.io/mediacapture-main/#dom-mediastream-onaddtrack
+//   https://w3c.github.io/mediacapture-main/#dom-mediastream-onremovetrack
+//   https://w3c.github.io/mediacapture-main/#overconstrainederror-interface
+//
+// Two unrelated IDL-shape behaviors tested together because each is a
+// one-liner:
+//
+//   MediaStream.onaddtrack — event handler IDL attribute for addtrack events.
+//   OverconstrainedError.code is 0 (the interface is NOT in the legacy
+//   DOMException name -> code mapping).
+
+if (window.testRunner) {
+    testRunner.setMicrophonePermission(true);
+    testRunner.setCameraPermission(true);
+}
+
+test(() => {
+    // MediaStream.onaddtrack IDL attribute exists, defaults to null,
+    // and is settable to a function.
+    const ms = new MediaStream();
+    assert_true("onaddtrack" in ms,
+        "MediaStream exposes onaddtrack IDL attribute");
+    assert_equals(ms.onaddtrack, null,
+        "onaddtrack defaults to null");
+    const handler = () => {};
+    ms.onaddtrack = handler;
+    assert_equals(ms.onaddtrack, handler,
+        "onaddtrack setter accepts a function and getter returns it");
+
+    // Same shape for onremovetrack (already covered by an existing
+    // WebRTC test for the firing path; here we verify the IDL surface).
+    assert_true("onremovetrack" in ms,
+        "MediaStream exposes onremovetrack IDL attribute");
+    assert_equals(ms.onremovetrack, null,
+        "onremovetrack defaults to null");
+}, "MediaStream.onaddtrack and onremovetrack IDL attributes (existence + default)");
+
+promise_test(async test => {
+    // Firing path: addtrack fires when the UA adds a track to a
+    // stream. We construct a fresh empty MediaStream, register onaddtrack,
+    // then add a track via the script-side addTrack API. Per spec, the
+    // UA is supposed to fire addtrack only for UA-initiated additions
+    // (e.g. PeerConnection remote tracks); script-initiated addTrack
+    // historically does fire addtrack in WebKit. Test what WebKit does:
+    // either way, the event payload must be a TrackEvent whose .track
+    // matches the added track.
+    const source = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => source.getTracks().forEach(t => t.stop()));
+    const audioTrack = source.getAudioTracks()[0];
+
+    const ms = new MediaStream();
+    let firedEvent = null;
+    ms.onaddtrack = e => { firedEvent = e; };
+
+    ms.addTrack(audioTrack);
+
+    // Give any UA-queued addtrack task time to fire.
+    await new Promise(r => test.step_timeout(r, 100));
+
+    if (firedEvent === null) {
+        // WebKit follows the strict spec reading: addtrack only fires
+        // for UA-initiated additions. The IDL handler exists and is
+        // settable (subtest above), but doesn't fire for script
+        // addTrack. This is spec-conforming.
+        assert_true(ms.getTracks().includes(audioTrack),
+            "track was added even though addtrack did not fire");
+    } else {
+        // WebKit fires addtrack for script-initiated addTrack — also
+        // observed in practice across browsers. Verify the event
+        // shape.
+        assert_true(firedEvent instanceof Event,
+            "addtrack event is an Event instance");
+        assert_equals(firedEvent.type, "addtrack",
+            "event type is 'addtrack'");
+        assert_equals(firedEvent.track, audioTrack,
+            "TrackEvent.track is the added track");
+    }
+}, "MediaStream.onaddtrack: addtrack event payload (when fired by UA or by script addTrack)");
+
+test(() => {
+    // OverconstrainedError.code is 0. OverconstrainedError extends
+    // DOMException. DOMException.code is the legacy numeric code mapped
+    // from .name via a fixed table — names not in the table get code 0.
+    // OverconstrainedError's .name is "OverconstrainedError", which is
+    // NOT in the legacy mapping, so .code must be 0.
+    const err = new OverconstrainedError("width", "no camera satisfies the width constraint");
+    assert_true(err instanceof DOMException,
+        "OverconstrainedError inherits from DOMException");
+    assert_equals(err.name, "OverconstrainedError",
+        "name is 'OverconstrainedError'");
+    assert_equals(err.code, 0,
+        "code is 0 (no legacy DOMException code mapping for OverconstrainedError)");
+    assert_equals(err.constraint, "width",
+        "constraint attribute is set from the constructor");
+    assert_equals(err.message, "no camera satisfies the width constraint",
+        "message attribute is set from the constructor");
+}, "OverconstrainedError.code is 0 (no legacy DOMException code mapping)");
+
+promise_test(async test => {
+    // Real path: an OverconstrainedError raised by the UA from
+    // applyConstraints must also have .code === 0.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getVideoTracks()[0];
+
+    let raisedError = null;
+    try {
+        // exact: impossibly-large width — no real camera satisfies.
+        await track.applyConstraints({ width: { exact: 99999999 } });
+        assert_unreached("applyConstraints with impossible exact width should reject");
+    } catch (e) {
+        raisedError = e;
+    }
+    assert_equals(raisedError.name, "OverconstrainedError",
+        "rejection is an OverconstrainedError");
+    assert_equals(raisedError.code, 0,
+        "UA-raised OverconstrainedError.code is also 0");
+}, "OverconstrainedError raised by applyConstraints also has code 0");
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/fast/mediastream/mediastreamtrack-readyState-enum-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-readyState-enum-expected.txt
@@ -1,0 +1,5 @@
+
+PASS readyState is in MediaStreamTrackState enum after creation and after stop()
+PASS readyState is in MediaStreamTrackState enum after cloning live and ended tracks
+PASS readyState stringifies and round-trips as an enum-set value
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-readyState-enum.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-readyState-enum.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MediaStreamTrackState enum: readyState only ever returns "live" or "ended"</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+// MediaCapture-Main §"MediaStreamTrackState" enum:
+//   https://w3c.github.io/mediacapture-main/#dom-mediastreamtrackstate
+//
+//   enum MediaStreamTrackState {
+//     "live",
+//     "ended"
+//   };
+//
+// MediaStreamTrack.readyState (a MediaStreamTrackState getter) must
+// return only one of these two values. There is no script API to "prove"
+// the enum is closed (we can't enumerate the enum from script), but we
+// can assert that every observable transition produces a value in the
+// allowed set — which is the strongest assertion script-side testing
+// supports for an IDL enum.
+
+const VALID = ["live", "ended"];
+
+function assertValidState(track, label) {
+    assert_in_array(track.readyState, VALID,
+        `${label}: readyState is one of ${JSON.stringify(VALID)}`);
+}
+
+promise_test(async test => {
+    // Newly created from getUserMedia.
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+
+    for (const t of stream.getTracks())
+        assertValidState(t, `fresh ${t.kind} track`);
+
+    // After stop().
+    for (const t of stream.getTracks()) {
+        t.stop();
+        assertValidState(t, `stopped ${t.kind} track`);
+        assert_equals(t.readyState, "ended", "stopped track is in 'ended' state");
+    }
+}, "readyState is in MediaStreamTrackState enum after creation and after stop()");
+
+promise_test(async test => {
+    // Clones of live and ended tracks must also yield valid states.
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const original = stream.getVideoTracks()[0];
+
+    const cloneOfLive = original.clone();
+    test.add_cleanup(() => cloneOfLive.stop());
+    assertValidState(cloneOfLive, "clone of live track");
+    assert_equals(cloneOfLive.readyState, "live",
+        "clone of a live track is also live");
+
+    original.stop();
+    const cloneOfEnded = original.clone();
+    assertValidState(cloneOfEnded, "clone of ended track");
+    assert_equals(cloneOfEnded.readyState, "ended",
+        "clone of an ended track is also ended");
+}, "readyState is in MediaStreamTrackState enum after cloning live and ended tracks");
+
+promise_test(async test => {
+    // Verify that JSON serialization round-trips the enum string verbatim
+    // (no extra modifier characters or stringification artifacts that
+    // would imply a different underlying type).
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
+    const track = stream.getAudioTracks()[0];
+
+    const round = JSON.parse(JSON.stringify({ s: track.readyState }));
+    assert_equals(typeof round.s, "string",
+        "readyState round-trips as a string");
+    assert_in_array(round.s, VALID,
+        "readyState round-trip value is in the spec-mandated enum set");
+}, "readyState stringifies and round-trips as an enum-set value");
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/webrtc/peerConnection-rvfc-metadata-timestamps-expected.txt
+++ b/LayoutTests/webrtc/peerConnection-rvfc-metadata-timestamps-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS VideoFrameMetadata.receiveTime is a DOMHighResTimeStamp relative to Performance.timeOrigin
+PASS VideoFrameMetadata.rtpTimestamp is an unsigned long (32-bit unsigned integer)
+FAIL VideoFrameMetadata.captureTime is a DOMHighResTimeStamp relative to Performance.timeOrigin assert_true: captureTime is reliably populated and is a DOMHighResTimeStamp relative to Performance.timeOrigin (small number close to performance.now(); not an NTP-epoch wall-clock value) expected true got false
+

--- a/LayoutTests/webrtc/peerConnection-rvfc-metadata-timestamps.html
+++ b/LayoutTests/webrtc/peerConnection-rvfc-metadata-timestamps.html
@@ -1,0 +1,152 @@
+<!doctype html><!-- webkit-test-runner [ RequestVideoFrameCallbackEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>VideoFrameMetadata WebRTC timestamp semantics: captureTime/receiveTime/rtpTimestamp</title>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <script src="routines.js"></script>
+</head>
+<body>
+    <video id="local" autoplay muted></video>
+    <video id="remote" autoplay muted></video>
+    <script>
+// MediaCapture Extensions §"Video Capture Frame Timestamp Concepts":
+//   https://w3c.github.io/mediacapture-extensions/#video-timestamp-concepts
+//
+// VideoFrameMetadata adds three WebRTC-only fields whose types are
+// spec-mandated:
+//   captureTime: DOMHighResTimeStamp, relative to Performance.timeOrigin
+//   receiveTime: DOMHighResTimeStamp, relative to Performance.timeOrigin
+//   rtpTimestamp: unsigned long (i.e. 32-bit unsigned integer)
+//
+// The upstream WPT test (imported/.../request-video-frame-callback-webrtc.https.html)
+// only asserts presence via `"x" in metadata`. This test asserts the
+// type/range semantics that the spec actually requires.
+//
+// captureTime is only populated for bidirectional streams and even then
+// only after enough RTCP reports flow back; the WPT test acknowledges it
+// as "too unreliable to include in tests". We grab a stretch of frames
+// and assert captureTime's type/range only when it does appear, while
+// always asserting receiveTime and rtpTimestamp (which populate from the
+// first received frame).
+
+async function grabNextMetadata(video) {
+    return new Promise((resolve, reject) => {
+        video.requestVideoFrameCallback((now, metadata) => resolve(metadata));
+        setTimeout(() => reject("Timed out waiting for metadata"), 5000);
+    });
+}
+
+// Collect up to `frameCount` frames of metadata so individual subtests
+// can find a frame that has the field they're checking. captureTime
+// requires the same track to flow in both directions, so add the local
+// track to both peers.
+async function collectFrames(test, frameCount) {
+    const localStream = await navigator.mediaDevices.getUserMedia({
+        video: { width: 640, height: 480 }, audio: true,
+    });
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
+
+    const remoteStream = await new Promise((resolve, reject) => {
+        createConnections(pc1 => {
+            for (const track of localStream.getTracks())
+                pc1.addTrack(track, localStream);
+        }, pc2 => {
+            for (const track of localStream.getTracks())
+                pc2.addTrack(track, localStream);
+            pc2.ontrack = e => resolve(e.streams[0]);
+        });
+        setTimeout(() => reject("PeerConnection setup timed out"), 5000);
+    });
+
+    const video = document.getElementById("remote");
+    video.srcObject = remoteStream;
+    await video.play();
+
+    // captureTime requires bidirectional flow + at least one RTCP
+    // sender-report; give the link time to settle before sampling frames.
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const frames = [];
+    for (let i = 0; i < frameCount; i++)
+        frames.push(await grabNextMetadata(video));
+    return frames;
+}
+
+// Shared across subtests so we don't re-establish a PeerConnection per
+// assertion (each setup takes ~1 second). The first subtest performs
+// the collection; subsequent subtests await the same promise.
+let framesPromise = null;
+function getFrames(test) {
+    if (!framesPromise)
+        framesPromise = collectFrames(test, 200);
+    return framesPromise;
+}
+
+// VideoFrameMetadata.receiveTime is DOMHighResTimeStamp relative to
+// Performance.timeOrigin. Should populate from the first received frame.
+promise_test(async test => {
+    const frames = await getFrames(test);
+    const frame = frames.find(f => "receiveTime" in f);
+    assert_not_equals(frame, undefined,
+        "at least one frame has receiveTime");
+    assert_equals(typeof frame.receiveTime, "number",
+        "receiveTime is a number");
+    assert_greater_than(frame.receiveTime, 0,
+        "receiveTime is positive");
+    assert_less_than(frame.receiveTime, performance.now() + 1000,
+        "receiveTime is in the past relative to performance.now() " +
+        "(i.e. measured against Performance.timeOrigin, not a wall clock)");
+}, "VideoFrameMetadata.receiveTime is a DOMHighResTimeStamp relative to Performance.timeOrigin");
+
+// VideoFrameMetadata.rtpTimestamp is unsigned long (32-bit unsigned
+// integer). Should populate from the first received frame.
+promise_test(async test => {
+    const frames = await getFrames(test);
+    const frame = frames.find(f => "rtpTimestamp" in f);
+    assert_not_equals(frame, undefined,
+        "at least one frame has rtpTimestamp");
+    assert_equals(typeof frame.rtpTimestamp, "number",
+        "rtpTimestamp is a number");
+    assert_true(Number.isInteger(frame.rtpTimestamp),
+        "rtpTimestamp is an integer");
+    assert_greater_than_equal(frame.rtpTimestamp, 0,
+        "rtpTimestamp is non-negative");
+    assert_less_than_equal(frame.rtpTimestamp, 0xFFFFFFFF,
+        "rtpTimestamp fits in unsigned long (32-bit)");
+}, "VideoFrameMetadata.rtpTimestamp is an unsigned long (32-bit unsigned integer)");
+
+// VideoFrameMetadata.captureTime is DOMHighResTimeStamp relative to
+// Performance.timeOrigin. captureTime is "too unreliable" to require on
+// every frame (WPT acknowledges this) and in many WebKit configurations
+// it doesn't populate at all over a finite frame window.
+//
+// Two spec deviations both cause this subtest to fail:
+//   (a) captureTime populates as an NTP-epoch wall-clock value
+//       (~4e12 ms since 1900-01-01) instead of relative to
+//       Performance.timeOrigin (~ small ms count).
+//   (b) captureTime never populates within the frame window.
+//
+// Both are tracked by rdar://180672837. We collapse them into a single
+// assertion with one deterministic message so the baseline is stable
+// regardless of which branch is hit on a given run.
+promise_test(async test => {
+    const frames = await getFrames(test);
+    const frame = frames.find(f => "captureTime" in f);
+    const captureOK = frame !== undefined
+        && typeof frame.captureTime === "number"
+        && frame.captureTime > 0
+        && frame.captureTime < performance.now() + 1000;
+    assert_true(captureOK,
+        "captureTime is reliably populated and is a DOMHighResTimeStamp " +
+        "relative to Performance.timeOrigin (small number close to " +
+        "performance.now(); not an NTP-epoch wall-clock value)");
+    if ("receiveTime" in frame) {
+        assert_greater_than_equal(frame.receiveTime, frame.captureTime,
+            "receiveTime >= captureTime (frame received after capture)");
+    }
+}, "VideoFrameMetadata.captureTime is a DOMHighResTimeStamp relative to Performance.timeOrigin");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 3e93b48a79d9ebd61a374d4c6395dea498821a8e
<pre>
[MediaStreams] Add tests for untested areas of the MediaCapture-Main and Extensions specifications
<a href="https://rdar.apple.com/180931617">rdar://180931617</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318115">https://bugs.webkit.org/show_bug.cgi?id=318115</a>

Reviewed by Eric Carlson.

Add tests covering previously untested areas of the MediaCapture-Streams
specifications, organized around two skeptical-audit cycles that
distinguished honest coverage from filename-keyword false positives in a
pre-existing area-coverage study.

constrainable-dictionary-shapes.html verifies the IDL shapes of
DoubleRange / ULongRange (via getCapabilities) and ConstrainDoubleRange /
ConstrainULongRange / ConstrainDOMStringParameters /
ConstrainBooleanOrDOMStringParameters (via applyConstraints round-trip,
using frameRate, width, facingMode, and echoCancellation as the
representative constrainable properties).

constrainable-pattern-getters.html verifies that
MediaStreamTrack.getCapabilities / getConstraints / getSettings each
return the corresponding [[Capabilities]] / [[Constraints]] /
[[Settings]] internal slot as a plain object, are idempotent across
calls without intervening mutation, and that getConstraints replaces
rather than merges across successive applyConstraints calls.

VideoFacingModeEnum-values.html asserts that any value returned via
getSettings().facingMode or getCapabilities().facingMode is from the
spec-defined VideoFacingModeEnum domain {&quot;user&quot;, &quot;environment&quot;, &quot;left&quot;,
&quot;right&quot;}. This is a partial coverage of behavior 122; exhaustive
enum-completeness testing would require mock-camera infrastructure that
honors the facingMode constructor argument through to getSettings()
(currently it does not).

mediastreamtrack-readyState-enum.html asserts that
MediaStreamTrack.readyState only returns values from the
MediaStreamTrackState enum ({&quot;live&quot;, &quot;ended&quot;}) across creation, stop,
and clone-of-live / clone-of-ended transitions.

mediastream-onaddtrack-and-overconstrainederror-code.html verifies
MediaStream.onaddtrack / onremovetrack IDL handler existence and
defaults, the addtrack event payload shape when fired by script
addTrack, and OverconstrainedError&apos;s spec-mandated DOMException
inheritance with .code = 0. The OverconstrainedError subtests fail
because WebKit&apos;s OverconstrainedError is a standalone RefCounted
interface that doesn&apos;t inherit DOMException and has no .code attribute;
the failure is recorded in the test&apos;s expected.txt baseline and tracked
by <a href="https://rdar.apple.com/180728516">rdar://180728516</a>.

MediaDevices-getSupportedConstraints.html (modification) is extended
with explicit assertions for backgroundBlur and powerEfficient
defaulting to true. The pre-existing for-each loop only caught keys the
UA already exposed, so the absence of these dictionary members went
untested.

enumerateDevices-truncation.html asserts the spec-mandated truncation
of microphone / camera lists in enumerateDevices() output to at most
one entry when the corresponding permission is denied (and the
&quot;information can be exposed&quot; predicate returns false). Both subtests
fail because WebKit returns the full device list with empty labels
instead of truncating, exposing the count to fingerprinting. Tracked
by <a href="https://rdar.apple.com/180672669">rdar://180672669</a>.

webrtc/peerConnection-rvfc-metadata-timestamps.html asserts the
type / range semantics of VideoFrameMetadata.captureTime,
.receiveTime, and .rtpTimestamp on a bidirectional RTCPeerConnection.
receiveTime and rtpTimestamp pass; captureTime fails because WebKit
returns NTP-epoch milliseconds (~4e12) instead of a value relative to
Performance.timeOrigin. Tracked by <a href="https://rdar.apple.com/180672837">rdar://180672837</a>.

configurationchange-defer-and-abort.html asserts that the
configurationchange task aborts when the track&apos;s readyState is already
&quot;ended&quot; (PASSes) and that the task is deferred until unmute when
triggered while the track is muted (FAILs because WebKit drops the
event entirely; tracked by <a href="https://rdar.apple.com/180728609">rdar://180728609</a>).

* LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt:
* LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints.html:
* LayoutTests/fast/mediastream/VideoFacingModeEnum-values-expected.txt: Added.
* LayoutTests/fast/mediastream/VideoFacingModeEnum-values.html: Added.
* LayoutTests/fast/mediastream/configurationchange-defer-and-abort-expected.txt: Added.
* LayoutTests/fast/mediastream/configurationchange-defer-and-abort.html: Added.
* LayoutTests/fast/mediastream/constrainable-dictionary-shapes-expected.txt: Added.
* LayoutTests/fast/mediastream/constrainable-dictionary-shapes.html: Added.
* LayoutTests/fast/mediastream/constrainable-pattern-getters-expected.txt: Added.
* LayoutTests/fast/mediastream/constrainable-pattern-getters.html: Added.
* LayoutTests/fast/mediastream/enumerateDevices-truncation-expected.txt: Added.
* LayoutTests/fast/mediastream/enumerateDevices-truncation.html: Added.
* LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code.html: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-readyState-enum-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-readyState-enum.html: Added.
* LayoutTests/webrtc/peerConnection-rvfc-metadata-timestamps-expected.txt: Added.
* LayoutTests/webrtc/peerConnection-rvfc-metadata-timestamps.html: Added.

Canonical link: <a href="https://commits.webkit.org/316096@main">https://commits.webkit.org/316096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee8372164c19c0801edbc5e9e25fbad9a72f1f35

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128560 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f4282d4-96de-4ce6-bf61-5a04ec9bcc7b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133254 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a23dd63-ca1d-4c1d-8863-bd6c068a9d19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113741 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c9bf93f-b701-4929-9fb0-7b4e8f2bee96) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35100 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33414 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28903 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182809 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141716 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38163 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45115 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109820 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36794 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43626 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8184 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43030 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43272 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->