### PR TITLE
(WIP) fix orphaned B3 nodes after CSE phase

### DIFF
--- a/JSTests/stress/cse-ssa-store-nop-orphan-value.js
+++ b/JSTests/stress/cse-ssa-store-nop-orphan-value.js
@@ -1,0 +1,6 @@
+//@ runDefault("--validateDFGClobberize=1", "--jitPolicyScale=0", "--useConcurrentJIT=0")
+
+for (let i = 0; i < 100; i++) {
+    for (let j = 0; j < 100; j++) {
+    }
+}

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -444,8 +444,11 @@ private:
             if (m_blocksWithSets.contains(block)) {
                 for (unsigned valueIndex = 0; valueIndex < block->size(); ++valueIndex) {
                     Value* value = block->at(valueIndex);
-                    if (!canHaveSets(value))
-                        continue;
+                    // Do not gate on canHaveSets(value) here: a value that was a
+                    // memory-access m_sets key when its entry was added can later
+                    // be turned into a Nop by store elimination. Its fixup extras
+                    // must still be materialized in this block, otherwise the SSA
+                    // Defs / Upsilons that reference them are left dangling.
                     auto iter = m_sets.find(value);
                     if (iter == m_sets.end())
                         continue;


### PR DESCRIPTION
#### b6788fc8ca2e0b590042edb359f4e9c1b379f789
<pre>
(WIP) fix orphaned B3 nodes after CSE phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=318160">https://bugs.webkit.org/show_bug.cgi?id=318160</a>
<a href="https://rdar.apple.com/180277164">rdar://180277164</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

Test: JSTests/stress/cse-ssa-store-nop-orphan-value.js

* JSTests/stress/cse-ssa-store-nop-orphan-value.js: Added.
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6788fc8ca2e0b590042edb359f4e9c1b379f789

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180295 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128631 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/201e23de-9f62-4389-b1b6-e13f4bce3f35) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133309 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94072 "2 flakes 17 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80c18e93-d58b-4bda-bcd8-327f80af3fa2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153751 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c572378e-eba0-46d5-99aa-fd3dad628426) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35158 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33467 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28975 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2153 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182880 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32172 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141766 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44497 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141576 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45186 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109891 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36838 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117077 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203594 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43697 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8240 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54498 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43101 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43343 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->