### PR TITLE
[css-values-5 random-item()] computed-value resolution (parse <random-key>, select item)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt
@@ -1,0 +1,30 @@
+
+PASS Property color value 'random-item(fixed 0, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(fixed 0.5, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(fixed 0.999, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(fixed 1, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(fixed 0, rgb(1, 0, 0))'
+PASS Property color value 'random-item(auto, rgb(1, 0, 0))'
+PASS Property color value 'random-item(auto, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(--key, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(element-scoped, rgb(1, 0, 0), rgb(0, 1, 0))'
+PASS Property color value 'random-item(--key element-scoped, rgb(1, 0, 0), rgb(0, 1, 0))'
+PASS Property font-family value 'random-item(fixed 0, {Times, serif}, {Arial, sans-serif})'
+PASS Property font-family value 'random-item(fixed 0.999, {Times, serif}, {Arial, sans-serif})'
+PASS Property font-family value 'random-item(fixed 0, { Times, serif }, { Arial, sans-serif })'
+PASS Property font-family value 'random-item(fixed 0.999, { Times, serif }, { Arial, sans-serif })'
+PASS Property color value 'random-item(fixed calc(0.5), rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(fixed calc(1 / 4), rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))'
+PASS Property color value 'random-item(fixed 1, rgb(1, 0, 0))'
+PASS Property color value 'random-item(element-scoped --key, rgb(1, 0, 0), rgb(0, 1, 0))'
+PASS random-item() with a var()-derived <random-key> resolves
+PASS random-item() selecting var(--a) into a registered <length>
+PASS random-item() selecting var(--b) into a registered <length>
+PASS random-item() into a registered <length>
+PASS random-item() into a registered <number>
+PASS Selecting an empty item is invalid at computed-value time
+PASS random-item() selection is stable across style recalculation
+PASS Independent auto random-item() instances each resolve to a valid item
+PASS A shared dashed-ident key selects the same item across properties
+PASS random() and random-item() using auto in one declaration both resolve
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<div id="container">
+  <div id="target"></div>
+</div>
+<style>
+  @property --length {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 0px;
+  }
+  @property --length2 {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 0px;
+  }
+  @property --number {
+    syntax: "<number>";
+    inherits: true;
+    initial-value: 0;
+  }
+  #container { --a: 10px; --b: 20px; --fixed-zero: fixed 0; }
+</style>
+<script>
+
+// fixed <number> deterministically selects by index: floor(value * count).
+test_computed_value('color', 'random-item(fixed 0, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', 'rgb(1, 0, 0)');
+test_computed_value('color', 'random-item(fixed 0.5, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', 'rgb(0, 1, 0)');
+test_computed_value('color', 'random-item(fixed 0.999, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', 'rgb(0, 0, 1)');
+test_computed_value('color', 'random-item(fixed 1, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', 'rgb(0, 0, 1)');
+
+// A single-item list always resolves to that item.
+test_computed_value('color', 'random-item(fixed 0, rgb(1, 0, 0))', 'rgb(1, 0, 0)');
+test_computed_value('color', 'random-item(auto, rgb(1, 0, 0))', 'rgb(1, 0, 0)');
+
+// auto and dashed-ident keys resolve to one of the listed items.
+test_computed_value('color', 'random-item(auto, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)', 'rgb(0, 0, 1)']);
+test_computed_value('color', 'random-item(--key, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)', 'rgb(0, 0, 1)']);
+test_computed_value('color', 'random-item(element-scoped, rgb(1, 0, 0), rgb(0, 1, 0))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)']);
+test_computed_value('color', 'random-item(--key element-scoped, rgb(1, 0, 0), rgb(0, 1, 0))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)']);
+
+// Brace-wrapped items preserve internal commas, with or without spaces around the braces.
+test_computed_value('font-family', 'random-item(fixed 0, {Times, serif}, {Arial, sans-serif})', 'Times, serif');
+test_computed_value('font-family', 'random-item(fixed 0.999, {Times, serif}, {Arial, sans-serif})', 'Arial, sans-serif');
+test_computed_value('font-family', 'random-item(fixed 0, { Times, serif }, { Arial, sans-serif })', 'Times, serif');
+test_computed_value('font-family', 'random-item(fixed 0.999, { Times, serif }, { Arial, sans-serif })', 'Arial, sans-serif');
+
+// fixed accepts calc()/var()-derived numbers (parity with random()).
+test_computed_value('color', 'random-item(fixed calc(0.5), rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', 'rgb(0, 1, 0)');
+test_computed_value('color', 'random-item(fixed calc(1 / 4), rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1))', 'rgb(1, 0, 0)');
+
+// fixed 1 with a single item still clamps to index 0.
+test_computed_value('color', 'random-item(fixed 1, rgb(1, 0, 0))', 'rgb(1, 0, 0)');
+
+// element-scoped combines order-independently with a dashed-ident.
+test_computed_value('color', 'random-item(element-scoped --key, rgb(1, 0, 0), rgb(0, 1, 0))', ['rgb(1, 0, 0)', 'rgb(0, 1, 0)']);
+
+function test_computed_custom_property(property, value, expected, description) {
+    test(() => {
+        const target = document.getElementById('target');
+        target.style.removeProperty(property);
+        target.style.setProperty(property, value);
+        assert_equals(getComputedStyle(target).getPropertyValue(property).trim(), expected);
+    }, description);
+}
+
+// The <random-key> is substituted before being parsed, so a var() in the key works.
+test_computed_custom_property('--length', 'random-item(var(--fixed-zero), 5px, 15px)', '5px', 'random-item() with a var()-derived <random-key> resolves');
+
+// The selected item may itself contain a var() reference, resolved after selection.
+test_computed_custom_property('--length', 'random-item(fixed 0, var(--a), var(--b))', '10px', 'random-item() selecting var(--a) into a registered <length>');
+test_computed_custom_property('--length', 'random-item(fixed 0.999, var(--a), var(--b))', '20px', 'random-item() selecting var(--b) into a registered <length>');
+
+// random-item() feeding a registered property directly.
+test_computed_custom_property('--length', 'random-item(fixed 0, 5px, 15px)', '5px', 'random-item() into a registered <length>');
+test_computed_custom_property('--number', 'random-item(fixed 0.999, 1, 2, 3)', '3', 'random-item() into a registered <number>');
+
+// Selecting an empty item substitutes nothing, making the declaration invalid at computed-value time.
+test(() => {
+    const target = document.getElementById('target');
+    target.style.color = 'green';
+    target.style.color = 'random-item(fixed 0.5, red, , blue)';
+    assert_equals(getComputedStyle(target).color, 'rgb(0, 0, 0)');
+}, 'Selecting an empty item is invalid at computed-value time');
+
+// Recompute stability: the same element keeps the same selection across style recalcs.
+test(() => {
+    const target = document.getElementById('target');
+    target.style.color = 'random-item(--stable, rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1), rgb(1, 1, 0), rgb(0, 1, 1))';
+    const first = getComputedStyle(target).color;
+    target.style.fontSize = (target.style.fontSize === '20px') ? '21px' : '20px';
+    void target.offsetWidth;
+    const second = getComputedStyle(target).color;
+    assert_equals(second, first, 'selection is stable across recompute');
+}, 'random-item() selection is stable across style recalculation');
+
+// Two auto instances in one declaration are keyed independently (regression guard for the
+// per-resolver auto index). With enough items they can differ; each must be a valid item and stable.
+test(() => {
+    const target = document.getElementById('target');
+    const items = 'rgb(1, 0, 0), rgb(0, 1, 0), rgb(0, 0, 1), rgb(1, 1, 0), rgb(0, 1, 1), rgb(1, 0, 1)';
+    target.style.cssText = `--p: random-item(auto, ${items}); --q: random-item(auto, ${items});`;
+    const set = ['rgb(1, 0, 0)', 'rgb(0, 1, 0)', 'rgb(0, 0, 1)', 'rgb(1, 1, 0)', 'rgb(0, 1, 1)', 'rgb(1, 0, 1)'];
+    assert_in_array(getComputedStyle(target).getPropertyValue('--p').trim(), set);
+    assert_in_array(getComputedStyle(target).getPropertyValue('--q').trim(), set);
+}, 'Independent auto random-item() instances each resolve to a valid item');
+
+// Deterministic value-sharing: the same dashed-ident key selects the same item on two properties.
+test(() => {
+    const target = document.getElementById('target');
+    const items = '5px, 15px, 25px, 35px, 45px';
+    target.style.cssText = `--length: random-item(--shared, ${items}); --length2: random-item(--shared, ${items});`;
+    const a = getComputedStyle(target).getPropertyValue('--length').trim();
+    const b = getComputedStyle(target).getPropertyValue('--length2').trim();
+    assert_equals(b, a, 'same key selects the same index');
+}, 'A shared dashed-ident key selects the same item across properties');
+
+// random() and random-item() both using auto in one declaration must each resolve. Their auto
+// indices are currently counted in separate spaces (see the FIXME in randomItemBaseValue), so true
+// cross-function independence is a follow-up; this guards that the shared substitution pass keeps
+// resolving both. random(fixed 0.5, 10px, 10px) is deterministic (min == max).
+test(() => {
+    const target = document.getElementById('target');
+    target.style.cssText = 'width: random(fixed 0.5, 10px, 10px); --i: random-item(auto, 1px, 2px, 3px);';
+    assert_equals(getComputedStyle(target).width, '10px');
+    assert_in_array(getComputedStyle(target).getPropertyValue('--i').trim(), ['1px', '2px', '3px']);
+}, 'random() and random-item() using auto in one declaration both resolve');
+
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS random-item() is not ignored in a keyframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: random-item() in @keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @keyframes --anim {
+    from {
+        color: rgb(0, 0, 0);
+        color: random-item(fixed 0, rgb(1, 0, 0), rgb(0, 1, 0));
+    }
+    to {
+        color: rgb(0, 0, 0);
+    }
+  }
+  #target {
+    animation: --anim 1000s step-end;
+  }
+</style>
+<div id="target"></div>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(target).color, "rgb(1, 0, 0)");
+  }, "random-item() is not ignored in a keyframe");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-nested-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-nested-expected.txt
@@ -1,0 +1,6 @@
+
+PASS random-item() nested inside random-item()
+PASS random-item() resolved through var()
+PASS random-item() used as a var() fallback
+PASS random-item() expands in a shorthand property
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-nested.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+
+const target = document.getElementById('target');
+
+// Nested random-item(): the inner function resolves after the outer selects it.
+test(() => {
+    target.style.color = 'green';
+    target.style.color = 'random-item(fixed 0, random-item(fixed 0.999, red, rgb(1, 2, 3)), blue)';
+    assert_equals(getComputedStyle(target).color, 'rgb(1, 2, 3)');
+}, 'random-item() nested inside random-item()');
+
+// random-item() inside a var() reference.
+test(() => {
+    target.style.cssText = '--list: random-item(fixed 0, rgb(1, 2, 3), rgb(4, 5, 6)); color: var(--list);';
+    assert_equals(getComputedStyle(target).color, 'rgb(1, 2, 3)');
+}, 'random-item() resolved through var()');
+
+// random-item() as a var() fallback.
+test(() => {
+    target.style.cssText = 'color: var(--missing, random-item(fixed 0, rgb(7, 8, 9), blue));';
+    assert_equals(getComputedStyle(target).color, 'rgb(7, 8, 9)');
+}, 'random-item() used as a var() fallback');
+
+// random-item() feeding a shorthand property.
+test(() => {
+    target.style.margin = '';
+    target.style.margin = 'random-item(fixed 0, 1px 2px, 3px 4px)';
+    const style = getComputedStyle(target);
+    assert_equals(style.marginTop, '1px');
+    assert_equals(style.marginRight, '2px');
+}, 'random-item() expands in a shorthand property');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-serialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-serialize-expected.txt
@@ -1,0 +1,17 @@
+
+PASS e.style['font-family'] = "random-item(auto, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(--x, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(element-scoped, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(--x element-scoped, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(element-scoped --x, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(fixed 0, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(fixed 0.5, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(fixed 1, serif, sans-serif)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, serif)" should set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif}, {Arial, sans-serif})" should set the property value
+PASS e.style['font-family'] = "random-item(auto, {Times, serif}, sans-serif, {monospace})" should set the property value
+PASS e.style['font-family'] = "random-item(auto, { Times, serif }, { Arial, sans-serif })" should set the property value
+PASS e.style['color'] = "random-item(auto, red, green, blue)" should set the property value
+PASS e.style['width'] = "random-item(auto, 1px, 2px, 3px)" should set the property value
+PASS e.style['width'] = "random-item(--x, var(--a), var(--b))" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-serialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-serialize.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<div id="target"></div>
+<script>
+
+// random-item() is an arbitrary substitution function: its specified value is
+// preserved verbatim and resolved at computed-value time.
+test_valid_value('font-family', 'random-item(auto, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(--x, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(element-scoped, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(--x element-scoped, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(element-scoped --x, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(fixed 0, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(fixed 0.5, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(fixed 1, serif, sans-serif)');
+test_valid_value('font-family', 'random-item(auto, serif)');
+test_valid_value('font-family', 'random-item(auto, {Times, serif}, {Arial, sans-serif})');
+test_valid_value('font-family', 'random-item(auto, {Times, serif}, sans-serif, {monospace})');
+test_valid_value('font-family', 'random-item(auto, { Times, serif }, { Arial, sans-serif })');
+test_valid_value('color', 'random-item(auto, red, green, blue)');
+test_valid_value('width', 'random-item(auto, 1px, 2px, 3px)');
+test_valid_value('width', 'random-item(--x, var(--a), var(--b))');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Selecting an item with an unresolvable var() is invalid at computed-value time
+PASS Selecting a resolvable item produces a value even when other items are unresolvable
+PASS A var() fallback inside the selected item is used
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>CSS Values: random-item() with an item that is invalid at computed-value time</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">
+<link rel="author" title="Joanne Pan" href="https://github.com/J0pan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="target"></div>
+<script>
+
+// When the selected item references a custom property that is guaranteed-invalid,
+// the declaration is invalid at computed-value time and color falls back to its
+// inherited/initial value, matching plain var() behavior.
+test(() => {
+    target.style.color = 'green';
+    target.style.color = 'random-item(fixed 0, var(--missing), blue)';
+    assert_equals(getComputedStyle(target).color, 'rgb(0, 0, 0)');
+}, 'Selecting an item with an unresolvable var() is invalid at computed-value time');
+
+// A different fixed index that selects a resolvable item still produces a value.
+test(() => {
+    target.style.color = 'green';
+    target.style.color = 'random-item(fixed 0.999, var(--missing), rgb(1, 2, 3))';
+    assert_equals(getComputedStyle(target).color, 'rgb(1, 2, 3)');
+}, 'Selecting a resolvable item produces a value even when other items are unresolvable');
+
+// A var() fallback inside the selected item is honored.
+test(() => {
+    target.style.color = 'green';
+    target.style.color = 'random-item(fixed 0, var(--missing, rgb(4, 5, 6)), blue)';
+    assert_equals(getComputedStyle(target).color, 'rgb(4, 5, 6)');
+}, 'A var() fallback inside the selected item is used');
+
+</script>

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -26,13 +26,17 @@
 #include "config.h"
 #include "StyleSubstitutionResolver.h"
 
+#include "CSSCalcRandomCachingKey.h"
 #include "CSSCustomPropertySyntax.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSPropertyParserConsumer+MetaConsumer.h"
+#include "CSSPropertyParserConsumer+NumberDefinitions.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CSSPropertyParserState.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSSelectorParser.h"
 #include "CSSSerializationContext.h"
@@ -59,12 +63,17 @@
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleLocalPropertyRegistry.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
 #include <wtf/IndexedRange.h>
 
 namespace WebCore {
 namespace Style {
+
+// The maximum number of tokens that may be produced by a substitution function reference or fallback value.
+// https://drafts.csswg.org/css-variables/#long-variables
+static constexpr size_t maxSubstitutionTokens = 65536;
 
 static bool containsURLTokens(std::span<const CSSParserToken> tokens)
 {
@@ -137,10 +146,6 @@ RefPtr<const CustomProperty> SubstitutionResolver::propertyValueForVariableName(
 
 bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range, CSSValueID functionId, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
 {
-    // The maximum number of tokens that may be produced by a substitution function reference or fallback value.
-    // https://drafts.csswg.org/css-variables/#long-variables
-    static constexpr size_t maxSubstitutionTokens = 65536;
-
     ASSERT(functionId == CSSValueVar || functionId == CSSValueEnv);
 
     range.consumeWhitespace();
@@ -766,6 +771,140 @@ bool SubstitutionResolver::substituteInternalAutoBaseFunction(CSSParserTokenRang
     return true;
 }
 
+bool SubstitutionResolver::substituteRandomItemFunction(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    // https://drafts.csswg.org/css-values-5/#funcdef-random-item
+    //
+    // The argument grammar is validated at parse time:
+    //   <random-item-args> = random-item( <declaration-value>, [ <declaration-value>? ]# )
+    // Here the full grammar is applied: substitute the argument grammar first, then parse the
+    // first argument as <random-key> and select an item. This follows substituteAttrFunction.
+
+    range.consumeWhitespace();
+
+    // Split at the first literal comma: the first argument is the <random-key>, the rest are items.
+    auto randomKeyStart = range;
+    while (!range.atEnd() && range.peek().type() != CommaToken)
+        range.consumeComponentValue();
+    auto randomKeyRange = randomKeyStart.rangeUntil(range);
+
+    if (!CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range))
+        return false;
+
+    // Collect the item ranges. Each item is a (possibly empty) <declaration-value>; a {}-wrapped
+    // block groups internal commas and is unwrapped when the selected item is substituted below.
+    Vector<CSSParserTokenRange> items;
+    do {
+        auto itemStart = range;
+        while (!range.atEnd() && range.peek().type() != CommaToken)
+            range.consumeComponentValue();
+        items.append(itemStart.rangeUntil(range));
+    } while (CSSPropertyParserHelpers::consumeCommaIncludingWhitespace(range));
+
+    if (items.isEmpty())
+        return false;
+
+    // <random-key> may itself contain arbitrary substitution functions (var(), attr(), ...);
+    // substitute them before parsing it as a <random-key>.
+    auto substitutedRandomKey = substituteTokenRange(randomKeyRange, context);
+    if (!substitutedRandomKey)
+        return false;
+
+    auto baseValue = randomItemBaseValue(WTF::move(*substitutedRandomKey));
+    if (!baseValue)
+        return false;
+
+    // https://drafts.csswg.org/css-values-5/#random-item
+    // "Let index be a random integer less than N (the number of items), given the base value R:
+    //  round(down, R * N, 1)." fixed accepts the closed range [0, 1], so R can be exactly 1,
+    // which makes R * N == N; the clamp below is required to keep the index in range.
+    auto index = static_cast<size_t>(*baseValue * items.size());
+    if (index >= items.size())
+        index = items.size() - 1;
+
+    auto selectedTokens = substituteTokenRange(unwrapArgumentBraces(items[index]), context);
+    if (!selectedTokens)
+        return false;
+
+    // https://drafts.csswg.org/css-variables/#long-variables
+    if (selectedTokens->size() > maxSubstitutionTokens)
+        return false;
+
+    tokens.appendVector(*selectedTokens);
+    return true;
+}
+
+std::optional<double> SubstitutionResolver::randomItemBaseValue(Vector<CSSParserToken> randomKey)
+{
+    // <random-key> = auto | <random-cache-key> | fixed <number [0,1]>
+    // The subset supported here matches random()'s current support:
+    //   [ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>
+    // property-scoped / property-index-scoped / <random-ua-ident> are a follow-up, in sync with random().
+    CSSParserTokenRange randomKeyRange { randomKey };
+    randomKeyRange.consumeWhitespace();
+    if (randomKeyRange.atEnd())
+        return { };
+
+    if (randomKeyRange.peek().id() == CSSValueFixed) {
+        randomKeyRange.consumeIncludingWhitespace();
+        // fixed <number [0,1]>, reusing random()'s number consumer so calc()/var()-derived numbers
+        // are accepted identically.
+        auto numberParsingState = CSS::PropertyParserState { .context = m_substitutionValue->context() };
+        auto number = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<CSS::ClosedUnitRange>>::consume(randomKeyRange, numberParsingState);
+        if (!number || !randomKeyRange.atEnd())
+            return { };
+        return Style::toStyle(*number, m_styleBuilder.state()).value;
+    }
+
+    std::optional<CSS::Keyword::ElementScoped> elementScoped;
+    std::optional<AtomString> dashedIdent;
+    bool isAuto = false;
+
+    while (!randomKeyRange.atEnd()) {
+        auto& token = randomKeyRange.peek();
+        if (!elementScoped && token.id() == CSSValueElementScoped) {
+            elementScoped = CSS::Keyword::ElementScoped { };
+            randomKeyRange.consumeIncludingWhitespace();
+            continue;
+        }
+        if (!isAuto && !dashedIdent && token.id() == CSSValueAuto) {
+            isAuto = true;
+            randomKeyRange.consumeIncludingWhitespace();
+            continue;
+        }
+        if (!isAuto && !dashedIdent && token.type() == IdentToken && isCustomPropertyName(token.value())) {
+            dashedIdent = token.value().toAtomString();
+            randomKeyRange.consumeIncludingWhitespace();
+            continue;
+        }
+        break;
+    }
+
+    if (!randomKeyRange.atEnd())
+        return { };
+
+    if (elementScoped && !m_styleBuilder.state().element())
+        return { };
+
+    if (dashedIdent)
+        return m_styleBuilder.state().lookupCSSRandomBaseValue(CSSCalc::RandomCachingKey { Style::CustomIdent { *dashedIdent } }, elementScoped);
+
+    // "auto" (or an omitted identifier alongside element-scoped) keys on the current property,
+    // disambiguated by a per-resolver index so independent auto instances in one declaration select
+    // independently.
+    //
+    // FIXME: This index is counted here, at substitution time, in a separate space from random()'s
+    // parse-time cssRandomFunctionCount. An auto random-item() and an auto random() in the same
+    // property value can therefore land on the same RandomCachingKey and share a base value, and the
+    // index follows the selected branch rather than parse position. Unifying this with random()'s
+    // counter is the job of the shared <random-key> helper follow-up.
+    auto autoKey = CSSCalc::RandomSharingOptions::Auto {
+        .property = m_styleBuilder.state().cssPropertyID(),
+        .index = m_randomItemAutoIndex++
+    };
+    return m_styleBuilder.state().lookupCSSRandomBaseValue(CSSCalc::RandomCachingKey { autoKey }, elementScoped);
+}
+
 std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange(CSSParserTokenRange range, const CSSParserContext& context)
 {
     Vector<CSSParserToken> tokens;
@@ -795,6 +934,11 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
             }
             if (token.value() == "-internal-first-valid"_s) {
                 if (!substituteFirstValid(range.consumeBlock(), tokens, context))
+                    success = false;
+                continue;
+            }
+            if (functionId == CSSValueRandomItem) {
+                if (!substituteRandomItemFunction(range.consumeBlock(), tokens, context))
                     success = false;
                 continue;
             }
@@ -862,6 +1006,7 @@ RefPtr<CSSVariableData> SubstitutionResolver::substitute(const CSSSubstitutionVa
 {
     m_isAttrTainted = false;
     m_hasTaintedURL = false;
+    m_randomItemAutoIndex = 0;
     m_substitutionValue = &value;
 
     if (auto data = trySimpleSubstitution(value)) {

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -70,6 +70,8 @@ private:
     RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&, ScopeOrdinal definitionScope);
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteInternalAutoBaseFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteRandomItemFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
+    std::optional<double> randomItemBaseValue(Vector<CSSParserToken> randomKey);
 
     struct AttrArgumentGrammarSubstitution {
         Vector<CSSParserToken> firstArg;
@@ -90,6 +92,7 @@ private:
     Vector<String> m_intermediateTokenStrings;
     Vector<RefPtr<const CustomProperty>> m_intermediateCustomProperties;
     unsigned m_urlContextDepth { 0 };
+    unsigned m_randomItemAutoIndex { 0 };
     bool m_isAttrTainted { false };
     bool m_hasTaintedURL { false };
 };


### PR DESCRIPTION
#### a2a0526673356774cd14b30ee6ee7701deb51eb9
<pre>
[css-values-5 random-item()] computed-value resolution (parse &lt;random-key&gt;, select item)
<a href="https://bugs.webkit.org/show_bug.cgi?id=317702">https://bugs.webkit.org/show_bug.cgi?id=317702</a>
<a href="https://rdar.apple.com/180457609">rdar://180457609</a>

Reviewed by Tim Nguyen.

Follow-up to #67706 (parse-time argument grammar, now landed). This resolves
random-item() at computed-value time.

Following substituteAttrFunction, substituteRandomItemFunction:
1. Substitutes the argument grammar first (so var() in the key resolve),
2. Parses the first argument as a &lt;random-key&gt;,
3. Selects one item via the random base value (round(down, R * N, 1)),
4. Substitutes the chosen item.

Spec: <a href="https://drafts.csswg.org/css-values-5/#funcdef-random-item">https://drafts.csswg.org/css-values-5/#funcdef-random-item</a> (grammar verified
against the current ED).

The &lt;random-key&gt; subset here matches random()&apos;s current support: auto | &lt;dashed-ident&gt; | element-scoped
| fixed &lt;number [0,1]&gt;. The remaining &lt;random-cache-key&gt; keywords (property-scoped |
property-index-scoped | &lt;random-ua-ident&gt;) are a separate follow-up, in sync with random().

auto is keyed by a substitution-time index in a space separate from random()&apos;s parse-time
cssRandomFunctionCount, so an auto random-item() and an auto random() in the same property value can
land on the same cache key and share a base value, and the index follows the selected branch rather
than parse position. Unifying the two counters is the job of the shared &lt;random-key&gt; helper follow-up
(<a href="https://rdar.apple.com/180934069">rdar://180934069</a>). A coexistence regression test is included.

Tests: imported/w3c/web-platform-tests/css/css-values/random-item-computed.html
       imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe.html
       imported/w3c/web-platform-tests/css/css-values/random-item-nested.html
       imported/w3c/web-platform-tests/css/css-values/random-item-serialize.html
       imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-in-keyframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-nested-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-nested.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-serialize-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-serialize.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/random-item-unresolvable-argument.html: Added.
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteVariableFunction):
(WebCore::Style::SubstitutionResolver::substituteRandomItemFunction):
(WebCore::Style::SubstitutionResolver::randomItemBaseValue):
(WebCore::Style::SubstitutionResolver::substituteTokenRange):
(WebCore::Style::SubstitutionResolver::substitute):
* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/316589@main">https://commits.webkit.org/316589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ece1734737f5c345580c601f7c517f180719cd4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182257 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130355 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c1a1b93-bc8e-4dcf-975b-c3ffcfec1a36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd315a0d-bff6-4c16-8985-20afcdbaa22d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114863 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97a63006-d32a-4016-be71-dfeddacac411) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36437 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34751 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184790 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37611 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38955 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143187 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47067 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112055 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38062 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118819 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45584 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9401 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->