### PR TITLE
[GLib] Explicitly type variables assigned from adoptGRef calls

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -218,7 +218,7 @@ bool GStreamerDataChannelHandler::sendRawData(std::span<const uint8_t> data)
 {
     DC_DEBUG("Sending raw data of length: %zu", data.size());
     DC_MEMDUMP("Sending raw data", data.data(), data.size());
-    auto bytes = adoptGRef(g_bytes_new(data.data(), data.size()));
+    GRefPtr bytes = adoptGRef(g_bytes_new(data.data(), data.size()));
 #if GST_CHECK_VERSION(1, 22, 0)
     GUniqueOutPtr<GError> error;
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1958

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -386,12 +386,12 @@ static GstWebRTCICEStream* webkitGstWebRTCIceAgentAddStream(GstWebRTCICE* ice, g
         return nullptr;
     }
 
-    auto riceStream = adoptGRef(rice_agent_add_stream(backend->priv->agent.get()));
+    GRefPtr riceStream = adoptGRef(rice_agent_add_stream(backend->priv->agent.get()));
     auto streamId = static_cast<unsigned>(rice_stream_get_id(riceStream.get()));
-    [[maybe_unused]] auto component = adoptGRef(rice_stream_add_component(riceStream.get()));
+    [[maybe_unused]] GRefPtr component = adoptGRef(rice_stream_add_component(riceStream.get()));
     GST_DEBUG_OBJECT(ice, "Component %zu added for stream %u", rice_component_get_id(component.get()), streamId);
 
-    auto stream = adoptGRef(GST_WEBRTC_ICE_STREAM(webkitGstWebRTCCreateIceStream(backend, WTF::move(riceStream))));
+    GRefPtr stream = adoptGRef(GST_WEBRTC_ICE_STREAM(webkitGstWebRTCCreateIceStream(backend, WTF::move(riceStream))));
     backend->priv->streams.add(sessionId, WTF::makeUnique<WebKitGstRiceStream>(streamId, WTF::move(stream)));
     auto item = backend->priv->streams.find(sessionId);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceStream.cpp
@@ -204,7 +204,7 @@ static gboolean webkitGstWebRTCIceStreamGatherCandidates(GstWebRTCICEStream* ice
 
     auto turnConfigDataStorage = turnConfigValues.releaseBuffer();
 
-    auto component = adoptGRef(rice_stream_get_component(stream->priv->riceStream.get(), 1));
+    GRefPtr component = adoptGRef(rice_stream_get_component(stream->priv->riceStream.get(), 1));
     auto error = rice_component_gather_candidates(component.get(), riceAddressValues.size(), addressDataStorage.data(), riceTransportStorage.data(), turnAddressDataStorage.size(), turnAddressDataStorage.data(), turnConfigDataStorage.span().data());
     webkitGstWebRTCIceAgentWakeup(agent.get());
     return (error == RICE_ERROR_SUCCESS || error == RICE_ERROR_ALREADY_IN_PROGRESS);
@@ -250,7 +250,7 @@ void webkitGstWebRTCIceStreamHandleIncomingData(const WebKitGstIceStream* stream
     if (result.data.size && result.data.ptr) {
         // Forward any non-STUN data to the pipeline for handling.
         if (auto transport = stream->priv->rtpTransport.get()) {
-            auto buffer = adoptGRef(gst_buffer_new_memdup(result.data.ptr, result.data.size));
+            GRefPtr buffer = adoptGRef(gst_buffer_new_memdup(result.data.ptr, result.data.size));
             webkitGstWebRTCIceTransportHandleIncomingData(WEBKIT_GST_WEBRTC_ICE_TRANSPORT(transport.get()), WTF::move(buffer));
         } else
             GST_WARNING_OBJECT(stream, "No RTP transport found for stream %u", stream->priv->streamId);
@@ -262,13 +262,13 @@ void webkitGstWebRTCIceStreamHandleIncomingData(const WebKitGstIceStream* stream
     gsize dataSize;
     auto recvData = rice_stream_poll_recv(stream->priv->riceStream.get(), &componentId, &dataSize);
     while (recvData) {
-        auto transport = adoptGRef(webkitGstWebRTCIceStreamFindTransport(GST_WEBRTC_ICE_STREAM(stream), static_cast<GstWebRTCICEComponent>(componentId)));
+        GRefPtr transport = adoptGRef(webkitGstWebRTCIceStreamFindTransport(GST_WEBRTC_ICE_STREAM(stream), static_cast<GstWebRTCICEComponent>(componentId)));
         if (!transport) [[unlikely]] {
             rice_free_data(recvData);
             break;
         }
 
-        auto buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(0), recvData, dataSize, 0, dataSize,
+        GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(0), recvData, dataSize, 0, dataSize,
             recvData, reinterpret_cast<GDestroyNotify>(rice_free_data)));
         webkitGstWebRTCIceTransportHandleIncomingData(WEBKIT_GST_WEBRTC_ICE_TRANSPORT(transport.get()), WTF::move(buffer));
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
@@ -82,7 +82,7 @@ static GstFlowReturn iceTransportHandleSample(WebKitGstIceTransport* self, GstAp
         return GST_FLOW_ERROR;
 
     const auto& riceStream = webkitGstWebRTCIceStreamGetRiceStream(stream.get());
-    auto component = adoptGRef(rice_stream_get_component(riceStream.get(), 1));
+    GRefPtr component = adoptGRef(rice_stream_get_component(riceStream.get(), 1));
     if (!component)
         return GST_FLOW_ERROR;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -129,8 +129,8 @@ void GStreamerMediaEndpoint::maybeInsertNetSimForElement(GstBin* bin, GstElement
 
     // Unlink the element, add a netsim element in bin and link it to the element to simulate varying network conditions.
     ASCIILiteral padName = isSource ? "src"_s : "sink"_s;
-    auto pad = adoptGRef(gst_element_get_static_pad(element, padName.characters()));
-    auto peer = adoptGRef(gst_pad_get_peer(pad.get()));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, padName.characters()));
+    GRefPtr peer = adoptGRef(gst_pad_get_peer(pad.get()));
     if (!peer) [[unlikely]]
         return;
 
@@ -157,7 +157,7 @@ void GStreamerMediaEndpoint::maybeInsertNetSimForElement(GstBin* bin, GstElement
 
 bool GStreamerMediaEndpoint::initializePipeline()
 {
-    auto webrtcBinFactory = adoptGRef(gst_element_factory_find("webrtcbin"));
+    GRefPtr webrtcBinFactory = adoptGRef(gst_element_factory_find("webrtcbin"));
     if (!webrtcBinFactory) {
         gst_printerrln("GStreamer element webrtcbin not found. Please install gst-plugins-bad");
         return false;
@@ -168,7 +168,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
     m_pipeline = gst_pipeline_new(pipelineName.ascii().data());
     registerActivePipeline(m_pipeline);
 
-    auto clock = adoptGRef(gst_system_clock_obtain());
+    GRefPtr clock = adoptGRef(gst_system_clock_obtain());
     gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
     gst_element_set_base_time(m_pipeline.get(), 0);
     gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
@@ -220,7 +220,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
     m_srcNetSimOptions = netSimOptionsFromEnvironment("WEBKIT_WEBRTC_NETSIM_SRC_OPTIONS"_s);
     m_sinkNetSimOptions = netSimOptionsFromEnvironment("WEBKIT_WEBRTC_NETSIM_SINK_OPTIONS"_s);
     if (!m_srcNetSimOptions.isEmpty() || !m_sinkNetSimOptions.isEmpty()) {
-        if (auto factory = adoptGRef(gst_element_factory_find("netsim"))) {
+        if (GRefPtr factory = adoptGRef(gst_element_factory_find("netsim"))) {
             g_signal_connect_swapped(m_webrtcBin.get(), "deep-element-added", G_CALLBACK(+[](GStreamerMediaEndpoint* self, GstBin* bin, GstElement* element) {
                 auto elementName = GMallocString::unsafeAdoptFromUTF8(gst_element_get_name(element));
                 if (startsWith(elementName.span(), "nice"_s) || startsWith(elementName.span(), "ice-sink"_s) || startsWith(elementName.span(), "ice-src"_s))
@@ -230,7 +230,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
             gst_printerrln("WEBKIT_WEBRTC_NETSIM_{SRC,SINK}_OPTIONS was/were set but the GStreamer netsim element is missing.");
     }
 
-    auto rtpBin = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_webrtcBin.get()), "rtpbin"));
+    GRefPtr rtpBin = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_webrtcBin.get()), "rtpbin"));
     if (!rtpBin) {
         GST_ERROR_OBJECT(m_webrtcBin.get(), "rtpbin not found. Please check that your GStreamer installation has the rtp and rtpmanager plugins.");
         return false;
@@ -241,7 +241,7 @@ bool GStreamerMediaEndpoint::initializePipeline()
         if (!startsWith(elementName.span(), "rtpptdemux"_s))
             return;
 
-        auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
             auto self = reinterpret_cast<GStreamerMediaEndpoint*>(userData);
             auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
@@ -408,8 +408,8 @@ void GStreamerMediaEndpoint::disposeElementChain(GstElement* element)
 {
     GST_DEBUG_OBJECT(m_pipeline.get(), "Got element EOS message from %" GST_PTR_FORMAT, element);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
-    auto peer = adoptGRef(gst_pad_get_peer(pad.get()));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+    GRefPtr peer = adoptGRef(gst_pad_get_peer(pad.get()));
 
     gstElementLockAndSetState(element, GST_STATE_NULL);
 
@@ -1147,7 +1147,7 @@ void GStreamerMediaEndpoint::setDescription(const RTCSessionDescription* descrip
     GUniquePtr<GstWebRTCSessionDescription> sessionDescription(gst_webrtc_session_description_new(type, message.release()));
     g_signal_emit_by_name(m_webrtcBin.get(), signalName.ascii().data(), sessionDescription.get(), gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
         auto* data = static_cast<SetDescriptionCallData*>(userData);
-        auto promise = adoptGRef(rawPromise);
+        GRefPtr promise = adoptGRef(rawPromise);
         auto result = gst_promise_wait(promise.get());
         const auto* reply = gst_promise_get_reply(promise.get());
         GST_DEBUG_OBJECT(data->webrtcBin.get(), "%s description reply: %u %" GST_PTR_FORMAT, data->typeString.characters(), result, reply);
@@ -1227,7 +1227,7 @@ void GStreamerMediaEndpoint::configureSource(RealtimeOutgoingMediaSourceGStreame
 GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allowedCaps, const String& mediaStreamID)
 {
     GST_DEBUG_OBJECT(m_pipeline.get(), "Requesting sink pad for %" GST_PTR_FORMAT " and mediaStreamID %s", allowedCaps.get(), mediaStreamID.ascii().data());
-    auto caps = adoptGRef(gst_caps_copy(allowedCaps.get()));
+    GRefPtr caps = adoptGRef(gst_caps_copy(allowedCaps.get()));
     int availablePayloadType = pickAvailablePayloadType();
     unsigned i = 0;
     while (i < gst_caps_get_size(caps.get())) {
@@ -1282,7 +1282,7 @@ GRefPtr<GstPad> GStreamerMediaEndpoint::requestPad(const GRefPtr<GstCaps>& allow
     });
 
     auto padTemplate = gst_element_get_pad_template(m_webrtcBin.get(), "sink_%u");
-    auto sinkPad = adoptGRef(gst_element_request_pad(m_webrtcBin.get(), padTemplate, nullptr, caps.get()));
+    GRefPtr sinkPad = adoptGRef(gst_element_request_pad(m_webrtcBin.get(), padTemplate, nullptr, caps.get()));
 
     if (!mediaStreamID.isEmpty()) {
         GST_DEBUG_OBJECT(m_pipeline.get(), "Setting msid to %s on sink pad %" GST_PTR_FORMAT, mediaStreamID.ascii().data(), sinkPad.get());
@@ -1433,7 +1433,7 @@ void GStreamerMediaEndpoint::initiate(bool isInitiator, GstStructure* rawOptions
 
     g_signal_emit_by_name(m_webrtcBin.get(), signalName.ascii().data(), options.get(), gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
         auto* holder = static_cast<GStreamerMediaEndpointHolder*>(userData);
-        auto promise = adoptGRef(rawPromise);
+        GRefPtr promise = adoptGRef(rawPromise);
         auto result = gst_promise_wait(promise.get());
         if (result != GST_PROMISE_RESULT_REPLIED) {
             holder->endPoint->createSessionDescriptionFailed(holder->sdpType, { });
@@ -1498,7 +1498,7 @@ void GStreamerMediaEndpoint::getStats(RTCRtpReceiver& receiver, Ref<DeferredProm
         return;
     }
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(bin, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(bin, "sink"));
     if (!sinkPad) {
         // The incoming source bin is not linked yet, so look for a matching upstream track processor.
         GRefPtr<GstPad> pad;
@@ -1512,7 +1512,7 @@ void GStreamerMediaEndpoint::getStats(RTCRtpReceiver& receiver, Ref<DeferredProm
         getStats(pad, WTF::move(promise));
         return;
     }
-    auto srcPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
+    GRefPtr srcPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
     getStats(srcPad, WTF::move(promise));
 }
 
@@ -1590,7 +1590,7 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
         GST_DEBUG_OBJECT(m_pipeline.get(), "New remote transceiver created for track");
     }
 
-    auto mediaStreamBin = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), data.mediaStreamBinName.ascii().data()));
+    GRefPtr mediaStreamBin = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), data.mediaStreamBinName.ascii().data()));
     auto& track = transceiver->receiver().track();
     auto& source = track.privateTrack().source();
     if (source.isIncomingAudioSource()) {
@@ -1663,7 +1663,7 @@ void GStreamerMediaEndpoint::notifyFirstPacketReceived(WebRTCTrackData& data)
 
 void GStreamerMediaEndpoint::connectPad(GstPad* pad)
 {
-    auto caps = adoptGRef(gst_pad_get_current_caps(pad));
+    GRefPtr caps = adoptGRef(gst_pad_get_current_caps(pad));
     if (!caps)
         caps = adoptGRef(gst_pad_query_caps(pad, nullptr));
 
@@ -1681,7 +1681,7 @@ void GStreamerMediaEndpoint::connectPad(GstPad* pad)
     auto bin = trackProcessor->bin();
     gst_bin_add(GST_BIN_CAST(m_pipeline.get()), bin);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(bin, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(bin, "sink"));
     gst_pad_link(pad, sinkPad.get());
     gst_element_set_state(bin, GST_STATE_PAUSED);
 
@@ -2077,7 +2077,7 @@ void GStreamerMediaEndpoint::addIceCandidate(const RTCIceCandidate& candidate, P
 
         g_signal_emit_by_name(m_webrtcBin.get(), "add-ice-candidate-full", candidate.sdpMLineIndex().value_or(0), sdpString.data(), gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
             auto* data = reinterpret_cast<AddIceCandidateCallData*>(userData);
-            auto promise = adoptGRef(rawPromise);
+            GRefPtr promise = adoptGRef(rawPromise);
             auto result = gst_promise_wait(promise.get());
             const auto* reply = gst_promise_get_reply(promise.get());
             if (result != GST_PROMISE_RESULT_REPLIED || (reply && gst_structure_has_field(reply, "error"))) {
@@ -2241,7 +2241,7 @@ void GStreamerMediaEndpoint::close()
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9379
 #if GST_CHECK_VERSION(1, 28, 0)
     g_signal_emit_by_name(m_webrtcBin.get(), "close", gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
-        auto promise = adoptGRef(rawPromise);
+        GRefPtr promise = adoptGRef(rawPromise);
         auto result = gst_promise_wait(promise.get());
         if (result != GST_PROMISE_RESULT_REPLIED)
             return;
@@ -2356,7 +2356,7 @@ void GStreamerMediaEndpoint::trackWasReplaced(const String& previousId, const St
         if (!caps)
             return false;
 
-        auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+        GRefPtr newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
         gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
             auto msid = gstStructureGetString(structure, "a-msid"_s);
             if (msid.isEmpty())
@@ -2706,7 +2706,7 @@ GUniquePtr<GstStructure> GStreamerMediaEndpoint::preprocessStats(const GRefPtr<G
 void GStreamerMediaEndpoint::gatherStatsForLogging()
 {
     g_signal_emit_by_name(m_webrtcBin.get(), "get-stats", nullptr, gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
-        auto promise = adoptGRef(rawPromise);
+        GRefPtr promise = adoptGRef(rawPromise);
         auto result = gst_promise_wait(promise.get());
         if (result != GST_PROMISE_RESULT_REPLIED)
             return;
@@ -2894,10 +2894,10 @@ void GStreamerMediaEndpoint::updatePtDemuxSrcPadCaps(GstElement* ptDemux, GstPad
     if (!description)
         return;
 
-    auto currentCaps = adoptGRef(gst_pad_get_current_caps(pad));
+    GRefPtr currentCaps = adoptGRef(gst_pad_get_current_caps(pad));
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(ptDemux, "sink"));
-    auto sinkCaps = adoptGRef(gst_pad_get_current_caps(sinkPad.get()));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(ptDemux, "sink"));
+    GRefPtr sinkCaps = adoptGRef(gst_pad_get_current_caps(sinkPad.get()));
     const auto structure = gst_caps_get_structure(sinkCaps.get(), 0);
     auto ssrc = gstStructureGet<unsigned>(structure, "ssrc"_s);
     if (!ssrc)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -130,7 +130,7 @@ bool GStreamerRtpTransceiverBackend::stopped() const
     const auto codecName = components[1];
 
     int payloadType = payloadTypeForEncodingName(codecName).value_or(dynamicPayloadType++);
-    auto caps = adoptGRef(gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, mediaType.ascii().data(), "encoding-name", G_TYPE_STRING, codecName.ascii().data(), "clock-rate", G_TYPE_INT, codec.clockRate, "payload", G_TYPE_INT, payloadType, nullptr));
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("application/x-rtp", "media", G_TYPE_STRING, mediaType.ascii().data(), "encoding-name", G_TYPE_STRING, codecName.ascii().data(), "clock-rate", G_TYPE_INT, codec.clockRate, "payload", G_TYPE_INT, payloadType, nullptr));
     if (codec.channels)
         gst_caps_set_simple(caps.get(), "channels", G_TYPE_INT, *codec.channels, nullptr);
 
@@ -178,7 +178,7 @@ ExceptionOr<void> GStreamerRtpTransceiverBackend::setCodecPreferences(const Vect
         });
     }
 
-    auto gstCodecs = adoptGRef(gst_caps_new_empty());
+    GRefPtr gstCodecs = adoptGRef(gst_caps_new_empty());
     int dynamicPayloadType = 96;
     for (auto& codec : codecs) {
         auto result = toRtpCodecCapability(codec, dynamicPayloadType, msid);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -559,7 +559,7 @@ void GStreamerStatsCollector::gatherStats(StatsCallback&& callback, const GRefPt
     holder->preprocessCallback = WTF::move(preprocessCallback);
     holder->pad = pad;
     g_signal_emit_by_name(webrtcBin.get(), "get-stats", pad.get(), gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) mutable {
-        auto promise = adoptGRef(rawPromise);
+        GRefPtr promise = adoptGRef(rawPromise);
         auto* holder = static_cast<CallbackHolder*>(userData);
         if (gst_promise_wait(promise.get()) != GST_PROMISE_RESULT_REPLIED) {
             holder->callback(nullptr);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -561,7 +561,7 @@ std::optional<int> payloadTypeForEncodingName(const String& encodingName)
 
 GRefPtr<GstCaps> capsFromRtpCapabilities(const RTPHeaderExtensionMapping& extensionMapping, const RTCRtpCapabilities& capabilities, Function<void(GstStructure*)> supplementCapsCallback)
 {
-    auto caps = adoptGRef(gst_caps_new_empty());
+    GRefPtr caps = adoptGRef(gst_caps_new_empty());
     for (unsigned index = 0; auto& codec : capabilities.codecs) {
         auto components = codec.mimeType.split('/');
         auto* codecStructure = gst_structure_new("application/x-rtp", "media", G_TYPE_STRING, components[0].ascii().data(),
@@ -620,7 +620,7 @@ GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia* media)
 {
     ensureDebugCategoryInitialized();
     unsigned numberOfFormats = gst_sdp_media_formats_len(media);
-    auto caps = adoptGRef(gst_caps_new_empty());
+    GRefPtr caps = adoptGRef(gst_caps_new_empty());
     for (unsigned i = 0; i < numberOfFormats; i++) {
         auto rtpMap = CStringView::unsafeFromUTF8(gst_sdp_media_get_attribute_val_n(media, "rtpmap", i));
         if (!rtpMap) {
@@ -978,7 +978,7 @@ GRefPtr<GstCaps> extractMidAndRidFromRTPBuffer(const GstMappedRtpBuffer& buffer,
     GST_DEBUG("Looking for mid and rid ext ids in %u SDP medias", totalMedias);
     for (unsigned i = 0; i < totalMedias; i++) {
         const auto media = gst_sdp_message_get_media(sdp, i);
-        auto mediaCaps = adoptGRef(gst_caps_new_empty_simple("application/x-rtp"));
+        GRefPtr mediaCaps = adoptGRef(gst_caps_new_empty_simple("application/x-rtp"));
         uint8_t midExtID = 0;
         uint8_t ridExtID = 0;
 
@@ -1013,7 +1013,7 @@ GRefPtr<GstCaps> extractMidAndRidFromRTPBuffer(const GstMappedRtpBuffer& buffer,
         GST_DEBUG("Probed midExtID %u and ridExtID %u from SDP", midExtID, ridExtID);
 
         uint16_t bits;
-        auto bytes = adoptGRef(gst_rtp_buffer_get_extension_bytes(buffer.mappedData(), &bits));
+        GRefPtr bytes = adoptGRef(gst_rtp_buffer_get_extension_bytes(buffer.mappedData(), &bits));
         if (!bytes)
             continue;
 

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -49,7 +49,7 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
     }
 
     auto channels = bus.numberOfChannels();
-    auto buffer = adoptGRef(gst_buffer_new_and_alloc(sizeof(float) * numberOfFrames * channels));
+    GRefPtr buffer = adoptGRef(gst_buffer_new_and_alloc(sizeof(float) * numberOfFrames * channels));
     GST_BUFFER_PTS(buffer.get()) = toGstClockTime(mediaTime);
     GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_LIVE);
 
@@ -66,7 +66,7 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
         gst_buffer_add_audio_level_meta(buffer.get(), 127, FALSE);
 #endif
 
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
     GStreamerAudioData audioBuffer(WTF::move(sample), m_info);
     GStreamerAudioStreamDescription description(&m_info);
     audioSamplesAvailable(mediaTime, audioBuffer, description, numberOfFrames);

--- a/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp
@@ -191,7 +191,7 @@ std::unique_ptr<MediaSessionGLib> MediaSessionGLib::create(MediaSessionManagerGL
         m_dBusAddressFailed = true;
         return nullptr;
     }
-    auto connection = adoptGRef(reinterpret_cast<GDBusConnection*>(g_object_new(G_TYPE_DBUS_CONNECTION,
+    GRefPtr connection = adoptGRef(reinterpret_cast<GDBusConnection*>(g_object_new(G_TYPE_DBUS_CONNECTION,
         "address", address.get(),
         "flags", G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
         "exit-on-close", TRUE, nullptr)));

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -118,7 +118,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSessionManagerGLib);
 RefPtr<PlatformMediaSessionManager> PlatformMediaSessionManager::create(PageIdentifier pageIdentifier)
 {
     GUniqueOutPtr<GError> error;
-    auto mprisInterface = adoptGRef(g_dbus_node_info_new_for_xml(s_mprisInterface, &error.outPtr()));
+    GRefPtr mprisInterface = adoptGRef(g_dbus_node_info_new_for_xml(s_mprisInterface, &error.outPtr()));
     if (!mprisInterface) {
         g_warning("Failed at parsing XML Interface definition: %s", error->message);
         return nullptr;

--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -219,7 +219,7 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
     GRefPtr<GstElement> harnessedElement = gst_bin_new(binName.ascii().data());
     auto audioconvert = gst_element_factory_make("audioconvert", nullptr);
     auto outputCapsFilter = gst_element_factory_make("capsfilter", nullptr);
-    auto outputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "F32LE", nullptr));
+    GRefPtr outputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "format", G_TYPE_STRING, "F32LE", nullptr));
     g_object_set(outputCapsFilter, "caps", outputCaps.get(), nullptr);
     gst_bin_add_many(GST_BIN_CAST(harnessedElement.get()), audioconvert, outputCapsFilter, element.get(), nullptr);
 
@@ -240,7 +240,7 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
 
     gst_element_link_many(head.get(), audioconvert, outputCapsFilter, nullptr);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(head.get(), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(head.get(), "sink"));
     gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("sink", pad.get()));
 
     pad = adoptGRef(gst_element_get_static_pad(outputCapsFilter, "src"));
@@ -316,7 +316,7 @@ void GStreamerInternalAudioDecoder::flush()
     }
 
     GST_DEBUG_OBJECT(m_harness->element(), "Pushing an empty buffer with discont flag");
-    auto buffer = adoptGRef(gst_buffer_new());
+    GRefPtr buffer = adoptGRef(gst_buffer_new());
     GST_BUFFER_FLAG_SET(buffer.get(), GST_BUFFER_FLAG_DISCONT);
     m_harness->pushBuffer(WTF::move(buffer));
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -68,14 +68,14 @@ static unsigned long maximumNumberOfOutputChannels()
             }
         }
 
-        auto monitor = adoptGRef(gst_device_monitor_new());
-        auto caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
+        GRefPtr monitor = adoptGRef(gst_device_monitor_new());
+        GRefPtr caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
         gst_device_monitor_add_filter(monitor.get(), "Audio/Sink", caps.get());
         bool started = gst_device_monitor_start(monitor.get());
         auto* devices = gst_device_monitor_get_devices(monitor.get());
         while (devices) {
-            auto device = adoptGRef(GST_DEVICE_CAST(devices->data));
-            auto caps = adoptGRef(gst_device_get_caps(device.get()));
+            GRefPtr device = adoptGRef(GST_DEVICE_CAST(devices->data));
+            GRefPtr caps = adoptGRef(gst_device_get_caps(device.get()));
             unsigned size = gst_caps_get_size(caps.get());
             for (unsigned i = 0; i < size; i++) {
                 auto* structure = gst_caps_get_structure(caps.get(), i);

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -170,12 +170,12 @@ GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder(AudioEncoder::Descr
     m_outputCapsFilter = gst_element_factory_make("capsfilter", nullptr);
     gst_bin_add_many(GST_BIN_CAST(harnessedElement.get()), audioconvert, audioresample, m_inputCapsFilter.get(), m_encoder.get(), m_outputCapsFilter.get(), nullptr);
     gst_element_link_many(audioconvert, audioresample, m_inputCapsFilter.get(), m_encoder.get(), m_outputCapsFilter.get(), nullptr);
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(audioconvert, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(audioconvert, "sink"));
     gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("sink", sinkPad.get()));
-    auto srcPad = adoptGRef(gst_element_get_static_pad(m_outputCapsFilter.get(), "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_outputCapsFilter.get(), "src"));
     gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("src", srcPad.get()));
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
     g_signal_connect_data(pad.get(), "notify::caps", G_CALLBACK(+[](GObject* pad, GParamSpec*, gpointer userData) {
         auto weakEncoder = static_cast<ThreadSafeWeakPtr<GStreamerInternalAudioEncoder>*>(userData);
         auto encoder = weakEncoder->get();
@@ -244,7 +244,7 @@ GStreamerInternalAudioEncoder::~GStreamerInternalAudioEncoder()
     if (!m_harness)
         return;
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_harness->element(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_harness->element(), "src"));
     g_signal_handlers_disconnect_by_data(pad.get(), this);
 }
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -207,7 +207,7 @@ static inline std::optional<int> channelTypeFromCaps(GstCaps* caps)
 
 GstFlowReturn AudioFileReader::handleSample(GstAppSink* sink)
 {
-    auto sample = adoptGRef(gst_app_sink_try_pull_sample(sink, 0));
+    GRefPtr sample = adoptGRef(gst_app_sink_try_pull_sample(sink, 0));
     if (!sample)
         return gst_app_sink_is_eos(sink) ? GST_FLOW_EOS : GST_FLOW_ERROR;
 
@@ -298,7 +298,7 @@ void AudioFileReader::handleNewDeinterleavePad(GstPad* pad)
     GstElement* sink = makeGStreamerElement("appsink"_s);
 
     if (!m_firstChannelType) {
-        auto caps = adoptGRef(gst_pad_query_caps(pad, nullptr));
+        GRefPtr caps = adoptGRef(gst_pad_query_caps(pad, nullptr));
         auto channelType = channelTypeFromCaps(caps.get());
         if (channelType)
             m_firstChannelType = WTF::move(channelType);
@@ -328,7 +328,7 @@ void AudioFileReader::handleNewDeinterleavePad(GstPad* pad)
 
     gst_bin_add(GST_BIN_CAST(m_pipeline.get()), sink);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(sink, "sink"));
     gst_pad_link_full(pad, sinkPad.get(), GST_PAD_LINK_CHECK_NOTHING);
 
     gst_element_sync_state_with_parent(sink);
@@ -347,7 +347,7 @@ void AudioFileReader::plugDeinterleave(GstPad* pad)
     if (m_deInterleave)
         return;
 
-    auto padCaps = adoptGRef(gst_pad_query_caps(pad, nullptr));
+    GRefPtr padCaps = adoptGRef(gst_pad_query_caps(pad, nullptr));
     if (!doCapsHaveType(padCaps.get(), "audio/x-raw"_s))
         return;
 
@@ -363,13 +363,13 @@ void AudioFileReader::plugDeinterleave(GstPad* pad)
     g_signal_connect_swapped(m_deInterleave.get(), "pad-added", G_CALLBACK(deinterleavePadAddedCallback), this);
     g_signal_connect_swapped(m_deInterleave.get(), "no-more-pads", G_CALLBACK(deinterleaveReadyCallback), this);
 
-    auto caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, static_cast<int>(m_sampleRate),
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, static_cast<int>(m_sampleRate),
         "format", G_TYPE_STRING, GST_AUDIO_NE(F32), "layout", G_TYPE_STRING, "interleaved", nullptr));
     g_object_set(capsFilter, "caps", caps.get(), nullptr);
 
     gst_bin_add_many(GST_BIN(m_pipeline.get()), audioConvert, audioResample, capsFilter, m_deInterleave.get(), nullptr);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(audioConvert, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(audioConvert, "sink"));
     gst_pad_link_full(pad, sinkPad.get(), GST_PAD_LINK_CHECK_NOTHING);
 
     gst_element_link_pads_full(audioConvert, "src", audioResample, "sink", GST_PAD_LINK_CHECK_NOTHING);
@@ -413,7 +413,7 @@ void AudioFileReader::decodeAudioForBusCreation()
     }, this, nullptr);
 
     auto* source = makeGStreamerElement("giostreamsrc"_s);
-    auto memoryStream = adoptGRef(g_memory_input_stream_new_from_data(m_data.data(), m_data.size(), nullptr));
+    GRefPtr memoryStream = adoptGRef(g_memory_input_stream_new_from_data(m_data.data(), m_data.size(), nullptr));
     g_object_set(source, "stream", memoryStream.get(), nullptr);
 
     m_decodebin = makeGStreamerElement("decodebin"_s, "decodebin"_s);

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -139,11 +139,11 @@ AudioSourceProviderGStreamer::AudioSourceProviderGStreamer(MediaStreamTrackPriva
     }), this);
 
     g_signal_connect_swapped(decodebin, "pad-added", G_CALLBACK(+[](AudioSourceProviderGStreamer* provider, GstPad* pad) {
-        auto padCaps = adoptGRef(gst_pad_query_caps(pad, nullptr));
+        GRefPtr padCaps = adoptGRef(gst_pad_query_caps(pad, nullptr));
         bool isAudio = doCapsHaveType(padCaps.get(), "audio"_s);
         RELEASE_ASSERT(isAudio);
 
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(provider->m_audioSinkBin.get(), "sink"));
+        GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(provider->m_audioSinkBin.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
         gst_element_sync_state_with_parent(provider->m_audioSinkBin.get());
     }), this);
@@ -189,7 +189,7 @@ AudioSourceProviderGStreamer::~AudioSourceProviderGStreamer()
     ASP_DEBUG("Disposing");
     m_notifier->invalidate();
 
-    auto deinterleave = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "deinterleave"));
+    GRefPtr deinterleave = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "deinterleave"));
     if (deinterleave && m_client) {
         g_signal_handler_disconnect(deinterleave.get(), m_deinterleavePadAddedHandlerId);
         g_signal_handler_disconnect(deinterleave.get(), m_deinterleavePadRemovedHandlerId);
@@ -221,7 +221,7 @@ void AudioSourceProviderGStreamer::configureAudioBin(GstElement* audioBin, GstEl
     gst_bin_add_many(GST_BIN_CAST(m_audioSinkBin.get()), audioTee, audioQueue, audioConvert, audioResample, volumeElement, audioConvert2, audioResample2, audioSink, nullptr);
 
     // Add a ghostpad to the bin so it can proxy to tee.
-    auto audioTeeSinkPad = adoptGRef(gst_element_get_static_pad(audioTee, "sink"));
+    GRefPtr audioTeeSinkPad = adoptGRef(gst_element_get_static_pad(audioTee, "sink"));
     gst_element_add_pad(m_audioSinkBin.get(), gst_ghost_pad_new("sink", audioTeeSinkPad.get()));
 
     // Link a new src pad from tee to queue ! audioconvert ! audioresample ! volume ! audioconvert !
@@ -250,7 +250,7 @@ void AudioSourceProviderGStreamer::provideInput(AudioBus& bus, size_t framesToPr
 GstFlowReturn AudioSourceProviderGStreamer::handleSample(GstAppSink* sink, bool isPreroll)
 {
     ASP_TRACE("Pulling audio sample from the sink");
-    auto sample = adoptGRef(isPreroll ? gst_app_sink_try_pull_preroll(sink, 0) : gst_app_sink_try_pull_sample(sink, 0));
+    GRefPtr sample = adoptGRef(isPreroll ? gst_app_sink_try_pull_preroll(sink, 0) : gst_app_sink_try_pull_sample(sink, 0));
     if (!sample)
         return gst_app_sink_is_eos(sink) ? GST_FLOW_EOS : GST_FLOW_ERROR;
 
@@ -294,22 +294,22 @@ void AudioSourceProviderGStreamer::setClient(WeakPtr<AudioSourceProviderClient>&
     // autoaudiosink. This is needed to avoid double playback of audio
     // from our audio sink and from the WebAudio AudioDestination node
     // supposedly configured already by application side.
-    auto volumeElement = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "volume"));
+    GRefPtr volumeElement = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "volume"));
 
     if (volumeElement) {
         bool shouldMute = !!m_client;
         g_object_set(volumeElement.get(), "mute", shouldMute, nullptr);
     }
 
-    auto audioTee = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "audioTee"));
+    GRefPtr audioTee = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "audioTee"));
     if (!m_client || previousClientWasValid) {
-        auto audioQueue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "queue"));
-        auto audioConvert = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "audioconvert"));
-        auto audioResample = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "audioresample"));
-        auto capsFilter = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "capsfilter"));
-        auto deInterleave = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "deinterleave"));
-        auto queueSinkPad = adoptGRef(gst_element_get_static_pad(audioQueue.get(), "sink"));
-        auto teeSrcPad = adoptGRef(gst_pad_get_peer(queueSinkPad.get()));
+        GRefPtr audioQueue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "queue"));
+        GRefPtr audioConvert = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "audioconvert"));
+        GRefPtr audioResample = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "audioresample"));
+        GRefPtr capsFilter = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "capsfilter"));
+        GRefPtr deInterleave = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_audioSinkBin.get()), "deinterleave"));
+        GRefPtr queueSinkPad = adoptGRef(gst_element_get_static_pad(audioQueue.get(), "sink"));
+        GRefPtr teeSrcPad = adoptGRef(gst_pad_get_peer(queueSinkPad.get()));
 
         ASP_DEBUG("Cleaning up audio deinterleave chain");
         gstElementLockAndSetState(audioQueue.get(), GST_STATE_NULL);
@@ -337,7 +337,7 @@ void AudioSourceProviderGStreamer::setClient(WeakPtr<AudioSourceProviderClient>&
         m_deinterleavePadAddedHandlerId = g_signal_connect(deInterleave, "pad-added", G_CALLBACK(onGStreamerDeinterleavePadAddedCallback), this);
         m_deinterleavePadRemovedHandlerId = g_signal_connect(deInterleave, "pad-removed", G_CALLBACK(onGStreamerDeinterleavePadRemovedCallback), this);
 
-        auto caps = adoptGRef(gst_caps_new_simple("audio/x-raw",
+        GRefPtr caps = adoptGRef(gst_caps_new_simple("audio/x-raw",
             "format", G_TYPE_STRING, GST_AUDIO_NE(F32), "layout", G_TYPE_STRING, "interleaved", nullptr));
         g_object_set(capsFilter, "caps", caps.get(), nullptr);
 
@@ -412,7 +412,7 @@ void AudioSourceProviderGStreamer::handleNewDeinterleavePad(GstPad* pad)
             gst_bus_post(pipeline->bus, gst_message_new_eos(GST_OBJECT(appsink)));
     }), sink);
 
-    auto caps = adoptGRef(gst_caps_new_simple("audio/x-raw",
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("audio/x-raw",
         "channels", G_TYPE_INT, 1, "format", G_TYPE_STRING, GST_AUDIO_NE(F32), "layout", G_TYPE_STRING, "interleaved", nullptr));
     gst_app_sink_set_caps(GST_APP_SINK(sink), caps.get());
 
@@ -420,7 +420,7 @@ void AudioSourceProviderGStreamer::handleNewDeinterleavePad(GstPad* pad)
 
     gst_element_link(queue, sink);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(queue, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(queue, "sink"));
     gst_pad_link_full(pad, sinkPad.get(), GST_PAD_LINK_CHECK_NOTHING);
 
     GQuark quark = g_quark_from_static_string("peer");
@@ -465,10 +465,10 @@ void AudioSourceProviderGStreamer::handleRemovedDeinterleavePad(GstPad* pad)
     if (!sinkPad)
         return;
 
-    auto queue = adoptGRef(gst_pad_get_parent_element(sinkPad));
-    auto srcPad = adoptGRef(gst_element_get_static_pad(queue.get(), "src"));
-    auto sinkSinkPad = adoptGRef(gst_pad_get_peer(srcPad.get()));
-    auto sink = adoptGRef(gst_pad_get_parent_element(sinkSinkPad.get()));
+    GRefPtr queue = adoptGRef(gst_pad_get_parent_element(sinkPad));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(queue.get(), "src"));
+    GRefPtr sinkSinkPad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    GRefPtr sink = adoptGRef(gst_pad_get_parent_element(sinkSinkPad.get()));
 
     g_signal_handlers_disconnect_by_data(sink.get(), sink.get());
 

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -85,14 +85,14 @@ RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_
         return nullptr;
     }
 
-    auto caps = adoptGRef(gst_audio_info_to_caps(&info));
+    GRefPtr caps = adoptGRef(gst_audio_info_to_caps(&info));
     GST_TRACE("Creating raw audio wrapper with caps %" GST_PTR_FORMAT, caps.get());
     GST_MEMDUMP("Source", sourceData.data(), sourceData.size());
 
     Ref data = SharedBuffer::create(Vector<uint8_t>(sourceData));
     gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->span().data()));
     auto bufferLength = data->size();
-    auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferLength, 0, bufferLength, reinterpret_cast<gpointer>(&data.leakRef()), [](gpointer data) {
+    GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferLength, 0, bufferLength, reinterpret_cast<gpointer>(&data.leakRef()), [](gpointer data) {
         static_cast<SharedBuffer*>(data)->deref();
     }));
     GST_BUFFER_DURATION(buffer.get()) = (numberOfFrames / sampleRate) * 1000000000;
@@ -106,7 +106,7 @@ RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_
 
     gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, nullptr);
 
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), &segment, nullptr));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), &segment, nullptr));
     return PlatformRawAudioDataGStreamer::create(WTF::move(sample));
 }
 

--- a/Source/WebCore/platform/glib/FileMonitorGLib.cpp
+++ b/Source/WebCore/platform/glib/FileMonitorGLib.cpp
@@ -39,7 +39,7 @@ FileMonitor::FileMonitor(const String& path, Ref<WorkQueue>&& handlerQueue, Func
         return;
 
     Function<void ()> createPlatformMonitor = [&] {
-        auto file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(path).data()));
+        GRefPtr file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(path).data()));
         GUniqueOutPtr<GError> error;
         m_platformMonitor = adoptGRef(g_file_monitor(file.get(), G_FILE_MONITOR_NONE, nullptr, &error.outPtr()));
         if (m_platformMonitor)

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -66,10 +66,10 @@ AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPl
 {
     ensureDebugCategoryInitialized();
 
-    auto caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
+    GRefPtr caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
     updateConfigurationFromCaps(WTF::move(caps));
 
-    auto tags = adoptGRef(gst_stream_get_tags(m_data->m_stream.get()));
+    GRefPtr tags = adoptGRef(gst_stream_get_tags(m_data->m_stream.get()));
     updateConfigurationFromTags(WTF::move(tags));
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -151,11 +151,11 @@ static void webKitGLVideoSinkConstructed(GObject* object)
         gst_caps_append(caps.get(), buildDMABufCaps().leakRef());
 #endif
 
-    auto glCaps = adoptGRef(gst_caps_from_string("video/x-raw, format = (string) " GST_GL_CAPS_FORMAT));
+    GRefPtr glCaps = adoptGRef(gst_caps_from_string("video/x-raw, format = (string) " GST_GL_CAPS_FORMAT));
     gst_caps_set_features(glCaps.get(), 0, gst_caps_features_new(GST_CAPS_FEATURE_MEMORY_GL_MEMORY, nullptr));
     gst_caps_append(caps.get(), glCaps.leakRef());
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink->priv->queue.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(sink->priv->queue.get(), "sink"));
 
     if (!quirkGLCaps) {
         auto upload = makeGStreamerElement("glupload"_s);
@@ -168,7 +168,7 @@ static void webKitGLVideoSinkConstructed(GObject* object)
         sinkPad = adoptGRef(gst_element_get_static_pad(upload, "sink"));
 
         GstElement* imxVideoConvert = nullptr;
-        if (auto imxVideoConvertFactory = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"))) {
+        if (GRefPtr imxVideoConvertFactory = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"))) {
             imxVideoConvert = gst_element_factory_create(imxVideoConvertFactory.get(), nullptr);
             gst_bin_add(GST_BIN_CAST(sink), imxVideoConvert);
             gst_element_link(imxVideoConvert, upload);
@@ -206,15 +206,15 @@ static void webKitGLVideoSinkConstructed(GObject* object)
             RELEASE_ASSERT(upload);
             RELEASE_ASSERT(colorconvert);
 
-            auto sinkPad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
+            GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
             gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(sinkPad.get()), nullptr);
 
             gst_bin_add_many(GST_BIN_CAST(sink.get()), upload, colorconvert, nullptr);
             gst_element_link_many(upload, colorconvert, priv->queue.get(), nullptr);
-            auto target = adoptGRef(gst_element_get_static_pad(upload, "sink"));
+            GRefPtr target = adoptGRef(gst_element_get_static_pad(upload, "sink"));
 
             GstElement* imxVideoConvert = nullptr;
-            if (auto imxVideoConvertFactory = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"))) {
+            if (GRefPtr imxVideoConvertFactory = adoptGRef(gst_element_factory_find("imxvideoconvert_g2d"))) {
                 imxVideoConvert = gst_element_factory_create(imxVideoConvertFactory.get(), nullptr);
                 gst_bin_add(GST_BIN_CAST(sink.get()), imxVideoConvert);
                 gst_element_link(imxVideoConvert, upload);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -150,15 +150,15 @@ GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink
 
     if (forcedSampleRate) {
         auto capsfilter = gst_element_factory_make("capsfilter", nullptr);
-        auto caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, *forcedSampleRate, nullptr));
+        GRefPtr caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, *forcedSampleRate, nullptr));
         g_object_set(capsfilter, "caps", caps.get(), nullptr);
         gst_bin_add(GST_BIN_CAST(bin), capsfilter);
         gst_element_link(audioResample, capsfilter);
     }
 
-    if (auto pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SRC)))
+    if (GRefPtr pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SRC)))
         gst_element_add_pad(GST_ELEMENT_CAST(bin), gst_ghost_pad_new("src", pad.get()));
-    if (auto pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SINK)))
+    if (GRefPtr pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SINK)))
         gst_element_add_pad(GST_ELEMENT_CAST(bin), gst_ghost_pad_new("sink", pad.get()));
 
     gst_bin_add_many(GST_BIN_CAST(mp.pipeline.get()), src, bin, nullptr);
@@ -166,8 +166,8 @@ GRefPtr<GstPad> GStreamerAudioMixer::registerProducer(GstElement* interaudioSink
 
     bool shouldStart = !mp.mixer->numsinkpads;
 
-    auto mixerPad = adoptGRef(gst_element_request_pad_simple(mp.mixer.get(), "sink_%u"));
-    auto srcPad = adoptGRef(gst_element_get_static_pad(bin, "src"));
+    GRefPtr mixerPad = adoptGRef(gst_element_request_pad_simple(mp.mixer.get(), "sink_%u"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(bin, "src"));
     gst_pad_link(srcPad.get(), mixerPad.get());
 
     if (shouldStart)
@@ -195,11 +195,11 @@ void GStreamerAudioMixer::unregisterProducer(const GRefPtr<GstPad>& mixerPad)
 
     GST_DEBUG_OBJECT(mp.pipeline.get(), "Unregistering audio producer %" GST_PTR_FORMAT " from device '%s'.", mixerPad.get(), deviceId.utf8().data());
 
-    auto peer = adoptGRef(gst_pad_get_peer(mixerPad.get()));
-    auto bin = adoptGRef(gst_pad_get_parent_element(peer.get()));
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(bin.get(), "sink"));
-    auto srcPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
-    auto interaudioSrc = adoptGRef(gst_pad_get_parent_element(srcPad.get()));
+    GRefPtr peer = adoptGRef(gst_pad_get_peer(mixerPad.get()));
+    GRefPtr bin = adoptGRef(gst_pad_get_parent_element(peer.get()));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(bin.get(), "sink"));
+    GRefPtr srcPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
+    GRefPtr interaudioSrc = adoptGRef(gst_pad_get_parent_element(srcPad.get()));
     GST_LOG_OBJECT(mp.pipeline.get(), "interaudiosrc: %" GST_PTR_FORMAT, interaudioSrc.get());
 
     gstElementLockAndSetState(interaudioSrc.get(), GST_STATE_NULL);
@@ -226,7 +226,7 @@ void GStreamerAudioMixer::configureSourcePeriodTime(CStringView sourceName, uint
 {
     DataMutexLocker locker { m_streamingMembers };
     for (auto& [deviceId, mp] : locker->m_pipelines) {
-        auto src = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(mp->pipeline.get()), sourceName.utf8()));
+        GRefPtr src = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(mp->pipeline.get()), sourceName.utf8()));
         if (!src)
             continue;
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -533,7 +533,7 @@ bool ensureGStreamerInitialized()
 static bool registerInternalVideoEncoder()
 {
 #if ENABLE(VIDEO)
-    if (auto factory = adoptGRef(gst_element_factory_find("webkitvideoencoder")))
+    if (GRefPtr factory = adoptGRef(gst_element_factory_find("webkitvideoencoder")))
         return false;
     return gst_element_register(nullptr, "webkitvideoencoder", GST_RANK_PRIMARY + 100, WEBKIT_TYPE_VIDEO_ENCODER);
 #endif
@@ -597,7 +597,7 @@ void registerWebKitGStreamerElements()
         // to fallback to MSE when this happens.
         auto hlsSupport = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_ENABLE_HLS_SUPPORT"));
         if (!hlsSupport || hlsSupport == "0"_s) {
-            if (auto factory = adoptGRef(gst_element_factory_find("hlsdemux")))
+            if (GRefPtr factory = adoptGRef(gst_element_factory_find("hlsdemux")))
                 gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_NONE);
         }
 
@@ -605,7 +605,7 @@ void registerWebKitGStreamerElements()
         // to fallback to MSE when this happens.
         auto dashSupport = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_ENABLE_DASH_SUPPORT"));
         if (!dashSupport || dashSupport == "0"_s) {
-            if (auto factory = adoptGRef(gst_element_factory_find("dashdemux")))
+            if (GRefPtr factory = adoptGRef(gst_element_factory_find("dashdemux")))
                 gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_NONE);
         }
 
@@ -615,13 +615,13 @@ void registerWebKitGStreamerElements()
         if (gst_check_version(1, 22, 0)) {
             std::array<ASCIILiteral, 3> elementNames = { "dashdemux2"_s, "hlsdemux2"_s, "mssdemux2"_s };
             for (auto& elementName : elementNames) {
-                if (auto factory = adoptGRef(gst_element_factory_find(elementName)))
+                if (GRefPtr factory = adoptGRef(gst_element_factory_find(elementName)))
                     gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_NONE);
             }
         }
 
         // Make sure isofmp4mux is auto-plugged in transcodebin pipelines.
-        if (auto factory = adoptGRef(gst_element_factory_find("isofmp4mux")))
+        if (GRefPtr factory = adoptGRef(gst_element_factory_find("isofmp4mux")))
             gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_PRIMARY + 1);
 
         // The VAAPI plugin is not much maintained anymore and prone to rendering issues. In the
@@ -630,14 +630,14 @@ void registerWebKitGStreamerElements()
         auto enableLegacyVAAPIPlugin = CStringView::unsafeFromUTF8(g_getenv("WEBKIT_GST_ENABLE_LEGACY_VAAPI"));
         if (enableLegacyVAAPIPlugin.isEmpty() || enableLegacyVAAPIPlugin == "0"_s) {
             auto* registry = gst_registry_get();
-            if (auto vaapiPlugin = adoptGRef(gst_registry_find_plugin(registry, "vaapi")))
+            if (GRefPtr vaapiPlugin = adoptGRef(gst_registry_find_plugin(registry, "vaapi")))
                 gst_registry_remove_plugin(registry, vaapiPlugin.get());
         }
 
         // Disable the pipewire device provider, usually the pulseaudio and v4l2 device providers would
         // be preferred anyway and pipewiresink is currently prone to deadlocks:
         // https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/5171
-        if (auto pipewireDeviceProviderFactory = adoptGRef(gst_device_provider_factory_find("pipewiredeviceprovider")))
+        if (GRefPtr pipewireDeviceProviderFactory = adoptGRef(gst_device_provider_factory_find("pipewiredeviceprovider")))
             gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(pipewireDeviceProviderFactory.get()), GST_RANK_NONE);
 
         // Make sure the quirks are created as early as possible.
@@ -757,7 +757,7 @@ void deinitializeGStreamer()
     bool isLeaksTracerActive = false;
     auto activeTracers = gst_tracing_get_active_tracers();
     while (activeTracers) {
-        auto tracer = adoptGRef(GST_TRACER_CAST(activeTracers->data));
+        GRefPtr tracer = adoptGRef(GST_TRACER_CAST(activeTracers->data));
         if (!isLeaksTracerActive && equal(unsafeSpan(G_OBJECT_TYPE_NAME(G_OBJECT(tracer.get()))), "GstLeaksTracer"_s))
             isLeaksTracerActive = true;
         activeTracers = g_list_delete_link(activeTracers, activeTracers);
@@ -1068,7 +1068,7 @@ void disconnectSimpleBusMessageCallback(GstElement* pipeline)
     if (!handler)
         return;
 
-    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
+    GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
     g_signal_handler_disconnect(bus.get(), handler);
     gst_bus_remove_signal_watch(bus.get());
     g_object_set_qdata(G_OBJECT(pipeline), customMessageHandlerQuark(), nullptr);
@@ -1103,7 +1103,7 @@ static void dumpPipeline(const GRefPtr<GstElement>& pipeline, String&& dotFileNa
 
 void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMessage*)>&& customHandler, AsynchronousPipelineDumping asynchronousPipelineDumping)
 {
-    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
+    GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
     gst_bus_add_signal_watch_full(bus.get(), RunLoopSourcePriority::RunLoopDispatcher);
 
     auto data = createMessageBusData();
@@ -1237,7 +1237,7 @@ bool webkitGstSetElementStateSynchronously(GstElement* pipeline, GstState target
         return true;
     }
 
-    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
+    GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
     gst_bus_enable_sync_message_emission(bus.get());
 
     auto cleanup = makeScopeExit([bus = GRefPtr<GstBus>(bus), pipeline, targetState] {
@@ -1257,7 +1257,7 @@ bool webkitGstSetElementStateSynchronously(GstElement* pipeline, GstState target
         return false;
 
     if (result == GST_STATE_CHANGE_ASYNC) {
-        while (auto message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), GST_CLOCK_TIME_NONE, GST_MESSAGE_STATE_CHANGED))) {
+        while (GRefPtr message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), GST_CLOCK_TIME_NONE, GST_MESSAGE_STATE_CHANGED))) {
             if (!messageHandler(message.get()))
                 return false;
 
@@ -2042,7 +2042,7 @@ GRefPtr<GstBuffer> wrapSpanData(const std::span<const uint8_t>& span)
     Vector<uint8_t> data { span };
     auto bufferSize = data.size();
     auto bufferData = data.mutableSpan().data();
-    auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferSize, 0, bufferSize, new Vector<uint8_t>(WTF::move(data)), [](gpointer data) {
+    GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferSize, 0, bufferSize, new Vector<uint8_t>(WTF::move(data)), [](gpointer data) {
         delete static_cast<Vector<uint8_t>*>(data);
     }));
     return buffer;
@@ -2259,7 +2259,7 @@ bool setGstElementGLContext(GstElement* element, ASCIILiteral contextType)
 
 GstStateChangeReturn gstElementLockAndSetState(GstElement* element, GstState state)
 {
-    auto parent = adoptGRef(gst_element_get_parent(element));
+    GRefPtr parent = adoptGRef(gst_element_get_parent(element));
     if (parent)
         GST_STATE_LOCK(parent.get());
 
@@ -2302,7 +2302,7 @@ GRefPtr<GstElement> createVideoConvertScaleElement(const String& name)
     gst_bin_add_many(GST_BIN_CAST(bin.get()), videoScale, videoConvert, nullptr);
     gst_element_link(videoScale, videoConvert);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(videoScale, "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(videoScale, "sink"));
     gst_element_add_pad(bin.get(), gst_ghost_pad_new("sink", pad.get()));
     pad = adoptGRef(gst_element_get_static_pad(videoConvert, "src"));
     gst_element_add_pad(bin.get(), gst_ghost_pad_new("src", pad.get()));

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -307,7 +307,7 @@ static Vector<GRefPtr<GstElementFactory>> findCompatibleFactories(GList* list, c
             if (capsTemplate->direction != direction)
                 continue;
 
-            auto templateCaps = adoptGRef(gst_static_caps_get(&capsTemplate->static_caps));
+            GRefPtr templateCaps = adoptGRef(gst_static_caps_get(&capsTemplate->static_caps));
             if (gst_caps_is_any(templateCaps.get()) || !gst_caps_can_intersect(caps.get(), templateCaps.get()))
                 continue;
 
@@ -819,7 +819,7 @@ void GStreamerRegistryScanner::initializeEncoders(const GStreamerRegistryScanner
 
 GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isHEVCCodecSupported(Configuration configuration, const String& codec, bool shouldCheckForHardwareUse) const
 {
-    auto h265Caps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
+    GRefPtr h265Caps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
     if (codec.find('.') == notFound) {
         GST_DEBUG("Codec has no profile/level, falling back to unconstrained caps");
         return areCapsSupported(configuration, h265Caps, shouldCheckForHardwareUse);
@@ -942,14 +942,14 @@ MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(
                 else if (mimeCodec == "av1"_s)
                     mimeCodec = "av01"_s;
             }
-            auto codecCaps = adoptGRef(gst_codec_utils_caps_from_mime_codec(mimeCodec.ascii().data()));
+            GRefPtr codecCaps = adoptGRef(gst_codec_utils_caps_from_mime_codec(mimeCodec.ascii().data()));
             if (!codecCaps) {
                 GST_WARNING("Unable to convert codec %s to caps", mimeCodec.ascii().data());
                 continue;
             }
             auto structure = gst_caps_get_structure(codecCaps.get(), 0);
             auto name = gstStructureGetName(structure);
-            auto caps = adoptGRef(gst_caps_new_simple("application/x-webm-enc", "original-media-type", G_TYPE_STRING, name.utf8(), nullptr));
+            GRefPtr caps = adoptGRef(gst_caps_new_simple("application/x-webm-enc", "original-media-type", G_TYPE_STRING, name.utf8(), nullptr));
             if (!factories.hasElementForCaps(ElementFactories::Type::Decryptor, caps))
                 return SupportsType::IsNotSupported;
         }
@@ -1021,7 +1021,7 @@ GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::areCapsSup
 
 GStreamerRegistryScanner::CodecLookupResult GStreamerRegistryScanner::isAVC1CodecSupported(Configuration configuration, const String& codec, bool shouldCheckForHardwareUse) const
 {
-    auto h264Caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+    GRefPtr h264Caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
     if (codec.find('.') == notFound) {
         GST_DEBUG("Codec has no profile/level, falling back to unconstrained caps");
         return areCapsSupported(configuration, h264Caps, shouldCheckForHardwareUse);
@@ -1208,7 +1208,7 @@ static inline Vector<RTCRtpCapabilities::HeaderExtensionCapability> probeRtpExte
 {
     Vector<RTCRtpCapabilities::HeaderExtensionCapability> extensions;
     for (const auto& uri : candidates) {
-        if (auto extension = adoptGRef(gst_rtp_header_extension_create_from_uri(uri.characters())))
+        if (GRefPtr extension = adoptGRef(gst_rtp_header_extension_create_from_uri(uri.characters())))
             extensions.append(String(byteCast<char8_t>(unsafeSpan(uri))));
     }
     return extensions;
@@ -1246,7 +1246,7 @@ void GStreamerRegistryScanner::fillAudioRtpCapabilities(Configuration configurat
 
     bool hasDtmfSupport = false;
     if (configuration == Configuration::Encoding) {
-        if (auto factory = adoptGRef(gst_element_factory_find("rtpdtmfsrc")))
+        if (GRefPtr factory = adoptGRef(gst_element_factory_find("rtpdtmfsrc")))
             hasDtmfSupport = true;
     } else
         hasDtmfSupport = factories.hasElementForMediaType(rtpElement, "audio/x-raw, format=(string)S16LE"_s);
@@ -1303,7 +1303,7 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
                     sps[1] = (spsAsInteger >> 8) & 0xff;
                     sps[2] = spsAsInteger & 0xff;
 
-                    auto caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+                    GRefPtr caps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
                     gst_codec_utils_h264_caps_set_level_and_profile(caps.get(), sps.data(), 3);
                     if (!gst_element_factory_can_sink_any_caps(gst_element_get_factory(element.get()), caps.get()))
                         continue;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
@@ -106,7 +106,7 @@ GRefPtr<GstSample> GStreamerVideoFrameConverter::Pipeline::run(const GRefPtr<Gst
 #endif
 
     unsigned capsSize = gst_caps_get_size(destinationCaps);
-    auto newCaps = adoptGRef(gst_caps_new_empty());
+    GRefPtr newCaps = adoptGRef(gst_caps_new_empty());
     for (unsigned i = 0; i < capsSize; i++) {
         auto structure = gst_caps_get_structure(destinationCaps, i);
         auto modifiedStructure = gst_structure_copy(structure);
@@ -124,8 +124,8 @@ GRefPtr<GstSample> GStreamerVideoFrameConverter::Pipeline::run(const GRefPtr<Gst
     gst_element_set_state(m_pipeline.get(), GST_STATE_PAUSED);
     gst_app_src_push_sample(GST_APP_SRC_CAST(m_src.get()), sample.get());
 
-    auto bus = adoptGRef(gst_element_get_bus(m_pipeline.get()));
-    auto message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), 400 * GST_MSECOND, static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_ASYNC_DONE)));
+    GRefPtr bus = adoptGRef(gst_element_get_bus(m_pipeline.get()));
+    GRefPtr message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), 400 * GST_MSECOND, static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_ASYNC_DONE)));
     if (!message) {
         GST_ERROR_OBJECT(m_pipeline.get(), "Video frame conversion 400ms timeout expired.");
         return nullptr;
@@ -197,12 +197,12 @@ GRefPtr<GstSample> GStreamerVideoFrameConverter::convert(const GRefPtr<GstSample
     if (!outputSample)
         return nullptr;
 
-    auto convertedSample = adoptGRef(gst_sample_make_writable(outputSample.leakRef()));
+    GRefPtr convertedSample = adoptGRef(gst_sample_make_writable(outputSample.leakRef()));
     gst_sample_set_caps(convertedSample.get(), destinationCaps.get());
 
     GRefPtr buffer = gst_sample_get_buffer(convertedSample.get());
 IGNORE_WARNINGS_BEGIN("cast-align")
-    auto writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GRefPtr writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
 IGNORE_WARNINGS_END
 
     if (auto meta = gst_buffer_get_video_meta(writableBuffer.get()))

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -215,7 +215,7 @@ void webKitVideoSinkDisconnectSignalHandlers(GstElement* appSink, const WebKitVi
     g_signal_handler_disconnect(appSink, identifiers.newPreroll);
     g_signal_handler_disconnect(appSink, identifiers.newSample);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
     if (identifiers.notifyCaps)
         g_signal_handler_disconnect(pad.get(), identifiers.notifyCaps);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -124,7 +124,7 @@ ImageDecoderGStreamer::ImageDecoderGStreamer(FragmentedSharedBuffer& data, const
     static Atomic<uint32_t> decoderId;
     GRefPtr<GstElement> parsebin = gst_element_factory_make("parsebin", makeString("image-decoder-parser-"_s, decoderId.exchangeAdd(1)).utf8().data());
     m_parserHarness = GStreamerElementHarness::create(WTF::move(parsebin), [](auto&, auto&&) { }, [this](auto& pad) -> RefPtr<GStreamerElementHarness> {
-        auto caps = adoptGRef(gst_pad_query_caps(pad.get(), nullptr));
+        GRefPtr caps = adoptGRef(gst_pad_query_caps(pad.get(), nullptr));
         auto identityHarness = GStreamerElementHarness::create(GRefPtr<GstElement>(gst_element_factory_make("identity", nullptr)), [](auto&, const auto&) { });
         GST_DEBUG_OBJECT(pad.get(), "Caps on parser source pad: %" GST_PTR_FORMAT, caps.get());
         if (!caps || !doCapsHaveType(caps.get(), "video"_s)) {
@@ -292,7 +292,7 @@ void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& shared
 {
     auto data = sharedBuffer.makeContiguous();
     auto bytes = data->createGBytes();
-    auto buffer = adoptGRef(gst_buffer_new_wrapped_bytes(bytes.get()));
+    GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_bytes(bytes.get()));
     m_eos = false;
     m_error = false;
 
@@ -303,7 +303,7 @@ void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& shared
         });
     });
 
-    auto caps = adoptGRef(gst_type_find_helper_for_buffer(GST_OBJECT_CAST(m_parserHarness->element()), buffer.get(), nullptr));
+    GRefPtr caps = adoptGRef(gst_type_find_helper_for_buffer(GST_OBJECT_CAST(m_parserHarness->element()), buffer.get(), nullptr));
     GST_DEBUG_OBJECT(m_parserHarness->element(), "Caps typefind result: %" GST_PTR_FORMAT, caps.get());
     if (!caps) {
         GST_WARNING_OBJECT(m_parserHarness->element(), "Typefinding failed");

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -62,7 +62,7 @@ InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index,
     GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_data->m_id, m_data->m_gstStreamId.utf8().data());
 
     GST_DEBUG("Stream %" GST_PTR_FORMAT, m_data->m_stream.get());
-    auto caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
+    GRefPtr caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
     m_kind = doCapsHaveType(caps.get(), "closedcaption/"_s) ? Kind::Captions : Kind::Subtitles;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -272,7 +272,7 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
         unregisterPipeline(m_originalPipelineName);
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
 
-        auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+        GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
         gst_bus_disable_sync_message_emission(bus.get());
         disconnectSimpleBusMessageCallback(m_pipeline.get());
         g_signal_handlers_disconnect_matched(m_pipeline.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
@@ -648,7 +648,7 @@ bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, b
 
     auto seekStart = toGstClockTime(startTime);
     auto seekStop = toGstClockTime(endTime);
-    auto event = adoptGRef(gst_event_new_seek(rate, GST_FORMAT_TIME, seekFlags, GST_SEEK_TYPE_SET, seekStart, GST_SEEK_TYPE_SET, seekStop));
+    GRefPtr event = adoptGRef(gst_event_new_seek(rate, GST_FORMAT_TIME, seekFlags, GST_SEEK_TYPE_SET, seekStart, GST_SEEK_TYPE_SET, seekStop));
 
     GST_DEBUG_OBJECT(pipeline(), "[Seek] Performing actual seek to %" GST_TIMEP_FORMAT " (endTime: %" GST_TIMEP_FORMAT ") at rate %f", &seekStart, &seekStop, rate);
 
@@ -1881,7 +1881,7 @@ void MediaPlayerPrivateGStreamer::updateTracks([[maybe_unused]] const GRefPtr<Gs
         RELEASE_ASSERT(stream);
         auto streamId = getStreamIdFromStream(stream).value_or(0);
         auto type = gst_stream_get_stream_type(stream.get());
-        auto caps = adoptGRef(gst_stream_get_caps(stream.get()));
+        GRefPtr caps = adoptGRef(gst_stream_get_caps(stream.get()));
 
         GST_DEBUG_OBJECT(pipeline(), "#%u %s track with ID %" PRIu64 ": %" GST_PTR_FORMAT, i, gst_stream_type_get_name(type), streamId, stream.get());
 
@@ -1943,7 +1943,7 @@ bool MediaPlayerPrivateGStreamer::handleNeedContextMessage(GstMessage* message)
     GST_DEBUG_OBJECT(pipeline(), "Handling %s need-context message for %s", contextType.utf8(), GST_MESSAGE_SRC_NAME(message));
 
     if (contextType == WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME) {
-        auto context = adoptGRef(gst_context_new(WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME.characters(), FALSE));
+        GRefPtr context = adoptGRef(gst_context_new(WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME.characters(), FALSE));
         GstStructure* contextStructure = gst_context_writable_structure(context.get());
 
         gst_structure_set(contextStructure, "loader", G_TYPE_POINTER, m_loader.ptr(), nullptr);
@@ -2414,7 +2414,7 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         GST_DEBUG_OBJECT(m_pipeline.get(), "Received STREAMS_SELECTED message selecting the following streams:");
         unsigned numStreams = gst_message_streams_selected_get_size(message);
         for (unsigned i = 0; i < numStreams; i++) {
-            auto stream = adoptGRef(gst_message_streams_selected_get_stream(message, i));
+            GRefPtr stream = adoptGRef(gst_message_streams_selected_get_stream(message, i));
             GST_DEBUG_OBJECT(pipeline(), "#%u %s %s", i, gst_stream_type_get_name(gst_stream_get_stream_type(stream.get())), gst_stream_get_stream_id(stream.get()));
         }
 #endif
@@ -3515,7 +3515,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     registerActivePipeline(m_pipeline, m_originalPipelineName);
 
     if (isMediaStream) {
-        auto clock = adoptGRef(gst_system_clock_obtain());
+        GRefPtr clock = adoptGRef(gst_system_clock_obtain());
         gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
         gst_element_set_base_time(m_pipeline.get(), 0);
         gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
@@ -3543,7 +3543,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     setPlaybackFlags(isMediaStream);
 
     // Let also other listeners subscribe to (application) messages in this bus.
-    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+    GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
     gst_bus_enable_sync_message_emission(bus.get());
     connectSimpleBusMessageCallback(m_pipeline.get(), [weakThis = ThreadSafeWeakPtr { *this }](GstMessage* message) {
         RefPtr player = weakThis.get();
@@ -3581,7 +3581,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 
     // From GStreamer 1.22.0, uridecodebin3 is created in playbin3's _init(), so "element-setup" isn't called with it.
     if (!m_isLegacyPlaybin && gst_check_version(1, 22, 0)) {
-        if (auto uriDecodeBin3 = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), "uridecodebin3")))
+        if (GRefPtr uriDecodeBin3 = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_pipeline.get()), "uridecodebin3")))
             configureElement(uriDecodeBin3.get());
     }
 
@@ -3619,7 +3619,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 void MediaPlayerPrivateGStreamer::setupCodecProbe(GstElement* element)
 {
 #if GST_CHECK_VERSION(1, 20, 0)
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
     auto probe = PadProbeHandle<MediaPlayerPrivateGStreamer>::create(*this, WTF::move(sinkPad), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, [](const auto& player, const auto& pad, auto info) -> GstPadProbeReturn {
         auto* event = gst_pad_probe_info_get_event(info);
         if (GST_EVENT_TYPE(event) != GST_EVENT_CAPS)
@@ -3695,7 +3695,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
     m_videoDecoderName = configureMediaStreamVideoDecoder(decoder);
 
     Locker locker { m_decoderConfigurationLock };
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(decoder, "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(decoder, "sink"));
     m_videoFrameInputProbe = PadProbeHandle<MediaPlayerPrivateGStreamer>::create(*this, WTF::move(sinkPad), GST_PAD_PROBE_TYPE_BUFFER, [](const auto& player, const auto&, auto info) -> GstPadProbeReturn {
         auto buffer = GST_PAD_PROBE_INFO_BUFFER(info);
         if (!GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT))
@@ -3704,7 +3704,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
         return GST_PAD_PROBE_OK;
     });
 
-    auto pad = adoptGRef(gst_element_get_static_pad(decoder, "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(decoder, "src"));
     if (!pad) {
         GST_INFO_OBJECT(pipeline(), "the decoder %s does not have a src pad, probably because it's a hardware decoder sink, can't get decoder stats", name.utf8());
         return;
@@ -3714,7 +3714,7 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
         if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
             player->incrementDecodedVideoFramesCount();
 
-            auto decoder = adoptGRef(gst_pad_get_parent_element(pad.get()));
+            GRefPtr decoder = adoptGRef(gst_pad_get_parent_element(pad.get()));
             auto processingTime = webkitGstBufferGetProcessingTime(gst_pad_probe_info_get_buffer(info), decoder.get());
             if (processingTime.isInvalid())
                 return GST_PAD_PROBE_OK;
@@ -3942,9 +3942,9 @@ void MediaPlayerPrivateGStreamer::updateVideoSizeAndOrientationFromCaps(const Gs
         return;
     }
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
     ASSERT(pad);
-    auto tagsEvent = adoptGRef(gst_pad_get_sticky_event(pad.get(), GST_EVENT_TAG, 0));
+    GRefPtr tagsEvent = adoptGRef(gst_pad_get_sticky_event(pad.get(), GST_EVENT_TAG, 0));
     auto orientation = ImageOrientation::Orientation::None;
     if (tagsEvent) {
         GstTagList* tagList;
@@ -4126,7 +4126,7 @@ void MediaPlayerPrivateGStreamer::flushCurrentBuffer()
         // necessary because the sample might have been allocated by a hardware decoder and memory
         // might have to be reclaimed by a non-sysmem buffer pool.
         const GstStructure* info = gst_sample_get_info(m_sample.get());
-        auto buffer = adoptGRef(gst_buffer_copy_deep(gst_sample_get_buffer(m_sample.get())));
+        GRefPtr buffer = adoptGRef(gst_buffer_copy_deep(gst_sample_get_buffer(m_sample.get())));
         if (!buffer)
             GST_DEBUG_OBJECT(pipeline(), "Buffer couldn't be deep-copied on this platform, setting null buffer on the sample instead");
         m_sample = adoptGRef(gst_sample_new(buffer.get(), gst_sample_get_caps(m_sample.get()),
@@ -4459,7 +4459,7 @@ GstElement* MediaPlayerPrivateGStreamer::createVideoSink()
         }), this);
         g_signal_connect_swapped(m_videoSink.get(), "repaint-cancelled", G_CALLBACK(repaintCancelledCallback), this);
 
-        auto pad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_videoSink.get(), "sink"));
         g_signal_connect(pad.get(), "notify::caps", G_CALLBACK(+[](GstPad* videoSinkPad, GParamSpec*, MediaPlayerPrivateGStreamer* player) {
             player->videoSinkCapsChanged(videoSinkPad);
         }), this);
@@ -4647,7 +4647,7 @@ void MediaPlayerPrivateGStreamer::cdmInstanceDetached(CDMInstance& instance)
     GST_DEBUG_OBJECT(m_pipeline.get(), "detaching CDM instance %p, setting empty context", m_cdmInstance.get());
     m_cdmInstance = nullptr;
     m_cdmContext = nullptr;
-    auto emptyContext = adoptGRef(gst_context_new("drm-cdm-proxy", TRUE));
+    GRefPtr emptyContext = adoptGRef(gst_context_new("drm-cdm-proxy", TRUE));
     gst_element_set_context(GST_ELEMENT(m_pipeline.get()), emptyContext.get());
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -135,7 +135,7 @@ void MediaSampleGStreamer::updateSampleTimestamps([[maybe_unused]] const String&
         GST_TIME_ARGS(newPts), GST_TIME_ARGS(GST_BUFFER_PTS(buffer.get())),
         GST_TIME_ARGS(newDts), GST_TIME_ARGS(GST_BUFFER_DTS(buffer.get())));
 
-    auto writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GRefPtr writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
     GST_BUFFER_PTS(writableBuffer.get()) = newPts;
     GST_BUFFER_DTS(writableBuffer.get()) = newDts;
     m_sample = adoptGRef(gst_sample_make_writable(m_sample.leakRef()));
@@ -182,11 +182,11 @@ Ref<MediaSample> MediaSampleGStreamer::createNonDisplayingCopy() const
     if (!m_sample)
         return createFakeSample(nullptr, m_pts, m_dts, m_duration, m_presentationSize, m_trackId);
 
-    auto sample = adoptGRef(gst_sample_copy(m_sample.get()));
+    GRefPtr sample = adoptGRef(gst_sample_copy(m_sample.get()));
 
     GRefPtr buffer = gst_sample_get_buffer(sample.get());
     RELEASE_ASSERT(buffer);
-    auto writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GRefPtr writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
 
     GST_BUFFER_FLAG_SET(writableBuffer.get(), GST_BUFFER_FLAG_DECODE_ONLY);
     sample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
@@ -212,7 +212,7 @@ Ref<MediaSample> MediaSampleGStreamer::createCopyWithAdjustedStartTime(const Med
     if (!buffer) [[unlikely]]
         return createFakeSample(nullptr, newPresentationTime, newDecodeTime, adjustedDuration, m_presentationSize, m_trackId);
 
-    auto newBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GRefPtr newBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
     GST_BUFFER_PTS(newBuffer.get()) = toGstClockTime(newPresentationTime);
     GST_BUFFER_DTS(newBuffer.get()) = toGstClockTime(newDecodeTime);
     GST_BUFFER_DURATION(newBuffer.get()) = toGstClockTime(adjustedDuration);

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
@@ -54,15 +54,15 @@ void webKitTextCombinerHandleCaps(WebKitTextCombiner* combiner, GstPad* pad, con
     ASSERT(caps);
     GST_DEBUG_OBJECT(combiner, "Handling caps %" GST_PTR_FORMAT, caps);
 
-    auto target = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(pad)));
+    GRefPtr target = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(pad)));
     auto targetParent = target ? adoptGRef(gst_pad_get_parent_element(target.get())) : nullptr;
     auto* combinerPad = WEBKIT_TEXT_COMBINER_PAD(pad);
 
     GRefPtr<GstPad> internalPad;
     g_object_get(combinerPad, "inner-combiner-pad", &internalPad.outPtr(), nullptr);
 
-    auto cea608Caps = adoptGRef(gst_caps_new_empty_simple("closedcaption/x-cea-608"));
-    auto textCaps = adoptGRef(gst_caps_new_empty_simple("text/x-raw"));
+    GRefPtr cea608Caps = adoptGRef(gst_caps_new_empty_simple("closedcaption/x-cea-608"));
+    GRefPtr textCaps = adoptGRef(gst_caps_new_empty_simple("text/x-raw"));
     if (gst_caps_can_intersect(textCaps.get(), caps)) {
         // Caps are plain text, we want a WebVTT encoder between the ghostpad and the combinerElement.
         if (!target || gstElementFactoryEquals(targetParent.get(), "webvttenc"_s)) {
@@ -74,13 +74,13 @@ void webKitTextCombinerHandleCaps(WebKitTextCombiner* combiner, GstPad* pad, con
             gst_element_sync_state_with_parent(encoder);
 
             // Switch the ghostpad to target the WebVTT encoder.
-            auto sinkPad = adoptGRef(gst_element_get_static_pad(encoder, "sink"));
+            GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(encoder, "sink"));
             ASSERT(sinkPad);
 
             gst_ghost_pad_set_target(GST_GHOST_PAD(pad), sinkPad.get());
 
             // Connect the WebVTT encoder to the combinerElement.
-            auto srcPad = adoptGRef(gst_element_get_static_pad(encoder, "src"));
+            GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(encoder, "src"));
             ASSERT(srcPad);
 
             gst_pad_link(srcPad.get(), internalPad.get());
@@ -99,19 +99,19 @@ void webKitTextCombinerHandleCaps(WebKitTextCombiner* combiner, GstPad* pad, con
         auto* webvttEncoder = makeGStreamerElement("cea608tott"_s);
         auto* vttCapsFilter = gst_element_factory_make("capsfilter", nullptr);
 
-        auto rawCaps = adoptGRef(gst_caps_new_simple("closedcaption/x-cea-608", "format", G_TYPE_STRING, "raw", nullptr));
+        GRefPtr rawCaps = adoptGRef(gst_caps_new_simple("closedcaption/x-cea-608", "format", G_TYPE_STRING, "raw", nullptr));
         g_object_set(rawCapsFilter, "caps", rawCaps.get(), nullptr);
-        auto vttCaps = adoptGRef(gst_caps_new_empty_simple("application/x-subtitle-vtt"));
+        GRefPtr vttCaps = adoptGRef(gst_caps_new_empty_simple("application/x-subtitle-vtt"));
         g_object_set(vttCapsFilter, "caps", vttCaps.get(), nullptr);
 
         gst_bin_add_many(GST_BIN_CAST(encoder), queue, converter, rawCapsFilter, webvttEncoder, vttCapsFilter, nullptr);
         gst_element_link_many(queue, converter, rawCapsFilter, webvttEncoder, vttCapsFilter, nullptr);
 
-        auto encoderSinkPad = adoptGRef(gst_element_get_static_pad(queue, "sink"));
+        GRefPtr encoderSinkPad = adoptGRef(gst_element_get_static_pad(queue, "sink"));
         auto* ghostSinkPad = gst_ghost_pad_new("sink", encoderSinkPad.get());
         gst_element_add_pad(encoder, ghostSinkPad);
 
-        auto encoderSrcPad = adoptGRef(gst_element_get_static_pad(vttCapsFilter, "src"));
+        GRefPtr encoderSrcPad = adoptGRef(gst_element_get_static_pad(vttCapsFilter, "src"));
         auto* ghostSrcPad = gst_ghost_pad_new("src", encoderSrcPad.get());
         gst_element_add_pad(encoder, ghostSrcPad);
 
@@ -162,8 +162,8 @@ static void webkitTextCombinerReleasePad(GstElement* element, GstPad* pad)
     auto* combiner = WEBKIT_TEXT_COMBINER(element);
     auto* combinerPad = WEBKIT_TEXT_COMBINER_PAD(pad);
 
-    if (auto target = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(pad)))) {
-        auto parent = adoptGRef(gst_pad_get_parent_element(target.get()));
+    if (GRefPtr target = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(pad)))) {
+        GRefPtr parent = adoptGRef(gst_pad_get_parent_element(target.get()));
         ASSERT(parent);
         if (parent) {
             gst_element_set_state(parent.get(), GST_STATE_NULL);
@@ -171,7 +171,7 @@ static void webkitTextCombinerReleasePad(GstElement* element, GstPad* pad)
         }
     }
 
-    auto internalPad = adoptGRef(webKitTextCombinerPadLeakInternalPadRef(combinerPad));
+    GRefPtr internalPad = adoptGRef(webKitTextCombinerPadLeakInternalPadRef(combinerPad));
     gst_element_release_request_pad(combiner->priv->combinerElement.get(), internalPad.get());
 
     gst_element_remove_pad(element, pad);
@@ -190,7 +190,7 @@ static void webKitTextCombinerConstructed(GObject* object)
 
     gst_bin_add(GST_BIN_CAST(combiner), priv->combinerElement.get());
 
-    auto pad = adoptGRef(gst_element_get_static_pad(priv->combinerElement.get(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(priv->combinerElement.get(), "src"));
     ASSERT(pad);
 
     gst_element_add_pad(GST_ELEMENT_CAST(combiner), gst_ghost_pad_new("src", pad.get()));

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
@@ -86,7 +86,7 @@ static GstFlowReturn webkitTextCombinerPadChain(GstPad* pad, GstObject* parent, 
                 return TRUE;
 
             auto* combinerPad = WEBKIT_TEXT_COMBINER_PAD(pad);
-            auto parent = adoptGRef(gst_pad_get_parent(pad));
+            GRefPtr parent = adoptGRef(gst_pad_get_parent(pad));
             GstCaps* caps;
             gst_event_parse_caps(*event, &caps);
             combinerPad->priv->shouldProcessStickyEvents = false;

--- a/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
@@ -52,7 +52,7 @@ static void webkitTextSinkHandleSample(WebKitTextSink* self, GRefPtr<GstSample>&
 {
     auto* priv = self->priv;
     if (!priv->streamId) {
-        auto pad = adoptGRef(gst_element_get_static_pad(priv->appSink.get(), "sink"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(priv->appSink.get(), "sink"));
         priv->streamId = getStreamIdFromPad(pad.get());
     }
 
@@ -82,10 +82,10 @@ static void webkitTextSinkConstructed(GObject* object)
     priv->appSink = makeGStreamerElement("appsink"_s);
     gst_bin_add(GST_BIN_CAST(sink), priv->appSink.get());
 
-    auto pad = adoptGRef(gst_element_get_static_pad(priv->appSink.get(), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(priv->appSink.get(), "sink"));
     gst_element_add_pad(GST_ELEMENT_CAST(sink), gst_ghost_pad_new("sink", pad.get()));
 
-    auto textCaps = adoptGRef(gst_caps_new_empty_simple("application/x-subtitle-vtt"));
+    GRefPtr textCaps = adoptGRef(gst_caps_new_empty_simple("application/x-subtitle-vtt"));
     g_object_set(priv->appSink.get(), "emit-signals", TRUE, "enable-last-sample", FALSE, "caps", textCaps.get(), nullptr);
 
     g_signal_connect(priv->appSink.get(), "new-sample", G_CALLBACK(+[](GstElement* appSink, WebKitTextSink* sink) -> GstFlowReturn {

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 
 static GRefPtr<GstTagList> getAllTags(const GRefPtr<GstPad>& pad)
 {
-    auto allTags = adoptGRef(gst_tag_list_new_empty());
+    GRefPtr allTags = adoptGRef(gst_tag_list_new_empty());
     GstTagList* taglist = nullptr;
     for (unsigned i = 0;; i++) {
         GRefPtr<GstEvent> tagsEvent = adoptGRef(gst_pad_get_sticky_event(pad.get(), GST_EVENT_TAG, i));
@@ -427,7 +427,7 @@ void TrackDataHolder::installUpdateConfigurationHandlers()
                 return;
             if (!holder->m_pad)
                 return;
-            auto caps = adoptGRef(gst_pad_get_current_caps(holder->m_pad.get()));
+            GRefPtr caps = adoptGRef(gst_pad_get_current_caps(holder->m_pad.get()));
             // We will receive a synchronous notification for caps being unset during pipeline teardown.
             if (!caps)
                 return;
@@ -465,7 +465,7 @@ void TrackDataHolder::installUpdateConfigurationHandlers()
                 auto holder = weakHolder.get();
                 if (!holder)
                     return;
-                auto caps = adoptGRef(gst_stream_get_caps(holder->m_stream.get()));
+                GRefPtr caps = adoptGRef(gst_stream_get_caps(holder->m_stream.get()));
                 holder->m_track.capsChanged(getStreamIdFromStream(holder->m_stream.get()).value_or(holder->m_index), WTF::move(caps));
             });
         }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {
@@ -480,7 +480,7 @@ void TrackDataHolder::installUpdateConfigurationHandlers()
             if (!holder)
                 return;
             if (isMainThread()) {
-                auto tags = adoptGRef(gst_stream_get_tags(holder->m_stream.get()));
+                GRefPtr tags = adoptGRef(gst_stream_get_tags(holder->m_stream.get()));
                 holder->m_track.updateConfigurationFromTags(WTF::move(tags));
                 return;
             }
@@ -488,7 +488,7 @@ void TrackDataHolder::installUpdateConfigurationHandlers()
                 auto holder = weakHolder.get();
                 if (!holder)
                     return;
-                auto tags = adoptGRef(gst_stream_get_tags(holder->m_stream.get()));
+                GRefPtr tags = adoptGRef(gst_stream_get_tags(holder->m_stream.get()));
                 holder->m_track.updateConfigurationFromTags(WTF::move(tags));
             });
         }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -231,14 +231,14 @@ GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder(const String& codec
         harnessedElement = gst_bin_new(nullptr);
         gst_bin_add_many(GST_BIN_CAST(harnessedElement.get()), parserElement, element.get(), nullptr);
         gst_element_link(parserElement, element.get());
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(parserElement, "sink"));
+        GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(parserElement, "sink"));
         gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("sink", sinkPad.get()));
-        auto srcPad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
+        GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
         gst_element_add_pad(harnessedElement.get(), gst_ghost_pad_new("src", srcPad.get()));
     } else
         harnessedElement = WTF::move(element);
 
-    auto allowedSinkCaps = adoptGRef(gst_caps_new_empty());
+    GRefPtr allowedSinkCaps = adoptGRef(gst_caps_new_empty());
 #if USE(GSTREAMER_GL)
 #if USE(GBM)
     gst_caps_append(allowedSinkCaps.get(), buildDMABufCaps().leakRef());

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -221,7 +221,7 @@ GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder(const VideoEncoder:
 {
     GRefPtr<GstElement> element = gst_element_factory_make("webkitvideoencoder", nullptr);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
     g_signal_connect_data(pad.get(), "notify::caps", G_CALLBACK(+[](GObject* pad, GParamSpec*, gpointer userData) {
         auto weakEncoder = static_cast<ThreadSafeWeakPtr<GStreamerInternalVideoEncoder>*>(userData);
         auto encoder = weakEncoder->get();
@@ -288,7 +288,7 @@ GStreamerInternalVideoEncoder::~GStreamerInternalVideoEncoder()
     if (!m_harness)
         return;
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_harness->element(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_harness->element(), "src"));
     g_signal_handlers_disconnect_by_data(pad.get(), this);
 }
 
@@ -327,8 +327,8 @@ bool GStreamerInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bo
     if (orientation != m_orientation) {
         auto orientationCString = orientation.utf8();
         GST_DEBUG_OBJECT(m_harness->element(), "New orientation: %s", orientationCString.data());
-        auto tags = adoptGRef(gst_tag_list_new(GST_TAG_IMAGE_ORIENTATION, orientationCString.data(), nullptr));
-        auto event = adoptGRef(gst_event_new_tag(tags.leakRef()));
+        GRefPtr tags = adoptGRef(gst_tag_list_new(GST_TAG_IMAGE_ORIENTATION, orientationCString.data(), nullptr));
+        GRefPtr event = adoptGRef(gst_event_new_tag(tags.leakRef()));
         m_harness->storeStickyEvent(event);
         m_orientation = WTF::move(orientation);
     }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -157,7 +157,7 @@ static RefPtr<ImageGStreamer> convertSampleToImage(const GRefPtr<GstSample>& sam
 #else
     auto format = GST_VIDEO_INFO_HAS_ALPHA(&videoInfo) ? "ARGB"_s : "xRGB"_s;
 #endif
-    auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, format.characters(), "framerate", GST_TYPE_FRACTION, GST_VIDEO_INFO_FPS_N(&videoInfo), GST_VIDEO_INFO_FPS_D(&videoInfo), "width", G_TYPE_INT, GST_VIDEO_INFO_WIDTH(&videoInfo), "height", G_TYPE_INT, GST_VIDEO_INFO_HEIGHT(&videoInfo), nullptr));
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, format.characters(), "framerate", GST_TYPE_FRACTION, GST_VIDEO_INFO_FPS_N(&videoInfo), GST_VIDEO_INFO_FPS_D(&videoInfo), "width", G_TYPE_INT, GST_VIDEO_INFO_WIDTH(&videoInfo), "height", G_TYPE_INT, GST_VIDEO_INFO_HEIGHT(&videoInfo), nullptr));
     auto convertedSample = GStreamerVideoFrameConverter::singleton().convert(sample, caps);
     if (!convertedSample)
         return nullptr;
@@ -221,9 +221,9 @@ RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage& image)
 
     gst_buffer_add_video_meta_full(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height, 1, offsets, strides);
 
-    auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, gst_video_format_to_string(format), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, gst_video_format_to_string(format), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
     auto info = VideoFrameGStreamer::infoFromCaps(caps);
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     return VideoFrameGStreamer::create(WTF::move(sample), { { width, height }, WTF::move(info) });
 }
 
@@ -253,7 +253,7 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
     gst_video_info_set_format(&info, GST_VIDEO_FORMAT_NV12, width, height);
     fillVideoInfoColorimetryFromColorSpace(&info, colorSpace);
 
-    auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
+    GRefPtr buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
     {
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
         auto destinationSpan = mappedBuffer.mutableSpan<uint8_t>();
@@ -262,8 +262,8 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
     }
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_NV12, width, height);
 
-    auto caps = adoptGRef(gst_video_info_to_caps(&info));
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    GRefPtr caps = adoptGRef(gst_video_info_to_caps(&info));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     return VideoFrameGStreamer::create(WTF::move(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTF::move(colorSpace));
 }
 
@@ -271,11 +271,11 @@ RefPtr<VideoFrame> VideoFrame::createNV12(std::span<const uint8_t> span, size_t 
     GstVideoInfo info;                                                                              \
     gst_video_info_set_format(&info, format, width, height);                                        \
     fillVideoInfoColorimetryFromColorSpace(&info, colorSpace);                                      \
-    auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr)); \
+    GRefPtr buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr)); \
     gst_buffer_fill(buffer.get(), plane.destinationOffset, span.data(), span.size_bytes());         \
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, format, width, height);      \
-    auto caps = adoptGRef(gst_video_info_to_caps(&info));                                           \
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));            \
+    GRefPtr caps = adoptGRef(gst_video_info_to_caps(&info));                                           \
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));            \
     return VideoFrameGStreamer::create(WTF::move(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTF::move(colorSpace))
 
 RefPtr<VideoFrame> VideoFrame::createRGBA(std::span<const uint8_t> span, size_t width, size_t height, const ComputedPlaneLayout& plane, PlatformVideoColorSpace&& colorSpace)
@@ -302,7 +302,7 @@ RefPtr<VideoFrame> VideoFrame::createI420(std::span<const uint8_t> span, size_t 
     gst_video_info_set_format(&info, GST_VIDEO_FORMAT_I420, width, height);
     fillVideoInfoColorimetryFromColorSpace(&info, colorSpace);
 
-    auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
+    GRefPtr buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
     gst_buffer_memset(buffer.get(), 0, 0, span.size_bytes());
     {
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
@@ -317,8 +317,8 @@ RefPtr<VideoFrame> VideoFrame::createI420(std::span<const uint8_t> span, size_t 
     }
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_I420, width, height);
 
-    auto caps = adoptGRef(gst_video_info_to_caps(&info));
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    GRefPtr caps = adoptGRef(gst_video_info_to_caps(&info));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     return VideoFrameGStreamer::create(WTF::move(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTF::move(colorSpace));
 }
 
@@ -328,7 +328,7 @@ RefPtr<VideoFrame> VideoFrame::createI420A(std::span<const uint8_t> span, size_t
     gst_video_info_set_format(&info, GST_VIDEO_FORMAT_A420, width, height);
     fillVideoInfoColorimetryFromColorSpace(&info, colorSpace);
 
-    auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
+    GRefPtr buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
     gst_buffer_memset(buffer.get(), 0, 0, span.size_bytes());
     {
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_WRITE);
@@ -342,8 +342,8 @@ RefPtr<VideoFrame> VideoFrame::createI420A(std::span<const uint8_t> span, size_t
     }
     gst_buffer_add_video_meta(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_A420, width, height);
 
-    auto caps = adoptGRef(gst_video_info_to_caps(&info));
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    GRefPtr caps = adoptGRef(gst_video_info_to_caps(&info));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     return VideoFrameGStreamer::create(WTF::move(sample), { { static_cast<int>(width), static_cast<int>(height) }, { { info } } }, WTF::move(colorSpace));
 }
 
@@ -420,7 +420,7 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
     auto dataBaseAddress = pixelBuffer->bytes().data();
     auto leakedPixelBuffer = &pixelBuffer.leakRef();
 
-    auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, dataBaseAddress, sizeInBytes, 0, sizeInBytes, leakedPixelBuffer, [](gpointer userData) {
+    GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, dataBaseAddress, sizeInBytes, 0, sizeInBytes, leakedPixelBuffer, [](gpointer userData) {
         static_cast<PixelBuffer*>(userData)->deref();
     }));
 
@@ -433,7 +433,7 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
     int frameRateNumerator, frameRateDenominator;
     gst_util_double_to_fraction(frameRate, &frameRateNumerator, &frameRateDenominator);
 
-    auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr));
     if (frameRate)
         gst_caps_set_simple(caps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
 
@@ -450,12 +450,12 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
         width = destinationSize.width();
         height = destinationSize.height();
         GST_CAT_DEBUG(GST_CAT_PERFORMANCE, "Resizing frame from %dx%d to %dx%d", size.width(), size.height(), width, height);
-        auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width,
+        GRefPtr outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width,
             "height", G_TYPE_INT, height, nullptr));
         if (frameRate)
             gst_caps_set_simple(outputCaps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
 
-        auto inputSample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+        GRefPtr inputSample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         sample = GStreamerVideoFrameConverter::singleton().convert(inputSample, outputCaps);
         if (!sample)
             return nullptr;
@@ -518,7 +518,7 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
 
 void VideoFrameGStreamer::setFrameRate(double frameRate)
 {
-    auto caps = adoptGRef(gst_caps_copy(gst_sample_get_caps(m_sample.get())));
+    GRefPtr caps = adoptGRef(gst_caps_copy(gst_sample_get_caps(m_sample.get())));
     int frameRateNumerator, frameRateDenominator;
     gst_util_double_to_fraction(frameRate, &frameRateNumerator, &frameRateDenominator);
     gst_caps_set_simple(caps.get(), "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
@@ -532,7 +532,7 @@ void VideoFrameGStreamer::setFrameRate(double frameRate)
 
 void VideoFrameGStreamer::setMaxFrameRate(double maxFrameRate)
 {
-    auto caps = adoptGRef(gst_caps_copy(gst_sample_get_caps(m_sample.get())));
+    GRefPtr caps = adoptGRef(gst_caps_copy(gst_sample_get_caps(m_sample.get())));
     int frameRateNumerator, frameRateDenominator;
     gst_util_double_to_fraction(maxFrameRate, &frameRateNumerator, &frameRateDenominator);
     gst_caps_set_simple(caps.get(), "framerate", GST_TYPE_FRACTION, 0, 1, "max-framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr);
@@ -730,7 +730,7 @@ GRefPtr<GstSample> VideoFrameGStreamer::convert(GstVideoFormat format, const Int
     auto width = destinationSize.width();
     auto height = destinationSize.height();
     auto formatName = CStringView::unsafeFromUTF8(gst_video_format_to_string(format));
-    auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
+    GRefPtr outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName.utf8(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
 
     if (gst_caps_is_equal(caps, outputCaps.get()))
         return GRefPtr<GstSample>(m_sample);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -71,7 +71,7 @@ static std::pair<GRefPtr<GstBuffer>, VideoFrameMetadataGStreamer*> ensureVideoFr
         return { WTF::move(buffer), meta };
 
     IGNORE_WARNINGS_BEGIN("cast-align");
-    auto modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GRefPtr modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
     IGNORE_WARNINGS_END;
     meta = VIDEO_FRAME_METADATA_CAST(gst_buffer_add_meta(modifiedBuffer.get(), videoFrameMetadataGetInfo(), nullptr));
     return { WTF::move(modifiedBuffer), meta };
@@ -142,7 +142,7 @@ void webkitGstBufferAddVideoFrameMetadata(GstBuffer* buffer, std::optional<WebCo
 GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameMetadata(GRefPtr<GstBuffer>&& buffer, std::optional<WebCore::VideoFrameTimeMetadata> metadata, VideoFrame::Rotation rotation, bool isMirrored, VideoFrameContentHint hint)
 {
     IGNORE_WARNINGS_BEGIN("cast-align");
-    auto modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+    GRefPtr modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
     IGNORE_WARNINGS_END;
     webkitGstBufferAddVideoFrameMetadata(modifiedBuffer.get(), metadata, rotation, isMirrored, hint);
     return modifiedBuffer;
@@ -155,8 +155,8 @@ void webkitGstTraceProcessingTimeForElement(GstElement* element)
         GST_DEBUG_CATEGORY_INIT(webkit_video_frame_meta_debug, "webkitvideoframemeta", 0, "Video frame processing metrics");
     });
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
-    auto srcPad = adoptGRef(gst_element_get_static_pad(element, "src"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(element, "src"));
     if (!sinkPad || !srcPad) {
         GST_WARNING("Can't add the processing time probes for %s", GST_OBJECT_NAME(element));
         ASSERT_NOT_REACHED();
@@ -170,7 +170,7 @@ void webkitGstTraceProcessingTimeForElement(GstElement* element)
     static auto probeType = static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_BUFFER);
 
     gst_pad_add_probe(sinkPad.get(), probeType, [](GstPad* pad, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
-        auto element = adoptGRef(gst_pad_get_parent_element(pad));
+        GRefPtr element = adoptGRef(gst_pad_get_parent_element(pad));
         if (!element) [[unlikely]]
             return GST_PAD_PROBE_REMOVE;
 
@@ -183,7 +183,7 @@ void webkitGstTraceProcessingTimeForElement(GstElement* element)
     }, nullptr, nullptr);
 
     gst_pad_add_probe(srcPad.get(), probeType, [](GstPad* pad, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
-        auto element = adoptGRef(gst_pad_get_parent_element(pad));
+        GRefPtr element = adoptGRef(gst_pad_get_parent_element(pad));
         if (!element) [[unlikely]]
             return GST_PAD_PROBE_REMOVE;
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -67,10 +67,10 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPl
 {
     ensureVideoTrackDebugCategoryInitialized();
 
-    auto caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
+    GRefPtr caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
     updateConfigurationFromCaps(WTF::move(caps));
 
-    auto tags = adoptGRef(gst_stream_get_tags(m_data->m_stream.get()));
+    GRefPtr tags = adoptGRef(gst_stream_get_tags(m_data->m_stream.get()));
     updateConfigurationFromTags(WTF::move(tags));
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -73,7 +73,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
     RELEASE_ASSERT(sink->priv->interAudioSink);
 
     gst_bin_add(GST_BIN_CAST(sink), sink->priv->interAudioSink.get());
-    auto targetPad = adoptGRef(gst_element_get_static_pad(sink->priv->interAudioSink.get(), "sink"));
+    GRefPtr targetPad = adoptGRef(gst_element_get_static_pad(sink->priv->interAudioSink.get(), "sink"));
     gst_element_add_pad(GST_ELEMENT_CAST(sink), webkitGstGhostPadFromStaticTemplate(&audioSinkTemplate, "sink"_s, targetPad.get()));
 
     if (sink->priv->role != "webaudio"_s)
@@ -100,7 +100,7 @@ static bool webKitAudioSinkConfigure(WebKitAudioSink* sink)
         if (!sampleRate) [[unlikely]]
             return GST_PAD_PROBE_OK;
 
-        auto sink = adoptGRef(gst_pad_get_parent_element(pad));
+        GRefPtr sink = adoptGRef(gst_pad_get_parent_element(pad));
         uint64_t periodTime = gst_util_uint64_scale_ceil(AudioUtilities::renderQuantumSize, GST_SECOND, *sampleRate);
         GStreamerAudioMixer::singleton().configureSourcePeriodTime(CStringView::unsafeFromUTF8(GST_ELEMENT_NAME(sink.get())), periodTime);
         return GST_PAD_PROBE_OK;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -114,8 +114,8 @@ static GstPadProbeReturn webkitMediaThunderParserSinkPadProbe(GstPad*, GstPadPro
         return GST_PAD_PROBE_OK;
 
     auto self = WEBKIT_MEDIA_THUNDER_PARSER(userData);
-    auto parserSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->parser.get(), "sink"));
-    auto caps = adoptGRef(gst_pad_get_current_caps(parserSinkPad.get()));
+    GRefPtr parserSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->parser.get(), "sink"));
+    GRefPtr caps = adoptGRef(gst_pad_get_current_caps(parserSinkPad.get()));
     GstCaps* newCaps;
     gst_event_parse_caps(event, &newCaps);
 
@@ -207,7 +207,7 @@ static void webkitMediaThunderParserConstructed(GObject* object)
             gst_ghost_pad_set_target(GST_GHOST_PAD_CAST(self->priv->srcPad.get()), pad);
     }), self);
 
-    auto decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
+    GRefPtr decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
     auto* ghostSink = gst_ghost_pad_new("sink", decryptorSinkPad.get());
     gst_pad_add_probe(ghostSink, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, webkitMediaThunderParserSinkPadProbe, self, nullptr);
 
@@ -217,19 +217,19 @@ static void webkitMediaThunderParserConstructed(GObject* object)
 
 static void tryInsertCencparser(WebKitMediaThunderParser* self)
 {
-    auto cencparserFactory = adoptGRef(gst_element_factory_find("cencparser"));
+    GRefPtr cencparserFactory = adoptGRef(gst_element_factory_find("cencparser"));
     if (!cencparserFactory)
         return;
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT(self), "sink"));
-    auto peerPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT(self), "sink"));
+    GRefPtr peerPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
     if (!peerPad) [[unlikely]] {
         GST_WARNING_OBJECT(self, "Couldn't find peer pad.");
         ASSERT_NOT_REACHED();
         return;
     }
 
-    auto peerCaps = adoptGRef(gst_pad_get_current_caps(peerPad.get()));
+    GRefPtr peerCaps = adoptGRef(gst_pad_get_current_caps(peerPad.get()));
     if (!peerCaps) {
         peerCaps = adoptGRef(gst_pad_query_caps(peerPad.get(), nullptr));
         if (!peerCaps) {
@@ -252,8 +252,8 @@ static void tryInsertCencparser(WebKitMediaThunderParser* self)
     }
 
     // Sanity check.
-    auto currentSinkPadTarget = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(sinkPad.get())));
-    auto currentSinkPadTargetParent = adoptGRef(gst_pad_get_parent_element(currentSinkPadTarget.get()));
+    GRefPtr currentSinkPadTarget = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(sinkPad.get())));
+    GRefPtr currentSinkPadTargetParent = adoptGRef(gst_pad_get_parent_element(currentSinkPadTarget.get()));
     if (gst_element_get_factory(currentSinkPadTargetParent.get()) == cencparserFactory) {
         GST_DEBUG_OBJECT(self, "Cencparser is already inserted.");
         return;
@@ -276,7 +276,7 @@ static void tryInsertCencparser(WebKitMediaThunderParser* self)
     // This empty result causes capsfilter linking to fail inside cencparser.
     // Workaround: intercept cencparser's caps query and append the media types
     // that cencparser expects.
-    auto decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
+    GRefPtr decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
     gst_pad_add_probe(
         decryptorSinkPad.get(),
         static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PULL | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM),

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -274,7 +274,7 @@ AppendPipeline::AppendPipeline(SourceBufferPrivateGStreamer& sourceBufferPrivate
     registerActivePipeline(m_pipeline);
     connectSimpleBusMessageCallback(m_pipeline.get());
 
-    auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+    GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
     gst_bus_enable_sync_message_emission(bus.get());
 
     g_signal_connect(bus.get(), "sync-message::error", G_CALLBACK(+[](GstBus*, GstMessage* message, AppendPipeline* appendPipeline) {
@@ -299,7 +299,7 @@ AppendPipeline::~AppendPipeline()
     // when changing the pipeline state.
 
     if (m_pipeline) {
-        auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+        GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
         ASSERT(bus);
         g_signal_handlers_disconnect_by_data(bus.get(), this);
         gst_bus_disable_sync_message_emission(bus.get());
@@ -380,11 +380,11 @@ GstPadProbeReturn AppendPipeline::appsrcEndOfAppendCheckerProbe(GstPadProbeInfo*
 
 void AppendPipeline::removeParserForDemuxerPad(const GRefPtr<GstPad>& pad)
 {
-    auto peer = adoptGRef(gst_pad_get_peer(pad.get()));
+    GRefPtr peer = adoptGRef(gst_pad_get_peer(pad.get()));
     if (!peer)
         return;
 
-    auto parser = adoptGRef(gst_pad_get_parent_element(peer.get()));
+    GRefPtr parser = adoptGRef(gst_pad_get_parent_element(peer.get()));
     if (!parser) [[unlikely]]
         return;
 
@@ -398,11 +398,11 @@ void AppendPipeline::removeParserForDemuxerPad(const GRefPtr<GstPad>& pad)
     if (!matchingTrack)
         return;
 
-    auto srcPad = adoptGRef(gst_element_get_static_pad(parser.get(), "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(parser.get(), "src"));
     if (!srcPad) [[unlikely]]
         return;
 
-    auto parserPeerPad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    GRefPtr parserPeerPad = adoptGRef(gst_pad_get_peer(srcPad.get()));
     if (!parserPeerPad) [[unlikely]]
         return;
 
@@ -942,9 +942,9 @@ static GRefPtr<GstCaps> aacSbrForceImplicitSignalling([[maybe_unused]] GstPad* p
     ASSERT_WITH_MESSAGE(writeResult, "AAC channels write failed");
 
     auto newCodecData = gst_bit_writer_get_data(&writer);
-    auto newCaps = adoptGRef(gst_caps_copy(caps));
+    GRefPtr newCaps = adoptGRef(gst_caps_copy(caps));
     gst_codec_utils_aac_caps_set_level_and_profile(newCaps.get(), newCodecData, 2);
-    auto newCodecDataBuffer = adoptGRef(gst_buffer_new_and_alloc(2));
+    GRefPtr newCodecDataBuffer = adoptGRef(gst_buffer_new_and_alloc(2));
     gst_buffer_fill(newCodecDataBuffer.get(), 0, newCodecData, 2);
     gst_caps_set_simple(newCaps.get(), "codec_data", GST_TYPE_BUFFER, newCodecDataBuffer.get(), nullptr);
     return newCaps;
@@ -1195,7 +1195,7 @@ bool AppendPipeline::recycleTrackForPad(GstPad* demuxerSrcPad)
         linkPadWithTrack(demuxerSrcPad, *matchingTrack);
     else {
         // Unlink from old track and link to new track.
-        auto peer = adoptGRef(gst_pad_get_peer(matchingTrack->entryPad.get()));
+        GRefPtr peer = adoptGRef(gst_pad_get_peer(matchingTrack->entryPad.get()));
         if (peer.get() != demuxerSrcPad) {
             if (peer) {
                 GST_DEBUG_OBJECT(peer.get(), "Unlinking from track %" PRIu64 "", matchingTrack->trackId);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -837,7 +837,7 @@ static GstStateChangeReturn webKitMediaSrcChangeState(GstElement* element, GstSt
 
 static gboolean webKitMediaSrcSendEvent(GstElement* element, GstEvent* eventTransferFull)
 {
-    auto event = adoptGRef(eventTransferFull);
+    GRefPtr event = adoptGRef(eventTransferFull);
     switch (GST_EVENT_TYPE(event.get())) {
     case GST_EVENT_SEEK: {
         double rate;

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -78,7 +78,7 @@ std::pair<CStringView, String> GStreamerCodecUtilities::parseH264ProfileAndLevel
 
 static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(const String& codecString)
 {
-    auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
+    GRefPtr outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h264"));
     auto [profile, level] = GStreamerCodecUtilities::parseH264ProfileAndLevel(codecString);
     if (profile)
         gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, profile.utf8(), nullptr);
@@ -107,7 +107,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h264CapsFromCodecString(con
 
     auto pixelFormat = formatBuilder.toString();
     GST_DEBUG("Setting pixel format %s for profile %s", pixelFormat.ascii().data(), profile.utf8());
-    auto inputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, pixelFormat.ascii().data(), nullptr));
+    GRefPtr inputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, pixelFormat.ascii().data(), nullptr));
     return { inputCaps, outputCaps };
 }
 
@@ -146,7 +146,7 @@ CStringView GStreamerCodecUtilities::parseHEVCProfile(const String& codec)
 
 static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h265CapsFromCodecString(const String& codecString)
 {
-    auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
+    GRefPtr outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-h265"));
     auto profile = GStreamerCodecUtilities::parseHEVCProfile(codecString);
     if (profile)
         gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, profile.utf8(), nullptr);
@@ -177,7 +177,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> h265CapsFromCodecString(con
 
     auto pixelFormat = formatBuilder.toString();
     GST_DEBUG("Setting pixel format %s for profile %s", pixelFormat.ascii().data(), profile.utf8());
-    auto inputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, pixelFormat.ascii().data(), nullptr));
+    GRefPtr inputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, pixelFormat.ascii().data(), nullptr));
     return { inputCaps, outputCaps };
 }
 
@@ -187,12 +187,12 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> vpxCapsFromCodecString(cons
     if (!parameters)
         return { nullptr, nullptr };
 
-    auto inputCaps = adoptGRef(gst_caps_new_any());
+    GRefPtr inputCaps = adoptGRef(gst_caps_new_any());
 
     if (parameters->codecName.startsWith("vp8"_s) || parameters->codecName.startsWith("vp08"_s))
         return { inputCaps, adoptGRef(gst_caps_new_empty_simple("video/x-vp8")) };
 
-    auto outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
+    GRefPtr outputCaps = adoptGRef(gst_caps_new_empty_simple("video/x-vp9"));
     auto profile = makeString(parameters->profile);
     gst_caps_set_simple(outputCaps.get(), "profile", G_TYPE_STRING, profile.ascii().data(), nullptr);
     auto yuvFormat = "I420"_s;
@@ -324,7 +324,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(cons
         break;
     }
 
-    auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "profile", G_TYPE_STRING, profile.characters(),
+    GRefPtr outputCaps = adoptGRef(gst_caps_new_simple("video/x-av1", "profile", G_TYPE_STRING, profile.characters(),
         "bit-depth-luma", G_TYPE_UINT, configurationRecord->bitDepth, "bit-depth-chroma", G_TYPE_UINT,
         configurationRecord->bitDepth, nullptr));
 
@@ -503,7 +503,7 @@ static std::pair<GRefPtr<GstCaps>, GRefPtr<GstCaps>> av1CapsFromCodecString(cons
     if (!gst_video_colorimetry_matches(&GST_VIDEO_INFO_COLORIMETRY(&info), GST_VIDEO_COLORIMETRY_SRGB))
         gst_caps_set_simple(outputCaps.get(), "chroma-format", G_TYPE_STRING, chromaFormat.characters(), nullptr);
 
-    auto inputCaps = adoptGRef(gst_video_info_to_caps(&info));
+    GRefPtr inputCaps = adoptGRef(gst_video_info_to_caps(&info));
     GST_DEBUG("Codec %s maps to input %" GST_PTR_FORMAT " and output %" GST_PTR_FORMAT, codecString.ascii().data(), inputCaps.get(), outputCaps.get());
     return { inputCaps, outputCaps };
 }

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -104,7 +104,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
 
     registerActivePipeline(m_element);
 
-    auto clock = adoptGRef(gst_system_clock_obtain());
+    GRefPtr clock = adoptGRef(gst_system_clock_obtain());
     gst_element_set_clock(m_element.get(), clock.get());
 
     bool hasSometimesSrcPad = false;
@@ -145,7 +145,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
 
     } else {
         GST_DEBUG_OBJECT(m_element.get(), "Expecting output buffers on static src pad.");
-        auto elementSrcPad = adoptGRef(gst_element_get_static_pad(m_element.get(), "src"));
+        GRefPtr elementSrcPad = adoptGRef(gst_element_get_static_pad(m_element.get(), "src"));
         auto stream = GStreamerElementHarness::Stream::create(WTF::move(elementSrcPad), nullptr, GRefPtr(m_streamAllowedOutputCaps));
         m_outputStreams.append(WTF::move(stream));
     }
@@ -163,7 +163,7 @@ GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, 
     }), this, nullptr);
 
     gst_pad_set_active(m_srcPad.get(), TRUE);
-    auto elementSinkPad = adoptGRef(gst_element_get_static_pad(m_element.get(), "sink"));
+    GRefPtr elementSinkPad = adoptGRef(gst_element_get_static_pad(m_element.get(), "sink"));
     auto result = gst_pad_link(m_srcPad.get(), elementSinkPad.get());
     if (GST_PAD_LINK_FAILED(result))
         GST_WARNING_OBJECT(m_element.get(), "Pad link failed: %s", gst_pad_link_get_name(result));
@@ -249,7 +249,7 @@ bool GStreamerElementHarness::pushSample(GRefPtr<GstSample>&& sample)
     if (!m_playing.load())
         start(WTF::move(caps), segment);
     else {
-        auto currentCaps = adoptGRef(gst_pad_get_current_caps(m_srcPad.get()));
+        GRefPtr currentCaps = adoptGRef(gst_pad_get_current_caps(m_srcPad.get()));
         GST_TRACE_OBJECT(m_element.get(), "Current caps: %" GST_PTR_FORMAT, currentCaps.get());
         if (!currentCaps || gst_pad_needs_reconfigure(m_srcPad.get()) || !m_segmentEventSent.load())
             pushStickyEvents(WTF::move(caps), segment);
@@ -325,14 +325,14 @@ GStreamerElementHarness::Stream::Stream(GRefPtr<GstPad>&& pad, RefPtr<GStreamerE
 
         const auto& caps = stream.outputCaps();
         const GstSegment* segment = nullptr;
-        if (auto segmentEvent = adoptGRef(gst_pad_get_sticky_event(stream.pad().get(), GST_EVENT_SEGMENT, 0)))
+        if (GRefPtr segmentEvent = adoptGRef(gst_pad_get_sticky_event(stream.pad().get(), GST_EVENT_SEGMENT, 0)))
             gst_event_parse_segment(segmentEvent.get(), &segment);
 
-        auto outputBuffer = adoptGRef(buffer);
+        GRefPtr outputBuffer = adoptGRef(buffer);
         return stream.chainSample(adoptGRef(gst_sample_new(outputBuffer.get(), caps.get(), segment, nullptr)));
     }), this, nullptr);
     gst_pad_set_event_function_full(m_targetPad.get(), reinterpret_cast<GstPadEventFunction>(+[](GstPad* pad, GstObject*, GstEvent* eventTransferFull) -> gboolean {
-        auto event = adoptGRef(eventTransferFull);
+        GRefPtr event = adoptGRef(eventTransferFull);
         auto& stream = *reinterpret_cast<GStreamerElementHarness::Stream*>(pad->eventdata);
         if (auto downstreamHarness = stream.downstreamHarness())
             return downstreamHarness->pushEvent(WTF::move(event));
@@ -393,7 +393,7 @@ const GRefPtr<GstCaps>& GStreamerElementHarness::Stream::outputCaps()
     if (m_outputCaps)
         return m_outputCaps;
 
-    auto stream = adoptGRef(gst_pad_get_stream(m_pad.get()));
+    GRefPtr stream = adoptGRef(gst_pad_get_stream(m_pad.get()));
     if (stream)
         m_outputCaps = adoptGRef(gst_stream_get_caps(stream.get()));
     else
@@ -436,7 +436,7 @@ bool GStreamerElementHarness::srcQuery(GstPad* pad, GstObject* parent, GstQuery*
 
         gst_query_parse_caps(query, &filter);
         if (filter) {
-            auto intersectedCaps = adoptGRef(gst_caps_intersect_full(filter, caps.get(), GST_CAPS_INTERSECT_FIRST));
+            GRefPtr intersectedCaps = adoptGRef(gst_caps_intersect_full(filter, caps.get(), GST_CAPS_INTERSECT_FIRST));
             gst_query_set_caps_result(query, intersectedCaps.get());
         } else
             gst_query_set_caps_result(query, caps.get());
@@ -531,7 +531,7 @@ MermaidBuilder::MermaidBuilder()
 
 String MermaidBuilder::generatePadId(GStreamerElementHarness& harness, GstPad* pad)
 {
-    auto parent = adoptGRef(gst_pad_get_parent(GST_OBJECT_CAST(pad)));
+    GRefPtr parent = adoptGRef(gst_pad_get_parent(GST_OBJECT_CAST(pad)));
     if (!parent)
         return makeString(unsafeSpan(GST_ELEMENT_NAME(harness.element())), "-harness-"_s, unsafeSpan(GST_PAD_NAME(pad)));
     return makeString(unsafeSpan(GST_OBJECT_NAME(parent.get())), '_', unsafeSpan(GST_PAD_NAME(pad)));
@@ -571,7 +571,7 @@ void MermaidBuilder::process(GStreamerElementHarness& harness, bool generateFoot
         m_stringBuilder.append(generatePadId(padHarness, srcPad.get()), ":::"_s, getPadClass(srcPad));
         if (GST_IS_PROXY_PAD(srcPad.get()))
             m_stringBuilder.append(" ---> "_s);
-        else if (auto srcCaps = adoptGRef(gst_pad_get_current_caps(srcPad.get()))) {
+        else if (GRefPtr srcCaps = adoptGRef(gst_pad_get_current_caps(srcPad.get()))) {
             auto capsString = describeCaps(srcCaps.get());
             m_stringBuilder.append(" --\""_s, capsString, "\"--> "_s);
         } else
@@ -593,11 +593,11 @@ void MermaidBuilder::dumpPad(GStreamerElementHarness& harness, GstPad* pad)
     m_stringBuilder.append("subgraph "_s, generatePadId(harness, pad), " ["_s, unsafeSpan(GST_PAD_NAME(pad)), "]\n"_s);
 
     if (gst_pad_is_linked(pad)) {
-        auto peerPad = adoptGRef(gst_pad_get_peer(pad));
+        GRefPtr peerPad = adoptGRef(gst_pad_get_peer(pad));
         if (gst_pad_get_direction(pad) == GST_PAD_SRC) {
             m_padLinks.append({ harness, pad, peerPad });
             if (GST_IS_PROXY_PAD(pad)) {
-                auto internalPad = adoptGRef(gst_proxy_pad_get_internal(GST_PROXY_PAD(pad)));
+                GRefPtr internalPad = adoptGRef(gst_proxy_pad_get_internal(GST_PROXY_PAD(pad)));
                 m_padLinks.append({ harness, GST_PAD_CAST(internalPad.get()), pad });
             }
         }
@@ -607,11 +607,11 @@ void MermaidBuilder::dumpPad(GStreamerElementHarness& harness, GstPad* pad)
     if (!GST_IS_GHOST_PAD(pad))
         return;
 
-    auto padTarget = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD_CAST(pad)));
+    GRefPtr padTarget = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD_CAST(pad)));
     if (!padTarget)
         return;
 
-    auto peerPad = adoptGRef(gst_pad_get_peer(padTarget.get()));
+    GRefPtr peerPad = adoptGRef(gst_pad_get_peer(padTarget.get()));
     if (!peerPad)
         return;
     dumpPad(harness, peerPad.get());

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
@@ -42,7 +42,7 @@ GstElement* GStreamerHolePunchQuirkWesteros::createHolePunchVideoSink(bool isLeg
     if (isPIPRequested) {
         g_object_set(videoSink, "res-usage", 0u, nullptr);
         // Set context for pipelines that use ERM in decoder elements.
-        auto context = adoptGRef(gst_context_new("erm", FALSE));
+        GRefPtr context = adoptGRef(gst_context_new("erm", FALSE));
         auto contextStructure = gst_context_writable_structure(context.get());
         gst_structure_set(contextStructure, "res-usage", G_TYPE_UINT, 0x0u, nullptr);
         auto playerPrivate = reinterpret_cast<const MediaPlayerPrivateGStreamer*>(player->playerPrivate());

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
@@ -38,7 +38,7 @@ GStreamerQuirkAmLogic::GStreamerQuirkAmLogic()
 
 bool GStreamerQuirkAmLogic::isPlatformSupported() const
 {
-    auto amlogicFactory = adoptGRef(gst_element_factory_find("amlhalasink"));
+    GRefPtr amlogicFactory = adoptGRef(gst_element_factory_find("amlhalasink"));
     return amlogicFactory;
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.cpp
@@ -37,8 +37,8 @@ GStreamerQuirkBcmNexus::GStreamerQuirkBcmNexus()
     m_disallowedWebAudioDecoders = { "brcmaudfilter"_s };
 
     auto registry = gst_registry_get();
-    auto brcmaudfilter = adoptGRef(gst_registry_lookup_feature(registry, "brcmaudfilter"));
-    auto mpegaudioparse = adoptGRef(gst_registry_lookup_feature(registry, "mpegaudioparse"));
+    GRefPtr brcmaudfilter = adoptGRef(gst_registry_lookup_feature(registry, "brcmaudfilter"));
+    GRefPtr mpegaudioparse = adoptGRef(gst_registry_lookup_feature(registry, "mpegaudioparse"));
 
     if (brcmaudfilter && mpegaudioparse) {
         GST_INFO("Overriding mpegaudioparse rank with brcmaudfilter rank + 1");
@@ -49,7 +49,7 @@ GStreamerQuirkBcmNexus::GStreamerQuirkBcmNexus()
 bool GStreamerQuirkBcmNexus::isPlatformSupported() const
 {
     auto registry = gst_registry_get();
-    auto feature = adoptGRef(gst_registry_lookup_feature(registry, "brcmaudfilter"));
+    GRefPtr feature = adoptGRef(gst_registry_lookup_feature(registry, "brcmaudfilter"));
     return feature;
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -39,7 +39,7 @@ GStreamerQuirkBroadcom::GStreamerQuirkBroadcom()
 
 bool GStreamerQuirkBroadcom::isPlatformSupported() const
 {
-    auto broadcomFactory = adoptGRef(gst_element_factory_find("brcmaudiosink"));
+    GRefPtr broadcomFactory = adoptGRef(gst_element_factory_find("brcmaudiosink"));
     return broadcomFactory;
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkOpenMAX.cpp
@@ -38,7 +38,7 @@ GStreamerQuirkOpenMAX::GStreamerQuirkOpenMAX()
 bool GStreamerQuirkOpenMAX::isPlatformSupported() const
 {
     auto registry = gst_registry_get();
-    auto feature = adoptGRef(gst_registry_lookup_feature(registry, "omx"));
+    GRefPtr feature = adoptGRef(gst_registry_lookup_feature(registry, "omx"));
     return feature;
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
@@ -36,7 +36,7 @@ GStreamerQuirkQualcomm::GStreamerQuirkQualcomm()
 
 bool GStreamerQuirkQualcomm::isPlatformSupported() const
 {
-    auto factory = adoptGRef(gst_element_factory_find("qtic2vdec"));
+    GRefPtr factory = adoptGRef(gst_element_factory_find("qtic2vdec"));
     if (!factory)
         return false;
 
@@ -53,7 +53,7 @@ bool GStreamerQuirkQualcomm::isPlatformSupported() const
         "vp9alphadecodebin"_s,
     };
     for (const auto& factoryName : s_disabledDecoders) {
-        if (auto factory = adoptGRef(gst_element_factory_find(factoryName.characters())))
+        if (GRefPtr factory = adoptGRef(gst_element_factory_find(factoryName.characters())))
             gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_NONE);
     }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -49,7 +49,7 @@ GStreamerQuirkRealtek::GStreamerQuirkRealtek()
 
 bool GStreamerQuirkRealtek::isPlatformSupported() const
 {
-    auto realtekFactory = adoptGRef(gst_element_factory_find("rtkaudiosink"));
+    GRefPtr realtekFactory = adoptGRef(gst_element_factory_find("rtkaudiosink"));
     return realtekFactory;
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.cpp
@@ -44,7 +44,7 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
     std::array<ASCIILiteral, 2> rialtoSinks = { "rialtomsevideosink"_s, "rialtomseaudiosink"_s };
 
     for (auto sink : rialtoSinks) {
-        auto sinkFactory = adoptGRef(gst_element_factory_find(sink.characters()));
+        GRefPtr sinkFactory = adoptGRef(gst_element_factory_find(sink.characters()));
         if (!sinkFactory) [[unlikely]]
             continue;
 
@@ -71,7 +71,7 @@ GStreamerQuirkRialto::GStreamerQuirkRialto()
 
 bool GStreamerQuirkRialto::isPlatformSupported() const
 {
-    auto sinkFactory = adoptGRef(gst_element_factory_find("rialtomsevideosink"));
+    GRefPtr sinkFactory = adoptGRef(gst_element_factory_find("rialtomsevideosink"));
     if (!sinkFactory)
         return false;
     return gst_plugin_feature_get_rank(GST_PLUGIN_FEATURE(sinkFactory.get())) > GST_RANK_MARGINAL;
@@ -108,13 +108,13 @@ GstElement* /* transfer floating */ GStreamerQuirkRialto::createWebAudioSink()
     // template and/or caps negotiation implementation.
     auto bin = gst_bin_new(nullptr);
     auto capsFilter = gst_element_factory_make("capsfilter", nullptr);
-    auto caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "layout", G_TYPE_STRING, "interleaved", nullptr));
+    GRefPtr caps = adoptGRef(gst_caps_new_simple("audio/x-raw", "layout", G_TYPE_STRING, "interleaved", nullptr));
     g_object_set(capsFilter, "caps", caps.get(), nullptr);
 
     gst_bin_add_many(GST_BIN_CAST(bin), capsFilter, sink, nullptr);
     gst_element_link(capsFilter, sink);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(capsFilter, "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(capsFilter, "sink"));
     gst_element_add_pad(bin, gst_ghost_pad_new("sink", pad.get()));
 
     return bin;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -35,7 +35,7 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
 {
     GST_DEBUG_CATEGORY_INIT(webkit_westeros_quirks_debug, "webkitquirkswesteros", 0, "WebKit Westeros Quirks");
 
-    auto westerosFactory = adoptGRef(gst_element_factory_find("westerossink"));
+    GRefPtr westerosFactory = adoptGRef(gst_element_factory_find("westerossink"));
     if (!westerosFactory) [[unlikely]]
         return;
 
@@ -53,7 +53,7 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
 
 bool GStreamerQuirkWesteros::isPlatformSupported() const
 {
-    auto westerosFactory = adoptGRef(gst_element_factory_find("westerossink"));
+    GRefPtr westerosFactory = adoptGRef(gst_element_factory_find("westerossink"));
     return westerosFactory;
 }
 

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -161,7 +161,7 @@ public:
     static void registerEncoder(EncoderId id, ASCIILiteral name, ASCIILiteral parserName, ASCIILiteral capsString, ASCIILiteral encodedFormatString,
         SetupFunc&& setupEncoder, ASCIILiteral bitratePropertyName, SetBitrateFunc&& setBitrate, ASCIILiteral keyframeIntervalPropertyName, SetBitrateModeFunc&& setBitrateMode, SetLatencyModeFunc&& setLatency, SetBitRateAllocationFunc&& setBitRateAllocation = defaultSetBitRateAllocation)
     {
-        auto encoderFactory = adoptGRef(gst_element_factory_find(name));
+        GRefPtr encoderFactory = adoptGRef(gst_element_factory_find(name));
         if (!encoderFactory) {
             GST_DEBUG("Encoder %s not found, will not be used", name.characters());
             return;
@@ -173,14 +173,14 @@ public:
         }
 
         if (parserName) {
-            auto parserFactory = adoptGRef(gst_element_factory_find(parserName.characters()));
+            GRefPtr parserFactory = adoptGRef(gst_element_factory_find(parserName.characters()));
             if (!parserFactory) {
                 GST_WARNING("Parser %s is required for encoder %s. Skipping registration", parserName.characters(), name.characters());
                 return;
             }
         }
 
-        auto caps = adoptGRef(gst_caps_from_string(capsString));
+        GRefPtr caps = adoptGRef(gst_caps_from_string(capsString));
         GST_MINI_OBJECT_FLAG_SET(caps.get(), GST_MINI_OBJECT_FLAG_MAY_BE_LEAKED);
 
         GRefPtr<GstCaps> encodedFormat;
@@ -310,7 +310,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     }
 
     auto priv = self->priv;
-    auto srcPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "src"));
 
     priv->encodedCaps = WTF::move(encodedCaps);
 
@@ -343,8 +343,8 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     }
 
     const auto& element = videoFlip ? videoFlip : videoConvert;
-    auto sinkPadTarget = adoptGRef(gst_element_get_static_pad(element.get(), "sink"));
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "sink"));
+    GRefPtr sinkPadTarget = adoptGRef(gst_element_get_static_pad(element.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "sink"));
     gst_ghost_pad_set_target(GST_GHOST_PAD(sinkPad.get()), sinkPadTarget.get());
 
     if (encoderDefinition->parserName) {
@@ -372,7 +372,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     if (!gst_element_link(inputCapsFilter, priv->encoder.get())) {
         GST_WARNING_OBJECT(self, "Failed to link input capsfilter to encoder, retrying with un-constrained caps");
 
-        auto unconstrainedCaps = adoptGRef(gst_caps_copy(inputCaps.get()));
+        GRefPtr unconstrainedCaps = adoptGRef(gst_caps_copy(inputCaps.get()));
         gst_structure_remove_field(gst_caps_get_structure(unconstrainedCaps.get(), 0), "format");
         g_object_set(inputCapsFilter, "caps", unconstrainedCaps.get(), nullptr);
         if (!gst_element_link(inputCapsFilter, priv->encoder.get())) {
@@ -386,7 +386,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
     }
 
     auto capsFilter = gst_element_factory_make("capsfilter", nullptr);
-    auto finalEncodedCaps = adoptGRef(gst_caps_copy(encoderDefinition->encodedFormat ? encoderDefinition->encodedFormat.get() : priv->encodedCaps.get()));
+    GRefPtr finalEncodedCaps = adoptGRef(gst_caps_copy(encoderDefinition->encodedFormat ? encoderDefinition->encodedFormat.get() : priv->encodedCaps.get()));
     if (useAnnexB) {
         GST_DEBUG_OBJECT(self, "Enabling AnnexB stream format");
         auto structure = gst_caps_get_structure(finalEncodedCaps.get(), 0);
@@ -402,7 +402,7 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
 
     gst_bin_add(bin, capsFilter);
 
-    auto srcPadTarget = adoptGRef(gst_element_get_static_pad(capsFilter, "src"));
+    GRefPtr srcPadTarget = adoptGRef(gst_element_get_static_pad(capsFilter, "src"));
     gst_ghost_pad_set_target(GST_GHOST_PAD(srcPad.get()), srcPadTarget.get());
 
     if (!gst_element_link(priv->parser ? priv->parser.get() : priv->encoder.get(), capsFilter)) {
@@ -490,7 +490,7 @@ void videoEncoderSetFrameRate(WebKitVideoEncoder* self, double frameRate)
     gst_util_double_to_fraction(frameRate, &framerateNumerator, &framerateDenominator);
 
     GRefPtr<GstCaps> caps, writableCaps;
-    if (auto inputCapsfilter = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self), "input-capsfilter"))) {
+    if (GRefPtr inputCapsfilter = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self), "input-capsfilter"))) {
         g_object_get(inputCapsfilter.get(), "caps", &caps.outPtr(), nullptr);
         if (gst_caps_is_any(caps.get()))
             writableCaps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
@@ -513,11 +513,11 @@ void videoEncoderScaleResolutionDownBy(WebKitVideoEncoder* self, double scaleRes
 {
     self->priv->scaleResolutionDownBy = scaleResolutionDownBy;
 
-    auto pad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT_CAST(self), "sink"));
     if (!pad)
         return;
 
-    auto peer = adoptGRef(gst_pad_get_peer(pad.get()));
+    GRefPtr peer = adoptGRef(gst_pad_get_peer(pad.get()));
     if (!peer)
         return;
 
@@ -620,7 +620,7 @@ static void videoEncoderConstructed(GObject* encoder)
                 GstCaps* caps;
                 gst_event_parse_caps(event, &caps);
                 if (caps && gst_caps_get_size(caps)) {
-                    auto writableCaps = adoptGRef(gst_caps_copy(caps));
+                    GRefPtr writableCaps = adoptGRef(gst_caps_copy(caps));
                     auto structure = gst_caps_get_structure(writableCaps.get(), 0);
                     auto width = gstStructureGet<int>(structure, "width"_s);
                     auto height = gstStructureGet<int>(structure, "height"_s);
@@ -629,7 +629,7 @@ static void videoEncoderConstructed(GObject* encoder)
                         int newHeight = *height / scaleResolutionDownBy;
                         gst_structure_set(structure, "width", G_TYPE_INT, newWidth, "height", G_TYPE_INT, newHeight, nullptr);
                         GST_DEBUG_OBJECT(self, "Modified caps: %" GST_PTR_FORMAT, writableCaps.get());
-                        auto newCapsEvent = adoptGRef(gst_event_new_caps(writableCaps.get()));
+                        GRefPtr newCapsEvent = adoptGRef(gst_event_new_caps(writableCaps.get()));
                         gst_event_replace(&event, newCapsEvent.get());
                     }
                 }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -343,9 +343,9 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateBackend::containerProfi
         containerCapsDescriptionBuilder.append(containerType);
 
     auto containerCapsDescription = containerCapsDescriptionBuilder.toString();
-    auto containerCaps = adoptGRef(gst_caps_from_string(containerCapsDescription.ascii().data()));
+    GRefPtr containerCaps = adoptGRef(gst_caps_from_string(containerCapsDescription.ascii().data()));
     GST_DEBUG("Creating container profile for caps %" GST_PTR_FORMAT, containerCaps.get());
-    auto profile = adoptGRef(gst_encoding_container_profile_new(nullptr, nullptr, containerCaps.get(), nullptr));
+    GRefPtr profile = adoptGRef(gst_encoding_container_profile_new(nullptr, nullptr, containerCaps.get(), nullptr));
 
     if (containerType.endsWith("mp4"_s)) {
         StringBuilder propertiesBuilder;
@@ -397,7 +397,7 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateBackend::containerProfi
         }
 
         RELEASE_ASSERT(!audioCapsName.isEmpty());
-        auto audioCaps = adoptGRef(gst_caps_from_string(audioCapsName.utf8().data()));
+        GRefPtr audioCaps = adoptGRef(gst_caps_from_string(audioCapsName.utf8().data()));
         GST_DEBUG("Creating audio encoding profile for caps %" GST_PTR_FORMAT, audioCaps.get());
         m_audioEncodingProfile = adoptGRef(GST_ENCODING_PROFILE(gst_encoding_audio_profile_new(audioCaps.get(), nullptr, nullptr, 1)));
 
@@ -408,7 +408,7 @@ GRefPtr<GstEncodingContainerProfile> MediaRecorderPrivateBackend::containerProfi
             // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4054
             auto sampleRate = audioCapsName == "audio/x-opus"_s ? 48000 : settings.sampleRate();
 
-            auto restrictionCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, sampleRate, nullptr));
+            GRefPtr restrictionCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, sampleRate, nullptr));
             GST_DEBUG("Setting audio restriction caps to %" GST_PTR_FORMAT, restrictionCaps.get());
             gst_encoding_profile_set_restriction(m_audioEncodingProfile.get(), restrictionCaps.leakRef());
         }
@@ -456,11 +456,11 @@ void MediaRecorderPrivateBackend::setSink(GstElement* element)
             static_cast<MediaRecorderPrivateBackend*>(userData)->notifyEOS();
         },
         [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            auto sample = adoptGRef(gst_app_sink_pull_preroll(sink));
+            GRefPtr sample = adoptGRef(gst_app_sink_pull_preroll(sink));
             return static_cast<MediaRecorderPrivateBackend*>(userData)->handleSample(sink, WTF::move(sample));
         },
         [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
-            auto sample = adoptGRef(gst_app_sink_pull_sample(sink));
+            GRefPtr sample = adoptGRef(gst_app_sink_pull_sample(sink));
             return static_cast<MediaRecorderPrivateBackend*>(userData)->handleSample(sink, WTF::move(sample));
         },
         // new_event
@@ -522,7 +522,7 @@ bool MediaRecorderPrivateBackend::preparePipeline()
     if (!m_pipeline)
         return false;
 
-    auto clock = adoptGRef(gst_system_clock_obtain());
+    GRefPtr clock = adoptGRef(gst_system_clock_obtain());
     gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
     gst_element_set_base_time(m_pipeline.get(), 0);
     gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.cpp
@@ -44,7 +44,7 @@ static const Seconds s_dbusCallTimeout = 10_ms;
 static GRefPtr<GDBusProxy> createDBusProxy(ASCIILiteral interfaceName)
 {
     GUniqueOutPtr<GError> error;
-    auto proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+    GRefPtr proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
         static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
         "org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", interfaceName.characters(), nullptr, &error.outPtr()));
     if (error) {
@@ -90,7 +90,7 @@ DesktopPortal::DesktopPortal(ASCIILiteral interfaceName, GRefPtr<GDBusProxy>&& p
 
 GRefPtr<GVariant> DesktopPortal::getProperty(ASCIILiteral name)
 {
-    auto propertiesResult = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "org.freedesktop.DBus.Properties.Get",
+    GRefPtr propertiesResult = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "org.freedesktop.DBus.Properties.Get",
         g_variant_new("(ss)", m_interfaceName.characters(), name.characters()), G_DBUS_CALL_FLAGS_NONE,
         s_dbusCallTimeout.millisecondsAs<int>(), nullptr, nullptr));
     if (propertiesResult) {
@@ -162,7 +162,7 @@ void DesktopPortalCamera::accessCamera(Function<void(std::optional<int>)>&& call
         }), this, nullptr);
 
     g_dbus_proxy_call(m_proxy.get(), "AccessCamera", g_variant_new("(a{sv})", &options), G_DBUS_CALL_FLAGS_NONE, -1, nullptr, reinterpret_cast<GAsyncReadyCallback>(+[](GDBusProxy* proxy, GAsyncResult* result, gpointer) {
-        auto finalResult = adoptGRef(g_dbus_proxy_call_finish(proxy, result, nullptr));
+        GRefPtr finalResult = adoptGRef(g_dbus_proxy_call_finish(proxy, result, nullptr));
     }), nullptr);
 
     while (m_currentResponseCallback)
@@ -177,7 +177,7 @@ std::optional<int> DesktopPortalCamera::openCameraPipewireRemote()
     GVariantBuilder options;
     g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
     GUniqueOutPtr<GError> error;
-    auto result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
+    GRefPtr result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
         g_variant_new("(a{sv})", &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &fdList.outPtr(), nullptr, &error.outPtr()));
     if (error) {
         gst_printerrln("Unable to open pipewire remote. Error: %s", error->message);
@@ -204,7 +204,7 @@ std::optional<DesktopPortalScreenCast::ScreencastSession> DesktopPortalScreenCas
     g_variant_builder_add(&options, "{sv}", "session_handle_token", g_variant_new_string(sessionToken.ascii().data()));
 
     GUniqueOutPtr<GError> error;
-    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "CreateSession", g_variant_new("(a{sv})", &options),
+    GRefPtr result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "CreateSession", g_variant_new("(a{sv})", &options),
         G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
     if (error) {
         gst_printerrln("Unable to create a Deskop portal session: %s", error->message);
@@ -224,7 +224,7 @@ std::optional<DesktopPortalScreenCast::ScreencastSession> DesktopPortalScreenCas
 void DesktopPortalScreenCast::closeSession(const String& path)
 {
     GUniqueOutPtr<GError> error;
-    auto proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+    GRefPtr proxy = adoptGRef(g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
         static_cast<GDBusProxyFlags>(G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS | G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES), nullptr,
         "org.freedesktop.portal.Desktop", path.ascii().data(), "org.freedesktop.portal.Session", nullptr, &error.outPtr()));
     if (error) {
@@ -232,7 +232,7 @@ void DesktopPortalScreenCast::closeSession(const String& path)
         return;
     }
     auto dbusCallTimeout = 100_ms;
-    auto result = adoptGRef(g_dbus_proxy_call_sync(proxy.get(), "Close", nullptr, G_DBUS_CALL_FLAGS_NONE,
+    GRefPtr result = adoptGRef(g_dbus_proxy_call_sync(proxy.get(), "Close", nullptr, G_DBUS_CALL_FLAGS_NONE,
         dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
     if (error)
         gst_printerrln("Portal session could not be closed: %s", error->message);
@@ -244,7 +244,7 @@ GRefPtr<GVariant> DesktopPortalScreenCast::ScreencastSession::selectSources(GVar
     g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
 
     GUniqueOutPtr<GError> error;
-    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "SelectSources",
+    GRefPtr result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "SelectSources",
         g_variant_new("(oa{sv})", m_path.ascii().data(), &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
     if (error) {
         gst_printerrln("SelectSources error: %s", error->message);
@@ -262,7 +262,7 @@ GRefPtr<GVariant> DesktopPortalScreenCast::ScreencastSession::start()
     g_variant_builder_add(&options, "{sv}", "handle_token", g_variant_new_string(token.ascii().data()));
 
     GUniqueOutPtr<GError> error;
-    auto result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "Start",
+    GRefPtr result = adoptGRef(g_dbus_proxy_call_sync(m_proxy.get(), "Start",
         g_variant_new("(osa{sv})", m_path.ascii().data(), "", &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &error.outPtr()));
     if (error) {
         gst_printerrln("Start error: %s", error->message);
@@ -277,7 +277,7 @@ std::optional<PipeWireNodeData> DesktopPortalScreenCast::ScreencastSession::open
     GVariantBuilder options;
     g_variant_builder_init(&options, G_VARIANT_TYPE_VARDICT);
     GUniqueOutPtr<GError> error;
-    auto result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
+    GRefPtr result = adoptGRef(g_dbus_proxy_call_with_unix_fd_list_sync(m_proxy.get(), "OpenPipeWireRemote",
         g_variant_new("(oa{sv})", m_path.ascii().data(), &options), G_DBUS_CALL_FLAGS_NONE, s_dbusCallTimeout.millisecondsAs<int>(), nullptr, &fdList.outPtr(), nullptr, &error.outPtr()));
     if (error) {
         gst_printerrln("Unable to open pipewire remote. Error: %s", error->message);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -68,12 +68,12 @@ void GStreamerAudioCapturer::setSinkAudioCallback(SinkAudioDataCallback&& callba
 
     m_sinkAudioDataCallback.second = WTF::move(callback);
     m_sinkAudioDataCallback.first.newSampleSignalId = g_signal_connect_swapped(sink(), "new-sample", G_CALLBACK(+[](GStreamerAudioCapturer* capturer, GstElement* sink) -> GstFlowReturn {
-        auto sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
+        GRefPtr sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
         capturer->handleSample(WTF::move(sample));
         return GST_FLOW_OK;
     }), this);
     m_sinkAudioDataCallback.first.prerollSignalId = g_signal_connect_swapped(sink(), "new-preroll", G_CALLBACK(+[](GStreamerAudioCapturer* capturer, GstElement* sink) -> GstFlowReturn {
-        auto sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
+        GRefPtr sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
         capturer->handleSample(WTF::move(sample));
         return GST_FLOW_OK;
     }), this);
@@ -96,9 +96,9 @@ GstElement* GStreamerAudioCapturer::createConverter()
     }
 #endif
 
-    if (auto pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SRC)))
+    if (GRefPtr pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SRC)))
         gst_element_add_pad(GST_ELEMENT_CAST(bin), gst_ghost_pad_new("src", pad.get()));
-    if (auto pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SINK)))
+    if (GRefPtr pad = adoptGRef(gst_bin_find_unlinked_pad(GST_BIN_CAST(bin), GST_PAD_SINK)))
         gst_element_add_pad(GST_ELEMENT_CAST(bin), gst_ghost_pad_new("sink", pad.get()));
 
     return bin;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioRTPPacketizer.cpp
@@ -59,7 +59,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
     GRefPtr<GstElement> payloader = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     GST_DEBUG("Using %" GST_PTR_FORMAT " for %s RTP packetizing", payloader.get(), encoding.ascii().data());
 
-    auto inputCaps = adoptGRef(gst_caps_new_any());
+    GRefPtr inputCaps = adoptGRef(gst_caps_new_any());
     GUniquePtr<GstStructure> structure(gst_structure_copy(codecParameters));
 
     auto ssrc = ssrcGenerator->generateSSRC();
@@ -133,7 +133,7 @@ RefPtr<GStreamerAudioRTPPacketizer> GStreamerAudioRTPPacketizer::create(RefPtr<U
     if (!payloadType)
         payloadType = gstStructureGet<int>(encodingParameters.get(), "payload"_s);
 
-    auto rtpCaps = adoptGRef(gst_caps_new_empty());
+    GRefPtr rtpCaps = adoptGRef(gst_caps_new_empty());
 
     // When not present in caps, the vad support of the ssrc-audio-level extension should be
     // enabled. In order to prevent caps negotiation issues with downstream, explicitely set it.

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -121,7 +121,7 @@ void GStreamerCaptureDeviceManager::stopMonitor()
     if (!m_deviceMonitor)
         return;
 
-    auto bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
+    GRefPtr bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
     gst_bus_remove_watch(bus.get());
     gst_device_monitor_stop(m_deviceMonitor.get());
     m_deviceMonitor.clear();
@@ -325,11 +325,11 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
         if (types.contains(CaptureDevice::DeviceType::Camera))
             gst_device_monitor_add_filter(m_deviceMonitor.get(), "Video/Source", nullptr);
         if (types.contains(CaptureDevice::DeviceType::Microphone)) {
-            auto caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
+            GRefPtr caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
             gst_device_monitor_add_filter(m_deviceMonitor.get(), "Audio/Source", caps.get());
         }
         if (types.contains(CaptureDevice::DeviceType::Speaker) || types.contains(CaptureDevice::DeviceType::SystemAudio)) {
-            auto caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
+            GRefPtr caps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
             gst_device_monitor_add_filter(m_deviceMonitor.get(), "Audio/Sink", caps.get());
         }
 
@@ -341,8 +341,8 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
 
 #if GST_CHECK_VERSION(1, 28, 0)
         {
-            auto bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
-            [[maybe_unused]] auto message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), GST_CLOCK_TIME_NONE, GST_MESSAGE_DEVICE_MONITOR_STARTED));
+            GRefPtr bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
+            [[maybe_unused]] GRefPtr message = adoptGRef(gst_bus_timed_pop_filtered(bus.get(), GST_CLOCK_TIME_NONE, GST_MESSAGE_DEVICE_MONITOR_STARTED));
             GST_DEBUG_OBJECT(m_deviceMonitor.get(), "Device provider(s) successfully started");
         }
 #endif
@@ -359,7 +359,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
     if (!monitorBus)
         return;
 
-    auto bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
+    GRefPtr bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
 
     // Flush out device-added messages queued during initial probe of the device providers.
     gst_bus_set_flushing(bus.get(), TRUE);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -165,7 +165,7 @@ GstElement* GStreamerCapturer::createSource() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     GST_DEBUG_OBJECT(m_pipeline.get(), "Source element created: %" GST_PTR_FORMAT " (factory: %" GST_PTR_FORMAT ")", m_src.get(), gst_element_get_factory(m_src.get()));
 
     if (gstElementFactoryEquals(m_src.get(), "pipewiresrc"_s)) {
-        auto srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
         m_pipewireProbe = PadProbeHandle<GStreamerCapturer>::create(*this, WTF::move(srcPad), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, [](const auto& self, const auto&, auto info) -> GstPadProbeReturn {
             auto event = gst_pad_probe_info_get_event(info);
             if (GST_EVENT_TYPE(event) != GST_EVENT_CAPS)
@@ -190,7 +190,7 @@ GstElement* GStreamerCapturer::createSource() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
         g_object_set(m_src.get(), "use-bufferpool", FALSE, nullptr);
 
     if (m_deviceType == CaptureDevice::DeviceType::Camera) {
-        auto srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
         gst_pad_add_probe(srcPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
             VideoFrameTimeMetadata metadata;
             metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
@@ -223,7 +223,7 @@ void GStreamerCapturer::setupPipeline()
     }
 
     m_pipeline = makeElement("pipeline"_s);
-    auto clock = adoptGRef(gst_system_clock_obtain());
+    GRefPtr clock = adoptGRef(gst_system_clock_obtain());
     gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
     gst_element_set_base_time(m_pipeline.get(), 0);
     gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
@@ -99,8 +99,8 @@ void GStreamerDTMFSenderPrivate::playTone(const RefPtr<RealtimeOutgoingAudioSour
         { 'D', 15 }
     };
 
-    auto element = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(source->bin().get()), "dtmfSource"));
-    auto pad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
+    GRefPtr element = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(source->bin().get()), "dtmfSource"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element.get(), "src"));
 
     if (tone == ',') {
         GST_DEBUG_OBJECT(element.get(), "Playing silence for 2 seconds");
@@ -124,7 +124,7 @@ void GStreamerDTMFSenderPrivate::playTone(const RefPtr<RealtimeOutgoingAudioSour
 
 void GStreamerDTMFSenderPrivate::sendEvent(const GRefPtr<GstPad>& pad, int number, int volume, bool start)
 {
-    auto event = adoptGRef(gst_event_new_custom(GST_EVENT_CUSTOM_UPSTREAM, gst_structure_new("dtmf-event", "type", G_TYPE_INT, 1, "number", G_TYPE_INT, number, "volume", G_TYPE_INT, volume, "start", G_TYPE_BOOLEAN, start, nullptr)));
+    GRefPtr event = adoptGRef(gst_event_new_custom(GST_EVENT_CUSTOM_UPSTREAM, gst_structure_new("dtmf-event", "type", G_TYPE_INT, 1, "number", G_TYPE_INT, number, "volume", G_TYPE_INT, volume, "start", G_TYPE_BOOLEAN, start, nullptr)));
     gst_pad_send_event(pad.get(), event.ref());
     gst_element_send_event(m_dtmfSrc.get(), event.leakRef());
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
@@ -119,7 +119,7 @@ CaptureSourceOrError GStreamerDisplayCaptureDeviceManager::createDisplayCaptureS
         // The portal interface allows multiple streams but we care only about the first one.
         GUniqueOutPtr<GVariantIter> iter;
         if (g_variant_lookup(responseData.get(), "streams", "a(ua{sv})", &iter.outPtr())) {
-            auto variant = adoptGRef(g_variant_iter_next_value(iter.get()));
+            GRefPtr variant = adoptGRef(g_variant_iter_next_value(iter.get()));
             if (!variant) {
                 WTFLogAlways("Stream list is empty");
                 return;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -49,7 +49,7 @@ void GStreamerIncomingTrackProcessor::configure(ThreadSafeWeakPtr<GStreamerMedia
     m_endPoint = WTF::move(endPoint);
     m_pad = WTF::move(pad);
 
-    auto caps = adoptGRef(gst_pad_get_current_caps(m_pad.get()));
+    GRefPtr caps = adoptGRef(gst_pad_get_current_caps(m_pad.get()));
     if (!caps)
         caps = adoptGRef(gst_pad_query_caps(m_pad.get(), nullptr));
 
@@ -111,13 +111,13 @@ void GStreamerIncomingTrackProcessor::configure(ThreadSafeWeakPtr<GStreamerMedia
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), trackProcessor.get(), queue, m_sink.get(), nullptr);
     gst_element_link(queue, m_sink.get());
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(trackProcessor.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(trackProcessor.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
 
     if (m_data.type != RealtimeMediaSource::Type::Video || !m_isDecoding)
         return;
 
-    auto sinkSinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    GRefPtr sinkSinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
     gst_pad_add_probe(sinkSinkPad.get(), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
         auto query = GST_PAD_PROBE_INFO_QUERY(info);
         if (GST_QUERY_TYPE(query) != GST_QUERY_ALLOCATION)
@@ -200,7 +200,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
         ASSERT(gst_structure_has_name(structure, "application/x-rtp"));
         auto encodingName = gstStructureGetString(structure, "encoding-name"_s);
         auto mediaType = makeString("video/x-"_s, String(encodingName.span()).convertToASCIILowercase());
-        auto codecCaps = adoptGRef(gst_caps_new_empty_simple(mediaType.ascii().data()));
+        GRefPtr codecCaps = adoptGRef(gst_caps_new_empty_simple(mediaType.ascii().data()));
 
         auto& scanner = GStreamerRegistryScanner::singleton();
         if (scanner.areCapsSupported(GStreamerRegistryScanner::Configuration::Decoding, codecCaps, true)) {
@@ -224,7 +224,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
             return;
 
         configureVideoRTPDepayloader(element);
-        auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         self->installRtpBufferPadProbe(pad);
     }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
         delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
@@ -243,7 +243,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
         self->m_videoDecoderName = configureMediaStreamVideoDecoder(element);
         webkitGstTraceProcessingTimeForElement(element);
 
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+        GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
             RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
             if (!self)
@@ -255,7 +255,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
             return GST_PAD_PROBE_OK;
         }, userData, nullptr);
 
-        auto pad = adoptGRef(gst_element_get_static_pad(element, "src"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, "src"));
         gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), [](GstPad* pad, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
             RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
             if (!self)
@@ -280,7 +280,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
 
             self->m_decodedVideoFrames++;
 
-            auto decoder = adoptGRef(gst_pad_get_parent_element(pad));
+            GRefPtr decoder = adoptGRef(gst_pad_get_parent_element(pad));
             auto processingTime = webkitGstBufferGetProcessingTime(gst_pad_probe_info_get_buffer(info), decoder.get());
             if (processingTime.isInvalid())
                 return GST_PAD_PROBE_OK;
@@ -297,8 +297,8 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
         if (!self)
             return;
 
-        auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
+        GRefPtr queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
+        GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
         self->trackReady();
     }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
@@ -322,7 +322,7 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
             return;
 
         configureVideoRTPDepayloader(element);
-        auto pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, "sink"));
         self->installRtpBufferPadProbe(pad);
     }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {
         delete static_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(data);
@@ -348,8 +348,8 @@ GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
         RefPtr self = reinterpret_cast<ThreadSafeWeakPtr<GStreamerIncomingTrackProcessor>*>(userData)->get();
         if (!self)
             return;
-        auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
+        GRefPtr queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(self->m_bin.get()), "queue"));
+        GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
         gst_pad_link(pad, sinkPad.get());
         self->trackReady();
     }), new ThreadSafeWeakPtr { *this }, [](gpointer data, GClosure*) {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -66,7 +66,7 @@ GST_DEBUG_CATEGORY_STATIC(webkitMediaStreamSrcDebug);
 
 [[nodiscard]] GRefPtr<GstTagList> mediaStreamTrackPrivateGetTags(const RefPtr<MediaStreamTrackPrivate>& track)
 {
-    auto tagList = adoptGRef(gst_tag_list_new_empty());
+    GRefPtr tagList = adoptGRef(gst_tag_list_new_empty());
 
     if (!track->label().isEmpty())
         gst_tag_list_add(tagList.get(), GST_TAG_MERGE_APPEND, GST_TAG_TITLE, track->label().utf8().data(), nullptr);
@@ -93,7 +93,7 @@ GST_DEBUG_CATEGORY_STATIC(webkitMediaStreamSrcDebug);
     }
 
     auto flags = track->enabled() ? GST_STREAM_FLAG_SELECT : GST_STREAM_FLAG_NONE;
-    auto stream = adoptGRef(gst_stream_new(track->id().utf8().data(), caps.get(), type, flags));
+    GRefPtr stream = adoptGRef(gst_stream_new(track->id().utf8().data(), caps.get(), type, flags));
     auto tags = mediaStreamTrackPrivateGetTags(track);
     gst_stream_set_tags(stream.get(), tags.get());
     return stream;
@@ -212,9 +212,9 @@ public:
         m_webrtcSourceClientId = clientId;
 
         auto incomingSource = static_cast<RealtimeIncomingSourceGStreamer*>(&trackSource);
-        auto srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
         m_incomingPadProbeHandle = PadProbeHandle<RealtimeIncomingSourceGStreamer>::create(*incomingSource, WTF::move(srcPad), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_UPSTREAM | GST_PAD_PROBE_TYPE_QUERY_UPSTREAM), [](const auto& incomingSource, const auto& pad, auto info) -> GstPadProbeReturn {
-            auto src = adoptGRef(gst_pad_get_parent_element(pad.get()));
+            GRefPtr src = adoptGRef(gst_pad_get_parent_element(pad.get()));
             if (GST_IS_QUERY(info->data)) {
                 switch (GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info))) {
                 case GST_QUERY_CAPS:
@@ -349,8 +349,8 @@ public:
     bool hasPrerolled()
     {
         // appsrc delays (EOS) events until it has received the caps event.
-        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
-        auto caps = adoptGRef(gst_pad_get_current_caps(pad.get()));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        GRefPtr caps = adoptGRef(gst_pad_get_current_caps(pad.get()));
         return !!caps;
     }
 
@@ -366,7 +366,7 @@ public:
         auto buffer = gst_sample_get_buffer(sample.get());
 
         if (!m_hasPushedInitialTags) {
-            auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+            GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
             gst_pad_push_event(pad.get(), gst_event_new_tag(gst_stream_get_tags(m_stream.get())));
             m_hasPushedInitialTags = true;
         }
@@ -487,7 +487,7 @@ public:
 
             auto orientation = makeString(videoMirrored ? "flip-"_s : ""_s, "rotate-"_s, m_videoRotation);
             GST_DEBUG_OBJECT(m_src.get(), "Setting orientation tag: %s", orientation.utf8().data());
-            auto tags = adoptGRef(gst_tag_list_make_writable(gst_stream_get_tags(m_stream.get())));
+            GRefPtr tags = adoptGRef(gst_tag_list_make_writable(gst_stream_get_tags(m_stream.get())));
             gst_tag_list_add(tags.get(), GST_TAG_MERGE_REPLACE, GST_TAG_IMAGE_ORIENTATION, orientation.utf8().data(), nullptr);
             gst_stream_set_tags(m_stream.get(), tags.get());
         }
@@ -544,8 +544,8 @@ public:
     GstStructure* queryAdditionalStats()
     {
         GUniquePtr<GstStructure> stats;
-        auto query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("webkit-video-decoder-stats")));
-        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        GRefPtr query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("webkit-video-decoder-stats")));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
         if (gst_pad_peer_query(pad.get(), query.get()))
             stats.reset(gst_structure_copy(gst_query_get_structure(query.get())));
 
@@ -628,7 +628,7 @@ private:
         if (m_track->source().isCaptureSource())
             m_trackSource = &(m_track->source());
 
-        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
         m_upstreamQueryPadProbeHandle = PadProbeHandle<InternalSource>::create(*this, WTF::move(pad), GST_PAD_PROBE_TYPE_QUERY_UPSTREAM, [](const auto& self, const auto&, auto info) -> GstPadProbeReturn {
             auto query = GST_PAD_PROBE_INFO_QUERY(info);
             switch (GST_QUERY_TYPE(query)) {
@@ -717,7 +717,7 @@ private:
 
         VideoFrameTimeMetadata metadata;
         metadata.captureTime = MonotonicTime::now().secondsSinceEpoch();
-        auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
+        GRefPtr buffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&info), nullptr));
         webkitGstBufferAddVideoFrameMetadata(buffer.get(), WTF::move(metadata), m_videoRotation, m_videoMirrored, VideoFrameContentHint::None);
         {
             GstMappedBuffer data(buffer, GST_MAP_WRITE);
@@ -733,7 +733,7 @@ private:
 
         GST_BUFFER_DTS(buffer.get()) = GST_BUFFER_PTS(buffer.get()) = timestamp;
 
-        auto sample = adoptGRef(gst_sample_new(buffer.get(), m_blackFrameCaps.get(), nullptr, nullptr));
+        GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), m_blackFrameCaps.get(), nullptr, nullptr));
         pushSample(sample, "Pushing black video frame"_s);
     }
 
@@ -754,7 +754,7 @@ private:
         }
 
         GST_BUFFER_DTS(m_silentBuffer.get()) = GST_BUFFER_PTS(m_silentBuffer.get()) = timestamp;
-        auto sample = adoptGRef(gst_sample_new(m_silentBuffer.get(), m_silentSampleCaps.get(), nullptr, nullptr));
+        GRefPtr sample = adoptGRef(gst_sample_new(m_silentBuffer.get(), m_silentSampleCaps.get(), nullptr, nullptr));
         pushSample(sample, "Pushing audio silence from disabled track"_s);
     }
 
@@ -766,7 +766,7 @@ private:
         m_stream = webkitMediaStreamNew(track());
 
         g_signal_connect_swapped(m_stream.get(), "notify::tags", G_CALLBACK(+[](InternalSource* self) {
-            auto pad = adoptGRef(gst_element_get_static_pad(self->m_src.get(), "src"));
+            GRefPtr pad = adoptGRef(gst_element_get_static_pad(self->m_src.get(), "src"));
             GST_DEBUG_OBJECT(self->m_src.get(), "Pushing tags for %" GST_PTR_FORMAT, self->m_stream.get());
             gst_pad_push_event(pad.get(), gst_event_new_tag(gst_stream_get_tags(self->m_stream.get())));
             self->m_hasPushedInitialTags = true;
@@ -970,7 +970,7 @@ static void webkitMediaStreamSrcCleanup(WebKitMediaStreamSrc* self, const RefPtr
     GST_DEBUG_OBJECT(self, "Cleaning-up internal source element %" GST_PTR_FORMAT, appSrc);
     source->cleanUp();
 
-    auto appSrcPad = adoptGRef(gst_element_get_static_pad(appSrc, "src"));
+    GRefPtr appSrcPad = adoptGRef(gst_element_get_static_pad(appSrc, "src"));
     self->priv->probes.removeFirstMatching([pad = WTF::move(appSrcPad)](auto& probe) -> bool {
         return probe->pad() == pad;
     });
@@ -983,8 +983,8 @@ static void webkitMediaStreamSrcCleanup(WebKitMediaStreamSrc* self, const RefPtr
     gstElementLockAndSetState(appSrc, GST_STATE_NULL);
     gst_bin_remove(GST_BIN_CAST(self), appSrc);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(element, source->padName().ascii().data()));
-    if (auto proxyPad = adoptGRef(GST_PAD_CAST(gst_proxy_pad_get_internal(GST_PROXY_PAD(pad.get())))))
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, source->padName().ascii().data()));
+    if (GRefPtr proxyPad = adoptGRef(GST_PAD_CAST(gst_proxy_pad_get_internal(GST_PROXY_PAD(pad.get())))))
         gst_flow_combiner_remove_pad(self->priv->flowCombiner.get(), proxyPad.get());
 
     gst_pad_set_active(pad.get(), FALSE);
@@ -1036,7 +1036,7 @@ void WebKitMediaStreamObserver::didRemoveTrack(MediaStreamTrackPrivate& track)
     }
 
     auto element = GST_ELEMENT_CAST(self);
-    auto pad = adoptGRef(gst_element_get_static_pad(element, source->padName().ascii().data()));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, source->padName().ascii().data()));
 
     gst_pad_push_event(pad.get(), gst_event_new_flush_start());
     gst_pad_push_event(pad.get(), gst_event_new_flush_stop(FALSE));
@@ -1279,7 +1279,7 @@ static GRefPtr<GstStreamCollection> webkitMediaStreamSrcCreateStreamCollection(W
     auto priv = self->priv;
     auto locker = GstObjectLocker(self);
     auto upstreamId = priv->stream ? priv->stream->id() : createVersion4UUIDString();
-    auto streamCollection = adoptGRef(gst_stream_collection_new(upstreamId.ascii().data()));
+    GRefPtr streamCollection = adoptGRef(gst_stream_collection_new(upstreamId.ascii().data()));
     if (isEmpty)
         return streamCollection;
 
@@ -1334,11 +1334,11 @@ void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPr
     self->priv->sources.add(WTF::move(sourceId), WTF::move(source));
     self->priv->tracks.append(track);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(element, "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(element, "src"));
     auto collection = webkitMediaStreamSrcCreateStreamCollection(self);
     RefPtr data = PadProbeData::create(GThreadSafeWeakPtr(GST_ELEMENT_CAST(self)), track->source().type(), GRefPtr(stream), WTF::move(collection));
 
-    auto stickyStreamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(stream.get())));
+    GRefPtr stickyStreamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(stream.get())));
     gst_event_set_group_id(stickyStreamStartEvent.get(), self->priv->groupId);
     gst_event_set_stream(stickyStreamStartEvent.get(), stream.get());
 
@@ -1360,7 +1360,7 @@ void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPr
             GST_DEBUG_OBJECT(self, "Replacing stream-start event");
             auto sequenceNumber = gst_event_get_seqnum(event);
 
-            auto streamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(stream.get())));
+            GRefPtr streamStartEvent = adoptGRef(gst_event_new_stream_start(gst_stream_get_stream_id(stream.get())));
             gst_event_set_group_id(streamStartEvent.get(), self->priv->groupId);
             gst_event_set_stream(streamStartEvent.get(), stream.get());
             gst_event_set_seqnum(streamStartEvent.get(), sequenceNumber);
@@ -1395,7 +1395,7 @@ void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc* self, MediaStreamTrackPr
     gst_pad_store_sticky_event(ghostPad, stickyStreamStartEvent.get());
     gst_element_add_pad(GST_ELEMENT_CAST(self), ghostPad);
 
-    auto proxyPad = adoptGRef(GST_PAD_CAST(gst_proxy_pad_get_internal(GST_PROXY_PAD(ghostPad))));
+    GRefPtr proxyPad = adoptGRef(GST_PAD_CAST(gst_proxy_pad_get_internal(GST_PROXY_PAD(ghostPad))));
     gst_flow_combiner_add_pad(self->priv->flowCombiner.get(), proxyPad.get());
 
     auto padChainData = createPadChainData();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -97,7 +97,7 @@ void webkitGstMockDeviceProviderSwitchDefaultDevice(const CaptureDevice& oldDevi
 
     CaptureDevice previousDefaultDevice = oldDevice;
     previousDefaultDevice.setIsDefault(false);
-    auto previousDefaultGstDevice = adoptGRef(webkitMockDeviceCreate(previousDefaultDevice));
+    GRefPtr previousDefaultGstDevice = adoptGRef(webkitMockDeviceCreate(previousDefaultDevice));
     gst_device_provider_device_changed(GST_DEVICE_PROVIDER_CAST(s_provider), previousDefaultGstDevice.get(), oldGstDevice.get());
 
     if (!newGstDevice) {
@@ -107,7 +107,7 @@ void webkitGstMockDeviceProviderSwitchDefaultDevice(const CaptureDevice& oldDevi
 
     CaptureDevice nextDefaultDevice = newDevice;
     nextDefaultDevice.setIsDefault(true);
-    auto nextDefaultGstDevice = adoptGRef(webkitMockDeviceCreate(nextDefaultDevice));
+    GRefPtr nextDefaultGstDevice = adoptGRef(webkitMockDeviceCreate(nextDefaultDevice));
     GST_DEBUG_OBJECT(s_provider, "Emitting device-changed notification");
     gst_device_provider_device_changed(GST_DEVICE_PROVIDER_CAST(s_provider), nextDefaultGstDevice.get(), newGstDevice.get());
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.cpp
@@ -55,9 +55,9 @@ GStreamerRTPPacketizer::GStreamerRTPPacketizer(GRefPtr<GstElement>&& encoder, GR
     m_valve = gst_element_factory_make("valve", nullptr);
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_inputQueue.get(), m_encoder.get(), m_payloader.get(), m_capsFilter.get(), m_outputQueue.get(), m_valve.get(), nullptr);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(m_inputQueue.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(m_inputQueue.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
-    auto srcPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "src"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("src", srcPad.get()));
 
     m_stats.reset(gst_structure_new_empty("stats"));
@@ -108,7 +108,7 @@ void GStreamerRTPPacketizer::configureExtensions()
         g_signal_emit_by_name(m_payloader.get(), "add-extension", m_ridExtension.get());
     }
 
-    auto extension = adoptGRef(gst_rtp_header_extension_create_from_uri(GST_RTP_HDREXT_BASE "sdes:repaired-rtp-stream-id"));
+    GRefPtr extension = adoptGRef(gst_rtp_header_extension_create_from_uri(GST_RTP_HDREXT_BASE "sdes:repaired-rtp-stream-id"));
     gst_rtp_header_extension_set_id(extension.get(), m_lastExtensionId);
     m_lastExtensionId++;
     if (!rid.isEmpty())
@@ -267,7 +267,7 @@ void GStreamerRTPPacketizer::startUpdatingStats()
     GST_DEBUG_OBJECT(m_bin.get(), "Starting buffer monitoring for stats gathering");
     auto holder = createRTPPacketizerHolder();
     holder->packetizer = this;
-    auto pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
     m_statsPadProbeId = gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_BUFFER, [](GstPad*, GstPadProbeInfo*, gpointer userData) -> GstPadProbeReturn {
         auto packetizer = static_cast<RTPPacketizerHolder*>(userData)->packetizer;
         packetizer->updateStats();
@@ -296,7 +296,7 @@ void GStreamerRTPPacketizer::stopUpdatingStats()
         return;
 
     GST_DEBUG_OBJECT(m_bin.get(), "Stopping buffer monitoring for stats gathering");
-    auto pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
     gst_pad_remove_probe(pad.get(), m_statsPadProbeId);
     m_statsPadProbeId = 0;
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -83,13 +83,13 @@ void GStreamerVideoCapturer::setSinkVideoFrameCallback(SinkVideoFrameCallback&& 
     }
     m_sinkVideoFrameCallback.second = WTF::move(callback);
     m_sinkVideoFrameCallback.first.newSampleSignalId = g_signal_connect_swapped(sink(), "new-sample", G_CALLBACK(+[](GStreamerVideoCapturer* capturer, GstElement* sink) -> GstFlowReturn {
-        auto sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
+        GRefPtr sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
         capturer->handleSample(WTF::move(sample));
         return GST_FLOW_OK;
     }), this);
 
     m_sinkVideoFrameCallback.first.prerollSignalId = g_signal_connect_swapped(sink(), "new-preroll", G_CALLBACK(+[](GStreamerVideoCapturer* capturer, GstElement* sink) -> GstFlowReturn {
-        auto sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
+        GRefPtr sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
         capturer->handleSample(WTF::move(sample));
         return GST_FLOW_OK;
     }), this);
@@ -116,7 +116,7 @@ void GStreamerVideoCapturer::setupPipeline()
     if (isCapturingDisplay() && gstElementMatchesFactoryAndHasProperty(m_src.get(), "pipewiresrc"_s, "use-bufferpool"_s))
         g_object_set(m_src.get(), "use-bufferpool", TRUE, nullptr);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
     gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
         if (GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) == GST_QUERY_ALLOCATION)
             gst_query_add_allocation_meta(GST_PAD_PROBE_INFO_QUERY(info), GST_VIDEO_META_API_TYPE, nullptr);
@@ -147,14 +147,14 @@ GstElement* GStreamerVideoCapturer::createConverter()
 
     m_videoSrcMIMETypeFilter = gst_element_factory_make("capsfilter", "mimetype-filter");
 
-    auto caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
+    GRefPtr caps = adoptGRef(gst_caps_new_empty_simple("video/x-raw"));
     g_object_set(m_videoSrcMIMETypeFilter.get(), "caps", caps.get(), nullptr);
 
     auto* decodebin = makeGStreamerElement("decodebin3"_s);
     gst_bin_add_many(GST_BIN_CAST(bin), m_videoSrcMIMETypeFilter.get(), decodebin, nullptr);
     gst_element_link(m_videoSrcMIMETypeFilter.get(), decodebin);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(videoConvert.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(videoConvert.get(), "sink"));
 
     g_signal_connect_data(decodebin, "pad-added", G_CALLBACK(+[](GstElement*, GstPad* srcPad, GstPad* sinkPad) {
         RELEASE_ASSERT(!gst_pad_is_linked(sinkPad));
@@ -168,7 +168,7 @@ GstElement* GStreamerVideoCapturer::createConverter()
     sinkPad = adoptGRef(gst_element_get_static_pad(m_videoSrcMIMETypeFilter.get(), "sink"));
     gst_element_add_pad(bin, gst_ghost_pad_new("sink", sinkPad.get()));
 
-    auto srcPad = adoptGRef(gst_element_get_static_pad(videorate, "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(videorate, "src"));
     gst_element_add_pad(bin, gst_ghost_pad_new("src", srcPad.get()));
 
     return bin;
@@ -198,7 +198,7 @@ bool GStreamerVideoCapturer::setSize(const IntSize& size)
         return false;
 
     m_size = size;
-    auto modifiedCaps = adoptGRef(gst_caps_make_writable(m_caps.leakRef()));
+    GRefPtr modifiedCaps = adoptGRef(gst_caps_make_writable(m_caps.leakRef()));
     gst_caps_set_simple(modifiedCaps.get(), "width", G_TYPE_INT, width, "height", G_TYPE_INT, height, nullptr);
     gst_caps_take(&m_caps.outPtr(), modifiedCaps.leakRef());
 
@@ -230,7 +230,7 @@ bool GStreamerVideoCapturer::setFrameRate(double frameRate)
     if (!m_capsfilter) [[unlikely]]
         return false;
 
-    auto modifiedCaps = adoptGRef(gst_caps_make_writable(m_caps.leakRef()));
+    GRefPtr modifiedCaps = adoptGRef(gst_caps_make_writable(m_caps.leakRef()));
     gst_caps_set_simple(modifiedCaps.get(), "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr);
     gst_caps_take(&m_caps.outPtr(), modifiedCaps.leakRef());
 
@@ -407,7 +407,7 @@ void GStreamerVideoCapturer::reconfigure()
             return TRUE;
         }), &selector);
 
-    auto caps = adoptGRef(gst_caps_new_simple(selector.mimeType.ascii().data(), "width", G_TYPE_INT, selector.maxWidth,
+    GRefPtr caps = adoptGRef(gst_caps_new_simple(selector.mimeType.ascii().data(), "width", G_TYPE_INT, selector.maxWidth,
         "height", G_TYPE_INT, selector.maxHeight, nullptr));
 
     GST_INFO_OBJECT(m_pipeline.get(), "Setting video capture device caps to %" GST_PTR_FORMAT, caps.get());

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -143,7 +143,7 @@ RefPtr<GStreamerVideoRTPPacketizer> GStreamerVideoRTPPacketizer::create(RefPtr<U
     if (ssrc != std::numeric_limits<uint32_t>::max())
         gst_structure_set(codecParameters.get(), "ssrc", G_TYPE_UINT, ssrc, nullptr);
 
-    auto rtpCaps = adoptGRef(gst_caps_new_empty());
+    GRefPtr rtpCaps = adoptGRef(gst_caps_new_empty());
     gst_caps_append_structure(rtpCaps.get(), codecParameters.release());
     return adoptRef(*new GStreamerVideoRTPPacketizer(WTF::move(encoder), WTF::move(payloader), WTF::move(encodingParameters), WTF::move(rtpCaps), WTF::move(payloadType)));
 }
@@ -166,14 +166,14 @@ GStreamerVideoRTPPacketizer::GStreamerVideoRTPPacketizer(GRefPtr<GstElement>&& e
     auto rtpStreamId = this->rtpStreamId();
     if (!rtpStreamId.isEmpty()) {
         GST_DEBUG_OBJECT(m_bin.get(), "Configuring rtp-stream-id extension for rid: %s", rtpStreamId.ascii().data());
-        auto extension = adoptGRef(gst_rtp_header_extension_create_from_uri(GST_RTP_HDREXT_BASE "sdes:rtp-stream-id"));
+        GRefPtr extension = adoptGRef(gst_rtp_header_extension_create_from_uri(GST_RTP_HDREXT_BASE "sdes:rtp-stream-id"));
         lastIdentifier++;
         gst_rtp_header_extension_set_id(extension.get(), lastIdentifier);
         g_object_set(extension.get(), "rid", rtpStreamId.ascii().data(), nullptr);
         g_signal_emit_by_name(m_payloader.get(), "add-extension", extension.get());
     }
 
-    auto extension = adoptGRef(gst_rtp_header_extension_create_from_uri(GST_RTP_HDREXT_BASE "sdes:mid"));
+    GRefPtr extension = adoptGRef(gst_rtp_header_extension_create_from_uri(GST_RTP_HDREXT_BASE "sdes:mid"));
     lastIdentifier++;
     gst_rtp_header_extension_set_id(extension.get(), lastIdentifier);
     g_signal_emit_by_name(m_payloader.get(), "add-extension", extension.get());
@@ -203,7 +203,7 @@ void GStreamerVideoRTPPacketizer::configure(const GstStructure* encodingParamete
             int numerator, denominator;
             gst_util_double_to_fraction(maxFrameRate, &numerator, &denominator);
 
-            auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr));
+            GRefPtr caps = adoptGRef(gst_caps_new_simple("video/x-raw", "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr));
             g_object_set(m_frameRateCapsFilter.get(), "caps", caps.get(), nullptr);
         }
     }
@@ -232,8 +232,8 @@ void GStreamerVideoRTPPacketizer::updateStats()
     g_object_get(m_encoder.get(), "bitrate", &bitrate, nullptr);
     gst_structure_set(m_stats.get(), "bitrate", G_TYPE_DOUBLE, static_cast<double>(bitrate * 1000), nullptr);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
-    auto caps = adoptGRef(gst_pad_get_current_caps(pad.get()));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "src"));
+    GRefPtr caps = adoptGRef(gst_pad_get_current_caps(pad.get()));
     if (caps && !gst_caps_is_empty(caps.get())) {
         auto structure = gst_caps_get_structure(caps.get(), 0);
         if (auto width = gstStructureGet<int>(structure, "width"_s))

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -201,7 +201,7 @@ void MockRealtimeAudioSourceGStreamer::render(Seconds delta)
 
         gst_buffer_add_audio_meta(buffer.get(), &m_info, bipBopCount, nullptr);
 
-        auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
+        GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
         // Mock GstDevice is an appsrc, see webkitMockDeviceCreateElement().
         auto appSrc = m_capturer->source();
         if (!appSrc || !GST_IS_APP_SRC(appSrc.get())) {

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -56,8 +56,8 @@ bool RealtimeIncomingSourceGStreamer::setBin(GRefPtr<GstElement>&& bin)
 
     auto handoffCallback = G_CALLBACK(+[](GstElement*, GstBuffer* buffer, GstPad* pad, gpointer userData) {
         auto source = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
-        auto caps = adoptGRef(gst_pad_get_current_caps(pad));
-        auto sample = adoptGRef(gst_sample_new(buffer, caps.get(), nullptr, nullptr));
+        GRefPtr caps = adoptGRef(gst_pad_get_current_caps(pad));
+        GRefPtr sample = adoptGRef(gst_sample_new(buffer, caps.get(), nullptr, nullptr));
         // dispatchSample might trigger RealtimeMediaSource::notifySettingsDidChangeObservers()
         // which expects to run in the main thread.
         callOnMainThread([source, sample = WTF::move(sample)]() mutable {
@@ -67,7 +67,7 @@ bool RealtimeIncomingSourceGStreamer::setBin(GRefPtr<GstElement>&& bin)
     g_signal_connect(m_sink.get(), "preroll-handoff", handoffCallback, this);
     g_signal_connect(m_sink.get(), "handoff", handoffCallback, this);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
     m_sinkPadProbeId = gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM), reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
         auto self = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
         if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
@@ -77,7 +77,7 @@ bool RealtimeIncomingSourceGStreamer::setBin(GRefPtr<GstElement>&& bin)
 
         auto query = GST_PAD_PROBE_INFO_QUERY(info);
         self->forEachClient([&](auto* appsrc) {
-            auto srcSrcPad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
+            GRefPtr srcSrcPad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
             gst_pad_peer_query(srcSrcPad.get(), query);
         });
         return GST_PAD_PROBE_OK;
@@ -92,7 +92,7 @@ void RealtimeIncomingSourceGStreamer::tearDown()
 
     g_object_set(m_sink.get(), "signal-handoffs", FALSE, nullptr);
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    GRefPtr sinkPad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
     gst_pad_remove_probe(sinkPad.get(), m_sinkPadProbeId);
     g_signal_handlers_disconnect_by_data(m_sink.get(), this);
 
@@ -145,7 +145,7 @@ void RealtimeIncomingSourceGStreamer::handleUpstreamEvent(GRefPtr<GstEvent>&& ev
         return;
 
     GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, event.get());
-    auto pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
     gst_pad_push_event(pad.get(), event.leakRef());
 }
 
@@ -155,7 +155,7 @@ bool RealtimeIncomingSourceGStreamer::handleUpstreamQuery(GstQuery* query)
         return false;
 
     GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, query);
-    auto pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
     return gst_pad_peer_query(pad.get(), query);
 }
 
@@ -196,7 +196,7 @@ GstPadProbeReturn RealtimeIncomingSourceGStreamer::handleDownstreamEvent(GRefPtr
     }
 
     forEachClient([&](auto* appsrc) {
-        auto pad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
+        GRefPtr pad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
         GST_DEBUG_OBJECT(m_sink.get(), "Forwarding event %" GST_PTR_FORMAT " to client %" GST_PTR_FORMAT, event.get(), appsrc);
         gst_pad_push_event(pad.get(), event.ref());
     });

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -99,8 +99,8 @@ void RealtimeOutgoingAudioSourceGStreamer::setupDTMFSource(int pt)
 
     gstPayloaderSetPayloadType(m_dtmfSource, pt);
     gst_bin_add(GST_BIN_CAST(m_bin.get()), m_dtmfSource.get());
-    auto srcPad = adoptGRef(gst_element_get_static_pad(m_dtmfSource.get(), "src"));
-    auto sinkPad = adoptGRef(gst_element_request_pad_simple(m_rtpFunnel.get(), "sink_%u"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_dtmfSource.get(), "src"));
+    GRefPtr sinkPad = adoptGRef(gst_element_request_pad_simple(m_rtpFunnel.get(), "sink_%u"));
     gst_pad_link(srcPad.get(), sinkPad.get());
 }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -96,7 +96,7 @@ void RealtimeOutgoingMediaSourceGStreamer::initialize()
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_inputSelector.get(), m_tee.get(), m_rtpFunnel.get(), m_rtpCapsfilter.get(), nullptr);
     gst_element_link(m_rtpFunnel.get(), m_rtpCapsfilter.get());
 
-    auto srcPad = adoptGRef(gst_element_get_static_pad(m_rtpCapsfilter.get(), "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_rtpCapsfilter.get(), "src"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("src", srcPad.get()));
 }
 
@@ -177,7 +177,7 @@ void RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource(StoppedCallback&& 
     data->source = this;
     data->callback = WTF::move(callback);
 
-    auto pad = adoptGRef(gst_element_get_static_pad(m_inputSelector.get(), "src"));
+    GRefPtr pad = adoptGRef(gst_element_get_static_pad(m_inputSelector.get(), "src"));
     gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
         auto event = GST_PAD_PROBE_INFO_EVENT(info);
         if (GST_EVENT_TYPE(event) != GST_EVENT_EOS)
@@ -258,7 +258,7 @@ void RealtimeOutgoingMediaSourceGStreamer::link()
 {
     GST_DEBUG_OBJECT(m_bin.get(), "Linking webrtcbin pad %" GST_PTR_FORMAT, m_webrtcSinkPad.get());
 
-    auto srcPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), "src"));
+    GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), "src"));
     gst_pad_link(srcPad.get(), m_webrtcSinkPad.get());
 }
 
@@ -312,7 +312,7 @@ void RealtimeOutgoingMediaSourceGStreamer::checkMid()
     auto extensionIdentifier = makeString("extmap-"_s, lookupResults.lastIdentifier);
     gst_structure_set(structure.get(), extensionIdentifier.ascii().data(), G_TYPE_STRING, GST_RTP_HDREXT_BASE "sdes:mid", nullptr);
 
-    auto newCaps = adoptGRef(gst_caps_new_full(structure.release(), nullptr));
+    GRefPtr newCaps = adoptGRef(gst_caps_new_full(structure.release(), nullptr));
     GST_DEBUG_OBJECT(m_bin.get(), "Setting RTP funnel caps to %" GST_PTR_FORMAT, newCaps.get());
     g_object_set(m_rtpCapsfilter.get(), "caps", newCaps.get(), nullptr);
 }
@@ -347,10 +347,10 @@ void RealtimeOutgoingMediaSourceGStreamer::codecPreferencesChanged()
         payloaderStates.add(*payloadType, sequenceNumber);
 
         auto bin = packetizer->bin();
-        auto binSinkPad = adoptGRef(gst_element_get_static_pad(bin, "sink"));
-        auto teeSrcPad = adoptGRef(gst_pad_get_peer(binSinkPad.get()));
-        auto binSrcPad = adoptGRef(gst_element_get_static_pad(bin, "src"));
-        auto funnelSinkPad = adoptGRef(gst_pad_get_peer(binSrcPad.get()));
+        GRefPtr binSinkPad = adoptGRef(gst_element_get_static_pad(bin, "sink"));
+        GRefPtr teeSrcPad = adoptGRef(gst_pad_get_peer(binSinkPad.get()));
+        GRefPtr binSrcPad = adoptGRef(gst_element_get_static_pad(bin, "src"));
+        GRefPtr funnelSinkPad = adoptGRef(gst_pad_get_peer(binSrcPad.get()));
         gst_element_set_state(bin, GST_STATE_NULL);
         gst_bin_remove(GST_BIN_CAST(m_bin.get()), bin);
         gst_element_release_request_pad(m_tee.get(), teeSrcPad.get());
@@ -402,7 +402,7 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(const RefPtr<MediaStream
     }
 
     auto srcPad = outgoingSourcePad();
-    auto activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    GRefPtr activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
     RELEASE_ASSERT(activePad);
     g_object_set(m_inputSelector.get(), "active-pad", activePad.get(), nullptr);
 
@@ -411,7 +411,7 @@ void RealtimeOutgoingMediaSourceGStreamer::replaceTrack(const RefPtr<MediaStream
         g_object_get(m_transceiver.get(), "codec-preferences", &caps.outPtr(), nullptr);
 
         m_pendingTrackId = trackPrivate ? trackPrivate->id() : emptyString();
-        auto newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+        GRefPtr newCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
         gst_caps_map_in_place(newCaps.get(), [](auto*, auto* structure, gpointer userData) -> gboolean {
             if (!gst_structure_has_field_typed(structure, "a-msid", G_TYPE_STRING)) [[unlikely]]
                 return TRUE;
@@ -522,7 +522,7 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
     if (gst_caps_is_empty(codecPreferences.get()) || gst_caps_is_any(codecPreferences.get())) [[unlikely]]
         return false;
 
-    auto inputSelectorSrcPad = adoptGRef(gst_element_get_static_pad(m_inputSelector.get(), "src"));
+    GRefPtr inputSelectorSrcPad = adoptGRef(gst_element_get_static_pad(m_inputSelector.get(), "src"));
     if (!gst_pad_is_linked(inputSelectorSrcPad.get()) && !gst_element_link(m_inputSelector.get(), m_tee.get()))
         return false;
 
@@ -532,10 +532,10 @@ bool RealtimeOutgoingMediaSourceGStreamer::configurePacketizers(GRefPtr<GstCaps>
             return false;
 
     }
-    auto activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
+    GRefPtr activePad = adoptGRef(gst_pad_get_peer(srcPad.get()));
     g_object_set(m_inputSelector.get(), "active-pad", activePad.get(), nullptr);
 
-    auto rtpCaps = adoptGRef(gst_caps_new_empty());
+    GRefPtr rtpCaps = adoptGRef(gst_caps_new_empty());
     unsigned totalCodecs = gst_caps_get_size(codecPreferences.get());
     for (unsigned i = 0; i < totalCodecs; i++) {
         const auto codecParameters = gst_caps_get_structure(codecPreferences.get(), i);
@@ -712,7 +712,7 @@ GUniquePtr<GstStructure> RealtimeOutgoingMediaSourceGStreamer::mediaCaptureStats
     gst_structure_set(stats.get(), "webkit-stats-type", G_TYPE_STRING, type.ascii().data(),
         "id", G_TYPE_STRING, id.utf8().data(), "timestamp", G_TYPE_DOUBLE, static_cast<double>(timestamp),
         "kind", G_TYPE_STRING, m_type == Type::Audio ? "audio" : "video", "track-identifier", G_TYPE_STRING, m_trackId.utf8().data(), nullptr);
-    auto query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("webkit-media-source-stats")));
+    GRefPtr query = adoptGRef(gst_query_new_custom(GST_QUERY_CUSTOM, gst_structure_new_empty("webkit-media-source-stats")));
     auto srcPad = outgoingSourcePad();
     if (gst_pad_query(srcPad.get(), query.get())) {
         gstStructureForeach(gst_query_get_structure(query.get()), [&](auto id, const auto* value) -> bool {
@@ -748,17 +748,17 @@ void RealtimeOutgoingMediaSourceGStreamer::teardown()
         stopUpdatingStats();
 
         if (GST_IS_PAD(m_webrtcSinkPad.get())) {
-            auto srcPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), "src"));
+            GRefPtr srcPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), "src"));
             if (gst_pad_unlink(srcPad.get(), m_webrtcSinkPad.get())) {
                 GST_DEBUG_OBJECT(m_bin.get(), "Removing webrtcbin pad %" GST_PTR_FORMAT, m_webrtcSinkPad.get());
-                if (auto parent = adoptGRef(gst_pad_get_parent_element(m_webrtcSinkPad.get())))
+                if (GRefPtr parent = adoptGRef(gst_pad_get_parent_element(m_webrtcSinkPad.get())))
                     gst_element_release_request_pad(parent.get(), m_webrtcSinkPad.get());
             }
         }
 
         gstElementLockAndSetState(m_bin.get(), GST_STATE_NULL);
 
-        if (auto pipeline = adoptGRef(gst_element_get_parent(m_bin.get())))
+        if (GRefPtr pipeline = adoptGRef(gst_element_get_parent(m_bin.get())))
             gst_bin_remove(GST_BIN_CAST(pipeline.get()), m_bin.get());
 
         m_packetizers.clear();

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
@@ -95,7 +95,7 @@ public:
         m_pipeline = makeElement("pipeline"_s);
         connectSimpleBusMessageCallback(m_pipeline.get());
 
-        auto clock = adoptGRef(gst_system_clock_obtain());
+        GRefPtr clock = adoptGRef(gst_system_clock_obtain());
         gst_pipeline_use_clock(GST_PIPELINE(m_pipeline.get()), clock.get());
         gst_element_set_base_time(m_pipeline.get(), 0);
         gst_element_set_start_time(m_pipeline.get(), GST_CLOCK_TIME_NONE);
@@ -105,7 +105,7 @@ public:
         // This is a decoder, everything should happen as fast as possible and not be synced on the clock.
         g_object_set(m_sink.get(), "sync", FALSE, nullptr);
 
-        auto sinkpad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
+        GRefPtr sinkpad = adoptGRef(gst_element_get_static_pad(m_sink.get(), "sink"));
         g_signal_connect(decoder, "pad-added", G_CALLBACK(decodebinPadAddedCb), sinkpad.get());
 
         auto& quirksManager = GStreamerQuirksManager::singleton();
@@ -131,7 +131,7 @@ public:
         if (m_requireParse) {
             caps = gst_caps_new_simple(mediaType(), "parsed", G_TYPE_BOOLEAN, TRUE, nullptr);
 
-            auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+            GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
             gst_bus_enable_sync_message_emission(bus.get());
             g_signal_connect_swapped(bus.get(), "sync-message::warning", G_CALLBACK(+[](GStreamerWebRTCVideoDecoder* decoder, GstMessage* message) {
                 GUniqueOutPtr<GError> error;
@@ -175,7 +175,7 @@ public:
             return WEBRTC_VIDEO_CODEC_OK;
 
         disconnectSimpleBusMessageCallback(m_pipeline.get());
-        auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
+        GRefPtr bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
         gst_bus_disable_sync_message_emission(bus.get());
 
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
@@ -219,13 +219,13 @@ public:
         encodedData->AddRef();
         auto data = const_cast<uint8_t*>(encodedData->data());
         auto dataSize = encodedData->size();
-        auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, data, dataSize, 0, dataSize, static_cast<gpointer>(encodedData.get()), [](gpointer data) {
+        GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, data, dataSize, 0, dataSize, static_cast<gpointer>(encodedData.get()), [](gpointer data) {
             static_cast<webrtc::EncodedImageBufferInterface*>(data)->Release();
         }));
         if (!m_requireParse)
             gst_buffer_add_reference_timestamp_meta(buffer.get(), m_rtpTimestampCaps.get(), inputImage.RtpTimestamp(), GST_CLOCK_TIME_NONE);
 
-        auto sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
+        GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), m_caps.get(), nullptr, nullptr));
         switch (gst_app_src_push_sample(GST_APP_SRC_CAST(m_src.get()), sample.get())) {
         case GST_FLOW_OK:
             break;
@@ -235,7 +235,7 @@ public:
             return WEBRTC_VIDEO_CODEC_ERROR;
         }
 
-        auto pulledSample = adoptGRef(gst_app_sink_try_pull_sample(GST_APP_SINK_CAST(m_sink.get()), GST_SECOND));
+        GRefPtr pulledSample = adoptGRef(gst_app_sink_try_pull_sample(GST_APP_SINK_CAST(m_sink.get()), GST_SECOND));
         if (!pulledSample) {
             GST_WARNING_OBJECT(pipeline(), "No decoded frame within timeout");
             return WEBRTC_VIDEO_CODEC_OK;

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -250,7 +250,7 @@ public:
             int framerateNumerator, framerateDenominator;
             gst_util_double_to_fraction(*m_frameRate, &framerateNumerator, &framerateDenominator);
             GRefPtr caps = gst_sample_get_caps(sample.get());
-            auto writableCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
+            GRefPtr writableCaps = adoptGRef(gst_caps_make_writable(caps.leakRef()));
 
             sample = adoptGRef(gst_sample_make_writable(sample.leakRef()));
             gst_caps_set_simple(writableCaps.get(), "framerate", GST_TYPE_FRACTION, framerateNumerator, framerateDenominator, nullptr);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
@@ -59,15 +59,15 @@ GRefPtr<GstSample> convertLibWebRTCVideoFrameToGStreamerSample(const webrtc::Vid
     };
     GstVideoInfo info;
     gst_video_info_set_format(&info, GST_VIDEO_FORMAT_I420, frame.width(), frame.height());
-    auto buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(GST_MEMORY_FLAG_NO_SHARE | GST_MEMORY_FLAG_READONLY),
+    GRefPtr buffer = adoptGRef(gst_buffer_new_wrapped_full(static_cast<GstMemoryFlags>(GST_MEMORY_FLAG_NO_SHARE | GST_MEMORY_FLAG_READONLY),
         const_cast<gpointer>(reinterpret_cast<const void*>(i420Buffer->DataY())), info.size, 0, info.size, i420Buffer, [](gpointer buffer) {
             reinterpret_cast<webrtc::I420Buffer*>(buffer)->Release();
     }));
 
     gst_buffer_add_video_meta_full(buffer.get(), GST_VIDEO_FRAME_FLAG_NONE, GST_VIDEO_FORMAT_I420, frame.width(), frame.height(), 3, offsets, strides);
     GST_BUFFER_PTS(buffer.get()) = toGstClockTime(WTF::MediaTime(frame.render_time_ms(), G_USEC_PER_SEC * 1000));
-    auto caps = adoptGRef(gst_video_info_to_caps(&info));
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    GRefPtr caps = adoptGRef(gst_video_info_to_caps(&info));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     return sample;
 }
 
@@ -109,7 +109,7 @@ webrtc::scoped_refptr<webrtc::I420BufferInterface> GStreamerVideoFrameLibWebRTC:
         auto info = inFrame.info();
         outInfo.fps_n = info->fps_n;
         outInfo.fps_d = info->fps_d;
-        auto caps = adoptGRef(gst_video_info_to_caps(&outInfo));
+        GRefPtr caps = adoptGRef(gst_video_info_to_caps(&outInfo));
 
         auto& converter = GStreamerVideoFrameConverter::singleton();
         auto sample = converter.convert(m_sample, caps);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
@@ -83,9 +83,9 @@ void RealtimeIncomingAudioSourceLibWebRTC::OnData(const void* audioData, int, in
     gst_audio_info_set_format(&info, format, sampleRate, numberOfChannels, NULL);
 
     auto bufferSize = GST_AUDIO_INFO_BPF(&info) * numberOfFrames;
-    auto buffer = adoptGRef(gst_buffer_new_memdup(const_cast<gpointer>(audioData), bufferSize));
+    GRefPtr buffer = adoptGRef(gst_buffer_new_memdup(const_cast<gpointer>(audioData), bufferSize));
     gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, nullptr);
-    auto caps = adoptGRef(gst_audio_info_to_caps(&info));
+    GRefPtr caps = adoptGRef(gst_audio_info_to_caps(&info));
 
     if (m_baseTime == MediaTime::invalidTime())
         m_baseTime = MediaTime::createWithSeconds(MonotonicTime::now().secondsSinceEpoch());
@@ -93,7 +93,7 @@ void RealtimeIncomingAudioSourceLibWebRTC::OnData(const void* audioData, int, in
     MediaTime mediaTime = m_baseTime + MediaTime((m_numberOfFrames * G_USEC_PER_SEC) / sampleRate, G_USEC_PER_SEC);
     GST_BUFFER_PTS(buffer.get()) = toGstUnsigned64Time(mediaTime);
 
-    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    GRefPtr sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     GStreamerAudioData data(WTF::move(sample), info);
     audioSamplesAvailable(mediaTime, data, GStreamerAudioStreamDescription(info), numberOfFrames);
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
@@ -87,8 +87,8 @@ void RealtimeOutgoingAudioSourceLibWebRTC::audioSamplesAvailable(const MediaTime
         m_inputStreamDescription = desc.getInfo();
         m_outputStreamDescription = libwebrtcAudioFormat(LibWebRTCAudioFormat::sampleRate, desc.numberOfChannels());
 #ifndef GST_DISABLE_GST_DEBUG
-        auto inputCaps = adoptGRef(gst_audio_info_to_caps(&m_inputStreamDescription));
-        auto outputCaps = adoptGRef(gst_audio_info_to_caps(&m_outputStreamDescription));
+        GRefPtr inputCaps = adoptGRef(gst_audio_info_to_caps(&m_inputStreamDescription));
+        GRefPtr outputCaps = adoptGRef(gst_audio_info_to_caps(&m_outputStreamDescription));
         GST_TRACE("Converting from %" GST_PTR_FORMAT " to %" GST_PTR_FORMAT, inputCaps.get(), outputCaps.get());
 #endif
         m_sampleConverter.reset(gst_audio_converter_new(GST_AUDIO_CONVERTER_FLAG_IN_WRITABLE, &m_inputStreamDescription,
@@ -121,7 +121,7 @@ void RealtimeOutgoingAudioSourceLibWebRTC::pullAudioData()
     size_t inBufferSize = inChunkSampleCount * m_inputStreamDescription.bpf;
 
     while (gst_adapter_available(m_adapter.get()) > inBufferSize) {
-        auto inBuffer = adoptGRef(gst_adapter_take_buffer(m_adapter.get(), inBufferSize));
+        GRefPtr inBuffer = adoptGRef(gst_adapter_take_buffer(m_adapter.get(), inBufferSize));
         m_audioBuffer.grow(outBufferSize);
         if (isSilenced()) {
             GST_TRACE("Audio buffer will contain silence");

--- a/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceRequestSoup.cpp
@@ -60,7 +60,7 @@ GRefPtr<SoupMessage> ResourceRequest::createSoupMessage(BlobRegistryImpl& blobRe
     if (!uri)
         return nullptr;
 
-    auto soupMessage = adoptGRef(soup_message_new_from_uri(httpMethod().ascii().data(), uri.get()));
+    GRefPtr soupMessage = adoptGRef(soup_message_new_from_uri(httpMethod().ascii().data(), uri.get()));
 
     soup_message_set_priority(soupMessage.get(), toSoupMessagePriority(priority()));
 

--- a/Source/WebCore/platform/rice/RiceGioBackend.cpp
+++ b/Source/WebCore/platform/rice/RiceGioBackend.cpp
@@ -164,7 +164,7 @@ GRefPtr<GSource> agentSourceNew(GThreadSafeWeakPtr<WebKitGstIceAgent>&& agent)
         GST_DEBUG_CATEGORY_INIT(GST_CAT_DEFAULT, "webkitwebrtcricegio", 0, "webkitwebrtcricegio");
     });
 
-    auto source = adoptGRef(g_source_new(&agentEventSourceFuncs, sizeof(AgentSource)));
+    GRefPtr source = adoptGRef(g_source_new(&agentEventSourceFuncs, sizeof(AgentSource)));
     g_source_set_priority(source.get(), RunLoopSourcePriority::AsyncIONetwork);
     g_source_set_name(source.get(), "[WebKit] ICE Agent loop");
 

--- a/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
+++ b/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
@@ -152,7 +152,7 @@ SpielSpeechWrapper::~SpielSpeechWrapper()
 
 String SpielSpeechWrapper::generateVoiceURI(const GRefPtr<SpielVoice>& voice, const String& language)
 {
-    auto provider = adoptGRef(spiel_voice_get_provider(voice.get()));
+    GRefPtr provider = adoptGRef(spiel_voice_get_provider(voice.get()));
     return makeString(URI_PREFIX, unsafeSpan(spiel_provider_get_well_known_name(provider.get())), '#', unsafeSpan(spiel_voice_get_identifier(voice.get())), '#', language);
 }
 
@@ -218,7 +218,7 @@ void SpielSpeechWrapper::speakUtterance(RefPtr<PlatformSpeechSynthesisUtterance>
 
     // TODO: Detect whether the utterance text is XML and enable SSML if that is the case.
     auto voice = m_voices.get(uri);
-    auto spielUtterance = adoptGRef(spiel_utterance_new(utterance->text().utf8().data()));
+    GRefPtr spielUtterance = adoptGRef(spiel_utterance_new(utterance->text().utf8().data()));
     spiel_utterance_set_language(spielUtterance.get(), utterance->lang().utf8().data());
     spiel_utterance_set_voice(spielUtterance.get(), voice);
     spiel_utterance_set_volume(spielUtterance.get(), utterance->volume());

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -227,7 +227,7 @@ RefPtr<FragmentedSharedBuffer> RenderThemeAdwaita::mediaControlsImageDataForIcon
 {
 #if USE(GLIB)
     auto path = makeString("/org/webkit/media-controls/"_s, iconName, '.', iconType);
-    auto data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+    GRefPtr data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return nullptr;
     return SharedBuffer::create(span(data));
@@ -246,7 +246,7 @@ String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const Str
 {
 #if USE(GLIB)
     auto path = makeString("/org/webkit/media-controls/"_s, iconName, '.', iconType);
-    auto data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+    GRefPtr data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return emptyString();
     return base64EncodeToString(span(data));


### PR DESCRIPTION
#### 27221ed7b61f58777d205e3057a29343fcf3f14e
<pre>
[GLib] Explicitly type variables assigned from adoptGRef calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=318118">https://bugs.webkit.org/show_bug.cgi?id=318118</a>

Reviewed by Claudio Saavedra.

Variables assigned from `adopt*` calls should use the corresponding smart pointer type, as
recommended by the coding style.

Canonical link: <a href="https://commits.webkit.org/316052@main">https://commits.webkit.org/316052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48270431257587c6ffce49c0c3e54850e4cc22ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/170796 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44722 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/172662 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/45994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/173755 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/45994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/45994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/28855 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/45994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182761 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/44357 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182761 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/44378 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182761 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45067 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109768 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26024 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45067 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/116958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/43578 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/42982 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43113 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->