### PR TITLE
[cleanup] Rename RenderBox::width()/height() to borderBoxWidth()/borderBoxHeight()

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1248,7 +1248,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
 
         if (image) {
             // check for one-dimensional image
-            if (image->height() <= 1 || image->width() <= 1)
+            if (image->borderBoxHeight() <= 1 || image->borderBoxWidth() <= 1)
                 return true;
 
             // check whether rendered image was stretched from one-dimensional file image
@@ -1317,7 +1317,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         }
 
         if (WeakPtr canvasBox = dynamicDowncast<RenderBox>(*m_renderer)) {
-            if (canvasBox->height() <= 1 || canvasBox->width() <= 1)
+            if (canvasBox->borderBoxHeight() <= 1 || canvasBox->borderBoxWidth() <= 1)
                 return true;
         }
         // Otherwise fall through; use presence of help text, title, or description to decide.

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10824,11 +10824,11 @@ void Document::updateMainArticleElementAfterLayout()
 
     for (auto& article : m_articleElements) {
         auto* box = article->renderBox();
-        float height = box ? box->height().toFloat() : 0;
+        float height = box ? box->borderBoxHeight().toFloat() : 0;
         if (height >= tallestArticleHeight) {
             secondTallestArticleHeight = tallestArticleHeight;
             tallestArticleHeight = height;
-            tallestArticleWidth = box ? box->width().toFloat() : 0;
+            tallestArticleWidth = box ? box->borderBoxWidth().toFloat() : 0;
             tallestArticle = article.ptr();
         } else if (height >= secondTallestArticleHeight)
             secondTallestArticleHeight = height;

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -626,7 +626,7 @@ static bool endsOfNodeAreVisuallyDistinctPositions(Node* node)
     if (is<HTMLTableElement>(*node))
         return false;
     
-    if (!node->renderer()->isBlockLevelReplacedOrAtomicInline() || !canHaveChildrenForEditing(*node) || !downcast<RenderBox>(*node->renderer()).height())
+    if (!node->renderer()->isBlockLevelReplacedOrAtomicInline() || !canHaveChildrenForEditing(*node) || !downcast<RenderBox>(*node->renderer()).borderBoxHeight())
         return false;
 
     // There is a VisiblePosition inside an empty inline-block container.

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1192,7 +1192,7 @@ RefPtr<Node> CompositeEditCommand::addBlockPlaceholderIfNeeded(Element* containe
             return nullptr;
 
         // Append the placeholder to make sure it follows any unrendered blocks.
-        if (blockFlow->height() && (!blockFlow->isRenderListItem() || blockFlow->firstChild()))
+        if (blockFlow->borderBoxHeight() && (!blockFlow->isRenderListItem() || blockFlow->firstChild()))
             return nullptr;
     }
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1028,7 +1028,7 @@ static bool NODELETE shouldEmitNewlineBeforeNode(Node& node, bool emitsNewlinesP
 static bool shouldEmitExtraNewlineForNode(Node& node, bool emitsNewlinesPerInnerTextSpec)
 {
     CheckedPtr renderBox = dynamicDowncast<RenderBox>(node.renderer());
-    if (!renderBox || !renderBox->height())
+    if (!renderBox || !renderBox->borderBoxHeight())
         return false;
 
     // Per the WHATWG spec, <p> elements get a required line break count of 2,
@@ -1118,7 +1118,7 @@ bool TextIterator::shouldRepresentNodeOffsetZero()
         return false;
 
     if (auto* renderBlockFlow = dynamicDowncast<RenderBlockFlow>(*currentNode->renderer())) {
-        if (!renderBlockFlow->height() && !is<HTMLBodyElement>(currentNode))
+        if (!renderBlockFlow->borderBoxHeight() && !is<HTMLBodyElement>(currentNode))
             return false;
     }
 

--- a/Source/WebCore/html/HTMLTableColElement.cpp
+++ b/Source/WebCore/html/HTMLTableColElement.cpp
@@ -86,7 +86,7 @@ void HTMLTableColElement::attributeChanged(const QualifiedName& name, const Atom
         if (!newValue.isEmpty()) {
             if (CheckedPtr col = dynamicDowncast<RenderTableCol>(renderer())) {
                 int newWidth = parseHTMLInteger(newValue).value_or(0);
-                if (newWidth != col->width())
+                if (newWidth != col->borderBoxWidth())
                     col->setNeedsLayoutAndInvalidateContentLogicalWidths();
             }
         }

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -392,7 +392,7 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
 
         // Cache selection if renderer is invisible.
         if (auto* renderer = this->renderer()) {
-            if (renderer->style().visibility() == Visibility::Hidden || !innerText->renderBox() || !innerText->renderBox()->height())
+            if (renderer->style().visibility() == Visibility::Hidden || !innerText->renderBox() || !innerText->renderBox()->borderBoxHeight())
                 return cacheSelection(start, end, direction);
         }
     }

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -164,13 +164,13 @@ void RenderSliderContainer::layout()
 
     double percentageOffset = sliderPosition(input).toDouble();
     LayoutUnit availableExtent = isVertical ? track->contentBoxHeight() : track->contentBoxWidth();
-    availableExtent -= isVertical ? thumb->height() : thumb->width();
+    availableExtent -= isVertical ? thumb->borderBoxHeight() : thumb->borderBoxWidth();
     LayoutUnit offset { percentageOffset * availableExtent };
     LayoutPoint thumbLocation = thumb->location();
     if (isVertical) {
         // appearance: slider-vertical in horizontal writing mode.
         if (writingMode().isHorizontal())
-            thumbLocation.setY(thumbLocation.y() + track->contentBoxHeight() - thumb->height() - offset);
+            thumbLocation.setY(thumbLocation.y() + track->contentBoxHeight() - thumb->borderBoxHeight() - offset);
         else {
             if (writingMode().isInlineTopToBottom())
                 thumbLocation.setY(thumbLocation.y() + offset);
@@ -261,12 +261,12 @@ void SliderThumbElement::setPositionFromPoint(const LayoutPoint& absolutePoint)
     LayoutUnit trackLength;
     LayoutUnit position;
     if (isVertical) {
-        trackLength = trackRenderer->contentBoxHeight() - thumbRenderer->height();
-        position = offset.y() - thumbRenderer->height() / 2 - trackBoundingBox.y();
+        trackLength = trackRenderer->contentBoxHeight() - thumbRenderer->borderBoxHeight();
+        position = offset.y() - thumbRenderer->borderBoxHeight() / 2 - trackBoundingBox.y();
         position -= !isInlineFlipped ? thumbRenderer->marginTop() : thumbRenderer->marginBottom();
     } else {
-        trackLength = trackRenderer->contentBoxWidth() - thumbRenderer->width();
-        position = offset.x() - thumbRenderer->width() / 2 - trackBoundingBox.x();
+        trackLength = trackRenderer->contentBoxWidth() - thumbRenderer->borderBoxWidth();
+        position = offset.x() - thumbRenderer->borderBoxWidth() / 2 - trackBoundingBox.x();
         position -= !isInlineFlipped ? thumbRenderer->marginLeft() : thumbRenderer->marginRight();
     }
 

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -141,13 +141,13 @@ void SpinButtonElement::defaultEventHandler(Event& event)
             CheckedRef renderer = *this->renderer();
             switch (renderer->theme().innerSpinButtonLayout(renderer.get())) {
             case RenderTheme::InnerSpinButtonLayout::Vertical:
-                m_upDownState = local.y() < box->height() / 2 ? Up : Down;
+                m_upDownState = local.y() < box->borderBoxHeight() / 2 ? Up : Down;
                 break;
             case RenderTheme::InnerSpinButtonLayout::HorizontalUpLeft:
-                m_upDownState = local.x() < box->width() / 2 ? Up : Down;
+                m_upDownState = local.x() < box->borderBoxWidth() / 2 ? Up : Down;
                 break;
             case RenderTheme::InnerSpinButtonLayout::HorizontalUpRight:
-                m_upDownState = local.x() > box->width() / 2 ? Up : Down;
+                m_upDownState = local.x() > box->borderBoxWidth() / 2 ? Up : Down;
                 break;
             }
             if (m_upDownState != oldUpDownState)

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -424,7 +424,7 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
     if (noBoxBaseline)
         return { };
 
-    auto borderBoxBottom = renderBox.height();
+    auto borderBoxBottom = renderBox.borderBoxHeight();
     auto marginBoxBottom = renderBox.marginBoxLogicalHeight(writingMode) - (writingMode.isHorizontal() ? renderBox.marginTop() : renderBox.marginRight());
 
     if (auto* renderImage = dynamicDowncast<RenderImage>(renderBox)) {
@@ -443,7 +443,7 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
         if (auto* baselineElement = rendererAttachment->attachmentElement().wideLayoutImageElement()) {
             if (auto* baselineElementRenderBox = baselineElement->renderBox()) {
                 // This is the bottom of the image assuming it is vertically centered.
-                return (borderBoxBottom + baselineElementRenderBox->height()) / 2 - marginBefore;
+                return (borderBoxBottom + baselineElementRenderBox->borderBoxHeight()) / 2 - marginBefore;
             }
             // Fallback to the bottom of the attachment if there is no image.
             return borderBoxBottom - marginBefore;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1135,7 +1135,7 @@ LayoutRect LineLayout::firstInlineBoxRect(const RenderInline& renderInline) cons
     case FlowDirection::LeftToRight:
         return firstBoxRect;
     case FlowDirection::RightToLeft:
-        firstBoxRect.setX(flow().width() - firstBoxRect.maxX());
+        firstBoxRect.setX(flow().borderBoxWidth() - firstBoxRect.maxX());
         return firstBoxRect;
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -113,8 +113,8 @@ std::unique_ptr<Layout::LayoutTree> TreeBuilder::buildLayoutTree(const RenderVie
     PhaseScope scope(Phase::Type::TreeBuilding);
 
     auto rootStyle = Style::ComputedStyle::clone(renderView.style());
-    rootStyle.setLogicalWidth(Style::PreferredSize::Fixed { renderView.width() });
-    rootStyle.setLogicalHeight(Style::PreferredSize::Fixed { renderView.height() });
+    rootStyle.setLogicalWidth(Style::PreferredSize::Fixed { renderView.borderBoxWidth() });
+    rootStyle.setLogicalHeight(Style::PreferredSize::Fixed { renderView.borderBoxHeight() });
 
     auto rootLayoutBox = makeUnique<InitialContainingBlock>(WTF::move(rootStyle));
     TreeBuilder().buildSubTree(renderView, *rootLayoutBox);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2398,7 +2398,7 @@ std::pair<FixedContainerEdges, WeakElementEdges> LocalFrameView::fixedContainerE
         if (!box)
             return { };
 
-        if (box->width() <= thinBorderWidth || box->height() <= thinBorderWidth)
+        if (box->borderBoxWidth() <= thinBorderWidth || box->borderBoxHeight() <= thinBorderWidth)
             return { };
 
         if (isHiddenOrNearlyTransparent(*box))

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -355,7 +355,7 @@ int LocalFrame::preferredHeight() const
     if (!block)
         return 0;
 
-    return block->height() + block->marginTop() + block->marginBottom();
+    return block->borderBoxHeight() + block->marginTop() + block->marginBottom();
 }
 
 void LocalFrame::updateLayout() const

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -228,7 +228,7 @@ static CGFloat attachmentDynamicTypeScaleFactor()
 AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle)
 {
     excludeTypographicLeading = true;
-    attachmentRect = FloatRect(0, 0, attachment.width().toFloat(), attachment.height().toFloat());
+    attachmentRect = FloatRect(0, 0, attachment.borderBoxWidth().toFloat(), attachment.borderBoxHeight().toFloat());
     wrappingWidth = attachmentWrappingTextMaximumWidth * attachmentDynamicTypeScaleFactor();
     widthPadding = attachmentRect.width();
 

--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -122,7 +122,7 @@ FontBaseline BaselineAlignmentState::dominantBaseline(WritingMode writingMode)
 
 LayoutUnit BaselineAlignmentState::synthesizedBaseline(const RenderBox& box, FontBaseline baselineType, WritingMode writingModeForSynthesis, LineDirection lineDirection, BaselineSynthesisEdge edge)
 {
-    auto boxSize = lineDirection == LineDirection::Horizontal ? box.height() : box.width();
+    auto boxSize = lineDirection == LineDirection::Horizontal ? box.borderBoxHeight() : box.borderBoxWidth();
     if (edge == BaselineSynthesisEdge::ContentBox)
         boxSize -= lineDirection == LineDirection::Horizontal ? box.verticalBorderAndPaddingExtent() : box.horizontalBorderAndPaddingExtent();
     else if (edge == BaselineSynthesisEdge::MarginBox)

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -274,11 +274,11 @@ static LayoutRect computeCaretRectForBox(const RenderBox& renderer, const Inline
     // They never refer to children.
     // FIXME: Paint the carets inside empty blocks differently than the carets before/after elements.
 
-    LayoutRect rect(renderer.location(), LayoutSize(caretWidth(), renderer.height()));
+    LayoutRect rect(renderer.location(), LayoutSize(caretWidth(), renderer.borderBoxHeight()));
     auto writingMode = boxAndOffset.box ? boxAndOffset.box->writingMode() : renderer.writingMode();
 
     if ((!boxAndOffset.offset) == writingMode.isInlineFlipped())
-        rect.move(LayoutSize(renderer.width() - caretWidth(), 0_lu));
+        rect.move(LayoutSize(renderer.borderBoxWidth() - caretWidth(), 0_lu));
 
     if (boxAndOffset.box) {
         auto lineBox = boxAndOffset.box->lineBox();
@@ -311,7 +311,7 @@ static LayoutRect computeCaretRectForBox(const RenderBox& renderer, const Inline
     }
 
     if (caretRectMode == CaretRectMode::ExpandToEndOfLine)
-        rect.shiftMaxXEdgeTo(renderer.x() + renderer.width());
+        rect.shiftMaxXEdgeTo(renderer.x() + renderer.borderBoxWidth());
 
     return writingMode.isHorizontal() ? rect : rect.transposedRect();
 }

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -168,13 +168,13 @@ LayoutUnit GridMasonryLayout::masonryAxisMarginBoxForItem(const RenderBox& gridI
     LayoutUnit marginBoxSize;
     if (m_masonryAxisDirection == Style::GridTrackSizingDirection::Rows) {
         if (GridLayoutFunctions::isOrthogonalGridItem(m_renderGrid, gridItem))
-            marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.width() + gridItem.horizontalMarginExtent() : gridItem.height() + gridItem.verticalMarginExtent();
+            marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.borderBoxWidth() + gridItem.horizontalMarginExtent() : gridItem.borderBoxHeight() + gridItem.verticalMarginExtent();
         else
             marginBoxSize = gridItem.logicalHeight() + gridItem.marginLogicalHeight();
 
     } else {
         if (GridLayoutFunctions::isOrthogonalGridItem(m_renderGrid, gridItem))
-            marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.height() + gridItem.verticalMarginExtent() : gridItem.width() + gridItem.horizontalMarginExtent();
+            marginBoxSize = gridItem.isHorizontalWritingMode() ? gridItem.borderBoxHeight() + gridItem.verticalMarginExtent() : gridItem.borderBoxWidth() + gridItem.horizontalMarginExtent();
         else
             marginBoxSize = gridItem.logicalWidth() + gridItem.marginLogicalWidth();
     }

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -251,8 +251,8 @@ FloatPoint LegacyInlineBox::locationIncludingFlipping() const
     if (!writingMode.isBlockFlipped())
         return topLeft();
     if (writingMode.isHorizontal())
-        return { x(), rootContainer.height() - height() - y() };
-    return { rootContainer.width() - width() - x(), y() };
+        return { x(), rootContainer.borderBoxHeight() - height() - y() };
+    return { rootContainer.borderBoxWidth() - width() - x(), y() };
 }
 
 void LegacyInlineBox::flipForWritingMode(FloatRect& rect) const

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -417,7 +417,7 @@ bool OutlinePainter::collectFocusRingRectsForBlock(const RenderBlock& renderer, 
     if (renderer.isRenderTextControl())
         return false;
 
-    if (renderer.width() && renderer.height())
+    if (renderer.borderBoxWidth() && renderer.borderBoxHeight())
         rects.append(LayoutRect(additionalOffset, renderer.borderBoxSize()));
 
     // Table rows share coordinate space with cells; don't recurse into cells

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -206,7 +206,7 @@ void PositionedLayoutConstraints::captureGridArea()
 
     if (!startIsBefore()) {
         auto containerSize = BoxAxis::Horizontal == m_physicalAxis
-            ? gridContainer->width() : gridContainer->height();
+            ? gridContainer->borderBoxWidth() : gridContainer->borderBoxHeight();
         m_containingRange.moveTo(containerSize - m_containingRange.max());
     }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1125,9 +1125,9 @@ bool RenderBlock::paintChild(RenderBox& child, PaintInfo& paintInfo, const Layou
         return false;
     }
 
-    if (!child.isFloating() && child.isBlockLevelReplacedOrAtomicInline() && usePrintRect && child.height() <= view().printRect().height()) {
+    if (!child.isFloating() && child.isBlockLevelReplacedOrAtomicInline() && usePrintRect && child.borderBoxHeight() <= view().printRect().height()) {
         // Paginate block-level replaced elements.
-        if (absoluteChildY + child.height() > view().printRect().maxY()) {
+        if (absoluteChildY + child.borderBoxHeight() > view().printRect().maxY()) {
             if (absoluteChildY < view().truncatedAt())
                 view().setBestTruncatedAt(absoluteChildY, &child);
             // If we were able to truncate, don't paint.
@@ -1147,9 +1147,9 @@ bool RenderBlock::paintChild(RenderBox& child, PaintInfo& paintInfo, const Layou
     // Check for page-break-after: always, and if it's set, break and bail.
     bool checkAfterAlways = !childrenInline() && (usePrintRect && alwaysPageBreak(child.style().breakAfter()));
     if (checkAfterAlways
-        && (absoluteChildY + child.height()) > paintInfo.rect.y()
-        && (absoluteChildY + child.height()) < paintInfo.rect.maxY()) {
-        view().setBestTruncatedAt(absoluteChildY + child.height() + std::max<LayoutUnit>(0, child.collapsedMarginAfter()), this, true);
+        && (absoluteChildY + child.borderBoxHeight()) > paintInfo.rect.y()
+        && (absoluteChildY + child.borderBoxHeight()) < paintInfo.rect.maxY()) {
+        view().setBestTruncatedAt(absoluteChildY + child.borderBoxHeight() + std::max<LayoutUnit>(0, child.collapsedMarginAfter()), this, true);
         return false;
     }
 
@@ -1500,7 +1500,7 @@ static void clipOutOutOfFlowBoxes(const PaintInfo* paintInfo, const LayoutPoint&
         return;
     
     for (auto& renderer : *outOfFlowBoxes)
-        paintInfo->context().clipOut(IntRect(offset.x() + renderer.x(), offset.y() + renderer.y(), renderer.width(), renderer.height()));
+        paintInfo->context().clipOut(IntRect(offset.x() + renderer.x(), offset.y() + renderer.y(), renderer.borderBoxWidth(), renderer.borderBoxHeight()));
 }
 
 LayoutUnit blockDirectionOffset(RenderBlock& rootBlock, const LayoutSize& offsetFromRootBlock)
@@ -1532,7 +1532,7 @@ GapRects RenderBlock::selectionGaps(RenderBlock& rootBlock, const LayoutPoint& r
     // Clip out floating and positioned objects when painting selection gaps.
     if (paintInfo) {
         // Note that we don't clip out overflow for positioned objects.  We just stick to the border box.
-        LayoutRect flippedBlockRect(offsetFromRootBlock.width(), offsetFromRootBlock.height(), width(), height());
+        LayoutRect flippedBlockRect(offsetFromRootBlock.width(), offsetFromRootBlock.height(), borderBoxWidth(), borderBoxHeight());
         rootBlock.flipForWritingMode(flippedBlockRect);
         flippedBlockRect.moveBy(rootBlockPhysicalPosition);
         clipOutOutOfFlowBoxes(paintInfo, flippedBlockRect.location(), outOfFlowBoxes());
@@ -2170,7 +2170,7 @@ PositionWithAffinity RenderBlock::positionForPointWithInlineChildren(const Layou
 static inline bool NODELETE isChildHitTestCandidate(const RenderBox& box, HitTestSource source)
 {
     auto visibility = source == HitTestSource::Script ? box.style().visibility() : box.style().usedVisibility();
-    return box.height() && visibility == Visibility::Visible && !box.isOutOfFlowPositioned() && !box.isRenderFragmentedFlow();
+    return box.borderBoxHeight() && visibility == Visibility::Visible && !box.isOutOfFlowPositioned() && !box.isRenderFragmentedFlow();
 }
 
 // Valid candidates in a FragmentedFlow must be rendered by the fragment.
@@ -3273,12 +3273,12 @@ void RenderBlock::adjustBorderBoxRectForPainting(LayoutRect& paintRect)
         return;
 
     if (writingMode().isHorizontal()) {
-        LayoutUnit yOff = std::max(0_lu, (legend->height() - RenderBox::borderBefore()) / 2);
+        LayoutUnit yOff = std::max(0_lu, (legend->borderBoxHeight() - RenderBox::borderBefore()) / 2);
         paintRect.setHeight(paintRect.height() - yOff);
         if (writingMode().isBlockTopToBottom())
             paintRect.setY(paintRect.y() + yOff);
     } else {
-        LayoutUnit xOff = std::max(0_lu, (legend->width() - RenderBox::borderBefore()) / 2);
+        LayoutUnit xOff = std::max(0_lu, (legend->borderBoxWidth() - RenderBox::borderBefore()) / 2);
         paintRect.setWidth(paintRect.width() - xOff);
         if (writingMode().isBlockLeftToRight())
             paintRect.setX(paintRect.x() + xOff);
@@ -3298,25 +3298,25 @@ LayoutRect RenderBlock::paintRectToClipOutFromBorder(const LayoutRect& paintRect
     if (writingMode().isHorizontal()) {
         clipRect.setX(paintRect.x() + legend->x());
         clipRect.setY(writingMode().isBlockTopToBottom() ? paintRect.y() : paintRect.y() + paintRect.height() - borderExtent);
-        clipRect.setWidth(legend->width());
+        clipRect.setWidth(legend->borderBoxWidth());
         clipRect.setHeight(borderExtent);
         // When the legend overlaps a non-block-start border (e.g. via negative
         // margin), extend the clip in the block direction to cover the legend's
         // layout box so that border behind it is not painted.
         if (!borderExtent) {
-            LayoutUnit adjustment = intrinsicBorderForFieldset() ? std::max(0_lu, (legend->height() - borderExtent) / 2) : 0_lu;
+            LayoutUnit adjustment = intrinsicBorderForFieldset() ? std::max(0_lu, (legend->borderBoxHeight() - borderExtent) / 2) : 0_lu;
             clipRect.setY(paintRect.y() + legend->y() - adjustment);
-            clipRect.setHeight(legend->height());
+            clipRect.setHeight(legend->borderBoxHeight());
         }
     } else {
         clipRect.setX(writingMode().isBlockLeftToRight() ? paintRect.x() : paintRect.x() + paintRect.width() - borderExtent);
         clipRect.setY(paintRect.y() + legend->y());
         clipRect.setWidth(borderExtent);
-        clipRect.setHeight(legend->height());
+        clipRect.setHeight(legend->borderBoxHeight());
         if (!borderExtent) {
-            LayoutUnit adjustment = intrinsicBorderForFieldset() ? std::max(0_lu, (legend->width() - borderExtent) / 2) : 0_lu;
+            LayoutUnit adjustment = intrinsicBorderForFieldset() ? std::max(0_lu, (legend->borderBoxWidth() - borderExtent) / 2) : 0_lu;
             clipRect.setX(paintRect.x() + legend->x() - adjustment);
-            clipRect.setWidth(legend->width());
+            clipRect.setWidth(legend->borderBoxWidth());
         }
     }
     return clipRect;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -189,8 +189,8 @@ public:
     
     // Accessors for logical width/height and margins in the containing block's block-flow direction.
     enum ApplyLayoutDeltaMode { ApplyLayoutDelta, DoNotApplyLayoutDelta };
-    LayoutUnit logicalWidthForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.width() : child.height(); }
-    LayoutUnit logicalHeightForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.height() : child.width(); }
+    LayoutUnit logicalWidthForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.borderBoxWidth() : child.borderBoxHeight(); }
+    LayoutUnit logicalHeightForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.borderBoxHeight() : child.borderBoxWidth(); }
     inline LayoutUnit logicalMarginBoxHeightForChild(const RenderBox& child) const;
     LayoutSize logicalSizeForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.borderBoxSize() : child.borderBoxSize().transposedSize(); }
     LayoutUnit logicalTopForChild(const RenderBox& child) const { return isHorizontalWritingMode() ? child.y() : child.x(); }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1307,7 +1307,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
             fragmentedFlow->fragmentedFlowDescendantBoxLaidOut(&child);
         // Check for an after page/column break.
         LayoutUnit newHeight = applyAfterBreak(child, logicalHeight(), marginInfo);
-        if (newHeight != height())
+        if (newHeight != borderBoxHeight())
             setLogicalHeight(newHeight);
     }
 
@@ -2735,7 +2735,7 @@ void RenderBlockFlow::clipOutFloatingBoxes(RenderBlock& rootBlock, const PaintIn
     for (auto& floatingObject : m_floatingObjects->set()) {
         if (!floatingObject->renderer())
             continue;
-        LayoutRect floatBox(offsetFromRootBlock.width(), offsetFromRootBlock.height(), floatingObject->renderer()->width(), floatingObject->renderer()->height());
+        LayoutRect floatBox(offsetFromRootBlock.width(), offsetFromRootBlock.height(), floatingObject->renderer()->borderBoxWidth(), floatingObject->renderer()->borderBoxHeight());
         floatBox.move(floatingObject->locationOffsetOfBorderBox());
         rootBlock.flipForWritingMode(floatBox);
         floatBox.move(rootBlockPhysicalPosition.x(), rootBlockPhysicalPosition.y());
@@ -3051,7 +3051,7 @@ void RenderBlockFlow::clearFloats(UsedClear usedClear)
     }
     // FIXME: The float search tree has floored float box position (see FloatingObjects::intervalForFloatingObject).
     newY = newY.floor();
-    if (height() < newY)
+    if (borderBoxHeight() < newY)
         setLogicalHeight(newY);
 }
 
@@ -3320,8 +3320,8 @@ LayoutPoint RenderBlockFlow::flipFloatForWritingModeForChild(const FloatingObjec
     // it's going to get added back in. We hide this complication here so that the calling code looks normal for the unflipped
     // case.
     if (isHorizontalWritingMode())
-        return LayoutPoint(point.x(), point.y() + height() - child.renderer()->height() - 2 * child.locationOffsetOfBorderBox().height());
-    return LayoutPoint(point.x() + width() - child.renderer()->width() - 2 * child.locationOffsetOfBorderBox().width(), point.y());
+        return LayoutPoint(point.x(), point.y() + borderBoxHeight() - child.renderer()->borderBoxHeight() - 2 * child.locationOffsetOfBorderBox().height());
+    return LayoutPoint(point.x() + borderBoxWidth() - child.renderer()->borderBoxWidth() - 2 * child.locationOffsetOfBorderBox().width(), point.y());
 }
 
 LayoutUnit RenderBlockFlow::computedClearDeltaForChild(RenderBox& child, LayoutUnit logicalTop)
@@ -3801,7 +3801,7 @@ RenderText* RenderBlockFlow::findClosestTextAtAbsolutePoint(const FloatPoint& po
     if (!block->childrenInline()) {
         // Look among our immediate children for an alternate box that contains the point.
         for (RenderBox* child = block->firstChildBox(); child; child = child->nextSiblingBox()) {
-            if (!child->height() || child->style().usedVisibility() != WebCore::Visibility::Visible || child->isFloatingOrOutOfFlowPositioned())
+            if (!child->borderBoxHeight() || child->style().usedVisibility() != WebCore::Visibility::Visible || child->isFloatingOrOutOfFlowPositioned())
                 continue;
             float top = child->y();
             
@@ -4539,10 +4539,10 @@ static inline float textMultiplier(RenderObject& renderer, float specifiedSize)
 
 void RenderBlockFlow::adjustComputedFontSizes(float size, float visibleWidth)
 {
-    LOG(TextAutosizing, "RenderBlockFlow %p adjustComputedFontSizes, size=%f visibleWidth=%f, width()=%f. Bailing: %d", this, size, visibleWidth, width().toFloat(), visibleWidth >= width());
+    LOG(TextAutosizing, "RenderBlockFlow %p adjustComputedFontSizes, size=%f visibleWidth=%f, borderBoxWidth()=%f. Bailing: %d", this, size, visibleWidth, borderBoxWidth().toFloat(), visibleWidth >= borderBoxWidth());
 
     // Don't do any work if the block is smaller than the visible area.
-    if (visibleWidth >= width())
+    if (visibleWidth >= borderBoxWidth())
         return;
     
     unsigned lineCount = m_lineCountForTextAutosizing;
@@ -4570,7 +4570,7 @@ void RenderBlockFlow::adjustComputedFontSizes(float size, float visibleWidth)
     if (lineCount == NO_LINE)
         return;
     
-    float actualWidth = m_widthForTextAutosizing != -1 ? static_cast<float>(m_widthForTextAutosizing) : static_cast<float>(width());
+    float actualWidth = m_widthForTextAutosizing != -1 ? static_cast<float>(m_widthForTextAutosizing) : static_cast<float>(borderBoxWidth());
     float scale = visibleWidth / actualWidth;
     float minFontSize = roundf(size / scale);
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -696,7 +696,7 @@ void RenderBox::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
     if (CheckedPtr fragmentedFlow = enclosingFragmentedFlow(); fragmentedFlow && fragmentedFlow->absoluteQuadsForBox(quads, wasFixed, *this))
         return;
 
-    auto localRect = FloatRect { 0, 0, width(), height() };
+    auto localRect = FloatRect { 0, 0, borderBoxWidth(), borderBoxHeight() };
     quads.append(localToAbsoluteQuad(localRect, MapCoordinatesMode::UseTransforms, wasFixed));
 }
 
@@ -935,8 +935,8 @@ LayoutRect RenderBox::paddingBoxRect() const
     return LayoutRect {
         borderWidths.left() + offsetForScrollbar,
         borderWidths.top(),
-        width() - borderWidths.left() - borderWidths.right() - verticalScrollbarWidth,
-        height() - borderWidths.top() - borderWidths.bottom() - horizontalScrollbarHeight
+        borderBoxWidth() - borderWidths.left() - borderWidths.right() - verticalScrollbarWidth,
+        borderBoxHeight() - borderWidths.top() - borderWidths.bottom() - horizontalScrollbarHeight
     };
 }
 
@@ -1956,7 +1956,7 @@ static bool isCandidateForOpaquenessTest(const RenderBox& childBox)
         return false;
     if (!childStyle.shapeOutside().isNone())
         return false;
-    if (!childBox.width() || !childBox.height())
+    if (!childBox.borderBoxWidth() || !childBox.borderBoxHeight())
         return false;
     if (CheckedPtr childLayer = childBox.layer()) {
         if (childLayer->isComposited())
@@ -1993,7 +1993,7 @@ bool RenderBox::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, u
                 return false;
             continue;
         }
-        if (childLocalRect.maxY() > childBox.height() || childLocalRect.maxX() > childBox.width())
+        if (childLocalRect.maxY() > childBox.borderBoxHeight() || childLocalRect.maxX() > childBox.borderBoxWidth())
             continue;
         if (childBox.backgroundIsKnownToBeOpaqueInRect(childLocalRect))
             return true;
@@ -2217,8 +2217,8 @@ bool RenderBox::repaintLayerRectsForImage(WrappedImagePtr image, const Layers& l
 
                     rendererRect = LayoutRect(-layerRenderer->marginLeft(),
                         -layerRenderer->marginTop(),
-                        std::max(layerRenderer->width() + layerRenderer->horizontalMarginExtent() + layerRenderer->borderLeft() + layerRenderer->borderRight(), rw),
-                        std::max(layerRenderer->height() + layerRenderer->verticalMarginExtent() + layerRenderer->borderTop() + layerRenderer->borderBottom(), rh));
+                        std::max(layerRenderer->borderBoxWidth() + layerRenderer->horizontalMarginExtent() + layerRenderer->borderLeft() + layerRenderer->borderRight(), rw),
+                        std::max(layerRenderer->borderBoxHeight() + layerRenderer->verticalMarginExtent() + layerRenderer->borderTop() + layerRenderer->borderBottom(), rh));
 
                     // If we're drawing the root background, then we want to use the bounds of the view
                     // (since root backgrounds cover the canvas, not just the element). If the root element
@@ -2368,7 +2368,7 @@ LayoutRect RenderBox::clipRect(const LayoutPoint& location) const
             // from the left and top edges. Therefore it's better to avoid constraining to smaller widths and heights.
 
             if (auto clipRight = rect.value->right().tryLength())
-                clipRect.contract(width() - LayoutUnit { clipRight->resolveZoom(Style::ZoomNeeded { }) }, 0_lu);
+                clipRect.contract(borderBoxWidth() - LayoutUnit { clipRight->resolveZoom(Style::ZoomNeeded { }) }, 0_lu);
 
             if (auto clipTop = rect.value->top().tryLength()) {
                 auto c = LayoutUnit { clipTop->resolveZoom(Style::ZoomNeeded { }) };
@@ -2377,7 +2377,7 @@ LayoutRect RenderBox::clipRect(const LayoutPoint& location) const
             }
 
             if (auto clipBottom = rect.value->bottom().tryLength())
-                clipRect.contract(0_lu, height() - LayoutUnit { clipBottom->resolveZoom(Style::ZoomNeeded { }) });
+                clipRect.contract(0_lu, borderBoxHeight() - LayoutUnit { clipBottom->resolveZoom(Style::ZoomNeeded { }) });
 
             return clipRect;
         }
@@ -4245,9 +4245,9 @@ LayoutRange RenderBox::containingBlockRangeForPositioned(const RenderBoxModelObj
             if (auto boxInfo = containingBlock->renderBoxFragmentInfo(fragment)) {
                 auto size = boxInfo->logicalWidth();
                 if (BoxAxis::Horizontal == physicalAxis)
-                    size -= containingBlock->width() - containingBlock->clientWidth();
+                    size -= containingBlock->borderBoxWidth() - containingBlock->clientWidth();
                 else
-                    size -= containingBlock->height() - containingBlock->clientHeight();
+                    size -= containingBlock->borderBoxHeight() - containingBlock->clientHeight();
                 return LayoutRange(startEdge, std::max<LayoutUnit>(0, size));
             }
         }
@@ -5067,9 +5067,9 @@ LayoutRect RenderBox::convertRectToParentWritingMode(LayoutRect rect, const Writ
     // We are putting ourselves into our parent's coordinate space. If there is a flipped block mismatch
     // in a particular axis, then we have to flip the rect along that axis.
     if (writingMode().blockDirection() == FlowDirection::RightToLeft || parentWritingMode.blockDirection() == FlowDirection::RightToLeft)
-        rect.setX(width() - rect.maxX());
+        rect.setX(borderBoxWidth() - rect.maxX());
     else if (writingMode().blockDirection() == FlowDirection::BottomToTop || parentWritingMode.blockDirection() == FlowDirection::BottomToTop)
-        rect.setY(height() - rect.maxY());
+        rect.setY(borderBoxHeight() - rect.maxY());
 
     return rect;
 }
@@ -5156,8 +5156,8 @@ LayoutPoint RenderBox::flipForWritingModeForChild(const RenderBox& child, const 
     // The child is going to add in its x() and y(), so we have to make sure it ends up in
     // the right place.
     if (isHorizontalWritingMode())
-        return LayoutPoint(point.x(), point.y() + height() - child.height() - (2 * child.y()));
-    return LayoutPoint(point.x() + width() - child.width() - (2 * child.x()), point.y());
+        return LayoutPoint(point.x(), point.y() + borderBoxHeight() - child.borderBoxHeight() - (2 * child.y()));
+    return LayoutPoint(point.x() + borderBoxWidth() - child.borderBoxWidth() - (2 * child.x()), point.y());
 }
 
 void RenderBox::flipForWritingMode(LayoutRect& rect) const
@@ -5166,9 +5166,9 @@ void RenderBox::flipForWritingMode(LayoutRect& rect) const
         return;
 
     if (isHorizontalWritingMode())
-        rect.setY(height() - rect.maxY());
+        rect.setY(borderBoxHeight() - rect.maxY());
     else
-        rect.setX(width() - rect.maxX());
+        rect.setX(borderBoxWidth() - rect.maxX());
 }
 
 LayoutUnit RenderBox::flipForWritingMode(LayoutUnit position) const
@@ -5182,21 +5182,21 @@ LayoutPoint RenderBox::flipForWritingMode(const LayoutPoint& position) const
 {
     if (!writingMode().isBlockFlipped())
         return position;
-    return isHorizontalWritingMode() ? LayoutPoint(position.x(), height() - position.y()) : LayoutPoint(width() - position.x(), position.y());
+    return isHorizontalWritingMode() ? LayoutPoint(position.x(), borderBoxHeight() - position.y()) : LayoutPoint(borderBoxWidth() - position.x(), position.y());
 }
 
 LayoutSize RenderBox::flipForWritingMode(const LayoutSize& offset) const
 {
     if (!writingMode().isBlockFlipped())
         return offset;
-    return isHorizontalWritingMode() ? LayoutSize(offset.width(), height() - offset.height()) : LayoutSize(width() - offset.width(), offset.height());
+    return isHorizontalWritingMode() ? LayoutSize(offset.width(), borderBoxHeight() - offset.height()) : LayoutSize(borderBoxWidth() - offset.width(), offset.height());
 }
 
 FloatPoint RenderBox::flipForWritingMode(const FloatPoint& position) const
 {
     if (!writingMode().isBlockFlipped())
         return position;
-    return isHorizontalWritingMode() ? FloatPoint(position.x(), height() - position.y()) : FloatPoint(width() - position.x(), position.y());
+    return isHorizontalWritingMode() ? FloatPoint(position.x(), borderBoxHeight() - position.y()) : FloatPoint(borderBoxWidth() - position.x(), position.y());
 }
 
 void RenderBox::flipForWritingMode(FloatRect& rect) const
@@ -5205,9 +5205,9 @@ void RenderBox::flipForWritingMode(FloatRect& rect) const
         return;
 
     if (isHorizontalWritingMode())
-        rect.setY(height() - rect.maxY());
+        rect.setY(borderBoxHeight() - rect.maxY());
     else
-        rect.setX(width() - rect.maxX());
+        rect.setX(borderBoxWidth() - rect.maxX());
 }
 
 void RenderBox::flipForWritingMode(RepaintRects& rects) const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -64,8 +64,8 @@ public:
 
     LayoutUnit x() const { return m_frameRect.x(); }
     LayoutUnit y() const { return m_frameRect.y(); }
-    LayoutUnit width() const { return m_frameRect.width(); }
-    LayoutUnit height() const { return m_frameRect.height(); }
+    LayoutUnit borderBoxWidth() const { return m_frameRect.width(); }
+    LayoutUnit borderBoxHeight() const { return m_frameRect.height(); }
 
     // These represent your location relative to your container as a physical offset.
     // In layout related methods you almost always want the logical location (e.g. x() and y()).
@@ -212,8 +212,8 @@ public:
 
     // IE extensions. Used to calculate offsetWidth/Height.  Overridden by inlines (RenderFlow)
     // to return the remaining width on a given line (and the height of a single line).
-    LayoutUnit offsetWidth() const override { return width(); }
-    LayoutUnit offsetHeight() const override { return height(); }
+    LayoutUnit offsetWidth() const override { return borderBoxWidth(); }
+    LayoutUnit offsetHeight() const override { return borderBoxHeight(); }
 
     // More IE extensions.  clientWidth and clientHeight represent the interior of an object
     // excluding border and scrollbar.  clientLeft/Top are just the borderLeftWidth and borderTopWidth.
@@ -500,10 +500,10 @@ public:
     // that just updates the object's position. If the size does change, the object remains dirty.
     bool tryLayoutDoingOutOfFlowMovementOnly()
     {
-        LayoutUnit oldWidth = width();
+        LayoutUnit oldWidth = borderBoxWidth();
         updateLogicalWidth();
         // If we shrink to fit our width may have changed, so we still need full layout.
-        if (oldWidth != width())
+        if (oldWidth != borderBoxWidth())
             return false;
         updateLogicalHeight();
         return true;

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-inline LayoutUnit RenderBox::marginBoxLogicalHeight(WritingMode writingMode) const { return writingMode.isHorizontal() ? m_marginBox.top() + height() + m_marginBox.bottom() : m_marginBox.right() + width() + m_marginBox.left(); }
+inline LayoutUnit RenderBox::marginBoxLogicalHeight(WritingMode writingMode) const { return writingMode.isHorizontal() ? m_marginBox.top() + borderBoxHeight() + m_marginBox.bottom() : m_marginBox.right() + borderBoxWidth() + m_marginBox.left(); }
 inline LayoutRect RenderBox::clientBoxRect() const { return LayoutRect(clientLeft(), clientTop(), clientWidth(), clientHeight()); }
 inline LayoutUnit RenderBox::clientLeft() const { return borderLeft(); }
 inline LayoutUnit RenderBox::clientLogicalBottom() const { return borderBefore() + clientLogicalHeight(); }
@@ -61,7 +61,7 @@ inline bool RenderBox::hasScrollableOverflowY() const { return scrollsOverflowY(
 inline bool RenderBox::hasVerticalOverflow() const { return scrollHeight() != roundToInt(paddingBoxHeight()); }
 inline LayoutUnit RenderBox::intrinsicLogicalHeight() const { return writingMode().isHorizontal() ? intrinsicSize().height() : intrinsicSize().width(); }
 inline LayoutUnit RenderBox::logicalBottom() const { return logicalTop() + logicalHeight(); }
-inline LayoutUnit RenderBox::logicalHeight() const { return writingMode().isHorizontal() ? height() : width(); }
+inline LayoutUnit RenderBox::logicalHeight() const { return writingMode().isHorizontal() ? borderBoxHeight() : borderBoxWidth(); }
 inline LayoutUnit RenderBox::logicalLeft() const { return writingMode().isHorizontal() ? x() : y(); }
 inline LayoutUnit RenderBox::logicalLeftLayoutOverflow() const { return writingMode().isHorizontal() ? layoutOverflowRect().x() : layoutOverflowRect().y(); }
 inline LayoutUnit RenderBox::logicalLeftVisualOverflow() const { return writingMode().isHorizontal() ? visualOverflowRect().x() : visualOverflowRect().y(); }
@@ -70,9 +70,9 @@ inline LayoutUnit RenderBox::logicalRightLayoutOverflow() const { return writing
 inline LayoutUnit RenderBox::logicalRightVisualOverflow() const { return writingMode().isHorizontal() ? visualOverflowRect().maxX() : visualOverflowRect().maxY(); }
 inline LayoutSize RenderBox::logicalSize() const { return writingMode().isHorizontal() ? m_frameRect.size() : m_frameRect.size().transposedSize(); }
 inline LayoutUnit RenderBox::logicalTop() const { return writingMode().isHorizontal() ? y() : x(); }
-inline LayoutUnit RenderBox::logicalWidth() const { return writingMode().isHorizontal() ? width() : height(); }
-inline LayoutUnit RenderBox::paddingBoxHeight() const { return std::max(0_lu, height() - borderTop() - borderBottom() - horizontalScrollbarHeight()); }
-inline LayoutUnit RenderBox::paddingBoxWidth() const { return std::max(0_lu, width() - borderLeft() - borderRight() - verticalScrollbarWidth()); }
+inline LayoutUnit RenderBox::logicalWidth() const { return writingMode().isHorizontal() ? borderBoxWidth() : borderBoxHeight(); }
+inline LayoutUnit RenderBox::paddingBoxHeight() const { return std::max(0_lu, borderBoxHeight() - borderTop() - borderBottom() - horizontalScrollbarHeight()); }
+inline LayoutUnit RenderBox::paddingBoxWidth() const { return std::max(0_lu, borderBoxWidth() - borderLeft() - borderRight() - verticalScrollbarWidth()); }
 inline int RenderBox::scrollbarLogicalHeight() const { return writingMode().isHorizontal() ? horizontalScrollbarHeight() : verticalScrollbarWidth(); }
 inline int RenderBox::scrollbarLogicalWidth() const { return writingMode().isHorizontal() ? verticalScrollbarWidth() : horizontalScrollbarHeight(); }
 inline void RenderBox::setLogicalLocation(LayoutPoint location) { setLocation(writingMode().isHorizontal() ? location : location.transposedPoint()); }
@@ -125,7 +125,7 @@ inline LayoutSize RenderBox::topLeftLocationOffset() const
 inline LayoutRect RenderBox::paddingBoxRectIncludingScrollbar() const
 {
     auto borderWidths = this->borderWidths();
-    return LayoutRect(borderWidths.left(), borderWidths.top(), width() - borderWidths.left() - borderWidths.right(), height() - borderWidths.top() - borderWidths.bottom());
+    return LayoutRect(borderWidths.left(), borderWidths.top(), borderBoxWidth() - borderWidths.left() - borderWidths.right(), borderBoxHeight() - borderWidths.top() - borderWidths.bottom());
 }
 
 inline LayoutRect RenderBox::contentBoxRect() const
@@ -152,8 +152,8 @@ inline LayoutRect RenderBox::contentBoxRect() const
     auto borderWidths = this->borderWidths();
     auto location = LayoutPoint { borderWidths.left() + padding.left() + leftScrollbarSpace, borderWidths.top() + padding.top() + topScrollbarSpace };
 
-    auto paddingBoxWidth = std::max(0_lu, width() - borderWidths.left() - borderWidths.right() - verticalScrollbarWidth);
-    auto paddingBoxHeight = std::max(0_lu, height() - borderWidths.top() - borderWidths.bottom() - horizontalScrollbarHeight);
+    auto paddingBoxWidth = std::max(0_lu, borderBoxWidth() - borderWidths.left() - borderWidths.right() - verticalScrollbarWidth);
+    auto paddingBoxHeight = std::max(0_lu, borderBoxHeight() - borderWidths.top() - borderWidths.bottom() - horizontalScrollbarHeight);
 
     auto width = std::max(0_lu, paddingBoxWidth - padding.left() - padding.right() - leftScrollbarSpace);
     auto height = std::max(0_lu, paddingBoxHeight - padding.top() - padding.bottom() - topScrollbarSpace);

--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -155,7 +155,7 @@ bool RenderButton::canHaveGeneratedChildren() const
 LayoutRect RenderButton::controlClipRect(const LayoutPoint& additionalOffset) const
 {
     // Clip to the padding box to at least give content the extra padding space.
-    return LayoutRect(additionalOffset.x() + borderLeft(), additionalOffset.y() + borderTop(), width() - borderLeft() - borderRight(), height() - borderTop() - borderBottom());
+    return LayoutRect(additionalOffset.x() + borderLeft(), additionalOffset.y() + borderTop(), borderBoxWidth() - borderLeft() - borderRight(), borderBoxHeight() - borderTop() - borderBottom());
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -399,7 +399,7 @@ void RenderDeprecatedFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren,
         updateInFlowDescendantTransformsAfterLayout();
         computeInFlowOverflow(contentArea);
 
-        if (isDocumentElementRenderer() || previousSize.height() != height())
+        if (isDocumentElementRenderer() || previousSize.height() != borderBoxHeight())
             layoutOutOfFlowBoxes(RelayoutChildren::Yes);
         else
             layoutOutOfFlowBoxes(relayoutChildren);
@@ -516,9 +516,9 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
 
             // Update our height and overflow height.
             if (style().boxAlign() == BoxAlignment::Baseline) {
-                LayoutUnit ascent = child->firstLineBaseline().value_or(child->height() + child->marginBottom());
+                LayoutUnit ascent = child->firstLineBaseline().value_or(child->borderBoxHeight() + child->marginBottom());
                 ascent += child->marginTop();
-                LayoutUnit descent = (child->height() + child->verticalMarginExtent()) - ascent;
+                LayoutUnit descent = (child->borderBoxHeight() + child->verticalMarginExtent()) - ascent;
 
                 // Update our maximum ascent.
                 maxAscent = std::max(maxAscent, ascent);
@@ -527,23 +527,23 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
                 maxDescent = std::max(maxDescent, descent);
 
                 // Now update our height.
-                setHeight(std::max(yPos + maxAscent + maxDescent, height()));
+                setHeight(std::max(yPos + maxAscent + maxDescent, borderBoxHeight()));
             }
             else
-                setHeight(std::max(height(), yPos + child->height() + child->verticalMarginExtent()));
+                setHeight(std::max(borderBoxHeight(), yPos + child->borderBoxHeight() + child->verticalMarginExtent()));
         }
         ASSERT(childIndex == childLayoutDeltas.size());
 
         if (!iterator.first() && hasLineIfEmpty())
-            setHeight(height() + lineHeight());
+            setHeight(borderBoxHeight() + lineHeight());
 
-        setHeight(height() + toAdd);
+        setHeight(borderBoxHeight() + toAdd);
 
-        oldHeight = height();
+        oldHeight = borderBoxHeight();
         updateLogicalHeight();
 
         relayoutChildren = RelayoutChildren::No;
-        if (oldHeight != height())
+        if (oldHeight != borderBoxHeight())
             heightSpecified = true;
 
         // Now that our height is actually known, we can place our boxes.
@@ -567,9 +567,9 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
             // We need to see if this child's height has changed, since we make block elements
             // fill the height of a containing box by default.
             // Now do a layout.
-            LayoutUnit oldChildHeight = child->height();
+            LayoutUnit oldChildHeight = child->borderBoxHeight();
             child->updateLogicalHeight();
-            if (oldChildHeight != child->height())
+            if (oldChildHeight != child->borderBoxHeight())
                 child->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
 
             child->markForPaginationRelayoutIfNeeded();
@@ -581,16 +581,16 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
             LayoutUnit childY = yPos;
             switch (style().boxAlign()) {
             case BoxAlignment::Center:
-                childY += child->marginTop() + std::max<LayoutUnit>(0, (contentBoxHeight() - (child->height() + child->verticalMarginExtent())) / 2);
+                childY += child->marginTop() + std::max<LayoutUnit>(0, (contentBoxHeight() - (child->borderBoxHeight() + child->verticalMarginExtent())) / 2);
                 break;
             case BoxAlignment::Baseline: {
-                LayoutUnit ascent = child->firstLineBaseline().value_or(child->height() + child->marginBottom());
+                LayoutUnit ascent = child->firstLineBaseline().value_or(child->borderBoxHeight() + child->marginBottom());
                 ascent += child->marginTop();
                 childY += child->marginTop() + (maxAscent - ascent);
                 break;
             }
             case BoxAlignment::End:
-                childY += contentBoxHeight() - child->marginBottom() - child->height();
+                childY += contentBoxHeight() - child->marginBottom() - child->borderBoxHeight();
                 break;
             default: // BoxAlignment::Start
                 childY += child->marginTop();
@@ -599,7 +599,7 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
 
             placeChild(child, LayoutPoint(xPos, childY), &childLayoutDelta);
 
-            xPos += child->width() + child->marginRight();
+            xPos += child->borderBoxWidth() + child->marginRight();
         }
         ASSERT(childIndex == childLayoutDeltas.size());
 
@@ -816,7 +816,7 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
     // out within the box.
     do {
         setHeight(borderTop() + paddingTop());
-        LayoutUnit minHeight = height() + toAdd;
+        LayoutUnit minHeight = borderBoxHeight() + toAdd;
 
         for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
             // Make sure we relayout children if we need it.
@@ -827,8 +827,8 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
                 child->containingBlock()->addOutOfFlowBox(*child);
                 CheckedPtr childLayer = child->layer();
                 childLayer->setStaticInlinePosition(borderAndPaddingStart()); // FIXME: Not right for regions.
-                if (childLayer->staticBlockPosition() != height()) {
-                    childLayer->setStaticBlockPosition(height());
+                if (childLayer->staticBlockPosition() != borderBoxHeight()) {
+                    childLayer->setStaticBlockPosition(borderBoxHeight());
                     if (child->style().hasStaticBlockPosition(writingMode().isHorizontal()))
                         child->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
                 }
@@ -839,7 +839,7 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
             child->computeAndSetBlockDirectionMargins(*this);
 
             // Add in the child's marginTop to our height.
-            setHeight(height() + child->marginTop());
+            setHeight(borderBoxHeight() + child->marginTop());
 
             if (!haveLineClamp)
                 child->markForPaginationRelayoutIfNeeded();
@@ -854,43 +854,43 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
             switch (style().boxAlign()) {
             case BoxAlignment::Center:
             case BoxAlignment::Baseline: // Baseline just maps to center for vertical boxes
-                childX += child->marginLeft() + std::max<LayoutUnit>(0, (contentBoxWidth() - (child->width() + child->horizontalMarginExtent())) / 2);
+                childX += child->marginLeft() + std::max<LayoutUnit>(0, (contentBoxWidth() - (child->borderBoxWidth() + child->horizontalMarginExtent())) / 2);
                 break;
             case BoxAlignment::End:
                 if (!style().writingMode().deprecatedIsLeftToRightDirection())
                     childX += child->marginLeft();
                 else
-                    childX += contentBoxWidth() - child->marginRight() - child->width();
+                    childX += contentBoxWidth() - child->marginRight() - child->borderBoxWidth();
                 break;
             default: // BoxAlignment::Start/BoxAlignment::Stretch
                 if (style().writingMode().deprecatedIsLeftToRightDirection())
                     childX += child->marginLeft();
                 else
-                    childX += contentBoxWidth() - child->marginRight() - child->width();
+                    childX += contentBoxWidth() - child->marginRight() - child->borderBoxWidth();
                 break;
             }
 
             // Place the child.
-            placeChild(child, LayoutPoint(childX, height()));
-            setHeight(height() + child->height() + child->marginBottom());
+            placeChild(child, LayoutPoint(childX, borderBoxHeight()));
+            setHeight(borderBoxHeight() + child->borderBoxHeight() + child->marginBottom());
         }
 
-        yPos = height();
+        yPos = borderBoxHeight();
 
         if (!iterator.first() && hasLineIfEmpty())
-            setHeight(height() + lineHeight());
+            setHeight(borderBoxHeight() + lineHeight());
 
-        setHeight(height() + toAdd);
+        setHeight(borderBoxHeight() + toAdd);
 
         // Negative margins can cause our height to shrink below our minimal height (border/padding).
         // If this happens, ensure that the computed height is increased to the minimal height.
-        if (height() < minHeight)
+        if (borderBoxHeight() < minHeight)
             setHeight(minHeight);
 
         // Now we have to calc our height, so we know how much space we have remaining.
-        oldHeight = height();
+        oldHeight = borderBoxHeight();
         updateLogicalHeight();
-        if (oldHeight != height())
+        if (oldHeight != borderBoxHeight())
             heightSpecified = true;
 
         remainingSpace = borderTop() + paddingTop() + contentBoxHeight() - yPos;
@@ -1039,11 +1039,11 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
             ASSERT_NOT_REACHED();
             return contentBoxLocation().y();
         };
-        auto usedHeight = height();
+        auto usedHeight = borderBoxHeight();
         auto clampedHeight = contentOffset() + clampedContent.contentHeight + borderBottom() + paddingBottom();
         setHeight(clampedHeight);
         updateLogicalHeight();
-        if (clampedHeight != height())
+        if (clampedHeight != borderBoxHeight())
             setHeight(heightSpecified ? oldHeight : usedHeight);
     } else if (heightSpecified)
         setHeight(oldHeight);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1613,7 +1613,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto* renderBox = dynamicDowncast<RenderBox>(*this);
                 if (!renderBox)
                     return { };
-                auto borderBoxWidth = renderBox->width();
+                auto borderBoxWidth = renderBox->borderBoxWidth();
                 return std::max({
                     renderBox->borderRight(),
                     Style::evaluate<LayoutUnit>(style.borderTopRightRadius().width(), borderBoxWidth, zoom),
@@ -1657,7 +1657,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
                 auto* renderBox = dynamicDowncast<RenderBox>(*this);
                 if (!renderBox)
                     return { };
-                auto borderBoxHeight = renderBox->height();
+                auto borderBoxHeight = renderBox->borderBoxHeight();
                 return std::max({
                     renderBox->borderBottom(),
                     Style::evaluate<LayoutUnit>(style.borderBottomLeftRadius().height(), borderBoxHeight, zoom),

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -143,8 +143,7 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
     // Push a clip.
     GraphicsContextStateSaver stateSaver(paintInfo.context(), false);
     if (paintInfo.phase == PaintPhase::Foreground || paintInfo.phase == PaintPhase::ChildBlockBackgrounds) {
-        IntRect clipRect = enclosingIntRect(LayoutRect(paintOffset.x() + borderLeft(), paintOffset.y() + borderTop(),
-                         width() - borderLeft() - borderRight(), height() - borderBottom() - borderTop() + buttonShadowHeight));
+        auto clipRect = enclosingIntRect(LayoutRect(paintOffset.x() + borderLeft(), paintOffset.y() + borderTop(), borderBoxWidth() - borderLeft() - borderRight(), borderBoxHeight() - borderBottom() - borderTop() + buttonShadowHeight));
         if (clipRect.isEmpty())
             return;
         stateSaver.save();

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -714,7 +714,7 @@ Style::FlexBasis RenderFlexibleBox::flexBasisForFlexItem(const RenderBox& flexIt
 
 LayoutUnit RenderFlexibleBox::crossAxisExtentForFlexItem(const RenderBox& flexItem) const
 {
-    return isHorizontalFlow() ? flexItem.height() : flexItem.width();
+    return isHorizontalFlow() ? flexItem.borderBoxHeight() : flexItem.borderBoxWidth();
 }
 
 LayoutUnit RenderFlexibleBox::flexItemContentLogicalHeight(const RenderBox& flexItem) const
@@ -1589,7 +1589,7 @@ void RenderFlexibleBox::performFlexLayout(RelayoutChildren relayoutChildren)
     if (allItems.isEmpty()) {
         if (hasLineIfEmpty()) {
             auto minHeight = borderAndPaddingLogicalHeight() + lineHeight() + scrollbarLogicalHeight();
-            if (height() < minHeight)
+            if (borderBoxHeight() < minHeight)
                 setLogicalHeight(minHeight);
         }
         updateLogicalHeight();

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -781,7 +781,7 @@ LayoutUnit RenderFragmentedFlow::offsetFromLogicalTopOfFirstFragment(const Rende
     // Use container() rather than containingBlock() since containingBlock()
     // skips non-RenderBlock ancestors like RenderTableSection.
     CheckedPtr<const RenderBox> currentBox = currentBlock;
-    LayoutRect blockRect(0_lu, 0_lu, currentBox->width(), currentBox->height());
+    LayoutRect blockRect(0_lu, 0_lu, currentBox->borderBoxWidth(), currentBox->borderBoxHeight());
     auto nextBoxContainer = [](const RenderElement& renderer) -> const RenderElement* {
         auto* container = renderer.container();
         // Skip non-box ancestors like RenderInline that don't contribute offsets.
@@ -800,9 +800,9 @@ LayoutUnit RenderFragmentedFlow::offsetFromLogicalTopOfFirstFragment(const Rende
             // and we have to take into account both the container and current block flipping modes
             if (containerBox->writingMode().isBlockFlipped()) {
                 if (containerBox->isHorizontalWritingMode())
-                    blockRect.setY(currentBox->height() - blockRect.maxY());
+                    blockRect.setY(currentBox->borderBoxHeight() - blockRect.maxY());
                 else
-                    blockRect.setX(currentBox->width() - blockRect.maxX());
+                    blockRect.setX(currentBox->borderBoxWidth() - blockRect.maxX());
             }
             currentBox->flipForWritingMode(blockRect);
         }

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -84,8 +84,8 @@ void RenderFrameSet::paintColumnBorder(const PaintInfo& paintInfo, const IntRect
     // Now stroke the edges but only if we have enough room to paint both edges with a little
     // bit of the fill color showing through.
     if (borderRect.width() >= 3) {
-        context.fillRect(IntRect(borderRect.location(), IntSize(1, height())), borderStartEdgeColor);
-        context.fillRect(IntRect(IntPoint(borderRect.maxX() - 1, borderRect.y()), IntSize(1, height())), borderEndEdgeColor);
+        context.fillRect(IntRect(borderRect.location(), IntSize(1, borderBoxHeight())), borderStartEdgeColor);
+        context.fillRect(IntRect(IntPoint(borderRect.maxX() - 1, borderRect.y()), IntSize(1, borderBoxHeight())), borderEndEdgeColor);
     }
 }
 
@@ -103,8 +103,8 @@ void RenderFrameSet::paintRowBorder(const PaintInfo& paintInfo, const IntRect& b
     // Now stroke the edges but only if we have enough room to paint both edges with a little
     // bit of the fill color showing through.
     if (borderRect.height() >= 3) {
-        context.fillRect(IntRect(borderRect.location(), IntSize(width(), 1)), borderStartEdgeColor);
-        context.fillRect(IntRect(IntPoint(borderRect.x(), borderRect.maxY() - 1), IntSize(width(), 1)), borderEndEdgeColor);
+        context.fillRect(IntRect(borderRect.location(), IntSize(borderBoxWidth(), 1)), borderStartEdgeColor);
+        context.fillRect(IntRect(IntPoint(borderRect.x(), borderRect.maxY() - 1), IntSize(borderBoxWidth(), 1)), borderEndEdgeColor);
     }
 }
 
@@ -130,7 +130,7 @@ void RenderFrameSet::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
             downcast<RenderElement>(*child).paint(paintInfo, adjustedPaintOffset);
             xPos += m_cols.m_sizes[c];
             if (borderThickness && m_cols.m_allowBorder[c + 1]) {
-                paintColumnBorder(paintInfo, snappedIntRect(LayoutRect(adjustedPaintOffset.x() + xPos, adjustedPaintOffset.y() + yPos, borderThickness, height())));
+                paintColumnBorder(paintInfo, snappedIntRect(LayoutRect(adjustedPaintOffset.x() + xPos, adjustedPaintOffset.y() + yPos, borderThickness, borderBoxHeight())));
                 xPos += borderThickness;
             }
             child = child->nextSibling();
@@ -139,7 +139,7 @@ void RenderFrameSet::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         }
         yPos += m_rows.m_sizes[r];
         if (borderThickness && m_rows.m_allowBorder[r + 1]) {
-            paintRowBorder(paintInfo, snappedIntRect(LayoutRect(adjustedPaintOffset.x(), adjustedPaintOffset.y() + yPos, width(), borderThickness)));
+            paintRowBorder(paintInfo, snappedIntRect(LayoutRect(adjustedPaintOffset.x(), adjustedPaintOffset.y() + yPos, borderBoxWidth(), borderThickness)));
             yPos += borderThickness;
         }
     }
@@ -453,8 +453,8 @@ void RenderFrameSet::layout()
     }
 
     LayoutUnit borderThickness = frameSetElement().border();
-    layOutAxis(m_rows, frameSetElement().rowDimensions(), height() - (rows - 1) * borderThickness);
-    layOutAxis(m_cols, frameSetElement().colDimensions(), width() - (cols - 1) * borderThickness);
+    layOutAxis(m_rows, frameSetElement().rowDimensions(), borderBoxHeight() - (rows - 1) * borderThickness);
+    layOutAxis(m_cols, frameSetElement().colDimensions(), borderBoxWidth() - (cols - 1) * borderThickness);
 
     positionFrames();
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2240,7 +2240,7 @@ LayoutRange RenderGrid::gridAreaRangeForOutOfFlow(const RenderBox& gridItem, Sty
         defaultRange = isRowAxis == writingMode().isHorizontal()
             ? scrollablePaddingAreaOverflowRect().xRange() : scrollablePaddingAreaOverflowRect().yRange();
         if (writingMode().isInlineFlipped() && isRowAxis)
-            defaultRange.moveTo(width() - defaultRange.max());
+            defaultRange.moveTo(borderBoxWidth() - defaultRange.max());
     }
 
     if (currentGrid().needsItemsPlacement()) {

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -112,16 +112,16 @@ void RenderImage::collectSelectionGeometries(Vector<SelectionGeometry>& geometri
     auto run = InlineIterator::boxFor(*this);
     if (!run) {
         // This is a block image.
-        imageRect = IntRect(0, 0, width(), height());
+        imageRect = IntRect(0, 0, borderBoxWidth(), borderBoxHeight());
         isFirstOnLine = true;
         isLastOnLine = true;
         lineExtentRect = imageRect;
         if (containingBlock->isHorizontalWritingMode()) {
             lineExtentRect.setX(containingBlock->x());
-            lineExtentRect.setWidth(containingBlock->width());
+            lineExtentRect.setWidth(containingBlock->borderBoxWidth());
         } else {
             lineExtentRect.setY(containingBlock->y());
-            lineExtentRect.setHeight(containingBlock->height());
+            lineExtentRect.setHeight(containingBlock->borderBoxHeight());
         }
     } else {
         auto selectionLogicalRect = LineSelection::logicalRect(*run->lineBox());

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2988,8 +2988,8 @@ LayoutSize RenderLayer::minimumSizeForResizing(float zoomFactor) const
     // Use the resizer size as the strict minimum size
     auto resizerRect = overflowControlsRects().resizer;
     auto& rendererStyle = renderer().style();
-    auto minWidth = Style::evaluateMinimum<LayoutUnit>(rendererStyle.minWidth(), renderer().containingBlock()->width(), rendererStyle.usedZoomForLength());
-    auto minHeight = Style::evaluateMinimum<LayoutUnit>(rendererStyle.minHeight(), renderer().containingBlock()->height(), rendererStyle.usedZoomForLength());
+    auto minWidth = Style::evaluateMinimum<LayoutUnit>(rendererStyle.minWidth(), renderer().containingBlock()->borderBoxWidth(), rendererStyle.usedZoomForLength());
+    auto minHeight = Style::evaluateMinimum<LayoutUnit>(rendererStyle.minHeight(), renderer().containingBlock()->borderBoxHeight(), rendererStyle.usedZoomForLength());
     minWidth = std::max(LayoutUnit(minWidth / zoomFactor), LayoutUnit(resizerRect.width()));
     minHeight = std::max(LayoutUnit(minHeight / zoomFactor), LayoutUnit(resizerRect.height()));
     return LayoutSize(minWidth, minHeight);
@@ -3023,7 +3023,7 @@ void RenderLayer::resize(const PlatformMouseEvent& evt, const LayoutSize& oldOff
     newOffset.setWidth(newOffset.width() / zoomFactor);
     newOffset.setHeight(newOffset.height() / zoomFactor);
 
-    LayoutSize currentSize = LayoutSize(renderer->width() / zoomFactor, renderer->height() / zoomFactor);
+    LayoutSize currentSize = LayoutSize(renderer->borderBoxWidth() / zoomFactor, renderer->borderBoxHeight() / zoomFactor);
 
     LayoutSize adjustedOldOffset = LayoutSize(oldOffset.width() / zoomFactor, oldOffset.height() / zoomFactor);
     if (renderer->shouldPlaceVerticalScrollbarOnLeft()) {
@@ -3045,7 +3045,7 @@ void RenderLayer::resize(const PlatformMouseEvent& evt, const LayoutSize& oldOff
             styledElement->setInlineStyleProperty(CSSPropertyMarginLeft, renderer->marginLeft() / zoomFactor, CSSUnitType::CSS_PX);
             styledElement->setInlineStyleProperty(CSSPropertyMarginRight, renderer->marginRight() / zoomFactor, CSSUnitType::CSS_PX);
         }
-        LayoutUnit baseWidth = renderer->width() - (isBoxSizingBorder ? 0_lu : renderer->horizontalBorderAndPaddingExtent());
+        LayoutUnit baseWidth = renderer->borderBoxWidth() - (isBoxSizingBorder ? 0_lu : renderer->horizontalBorderAndPaddingExtent());
         baseWidth = baseWidth / zoomFactor;
         styledElement->setInlineStyleProperty(CSSPropertyWidth, roundToInt(baseWidth + difference.width()), CSSUnitType::CSS_PX);
 
@@ -3060,7 +3060,7 @@ void RenderLayer::resize(const PlatformMouseEvent& evt, const LayoutSize& oldOff
             styledElement->setInlineStyleProperty(CSSPropertyMarginTop, renderer->marginTop() / zoomFactor, CSSUnitType::CSS_PX);
             styledElement->setInlineStyleProperty(CSSPropertyMarginBottom, renderer->marginBottom() / zoomFactor, CSSUnitType::CSS_PX);
         }
-        LayoutUnit baseHeight = renderer->height() - (isBoxSizingBorder ? 0_lu : renderer->verticalBorderAndPaddingExtent());
+        LayoutUnit baseHeight = renderer->borderBoxHeight() - (isBoxSizingBorder ? 0_lu : renderer->verticalBorderAndPaddingExtent());
         baseHeight = baseHeight / zoomFactor;
         styledElement->setInlineStyleProperty(CSSPropertyHeight, roundToInt(baseHeight + difference.height()), CSSUnitType::CSS_PX);
 

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -593,16 +593,16 @@ int RenderListBox::listIndexAtOffset(const LayoutSize& offset) const
     if (RefPtr hBar = horizontalScrollbar())
         scrollbarHeight = hBar->height();
 
-    if (offset.height() < borderTop() || offset.height() > height() - borderBottom() - scrollbarHeight)
+    if (offset.height() < borderTop() || offset.height() > borderBoxHeight() - borderBottom() - scrollbarHeight)
         return -1;
 
     int scrollbarWidth = 0;
     if (RefPtr vBar = verticalScrollbar())
         scrollbarWidth = vBar->width();
 
-    if (shouldPlaceVerticalScrollbarOnLeft() && (offset.width() < borderLeft() + paddingLeft() + scrollbarWidth || offset.width() > width() - borderRight() - paddingRight()))
+    if (shouldPlaceVerticalScrollbarOnLeft() && (offset.width() < borderLeft() + paddingLeft() + scrollbarWidth || offset.width() > borderBoxWidth() - borderRight() - paddingRight()))
         return -1;
-    if (!shouldPlaceVerticalScrollbarOnLeft() && (offset.width() < borderLeft() + paddingLeft() || offset.width() > width() - borderRight() - paddingRight() - scrollbarWidth))
+    if (!shouldPlaceVerticalScrollbarOnLeft() && (offset.width() < borderLeft() + paddingLeft() || offset.width() > borderBoxWidth() - borderRight() - paddingRight() - scrollbarWidth))
         return -1;
 
     auto offsetLogicalHeight = writingMode().isHorizontal() ? offset.height() : offset.width();
@@ -1027,14 +1027,14 @@ LayoutRect RenderListBox::rectForScrollbar(const Scrollbar& scrollbar) const
     LayoutUnit left, top, width, height;
 
     if (scrollbar.orientation() == ScrollbarOrientation::Vertical) {
-        left = shouldPlaceVerticalScrollbarOnLeft() ? borderLeft() : this->width() - borderRight() - scrollbar.width();
+        left = shouldPlaceVerticalScrollbarOnLeft() ? borderLeft() : this->borderBoxWidth() - borderRight() - scrollbar.width();
         top = borderTop();
         width = scrollbar.width();
-        height = this->height() - verticalBorderExtent();
+        height = this->borderBoxHeight() - verticalBorderExtent();
     } else {
         left = borderLeft();
-        top = this->height() - borderBottom() - scrollbar.height();
-        width = this->width() - horizontalBorderExtent();
+        top = this->borderBoxHeight() - borderBottom() - scrollbar.height();
+        width = this->borderBoxWidth() - horizontalBorderExtent();
         height = scrollbar.height();
     }
 

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -147,7 +147,7 @@ private:
     Scrollbar* NODELETE verticalScrollbar() const final;
     Scrollbar* NODELETE horizontalScrollbar() const final;
     IntSize contentsSize() const final;
-    IntSize visibleSize() const final { return IntSize(width(), height()); }
+    IntSize visibleSize() const final { return IntSize(borderBoxWidth(), borderBoxHeight()); }
     IntPoint lastKnownMousePositionInView() const final;
     bool isHandlingWheelEvent() const final;
     bool shouldSuspendScrollAnimations() const final;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -341,7 +341,7 @@ void RenderListMarker::layout()
         RefPtr image = m_image;
         setWidth(image->imageSize(this, style().usedZoom()).width());
         setHeight(image->imageSize(this, style().usedZoom()).height());
-        m_layoutBounds = { height(), 0 };
+        m_layoutBounds = { borderBoxHeight(), 0 };
     } else {
         setLogicalWidth(minContentLogicalWidthContribution());
         setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
@@ -364,7 +364,7 @@ void RenderListMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
     if (parent()) {
         RefPtr image = m_image;
         if (image && o == image->data()) {
-            if (width() != image->imageSize(this, style().usedZoom()).width() || height() != image->imageSize(this, style().usedZoom()).height() || image->errorOccurred())
+            if (borderBoxWidth() != image->imageSize(this, style().usedZoom()).width() || borderBoxHeight() != image->imageSize(this, style().usedZoom()).height() || image->errorOccurred())
                 setNeedsLayoutAndInvalidateContentLogicalWidths();
             else
                 repaint();
@@ -567,7 +567,7 @@ FloatRect RenderListMarker::relativeMarkerRect()
 
     if (!writingMode().isHorizontal()) {
         relativeRect = relativeRect.transposedRect();
-        relativeRect.setX(width() - relativeRect.x() - relativeRect.width());
+        relativeRect.setX(borderBoxWidth() - relativeRect.x() - relativeRect.width());
     }
 
     return relativeRect;

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -146,7 +146,7 @@ int RenderMarquee::computePosition(MarqueeDirection dir, bool stopAtContentEdge)
         if (ltr)
             contentWidth += (box->paddingRight() - box->borderLeft());
         else {
-            contentWidth = box->width() - contentWidth;
+            contentWidth = box->borderBoxWidth() - contentWidth;
             contentWidth += (box->paddingLeft() - box->borderRight());
         }
         if (dir == MarqueeDirection::Right) {

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -688,9 +688,9 @@ void RenderMultiColumnSet::paintColumnRules(PaintInfo& paintInfo, const LayoutPo
 
         if (!topToBottom) {
             if (isHorizontalWritingMode())
-                ruleRect.setY(height() - ruleRect.maxY());
+                ruleRect.setY(borderBoxHeight() - ruleRect.maxY());
             else
-                ruleRect.setX(width() - ruleRect.maxX());
+                ruleRect.setX(borderBoxWidth() - ruleRect.maxX());
         }
 
         ruleRect.moveBy(paintOffset);

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -62,7 +62,7 @@ void RenderReplica::layout()
 
 void RenderReplica::computeIntrinsicLogicalWidthContributions()
 {
-    m_minContentLogicalWidthContribution = parentBox()->width();
+    m_minContentLogicalWidthContribution = parentBox()->borderBoxWidth();
     m_maxContentLogicalWidthContribution = m_minContentLogicalWidthContribution;
     clearContentLogicalWidthsInvalidation();
 }

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -64,8 +64,8 @@ RenderScrollbar::RenderScrollbar(ScrollableArea& scrollableArea, ScrollbarOrient
     updateScrollbarPart(ScrollbarBGPart);
     if (CheckedPtr part = m_parts.get(ScrollbarBGPart)) {
         part->layout();
-        width = part->width();
-        height = part->height();
+        width = part->borderBoxWidth();
+        height = part->borderBoxHeight();
     } else if (this->orientation() == ScrollbarOrientation::Horizontal)
         width = this->width();
     else
@@ -190,7 +190,7 @@ void RenderScrollbar::updateScrollbarParts()
     int newThickness = 0;
     if (CheckedPtr part = m_parts.get(ScrollbarBGPart)) {
         part->layout();
-        newThickness = isHorizontal ? part->height() : part->width();
+        newThickness = isHorizontal ? part->borderBoxHeight() : part->borderBoxWidth();
     }
 
     if (newThickness != oldThickness) {
@@ -358,7 +358,7 @@ int RenderScrollbar::minimumThumbLength() const
     if (!partRenderer)
         return 0;    
     partRenderer->layout();
-    return orientation() == ScrollbarOrientation::Horizontal ? partRenderer->width() : partRenderer->height();
+    return orientation() == ScrollbarOrientation::Horizontal ? partRenderer->borderBoxWidth() : partRenderer->borderBoxHeight();
 }
 
 float RenderScrollbar::opacity() const

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -217,7 +217,7 @@ int RenderSearchField::clientInsetLeft() const
 {
     // Inset the menu by the radius of the cap on the left so that
     // it only runs along the straight part of the bezel.
-    return height() / 2;
+    return borderBoxHeight() / 2;
 }
 
 int RenderSearchField::clientInsetRight() const
@@ -225,7 +225,7 @@ int RenderSearchField::clientInsetRight() const
     // Inset the menu by the radius of the cap on the right so that
     // it only runs along the straight part of the bezel (unless it needs
     // to be wider).
-    return height() / 2;
+    return borderBoxHeight() / 2;
 }
 
 LayoutUnit RenderSearchField::clientPaddingLeft() const
@@ -244,7 +244,7 @@ LayoutUnit RenderSearchField::clientPaddingRight() const
     if (CheckedPtr containerBox = container ? container->renderBox() : nullptr) {
         RefPtr innerBlock = innerBlockElement();
         if (auto* innerBlockBox = innerBlock ? innerBlock->renderBox() : nullptr)
-            padding += containerBox->width() - (innerBlockBox->x() + innerBlockBox->width());
+            padding += containerBox->borderBoxWidth() - (innerBlockBox->x() + innerBlockBox->borderBoxWidth());
     }
     return padding;
 }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -769,9 +769,9 @@ void RenderTable::addOverflowFromInFlowChildren(OptionSet<ComputeOverflowOptions
     // Technically it's odd that we are incorporating the borders into layout overflow, which is only supposed to be about overflow from our
     // descendant objects, but since tables don't support overflow:auto, this works out fine.
     if (collapseBorders()) {
-        LayoutUnit rightBorderOverflow = width() + outerBorderRight() - borderRight();
+        LayoutUnit rightBorderOverflow = borderBoxWidth() + outerBorderRight() - borderRight();
         LayoutUnit leftBorderOverflow = borderLeft() - outerBorderLeft();
-        LayoutUnit bottomBorderOverflow = height() + outerBorderBottom() - borderBottom();
+        LayoutUnit bottomBorderOverflow = borderBoxHeight() + outerBorderBottom() - borderBottom();
         LayoutUnit topBorderOverflow = borderTop() - outerBorderTop();
         LayoutRect borderOverflowRect(leftBorderOverflow, topBorderOverflow, rightBorderOverflow - leftBorderOverflow, bottomBorderOverflow - topBorderOverflow);
         if (borderOverflowRect != borderBoxRect()) {
@@ -1717,10 +1717,10 @@ LayoutRect RenderTable::overflowClipRect(const LayoutPoint& location, OverlayScr
     // we might have to hack this code first (depending on what order we do these bug fixes in).
     if (!m_captions.isEmpty()) {
         if (writingMode().isHorizontal()) {
-            rect.setHeight(height());
+            rect.setHeight(borderBoxHeight());
             rect.setY(location.y());
         } else {
-            rect.setWidth(width());
+            rect.setWidth(borderBoxWidth());
             rect.setX(location.x());
         }
     }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -567,7 +567,7 @@ auto RenderTableCell::localRectsForRepaint(RepaintOutlineBounds repaintOutlineBo
     }
 
     LayoutPoint location(std::max<LayoutUnit>(left, -visualOverflowRect().x()), std::max<LayoutUnit>(top, -visualOverflowRect().y()));
-    auto overflowRect = LayoutRect(-location.x(), -location.y(), location.x() + std::max(width() + right, visualOverflowRect().maxX()), location.y() + std::max(height() + bottom, visualOverflowRect().maxY()));
+    auto overflowRect = LayoutRect(-location.x(), -location.y(), location.x() + std::max(borderBoxWidth() + right, visualOverflowRect().maxX()), location.y() + std::max(borderBoxHeight() + bottom, visualOverflowRect().maxY()));
 
     // FIXME: layoutDelta needs to be applied in parts before/after transforms and
     // repaint containers. https://bugs.webkit.org/show_bug.cgi?id=23308
@@ -1557,7 +1557,7 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
         paintInfo.context().clip({ adjustedPaintOffset, borderBoxSize() });
     else if (shouldClip) {
         LayoutRect clipRect(adjustedPaintOffset.x() + borderLeft(), adjustedPaintOffset.y() + borderTop(),
-            width() - borderLeft() - borderRight(), height() - borderTop() - borderBottom());
+            borderBoxWidth() - borderLeft() - borderRight(), borderBoxHeight() - borderTop() - borderBottom());
         paintInfo.context().clip(clipRect);
     }
     LayoutRect fillRect;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1200,7 +1200,7 @@ LayoutUnit RenderTableSection::offsetLeftForRowGroupBorder(RenderTableCell* cell
 
     if (table()->writingMode().isHorizontal()) {
         if (table()->writingMode().isInlineLeftToRight())
-            return cell ? cell->x() + cell->width() : 0_lu;
+            return cell ? cell->x() + cell->borderBoxWidth() : 0_lu;
         return -outerBorderLeft(table()->writingMode());
     }
     bool isLastRow = row + 1 == m_grid.size();
@@ -1214,7 +1214,7 @@ LayoutUnit RenderTableSection::offsetTopForRowGroupBorder(RenderTableCell* cell,
     if (table()->writingMode().isHorizontal())
         return m_rowPos[row] + (!row && borderSide == BoxSide::Right ? -outerBorderTop(table()->writingMode()) : isLastRow && borderSide == BoxSide::Left ? outerBorderTop(table()->writingMode()) : 0_lu);
     if (table()->writingMode().isInlineTopToBottom())
-        return (cell ? cell->y() + cell->height() : 0_lu) + (borderSide == BoxSide::Left ? outerBorderTop(table()->writingMode()) : 0_lu);
+        return (cell ? cell->y() + cell->borderBoxHeight() : 0_lu) + (borderSide == BoxSide::Left ? outerBorderTop(table()->writingMode()) : 0_lu);
     return borderSide == BoxSide::Right ? -outerBorderTop(table()->writingMode()) : 0_lu;
 }
 
@@ -1225,16 +1225,16 @@ LayoutUnit RenderTableSection::verticalRowGroupBorderHeight(RenderTableCell* cel
     if (table()->writingMode().isHorizontal())
         return m_rowPos[row + 1] - m_rowPos[row] + (!row ? outerBorderTop(table()->writingMode()) : isLastRow ? outerBorderBottom(table()->writingMode()) : 0_lu);
     if (table()->writingMode().isInlineTopToBottom())
-        return rowGroupRect.height() - (cell ? cell->y() + cell->height() : 0_lu) + outerBorderBottom(table()->writingMode());
-    return cell ? rowGroupRect.height() - (cell->y() - cell->height()) : 0_lu;
+        return rowGroupRect.height() - (cell ? cell->y() + cell->borderBoxHeight() : 0_lu) + outerBorderBottom(table()->writingMode());
+    return cell ? rowGroupRect.height() - (cell->y() - cell->borderBoxHeight()) : 0_lu;
 }
 
 LayoutUnit RenderTableSection::horizontalRowGroupBorderWidth(RenderTableCell* cell, const LayoutRect& rowGroupRect, unsigned row, unsigned column)
 {
     if (table()->writingMode().isHorizontal()) {
         if (table()->writingMode().isInlineLeftToRight())
-            return rowGroupRect.width() - (cell ? cell->x() + cell->width() : 0_lu) + (!column ? outerBorderLeft(table()->writingMode()) : column == table()->numEffCols() ? outerBorderRight(table()->writingMode()) : 0_lu);
-        return cell ? rowGroupRect.width() - (cell->x() - cell->width()) : 0_lu;
+            return rowGroupRect.width() - (cell ? cell->x() + cell->borderBoxWidth() : 0_lu) + (!column ? outerBorderLeft(table()->writingMode()) : column == table()->numEffCols() ? outerBorderRight(table()->writingMode()) : 0_lu);
+        return cell ? rowGroupRect.width() - (cell->x() - cell->borderBoxWidth()) : 0_lu;
     }
     bool isLastRow = row + 1 == m_grid.size();
     return m_rowPos[row + 1] - m_rowPos[row] + (isLastRow ? outerBorderLeft(table()->writingMode()) : !row ? outerBorderRight(table()->writingMode()) : 0_lu);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1164,7 +1164,7 @@ Color RenderTheme::platformInactiveListBoxSelectionForegroundColor(OptionSet<Sty
 
 int RenderTheme::baselinePosition(const RenderBox& box) const
 {
-    return box.isHorizontalWritingMode() ? box.height() : LayoutUnit(box.width() / 2.0f);
+    return box.isHorizontalWritingMode() ? box.borderBoxHeight() : LayoutUnit(box.borderBoxWidth() / 2.0f);
 }
 
 bool RenderTheme::isControlContainer(StyleAppearance appearance) const

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -229,7 +229,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         // captured by the results.
         // FIXME: Cell positions are row-relative but we dump them as section-relative to avoid rebaselining every table test.
         auto rowOffset = cell->parent() ? downcast<RenderBox>(*cell->parent()).location() : LayoutPoint();
-        r = LayoutRect(cell->x() + rowOffset.x(), cell->y() + rowOffset.y() + cell->intrinsicPaddingBefore(), cell->width(), cell->height() - cell->intrinsicPaddingBefore() - cell->intrinsicPaddingAfter());
+        r = LayoutRect(cell->x() + rowOffset.x(), cell->y() + rowOffset.y() + cell->intrinsicPaddingBefore(), cell->borderBoxWidth(), cell->borderBoxHeight() - cell->intrinsicPaddingBefore() - cell->intrinsicPaddingAfter());
     } else if (auto* box = dynamicDowncast<RenderBox>(o))
         r = box->frameRect();
     else if (auto* svgModelObject = dynamicDowncast<RenderSVGModelObject>(o)) {
@@ -849,7 +849,7 @@ String externalRepresentation(LocalFrame* frame, OptionSet<RenderAsTextFlag> beh
 
     Ref printContext = PrintContext::create(frame);
     if (behavior.contains(RenderAsTextFlag::PrintingMode))
-        printContext->begin(renderer->width());
+        printContext->begin(renderer->borderBoxWidth());
 
     return externalRepresentation(*renderer, behavior);
 }

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -138,7 +138,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     // 6. Vertical Growing Left: Decrease position by the width of the
     // bounding box of the boxes in boxes, then increase position by step.
     if (cue->vertical() == VTTCue::DirectionSetting::VerticalGrowingLeft) {
-        position -= width();
+        position -= borderBoxWidth();
         position += step;
     }
 
@@ -146,7 +146,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     if (linePosition < 0) {
         // Horizontal / Vertical: ... then increase position by the
         // height / width of the video's rendering area ...
-        position += cue->vertical() == VTTCue::DirectionSetting::Horizontal ? containingBlock()->height() : containingBlock()->width();
+        position += cue->vertical() == VTTCue::DirectionSetting::Horizontal ? containingBlock()->borderBoxHeight() : containingBlock()->borderBoxWidth();
 
         // ... and negate step.
         step = -step;
@@ -235,7 +235,7 @@ bool RenderVTTCue::shouldSwitchDirection(const InlineIterator::InlineBox& firstI
     // or if step is positive and the bottom of the first line box in
     // boxes is now below the bottom of the video's rendering area, jump
     // to the step labeled switch direction.
-    LayoutUnit parentHeight = containingBlock()->height();
+    LayoutUnit parentHeight = containingBlock()->borderBoxHeight();
     if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal && ((step < 0 && top < 0) || (step > 0 && bottom > parentHeight)))
         return true;
 
@@ -244,7 +244,7 @@ bool RenderVTTCue::shouldSwitchDirection(const InlineIterator::InlineBox& firstI
     // rendering area, or if step is positive and the right edge of the
     // first line box in boxes is now to the right of the right edge of
     // the video's rendering area, jump to the step labeled switch direction.
-    LayoutUnit parentWidth = containingBlock()->width();
+    LayoutUnit parentWidth = containingBlock()->borderBoxWidth();
     if (m_cue->vertical() != VTTCue::DirectionSetting::Horizontal && ((step < 0 && left < 0) || (step > 0 && right > parentWidth)))
         return true;
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -185,7 +185,7 @@ void RenderView::layout()
     }
 
     // Use calcWidth/Height to get the new width/height, since this will take the full page zoom factor into account.
-    bool relayoutChildren = !shouldUsePrintingLayout() && (width() != viewWidth() || height() != viewHeight());
+    bool relayoutChildren = !shouldUsePrintingLayout() && (borderBoxWidth() != viewWidth() || borderBoxHeight() != viewHeight());
     if (relayoutChildren) {
         setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
 
@@ -442,7 +442,7 @@ void RenderView::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint&)
     if (RenderElement* rootRenderer = documentElement ? documentElement->renderer() : nullptr) {
         // The document element's renderer is currently forced to be a block, but may not always be.
         auto* rootBox = dynamicDowncast<RenderBox>(*rootRenderer);
-        rootFillsViewport = rootBox && !rootBox->x() && !rootBox->y() && rootBox->width() >= width() && rootBox->height() >= height();
+        rootFillsViewport = rootBox && !rootBox->x() && !rootBox->y() && rootBox->borderBoxWidth() >= borderBoxWidth() && rootBox->borderBoxHeight() >= borderBoxHeight();
         rootObscuresBackground = rendererObscuresBackground(*rootRenderer);
         shouldPropagateBackgroundPaintingToInitialContainingBlock = !!rendererForRootBackground();
     }

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1444,7 +1444,7 @@ LayoutRect RenderThemeCocoa::adjustedPaintRect(const RenderBox& box, const Layou
     if (box.style().usedAppearance() == StyleAppearance::Checkbox || box.style().usedAppearance() == StyleAppearance::Radio) {
         float width = std::min(paintRect.width(), paintRect.height());
         float height = width;
-        return enclosingLayoutRect(FloatRect(paintRect.x(), paintRect.y() + (box.height() - height) / 2, width, height)); // Vertically center the checkbox.
+        return enclosingLayoutRect(FloatRect(paintRect.x(), paintRect.y() + (box.borderBoxHeight() - height) / 2, width, height)); // Vertically center the checkbox.
     }
 #else
     UNUSED_PARAM(box);
@@ -1843,7 +1843,7 @@ static RoundedShape shapeForButton(const RenderElement& box, const FloatRect& re
         // at different positions don't fall on different sides of the
         // threshold due to device pixel snapping.
         if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(box)) {
-            const auto sizeRatio = (renderBox->width() / renderBox->height()).toFloat();
+            const auto sizeRatio = (renderBox->borderBoxWidth() / renderBox->borderBoxHeight()).toFloat();
             const auto limitingRatio = 1.5f;
             if (limitingRatio > sizeRatio && sizeRatio > 1 / limitingRatio)
                 controlRadius = radiusForLargeButton;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -432,7 +432,7 @@ void RenderThemeIOS::adjustRoundBorderRadius(Style::ComputedStyle& style, Render
     auto boxLogicalHeight = box.logicalHeight();
     auto unzoomedBoxLogicalHeight = box.logicalHeight() / usedZoom.value;
 
-    auto minDimension = std::min(box.width(), box.height());
+    auto minDimension = std::min(box.borderBoxWidth(), box.borderBoxHeight());
     auto unzoomedMinDimension = minDimension / usedZoom.value;
 
     if ((isAnyOf<RenderButton, RenderMenuList>(box)) && boxLogicalHeight >= largeButtonSize) {

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -172,21 +172,21 @@ void RenderMathMLBlock::layoutItems(RelayoutChildren relayoutChildren)
 
         LayoutUnit childPreferredSize = childSize + child->horizontalBorderAndPaddingExtent();
 
-        if (childPreferredSize != child->width())
+        if (childPreferredSize != child->borderBoxWidth())
             child->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
 
         updateBlockChildDirtyBitsBeforeLayout(relayoutChildren, *child);
         child->layoutIfNeeded();
 
         LayoutUnit childVerticalMarginBoxExtent;
-        childVerticalMarginBoxExtent = child->height() + child->verticalMarginExtent();
+        childVerticalMarginBoxExtent = child->borderBoxHeight() + child->verticalMarginExtent();
 
         setLogicalHeight(std::max(logicalHeight(), verticalOffset + borderAndPaddingAfter() + childVerticalMarginBoxExtent + horizontalScrollbarHeight()));
 
         horizontalOffset += child->marginStart();
 
-        LayoutUnit childHorizontalExtent = child->width();
-        LayoutPoint childLocation(writingMode().isBidiLTR() ? horizontalOffset : width() - horizontalOffset - childHorizontalExtent,
+        LayoutUnit childHorizontalExtent = child->borderBoxWidth();
+        LayoutPoint childLocation(writingMode().isBidiLTR() ? horizontalOffset : borderBoxWidth() - horizontalOffset - childHorizontalExtent,
             verticalOffset + child->marginBefore());
 
         child->setLocation(childLocation);

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -247,7 +247,7 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
     auto zoom = style.usedZoomForLength();
 
     auto boxSize = computeLogicalBoxSize(renderer, isHorizontalWritingMode);
-    auto borderBoxLogicalWidth = isHorizontalWritingMode ? renderer.width() : renderer.height();
+    auto borderBoxLogicalWidth = isHorizontalWritingMode ? renderer.borderBoxWidth() : renderer.borderBoxHeight();
 
     auto logicalMargin = [&] {
         auto shapeMargin = Style::evaluate<LayoutUnit>(style.shapeMargin(), containingBlock.contentBoxLogicalWidth(), zoom).toFloat();

--- a/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
@@ -140,9 +140,9 @@
     auto* renderer = core(self)->renderBox();
     if (renderer) {
         if (w)
-            *w = renderer->width();
+            *w = renderer->borderBoxWidth();
         if (h)
-            *h = renderer->width();
+            *h = renderer->borderBoxWidth();
         if (x && y) {
             WebCore::FloatPoint floatPoint(*x, *y);
             renderer->localToAbsolute(floatPoint);

--- a/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
@@ -270,7 +270,7 @@ static WebCore::Node* firstNodeAfter(const WebCore::BoundaryPoint& point)
             BOOL noCost = NO;
             if (auto renderBox = dynamicDowncast<RenderBox>(*renderer)) {
                 auto* parentRenderBox = dynamicDowncast<RenderBox>(renderBox->parent());
-                if (parentRenderBox && renderBox->width() == parentRenderBox->width())
+                if (parentRenderBox && renderBox->borderBoxWidth() == parentRenderBox->borderBoxWidth())
                     noCost = YES;
             }
             result = (noCost ? 0 : 1);

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1304,7 +1304,7 @@ static WebFrameLoadType NODELETE toWebFrameLoadType(WebCore::FrameLoadType frame
     if (!n)
         return CGSizeMake(0, 0);
     if (auto* renderBox = dynamicDowncast<WebCore::RenderBox>(n->renderer()))
-        return CGSizeMake(std::min((float)renderBox->maxContentLogicalWidthContribution(), width), renderBox->height());
+        return CGSizeMake(std::min((float)renderBox->maxContentLogicalWidthContribution(), width), renderBox->borderBoxHeight());
     return CGSizeMake(0, 0);
 }
 


### PR DESCRIPTION
#### b394fb2309d4f50f9324285c064f43c0ea36bf9d
<pre>
[cleanup] Rename RenderBox::width()/height() to borderBoxWidth()/borderBoxHeight()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318037">https://bugs.webkit.org/show_bug.cgi?id=318037</a>
&lt;<a href="https://rdar.apple.com/problem/180943529">rdar://problem/180943529</a>&gt;

Reviewed by Antti Koivisto.

RenderBox::width()/height() return the border box width/height, but the bare
names don&apos;t say so. They were the unqualified odd ones out next to
contentBoxWidth()/paddingBoxWidth()/clientWidth(), and now next to
borderBoxSize(). Name them for what they are.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateMainArticleElementAfterLayout):
* Source/WebCore/dom/Position.cpp:
(WebCore::endsOfNodeAreVisuallyDistinctPositions):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::addBlockPlaceholderIfNeeded):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::shouldEmitExtraNewlineForNode):
(WebCore::TextIterator::shouldRepresentNodeOffsetZero):
* Source/WebCore/html/HTMLTableColElement.cpp:
(WebCore::HTMLTableColElement::attributeChanged):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setSelectionRange):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::layout):
(WebCore::SliderThumbElement::setPositionFromPoint):
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::defaultEventHandler):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::baselineForBox):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::firstInlineBoxRect const):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::buildLayoutTree):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::preferredHeight const):
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::AttachmentLayout):
* Source/WebCore/rendering/BaselineAlignment.cpp:
(WebCore::BaselineAlignmentState::synthesizedBaseline):
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForBox):
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::masonryAxisMarginBoxForItem):
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::locationIncludingFlipping const):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::collectFocusRingRectsForBlock):
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::captureGridArea):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintChild):
(WebCore::clipOutOutOfFlowBoxes):
(WebCore::RenderBlock::selectionGaps):
(WebCore::isChildHitTestCandidate):
(WebCore::RenderBlock::adjustBorderBoxRectForPainting):
(WebCore::RenderBlock::paintRectToClipOutFromBorder):
* Source/WebCore/rendering/RenderBlock.h:
(WebCore::RenderBlock::logicalWidthForChild const):
(WebCore::RenderBlock::logicalHeightForChild const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlockChild):
(WebCore::RenderBlockFlow::clipOutFloatingBoxes):
(WebCore::RenderBlockFlow::clearFloats):
(WebCore::RenderBlockFlow::flipFloatForWritingModeForChild const):
(WebCore::RenderBlockFlow::findClosestTextAtAbsolutePoint):
(WebCore::RenderBlockFlow::adjustComputedFontSizes):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::absoluteQuads const):
(WebCore::RenderBox::paddingBoxRect const):
(WebCore::isCandidateForOpaquenessTest):
(WebCore::RenderBox::foregroundIsKnownToBeOpaqueInRect const):
(WebCore::RenderBox::repaintLayerRectsForImage):
(WebCore::RenderBox::clipRect const):
(WebCore::RenderBox::containingBlockRangeForPositioned const):
(WebCore::RenderBox::convertRectToParentWritingMode const):
(WebCore::RenderBox::flipForWritingModeForChild const):
(WebCore::RenderBox::flipForWritingMode const):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::borderBoxWidth const):
(WebCore::RenderBox::borderBoxHeight const):
(WebCore::RenderBox::tryLayoutDoingOutOfFlowMovementOnly):
(WebCore::RenderBox::width const): Deleted.
(WebCore::RenderBox::height const): Deleted.
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::marginBoxLogicalHeight const):
(WebCore::RenderBox::logicalHeight const):
(WebCore::RenderBox::logicalWidth const):
(WebCore::RenderBox::paddingBoxHeight const):
(WebCore::RenderBox::paddingBoxWidth const):
(WebCore::RenderBox::paddingBoxRectIncludingScrollbar const):
(WebCore::RenderBox::contentBoxRect const):
* Source/WebCore/rendering/RenderButton.cpp:
(WebCore::RenderButton::controlClipRect const):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::RenderDeprecatedFlexibleBox::layoutBlock):
(WebCore::RenderDeprecatedFlexibleBox::layoutHorizontalBox):
(WebCore::RenderDeprecatedFlexibleBox::layoutVerticalBox):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::paintControl):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::crossAxisExtentForFlexItem const):
(WebCore::RenderFlexibleBox::performFlexLayout):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::offsetFromLogicalTopOfFirstFragment const):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::paintColumnBorder):
(WebCore::RenderFrameSet::paintRowBorder):
(WebCore::RenderFrameSet::paint):
(WebCore::RenderFrameSet::layout):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaRangeForOutOfFlow const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::collectSelectionGeometries):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::minimumSizeForResizing const):
(WebCore::RenderLayer::resize):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::listIndexAtOffset const):
(WebCore::RenderListBox::rectForScrollbar const):
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::layout):
(WebCore::RenderListMarker::imageChanged):
(WebCore::RenderListMarker::relativeMarkerRect):
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::computePosition):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::paintColumnRules):
* Source/WebCore/rendering/RenderReplica.cpp:
(WebCore::RenderReplica::computeIntrinsicLogicalWidthContributions):
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::RenderScrollbar::RenderScrollbar):
(WebCore::RenderScrollbar::updateScrollbarParts):
(WebCore::RenderScrollbar::minimumThumbLength const):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::clientInsetLeft const):
(WebCore::RenderSearchField::clientInsetRight const):
(WebCore::RenderSearchField::clientPaddingRight const):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::addOverflowFromInFlowChildren):
(WebCore::RenderTable::overflowClipRect const):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::localRectsForRepaint const):
(WebCore::RenderTableCell::paintBackgroundsBehindCell):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::offsetLeftForRowGroupBorder):
(WebCore::RenderTableSection::offsetTopForRowGroupBorder):
(WebCore::RenderTableSection::verticalRowGroupBorderHeight):
(WebCore::RenderTableSection::horizontalRowGroupBorderWidth):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::baselinePosition const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::externalRepresentation):
* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::initializeLayoutParameters):
(WebCore::RenderVTTCue::shouldSwitchDirection const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::layout):
(WebCore::RenderView::paintBoxDecorations):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::adjustedPaintRect const):
(WebCore::shapeForButton):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustRoundBorderRadius):
* Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp:
(WebCore::RenderMathMLBlock::layoutItems):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::makeShapeForShapeOutside):
* Source/WebKitLegacy/mac/DOM/DOMHTML.mm:
(-[DOMHTMLElement absolutePosition::::]):
* Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm:
(-[DOMHTMLElement structuralComplexityContribution]):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame renderedSizeOfNode:constrainedToWidth:]):

Canonical link: <a href="https://commits.webkit.org/316085@main">https://commits.webkit.org/316085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c8181cc93c6f28bb842f52e2e8d2f2915f8041d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128513 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1cd6cbf0-e65d-4b1b-981b-6cf7122d257b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133227 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5c48257-12ea-47c3-9239-37dcdef83a8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153676 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113716 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d26f61b6-f70f-467b-8ff3-3f873802c2cf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35062 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33376 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28857 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182763 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141683 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44380 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38156 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45069 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109770 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36763 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116960 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43580 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8153 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->