### PR TITLE
[css-mixins-1] Function body should inherit computed custom property values from the calling context

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
@@ -2,8 +2,8 @@
 PASS Local with self-cycle
 PASS Cycle reference without fallback makes result invalid
 FAIL Local with self-cycle in unused fallback assert_equals: expected "PASS" but got "FAIL"
-FAIL Local shadowing cyclic property --x assert_equals: expected "PASS" but got ""
-FAIL Local shadowing cyclic outer local --x assert_equals: expected "PASS" but got ""
+PASS Local shadowing cyclic property --x
+PASS Local shadowing cyclic outer local --x
 PASS Argument shadowing cyclic outer local --x
 PASS Arguments shadowing cyclic properties
 PASS Observing property cycle locally

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
@@ -46,7 +46,7 @@ PASS Inner argument shadowing outer argument
 PASS Inner argument shadowing outer local
 PASS Inner local shadowing outer argument
 PASS Inner local shadowing outer local
-FAIL Referencing outer local containing var() assert_equals: expected "1" but got "0"
+PASS Referencing outer local containing var()
 PASS Referencing outer typed argument
 PASS Same function with different scopes
 PASS Referencing local two frames up
@@ -69,23 +69,23 @@ FAIL Passing non-whole-value {} as argument assert_equals: expected "foo{}" but 
 PASS Local variable with initial keyword
 PASS Local variable with initial keyword, defaulted
 FAIL Local variable with initial keyword, no value via IACVT-capture assert_equals: expected "PASS" but got ""
-FAIL Default with initial keyword assert_equals: expected "PASS" but got ""
+PASS Default with initial keyword
 FAIL initial appearing via fallback assert_equals: expected "PASS" but got ""
 PASS Local variable with inherit keyword
-FAIL Local variable with inherit keyword (nested) assert_equals: expected "PASS" but got "FAIL3"
-FAIL Inheriting an invalid value assert_equals: expected "PASS" but got "FAIL1"
-FAIL Default with inherit keyword assert_equals: expected "PASS1 PASS2" but got ""
-FAIL Default with inherit keyword (nested) assert_equals: expected "PASS1 PASS2" but got ""
+PASS Local variable with inherit keyword (nested)
+PASS Inheriting an invalid value
+PASS Default with inherit keyword
+PASS Default with inherit keyword (nested)
 PASS Local with the unset keyword
 PASS Local with the revert keyword
 PASS Local with the revert-layer keyword
 PASS Local with the revert-rule keyword
 PASS initial keyword left unresolved on result descriptor
-FAIL inherit keyword left unresolved on result descriptor assert_equals: expected "PASS" but got "FAIL"
-FAIL unset keyword left unresolved on result descriptor assert_equals: expected "PASS" but got "FAIL"
-FAIL revert keyword left unresolved on result descriptor assert_equals: expected "PASS" but got "FAIL"
-FAIL revert-layer keyword left unresolved on result descriptor assert_equals: expected "PASS" but got "FAIL"
-FAIL revert-rule keyword left unresolved on result descriptor assert_equals: expected "PASS" but got "FAIL"
-FAIL Keyword can be returned from function into local variable assert_equals: expected "PASS" but got "FAIL2"
+PASS inherit keyword left unresolved on result descriptor
+PASS unset keyword left unresolved on result descriptor
+PASS revert keyword left unresolved on result descriptor
+PASS revert-layer keyword left unresolved on result descriptor
+PASS revert-rule keyword left unresolved on result descriptor
+FAIL Keyword can be returned from function into local variable assert_equals: expected "PASS" but got ""
 PASS Can not return CSS-wide keyword as length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
@@ -9,13 +9,13 @@ PASS Return attr(type(*)) from typed function
 PASS Return attr(type(*)) from untyped function
 FAIL attr() in default parameter value assert_equals: expected "42px" but got "784px"
 PASS attr() in local variable
-FAIL Returned url() is attr-tainted assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
+PASS Returned url() is attr-tainted
 PASS Returned url() is attr-tainted, typed attr()
 PASS Returned url() is attr-tainted, typed return
 PASS Returned url() is attr-tainted, local
 PASS Returned url() is attr-tainted, argument
 PASS Returned url() is attr-tainted, default
-FAIL Returned url() is attr-tainted, parent stack frame assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
+PASS Returned url() is attr-tainted, parent stack frame
 PASS Returned url() is attr-tainted, initial
 PASS Returned url() is attr-tainted, inherit
 

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -99,6 +99,11 @@ static const StyleProperties* NODELETE positionTryFallbackProperties(const Build
     return context.positionTryFallback ? context.positionTryFallback->properties.get() : nullptr;
 }
 
+static bool isInheritedCustomProperty(const CSSRegisteredCustomProperty* registered)
+{
+    return !registered || registered->inherits;
+}
+
 Builder::Builder(Style::ComputedStyle& style, BuilderContext&& context, const MatchResult& matchResult, PropertyCascade::IncludedProperties&& includedProperties, const HashMap<AnimatableCSSProperty, EnumSet<PropertyCascade::AnimationSource>>* animatedProperties)
     : m_cascade(matchResult, WTF::move(includedProperties), animatedProperties, positionTryFallbackProperties(context))
     , m_state(BuilderState::create(style, WTF::move(context)))
@@ -220,8 +225,20 @@ void Builder::applyCustomProperty(const AtomString& name)
         return;
 
     auto iterator = m_cascade.customProperties().find(name);
-    if (iterator == m_cascade.customProperties().end())
+    if (iterator == m_cascade.customProperties().end()) {
+        // The property is not in this cascade, but a custom function body inherits the calling
+        // context's custom properties, which are resolved lazily. Resolve it there and copy in the
+        // computed value so var() references can find it.
+        if (auto* callingContextBuilder = m_state->callingContextBuilder()) {
+            callingContextBuilder->applyCustomProperty(name);
+            if (RefPtr value = callingContextBuilder->state().style().customPropertyValue(name)) {
+                bool isInherited = isInheritedCustomProperty(m_state->registeredProperty(name));
+                m_state->style().setCustomPropertyValue(value.releaseNonNull(), isInherited);
+            }
+            m_state->m_appliedCustomProperties.add(name);
+        }
         return;
+    }
 
     applyCustomPropertyImpl(name, iterator->value);
 }
@@ -239,7 +256,7 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
     if (guard.isCyclicContext())
         return;
 
-    auto createInvalidOrUnset = [&] -> Variant<Ref<const Style::CustomProperty>, CSSWideKeyword> {
+    auto createInvalidOrUnset = [&] -> CustomPropertyOrKeyword {
         // https://drafts.csswg.org/css-variables-2/#invalid-variables
         auto* registered = m_state->registeredProperty(name);
         // The property is a non-registered custom property:
@@ -437,15 +454,14 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     }
 }
 
-void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&& parsedCustomProperty)
+void Builder::applyCustomProperty(const AtomString& name, CustomPropertyOrKeyword&& parsedCustomProperty)
 {
     auto& style = m_state->style();
 
     auto registeredCustomProperty = m_state->registeredProperty(name);
 
     auto applyValue = [&](Ref<const CustomProperty>&& valueToApply) {
-        bool isInherited = !registeredCustomProperty || registeredCustomProperty->inherits;
-        state().style().setCustomPropertyValue(WTF::move(valueToApply), isInherited);
+        state().style().setCustomPropertyValue(WTF::move(valueToApply), isInheritedCustomProperty(registeredCustomProperty));
     };
 
     auto applyInitial = [&] {
@@ -457,8 +473,12 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
     };
 
     auto applyInherit = [&] {
+        // For a custom function's hypothetical element, the inherited value comes from the calling
+        // context, whose custom properties are resolved lazily. Ensure this one is resolved there.
+        if (auto* callingContextBuilder = m_state->callingContextBuilder())
+            callingContextBuilder->applyCustomProperty(name);
         RefPtr parentValue = protect(state().parentStyle().inheritedCustomProperties())->get(name);
-        if (parentValue && !(registeredCustomProperty && !registeredCustomProperty->inherits)) {
+        if (parentValue && isInheritedCustomProperty(registeredCustomProperty)) {
             applyValue(*parentValue);
             return;
         }
@@ -476,14 +496,10 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
             bool isRevertLayer = false;
             bool isRevertRule = false;
 
-            auto isInheritedProperty = [&] {
-                return registeredCustomProperty ? registeredCustomProperty->inherits : true;
-            };
-
             auto unsetValueType = [&] {
                 // https://drafts.csswg.org/css-cascade-4/#inherit-initial
                 // The unset CSS-wide keyword acts as either inherit or initial, depending on whether the property is inherited or not.
-                return isInheritedProperty() ? ApplyValueType::Inherit : ApplyValueType::Initial;
+                return isInheritedCustomProperty(registeredCustomProperty) ? ApplyValueType::Inherit : ApplyValueType::Initial;
             };
 
             switch (keyword) {
@@ -541,7 +557,7 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
                 return;
             }
 
-            if (valueType == ApplyValueType::Inherit && !isInheritedProperty())
+            if (valueType == ApplyValueType::Inherit && !isInheritedCustomProperty(registeredCustomProperty))
                 style.setHasExplicitlyInheritedProperties();
 
             switch (valueType) {
@@ -597,7 +613,7 @@ RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(c
         [&](const CSSWideKeyword& keyword) -> RefPtr<const CustomProperty> {
             auto name = value.name();
             auto* registered = m_state->registeredProperty(name);
-            bool isInherited = !registered || registered->inherits;
+            bool isInherited = isInheritedCustomProperty(registered);
 
             auto initial = [&]() -> RefPtr<const CustomProperty> {
                 if (registered)
@@ -639,25 +655,16 @@ RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(c
     );
 }
 
-RefPtr<const CustomProperty> Builder::resolveFunctionResult(const CSSCustomPropertyValue& value)
+std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveFunctionResult(const CSSCustomPropertyValue& value)
 {
     SetForScope resultScope(m_state->m_currentProperty, &m_cascade.functionResultProperty());
 
-    auto resolvedValue = resolveCustomPropertyValue(const_cast<CSSCustomPropertyValue&>(value));
-    if (!resolvedValue)
-        return nullptr;
-
-    return WTF::switchOn(*resolvedValue,
-        [&](const CSSWideKeyword&) -> RefPtr<const CustomProperty> {
-            return nullptr;
-        },
-        [](const Ref<const CustomProperty>& resolved) -> RefPtr<const CustomProperty> {
-            return resolved.copyRef();
-        }
-    );
+    // The caller (custom function evaluation) handles a CSS-wide keyword result, which per spec is
+    // left unresolved. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+    return resolveCustomPropertyValue(const_cast<CSSCustomPropertyValue&>(value));
 }
 
-std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder::resolveCustomPropertyValue(CSSCustomPropertyValue& value)
+std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyValue(CSSCustomPropertyValue& value)
 {
     auto name = value.name();
 
@@ -666,15 +673,15 @@ std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> Builder
 
     auto* registered = m_state->registeredProperty(name);
     auto preResolved = switchOn(value.value(),
-        [&](const Ref<CSSSubstitutionValue>&) -> std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> {
+        [&](const Ref<CSSSubstitutionValue>&) -> std::optional<CustomPropertyOrKeyword> {
             return { };
         },
-        [&](const Ref<CSSVariableData>& data) -> std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> {
+        [&](const Ref<CSSVariableData>& data) -> std::optional<CustomPropertyOrKeyword> {
             if (!registered)
                 return { { CustomProperty::createForVariableData(name, data.copyRef()) } };
             return { };
         },
-        [&](const CSSWideKeyword& keyword) -> std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> {
+        [&](const CSSWideKeyword& keyword) -> std::optional<CustomPropertyOrKeyword> {
             if (!registered)
                 return { { keyword } };
             return { };

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -54,8 +54,10 @@ public:
     void applyProperty(CSSPropertyID propertyID) { applyProperties(propertyID, propertyID); }
     void applyCustomProperty(const AtomString& name);
 
+    using CustomPropertyOrKeyword = Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>;
+
     RefPtr<const CustomProperty> resolveCustomPropertyForContainerQueries(const CSSCustomPropertyValue&);
-    RefPtr<const CustomProperty> resolveFunctionResult(const CSSCustomPropertyValue&);
+    std::optional<CustomPropertyOrKeyword> resolveFunctionResult(const CSSCustomPropertyValue&);
 
     BuilderState& state() { return m_state; }
     const MatchResult& matchResult() const { return m_cascade.matchResult(); }
@@ -75,10 +77,10 @@ private:
     bool applyRollbackCascadeProperty(const PropertyCascade&, CSSPropertyID, SelectorChecker::LinkMatchMask);
     bool applyRollbackCascadeCustomProperty(const PropertyCascade&, const AtomString&);
     void applyProperty(CSSPropertyID, CSSValue&, SelectorChecker::LinkMatchMask, PropertyCascade::Origin);
-    void applyCustomProperty(const AtomString& name, Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>&&);
+    void applyCustomProperty(const AtomString& name, CustomPropertyOrKeyword&&);
 
     Ref<CSSValue> resolveSubstitutionFunctions(CSSPropertyID, CSSValue&);
-    std::optional<Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>> resolveCustomPropertyValue(CSSCustomPropertyValue&);
+    std::optional<CustomPropertyOrKeyword> resolveCustomPropertyValue(CSSCustomPropertyValue&);
 
     void applyPageSizeDescriptor(CSSValue&);
 

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -53,6 +53,7 @@ struct RandomCachingKey;
 namespace Style {
 
 class BuilderState;
+class Builder;
 class CustomPropertyRegistry;
 class Image;
 class LocalPropertyRegistry;
@@ -99,6 +100,9 @@ struct BuilderContext {
     CheckedPtr<TreeResolutionState> treeResolutionState { };
     std::optional<BuilderPositionTryFallback> positionTryFallback { };
     const LocalPropertyRegistry* localPropertyRegistry { nullptr };
+    // For a custom function's hypothetical element: the builder of the calling context, used to
+    // resolve inherited custom properties on demand. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+    Builder* callingContextBuilder { nullptr };
 };
 
 class BuilderState : public CanMakeCheckedPtr<BuilderState> {
@@ -126,6 +130,8 @@ public:
 
     const ComputedStyle& parentStyle() const { return *m_context.parentStyle; }
     const Style::ComputedStyle& parentRenderStyle() const LIFETIME_BOUND { return *m_context.parentStyle; }
+
+    Builder* callingContextBuilder() const { return m_context.callingContextBuilder; }
 
     const ComputedStyle* rootElementStyle() const { return m_context.rootElementStyle; }
     const Style::ComputedStyle* rootElementRenderStyle() const LIFETIME_BOUND { return m_context.rootElementStyle; }

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -31,6 +31,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
+#include "CSSPropertyParserConsumer+Ident.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSRegisteredCustomProperty.h"
 #include "CSSSelectorParser.h"
@@ -41,6 +42,7 @@
 #include "CSSUnits.h"
 #include "CSSValueKeywords.h"
 #include "CSSVariableData.h"
+#include "CSSWideKeyword.h"
 #include "ConstantPropertyMap.h"
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
@@ -199,22 +201,31 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
         if (!argumentData)
             return nullptr;
 
-        auto value = CSSCustomPropertyValue::createSyntaxAll(parameter.name, argumentData.releaseNonNull());
+        // A bare CSS-wide keyword argument/default (e.g. a parameter defaulting to `inherit`) must keep
+        // its keyword semantics so it resolves against the calling context, rather than being treated as
+        // a literal universal value. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+        auto value = [&] -> Ref<CSSCustomPropertyValue> {
+            auto tokens = argumentData->tokenRange();
+            tokens.consumeWhitespace();
+            if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(tokens); keyword && tokens.atEnd())
+                return CSSCustomPropertyValue::createWithCSSWideKeyword(parameter.name, *keyword);
+            return CSSCustomPropertyValue::createSyntaxAll(parameter.name, argumentData.releaseNonNull());
+        }();
         argumentRule->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
     }
 
     // "Resolve function styles using custom function, argument rule, registrations, and calling context."
-    Ref parentMatchResult = m_styleBuilder.matchResult();
-
+    // The hypothetical element acts as a child of the calling element, inheriting its computed custom
+    // properties on demand, so defaults like `var(--caller-prop)` or `inherit` resolve against it.
     auto argumentMatchResult = MatchResult::create();
-    argumentMatchResult->copyDeclarationsFrom(parentMatchResult);
     argumentMatchResult->authorDeclarations.append({ WTF::move(argumentRule) });
 
     auto builderContext = BuilderContext {
         .document = m_styleBuilder.state().document(),
         .parentStyle = &m_styleBuilder.state().renderStyle(),
         .element = m_styleBuilder.state().element(),
-        .localPropertyRegistry = &argumentRegistrations
+        .localPropertyRegistry = &argumentRegistrations,
+        .callingContextBuilder = &m_styleBuilder
     };
 
     auto argumentStyles = Style::ComputedStyle::createPtr();
@@ -228,7 +239,6 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
     auto resolvedArgumentProperties = MutableStyleProperties::create();
     for (auto& parameter : parameters) {
         RefPtr resolvedValue = argumentStyles->customPropertyValue(parameter.name);
-
         registrations.add({
             .name = AtomString { parameter.name },
             .syntax = CSSCustomPropertySyntax::universal(),
@@ -313,19 +323,19 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     }
 
     // "Let body rule be the function body."
-    Ref parentMatchResult = m_styleBuilder.matchResult();
-
     auto bodyMatchResult = MatchResult::create();
-    bodyMatchResult->copyDeclarationsFrom(parentMatchResult);
     bodyMatchResult->authorDeclarations.append({ *resolvedArgumentProperties });
     bodyMatchResult->authorDeclarations.append({ customFunction->properties });
 
     // "Resolve function styles using custom function, body rule, registrations, and calling context."
+    // The hypothetical element acts as a child of the calling element, inheriting its computed custom
+    // properties on demand via the calling context's builder (https://drafts.csswg.org/css-mixins/#evaluating-custom-functions).
     auto builderContext = BuilderContext {
         .document = m_styleBuilder.state().document(),
         .parentStyle = &m_styleBuilder.state().renderStyle(),
         .element = m_styleBuilder.state().element(),
-        .localPropertyRegistry = &registrations
+        .localPropertyRegistry = &registrations,
+        .callingContextBuilder = &m_styleBuilder
     };
 
     auto bodyStyles = Style::ComputedStyle::createPtr();
@@ -333,6 +343,7 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     bodyBuilder.state().addGuardedFunctionContexts(m_styleBuilder.state());
 
     // "Return the value of the result property in body styles."
+    // Body custom properties are applied lazily as result's var() references reach them.
     auto resolvedResult = bodyBuilder.resolveFunctionResult(*resultValue);
     if (!resolvedResult)
         return false;
@@ -341,10 +352,26 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     if (guard.isCyclicContext())
         return false;
 
-    // Tokens reference resolvedResult's string backing; keep it alive until CSSVariableData re-captures.
-    tokens.appendVector(resolvedResult->tokens());
-    m_intermediateCustomProperties.append(WTF::move(resolvedResult));
-    return true;
+    return WTF::switchOn(*resolvedResult,
+        [&](const Ref<const CustomProperty>& result) {
+            // https://drafts.csswg.org/css-values-5/#attr-security
+            // Propagate attr()-taint from the function result into the calling context.
+            propagateAttrTaint(result->isAttrTainted(), result->tokens());
+            // Tokens reference result's string backing; keep it alive until CSSVariableData re-captures.
+            tokens.appendVector(result->tokens());
+            m_intermediateCustomProperties.append(result.copyRef());
+            return true;
+        },
+        [&](CSSWideKeyword keyword) {
+            // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+            // CSS-wide keywords are left unresolved on result: the function evaluates to the keyword
+            // itself (e.g. result: inherit makes the dashed-function evaluate to the inherit keyword).
+            // A declared (typed) return type cannot be a CSS-wide keyword, so it is invalid then.
+            if (!customFunction->returnType.isUniversal())
+                return false;
+            tokens.append(CSSParserToken { IdentToken, nameLiteral(toValueID(keyword)) });
+            return true;
+        });
 }
 
 auto SubstitutionResolver::substituteAttrArgumentGrammar(CSSParserTokenRange range, const CSSParserContext& context) -> std::optional<AttrArgumentGrammarSubstitution>

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -44,6 +44,7 @@ class MutableStyleProperties;
 namespace Style {
 
 class Builder;
+class ComputedStyle;
 class CustomProperty;
 class LocalPropertyRegistry;
 


### PR DESCRIPTION
#### 97e17db91411c05c25be1c624107db47e1f39010
<pre>
[css-mixins-1] Function body should inherit computed custom property values from the calling context
<a href="https://bugs.webkit.org/show_bug.cgi?id=318117">https://bugs.webkit.org/show_bug.cgi?id=318117</a>
<a href="https://rdar.apple.com/180942670">rdar://180942670</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-mixins-1/#evaluating-custom-functions">https://drafts.csswg.org/css-mixins-1/#evaluating-custom-functions</a>

&quot;The hypothetical element `inherits` the values of all custom properties as if it were
 a child of its calling context, with its function parameters overriding `inherited`
 custom properties of the same name.&quot;

The function body&apos;s builder keeps a pointer to the calling context&apos;s builder and resolves
inherited custom properties against it lazily, only when the body references them, so no
snapshot of the calling style is needed. Also handles CSS-wide keyword arguments/defaults
and results, and propagates attr()-taint through function results.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomProperty):

Resolve an inherited custom property (var() or the inherit keyword) on the calling
context&apos;s builder on demand.

(WebCore::Style::Builder::applyCustomPropertyImpl):
(WebCore::Style::Builder::resolveFunctionResult):

Return the resolved value or, per spec, an unresolved CSS-wide keyword.

(WebCore::Style::Builder::resolveCustomPropertyValue):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::callingContextBuilder const):

The calling context&apos;s builder while resolving a function&apos;s hypothetical element.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::resolveAndRegisterDashedFunctionArguments):

Construct a bare CSS-wide keyword argument/default as a keyword so it resolves against
the calling context.

(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Emit a CSS-wide keyword result as the keyword token for an untyped function (invalid
for a typed return type), and propagate attr()-taint from the result.

* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/316066@main">https://commits.webkit.org/316066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce2e7e06537bef93f1e862574a3fc27820ab3a09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180222 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5de5396a-dc10-4630-bdd0-84f4f2995893) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44403 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4983bb73-9f46-4371-b139-47f067f97ac7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173801 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113740 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d6832da-5162-4aa8-bc4e-c9643c58013e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28901 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182807 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141714 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44424 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45113 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109818 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36792 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43624 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8182 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43028 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->