### PR TITLE
Strip SVGStyleElement in ReplaceSelectionCommand

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-strips-svg-style-element-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-strips-svg-style-element-expected.txt
@@ -1,0 +1,3 @@
+This test inserts HTML containing both an HTML <style> element and an SVG <style> element into an editable region via InsertHTML. Both must be stripped by the paste sanitizer, while the rest of the SVG content is preserved.
+Number of <style> elements remaining (HTML or SVG): 0 (PASS)
+Number of <rect> elements preserved: 1 (PASS)

--- a/LayoutTests/editing/pasteboard/paste-strips-svg-style-element.html
+++ b/LayoutTests/editing/pasteboard/paste-strips-svg-style-element.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="edit" contenteditable="true"></div>
+<pre id="result"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+// InsertHTML routes the markup straight through ReplaceSelectionCommand's
+// ReplacementFragment sanitizer (removeContentsWithSideEffects), with no
+// clipboard-side markup sanitizer in front of it. That sanitizer strips
+// <style> elements; this test verifies that an SVG <style> element is
+// stripped too (and not just the HTML one), while other SVG content is kept.
+var markup = "<div>before</div>"
+    + "<style>.html-style { color: red; }</style>"
+    + "<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'>"
+    + "<style>.svg-style { fill: green; }</style>"
+    + "<rect width='10' height='10'></rect>"
+    + "</svg>"
+    + "<div>after</div>";
+
+var edit = document.getElementById("edit");
+edit.focus();
+
+// Place a caret inside the editable region so InsertHTML has a selection to act on.
+var selection = window.getSelection();
+selection.removeAllRanges();
+var range = document.createRange();
+range.setStart(edit, 0);
+range.collapse(true);
+selection.addRange(range);
+
+document.execCommand("InsertHTML", false, markup);
+
+var styleCount = edit.querySelectorAll("style").length;
+var rectCount = edit.querySelectorAll("rect").length;
+
+var lines = [];
+lines.push("This test inserts HTML containing both an HTML <style> element and an SVG <style> element into an editable region via InsertHTML. Both must be stripped by the paste sanitizer, while the rest of the SVG content is preserved.");
+lines.push("Number of <style> elements remaining (HTML or SVG): " + styleCount + (styleCount === 0 ? " (PASS)" : " (FAIL)"));
+lines.push("Number of <rect> elements preserved: " + rectCount + (rectCount === 1 ? " (PASS)" : " (FAIL)"));
+
+document.getElementById("result").textContent = lines.join("\n");
+edit.remove();
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -79,6 +79,8 @@
 #include "StyleExtractor.h"
 #include "StyleKeyword+Mappings.h"
 #include "StylePropertiesInlines.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGStyleElement.h"
 #include "Text.h"
 #include "TextIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
@@ -259,7 +261,7 @@ void ReplacementFragment::removeContentsWithSideEffects()
     while (it != end) {
         Ref element = *it;
         if (isScriptElement(element) || (is<HTMLStyleElement>(element) && element->getAttribute(classAttr) != WebKitMSOListQuirksStyle)
-            || isAnyOf<HTMLBaseElement, HTMLLinkElement, HTMLMetaElement, HTMLTitleElement>(element)) {
+            || isAnyOf<HTMLBaseElement, HTMLLinkElement, HTMLMetaElement, HTMLTitleElement, SVGStyleElement>(element)) {
             elementsToRemove.append(WTF::move(element));
             it.traverseNextSkippingChildren();
             continue;


### PR DESCRIPTION
#### a3a6a4976b58db93b275c8062c9ad9295f3a0021
<pre>
Strip SVGStyleElement in ReplaceSelectionCommand
<a href="https://bugs.webkit.org/show_bug.cgi?id=318119">https://bugs.webkit.org/show_bug.cgi?id=318119</a>
<a href="https://rdar.apple.com/180944892">rdar://180944892</a>

Reviewed by Chris Dumez.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1931412">https://chromium-review.googlesource.com/c/chromium/src/+/1931412</a>

ReplacementFragment::removeContentsWithSideEffects() sanitizes fragments
inserted by paste, drop, and InsertHTML. It strips script elements and
HTMLStyleElement (along with base/link/meta/title), but it never checked
for SVGStyleElement, so an SVG &lt;style&gt; element survived sanitization and
its stylesheet could be applied to the destination document.

On Cocoa the paste path masks this because incoming markup is run through
sanitizeMarkup() first, but InsertHTML (execCommand) reaches
removeContentsWithSideEffects() directly with no other sanitizer in front
of it, leaving the loophole web-reachable.

Add SVGStyleElement to the set of elements removed by
removeContentsWithSideEffects().

Test: editing/pasteboard/paste-strips-svg-style-element.html

* LayoutTests/editing/pasteboard/paste-strips-svg-style-element-expected.txt: Added.
* LayoutTests/editing/pasteboard/paste-strips-svg-style-element.html: Added.
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::removeContentsWithSideEffects):

Canonical link: <a href="https://commits.webkit.org/316236@main">https://commits.webkit.org/316236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e19c4b673b300000aadc87dbc4b9221e034e055

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128502 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22216df1-58ad-489f-a2d2-960b03acc985) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133210 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94002 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85a11f3c-082b-46a0-b487-387d4191b795) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113701 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb97f24a-4bc9-413a-9b92-8a286e9e62a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35052 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33365 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37540 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141671 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141482 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38351 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45058 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109757 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36749 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116949 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43569 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8137 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42973 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->