### PR TITLE
analyze-safer-cpp: Improve header-only analysis

### DIFF
--- a/Tools/Scripts/analyze-safer-cpp
+++ b/Tools/Scripts/analyze-safer-cpp
@@ -217,7 +217,7 @@ def resolve_preset_build_dir(presetName):
     return binaryDir
 
 
-def rewrite_argv(entry, absSrc, clang, checkers):
+def rewrite_argv(entry, absSrc, clang, checkers, header_only=False):
     tokens = shlex.split(entry['command'])
     out = [clang]
     i = 1
@@ -227,6 +227,9 @@ def rewrite_argv(entry, absSrc, clang, checkers):
     while i < n:
         t = tokens[i]
         if t == '-o' or t == '-MT' or t == '-MF' or t == '-MQ' or t == '-include':
+            i += 2
+            continue
+        if t == '-x' and i + 1 < n:
             i += 2
             continue
         if t in ('-c', '-MD', '-MMD', '-Winvalid-pch', '-fpch-instantiate-templates',
@@ -250,6 +253,8 @@ def rewrite_argv(entry, absSrc, clang, checkers):
         out.append(t)
         i += 1
 
+    if header_only:
+        out += ['-x', 'c++-header']
     out += [
         absSrc,
         '--analyze',
@@ -354,30 +359,21 @@ def map_header_to_tu(headerPath, db):
         candidate = stem + suffix
         if os.path.isfile(candidate) and db.lookup(candidate):
             return candidate
-
-    basename = os.path.basename(headerPath)
-    headerDir = os.path.dirname(headerPath)
-    patterns = ['-e', '"{}"'.format(basename)]
-    project, _ = project_for_path(headerPath)
-    if project:
-        patterns += ['-e', '<{}/{}>'.format(project, basename)]
-    proc = subprocess.run(
-        ['git', '-C', WEBKIT_ROOT, 'grep', '-l', '-F'] + patterns +
-        ['--', ':(glob)Source/**/*.cpp', ':(glob)Source/**/*.mm'],
-        capture_output=True, text=True)
-    candidates = []
-    for line in proc.stdout.splitlines():
-        path = os.path.realpath(os.path.join(WEBKIT_ROOT, line.strip()))
-        try:
-            size = os.path.getsize(path)
-        except OSError:
-            continue
-        candidates.append((os.path.dirname(path) != headerDir, size, path))
-    candidates.sort()
-    for _, _, path in candidates:
-        if db.lookup(path):
-            return path
     return None
+
+
+def find_flags_entry(headerPath, db):
+    headerDir = os.path.dirname(headerPath)
+    _, projectRoot = project_for_path(headerPath)
+    fallback = None
+    for path, entry in db.byFile.items():
+        if '/unified-sources/UnifiedSource' in path:
+            continue
+        if os.path.dirname(path) == headerDir:
+            return entry
+        if fallback is None and projectRoot and path.startswith(projectRoot + os.sep):
+            fallback = entry
+    return fallback
 
 
 def normalize_checkers(values, parser):
@@ -562,45 +558,56 @@ def main():
     seenTUs = set()
     for path in requested:
         ext = os.path.splitext(path)[1]
+        header_only = False
+        flags_entry = None
         if ext in HEADER_EXT:
             tu = map_header_to_tu(path, db)
-            if not tu:
-                print('SKIP: {} (header has no sibling or direct includer in this checkout)'.format(repo_relative(path)))
-                continue
-            tu = os.path.realpath(tu)
-            if args.verbose:
-                sys.stderr.write('header {} -> {}\n'.format(repo_relative(path), repo_relative(tu)))
-            requestedPaths.add(tu)
+            if tu:
+                tu = os.path.realpath(tu)
+                if args.verbose:
+                    sys.stderr.write('header {} -> {}\n'.format(repo_relative(path), repo_relative(tu)))
+                requestedPaths.add(tu)
+            else:
+                flags_entry = find_flags_entry(path, db)
+                if not flags_entry:
+                    print('SKIP: {} (no compile command found for project)'.format(repo_relative(path)))
+                    continue
+                if args.verbose:
+                    sys.stderr.write('header {} -> header-only (flags from {})\n'.format(
+                        repo_relative(path), repo_relative(os.path.realpath(flags_entry['file']))))
+                tu = path
+                header_only = True
         else:
             tu = path
         if tu in seenTUs:
             continue
-        entry = db.lookup(tu)
+        entry = flags_entry if header_only else db.lookup(tu)
         if not entry:
             print('SKIP: {} (no compile command found; is the build configured?)'.format(repo_relative(tu)))
             continue
         seenTUs.add(tu)
-        workItems.append((tu, entry))
+        workItems.append((tu, entry, header_only))
 
     if not workItems:
         print('Nothing to analyze.')
         return 0
 
     def runOne(item):
-        tu, entry = item
-        argv, cwd = rewrite_argv(entry, tu, clang, args.checkers)
+        tu, entry, header_only = item
+        argv, cwd = rewrite_argv(entry, tu, clang, args.checkers, header_only)
         if args.verbose:
             sys.stderr.write(' '.join(shlex.quote(a) for a in argv) + '\n')
         proc = subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
-        return tu, proc.stderr
+        return tu, proc.stderr, header_only
 
     totalUnexpected = 0
     totalErrors = 0
     with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.j)) as pool:
-        for tu, stderr in pool.map(runOne, workItems):
+        for tu, stderr, header_only in pool.map(runOne, workItems):
             blocks, unexpected, errors = filter_diagnostics(
                 stderr, requestedPaths, expectations, args.ignore_expectations)
-            print('==> {}'.format(repo_relative(tu)))
+            label = repo_relative(tu) + ' (header-only)' if header_only else repo_relative(tu)
+            print('==> {}'.format(label))
             if blocks:
                 for b in blocks:
                     print(b)


### PR DESCRIPTION
#### 5237eb1d8302b04c9e8fe380f173be9492657620
<pre>
analyze-safer-cpp: Improve header-only analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=318120">https://bugs.webkit.org/show_bug.cgi?id=318120</a>
<a href="https://rdar.apple.com/180945755">rdar://180945755</a>

Reviewed by David Kilzer.

* Tools/Scripts/analyze-safer-cpp: When a header changes, instead of searching
the whole project for a .cpp file that #includes it (which is slow, and can
fail), just compile the header stand-alone. .h files don&apos;t get entries in
compile_commands.json, so just borrow the compiler flags from any other file
in the same folder.

We still prefer to compile a related .cpp file if we can find one trivially
because the .cpp file may instantiate templates, revealing failures that weren&apos;t
visible in the template definitions alone.

Canonical link: <a href="https://commits.webkit.org/316054@main">https://commits.webkit.org/316054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaed6f59f6b2ec0ddea5c551f03e39e7c002c1ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180168 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128504 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26e0884e-0e0a-48e2-b40a-ff50b752598d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44350 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133212 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bc22f33-df82-4b8a-9c9d-048aef7b145f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173748 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113703 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/907897f7-fef1-478c-a8ea-5cdf17129973) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28848 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182754 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141672 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44371 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141483 "Failed to checkout and rebase branch from PR 68105") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45060 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109759 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36751 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43571 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8138 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43217 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->