### PR TITLE
Add C++ coding style check for auto = adoptGRef cases

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3149,7 +3149,7 @@ def check_auto_with_adopt(clean_lines, line_number, file_state, error):
 
     line = clean_lines.elided[line_number]  # Get rid of comments and strings.
 
-    matched = search(r'\bauto\b\s+\w+\s*=\s*adopt(NS|CF|GDIObject|OSObject|Ref)\b', line)
+    matched = search(r'\bauto\b\s+\w+\s*=\s*adopt(NS|CF|GDIObject|OSObject|Ref|GRef)\b', line)
     if matched:
         adopt_func = 'adopt' + matched.group(1)
         type_map = {
@@ -3158,6 +3158,7 @@ def check_auto_with_adopt(clean_lines, line_number, file_state, error):
             'adoptGDIObject': 'GDIObject',
             'adoptOSObject': 'OSObjectPtr',
             'adoptRef': 'Ref/RefPtr',
+            'adoptGRef': 'GRefPtr',
         }
         smart_ptr = type_map.get(adopt_func, 'the appropriate smart pointer type')
         error(line_number, 'runtime/auto_with_adopt', 4, "Use '%s' instead of 'auto' with '%s()'." % (smart_ptr, adopt_func))

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6197,7 +6197,15 @@ class WebKitStyleTest(CppStyleTestBase):
             'auto x = someOtherFunction();',
             '',
             'foo.cpp')
-
+        self.assert_lint(
+            'GRefPtr caps = adoptGRef(gst_caps_new_empty_simple("bleh"));',
+            '',
+            'foo.cpp')
+        self.assert_lint(
+            'auto caps = adoptGRef(gst_caps_new_empty_simple("bleh"));',
+            "Use 'GRefPtr' instead of 'auto' with 'adoptGRef()'."
+            "  [runtime/auto_with_adopt] [4]",
+            'foo.cpp')
 
     def test_wtf_make_unique(self):
         self.assert_lint(


### PR DESCRIPTION
#### 56939ebf3e60c91e41ee69d7b891c04c13c3e546
<pre>
Add C++ coding style check for auto = adoptGRef cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=318121">https://bugs.webkit.org/show_bug.cgi?id=318121</a>

Reviewed by Claudio Saavedra.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_auto_with_adopt):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_auto_with_adopt):

Canonical link: <a href="https://commits.webkit.org/316057@main">https://commits.webkit.org/316057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfd804e35e4a4c75c17087780c1d452bdebb0fc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170815 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44741 "Failed to checkout and rebase branch from PR 68108") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38160 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180194 "Failed to checkout and rebase branch from PR 68108") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44376 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/180194 "Failed to checkout and rebase branch from PR 68108") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173774 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/180194 "Failed to checkout and rebase branch from PR 68108") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170136 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28874 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182780 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44397 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/141503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45086 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109790 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26029 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36770 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43597 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43243 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->