### PR TITLE
Large pages can overflow the CachedMatchFinder buffer

### DIFF
--- a/LayoutTests/editing/text-iterator/find-matches-oversized-buffer-fallback-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-matches-oversized-buffer-fallback-expected.txt
@@ -1,0 +1,8 @@
+PASS internals.countMatchesForText(target, [], '') is 50
+PASS internals.countMatchesForText(target, [], '') is 51
+PASS found is true
+PASS getSelection().toString() is "wkfindtoken"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/text-iterator/find-matches-oversized-buffer-fallback.html
+++ b/LayoutTests/editing/text-iterator/find-matches-oversized-buffer-fallback.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container"></div>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+
+const target = "wkfindtoken";
+const container = document.getElementById("container");
+for (let i = 0; i < 50; i++)
+    container.appendChild(document.createElement("p")).textContent = target;
+
+window.jsTestIsAsync = true;
+
+shouldBe("internals.countMatchesForText(target, [], '')", "50");
+
+internals.setCachedFindMatchBufferLimitForTesting(5);
+container.appendChild(document.createElement("p")).textContent = target;
+
+shouldBe("internals.countMatchesForText(target, [], '')", "51");
+
+(async () => {
+    window.found = await testRunner.findString(target, []);
+    shouldBeTrue("found");
+    shouldBeEqualToString("getSelection().toString()", "wkfindtoken");
+
+    container.remove();
+    finishJSTest();
+})();
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/text-iterator/find-oversized-shadow-scope-fallback-expected.txt
+++ b/LayoutTests/editing/text-iterator/find-oversized-shadow-scope-fallback-expected.txt
@@ -1,0 +1,3 @@
+PASS: found match with the find-match cache enabled
+PASS: found match via uncached fallback when the shadow scope is oversized
+

--- a/LayoutTests/editing/text-iterator/find-oversized-shadow-scope-fallback.html
+++ b/LayoutTests/editing/text-iterator/find-oversized-shadow-scope-fallback.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="test-content"><span id="host"></span></div>
+<pre id="console" style="visibility: hidden;"></pre>
+<script>
+
+const target = "wkfindtoken";
+
+function log(message)
+{
+    document.getElementById("console").appendChild(document.createTextNode(message + "\n"));
+}
+
+// The document scope (searched with DoNotTraverseFlatTree) excludes shadow content, so it stays
+// tiny. The shadow scope is filled with many text runs so that, once a small run-count limit is
+// set, textForScope() treats it as oversized.
+const host = document.getElementById('host');
+const shadowRoot = host.attachShadow({ mode: 'closed' });
+const shadowRunCount = 50;
+for (let i = 0; i < shadowRunCount; i++)
+    shadowRoot.appendChild(document.createElement('p')).textContent = target;
+
+async function navigateSelectionIntoShadow()
+{
+    getSelection().empty();
+    // Uses the flat-tree buffer (which includes shadow content) to move the selection into the
+    // shadow scope, so the subsequent window.find() starts from inside the shadow root.
+    await testRunner.findString(target, []);
+}
+
+onload = async () => {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    // Baseline: with no limit, window.find() (which uses DoNotTraverseFlatTree) finds a match
+    // through findNextMatchInShadowIncludingAncestorTree's cached path.
+    await navigateSelectionIntoShadow();
+    if (window.find(target, false, false))
+        log("PASS: found match with the find-match cache enabled");
+    else
+        log("FAIL: did not find match with the find-match cache enabled");
+
+    // Shrink the run-count limit so the shadow scope is treated as oversized. The document scope
+    // has far fewer runs, so findMatchFrom() passes its own oversized check and enters
+    // findNextMatchInShadowIncludingAncestorTree, where textForScope() on the shadow scope returns
+    // nullopt -> CacheUnusable::Oversized. Editor::findString then falls back to the uncached
+    // rangeOfString(), which still finds the match.
+    internals.setCachedFindMatchBufferLimitForTesting(5);
+
+    await navigateSelectionIntoShadow();
+    if (window.find(target, false, false))
+        log("PASS: found match via uncached fallback when the shadow scope is oversized");
+    else
+        log("FAIL: match missed when the shadow scope is oversized");
+
+    document.getElementById("console").style.removeProperty("visibility");
+    testRunner.notifyDone();
+};
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -34,6 +34,8 @@
 #include "TextIterator.h"
 #include "TextIteratorBehavior.h"
 #include "dom/BoundaryPoint.h"
+#include <wtf/Expected.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
@@ -45,6 +47,17 @@ static inline FindOptions matchAffectingOptions(FindOptions options)
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedMatchFinder);
+
+static std::optional<unsigned>& maximumRunCountForTesting()
+{
+    static std::optional<unsigned> value;
+    return value;
+}
+
+void CachedMatchFinder::setMaximumRunCountForTesting(std::optional<unsigned> limit)
+{
+    maximumRunCountForTesting() = limit;
+}
 
 CachedMatchFinder::CachedMatchFinder(Document& document)
     : m_document(document)
@@ -158,10 +171,15 @@ std::optional<SimpleRange> CachedMatchFinder::findNextMatch(StringView buffer, c
     return result;
 }
 
-std::optional<SimpleRange> CachedMatchFinder::findNextMatchInShadowIncludingAncestorTree(ShadowRoot& startingShadowRoot, const SimpleRange& selectionRange, const String& target, FindOptions options)
+Expected<std::optional<SimpleRange>, CachedMatchFinder::CacheUnusable> CachedMatchFinder::findNextMatchInShadowIncludingAncestorTree(ShadowRoot& startingShadowRoot, const SimpleRange& selectionRange, const String& target, FindOptions options)
 {
     RefPtr shadowRoot = &startingShadowRoot;
-    auto [shadowBuffer, shadowRuns] = textForScope(*shadowRoot, options);
+    String shadowBuffer;
+    Vector<TextRun> shadowRuns;
+    if (auto built = textForScope(*shadowRoot, options))
+        std::tie(shadowBuffer, shadowRuns) = *built;
+    else
+        return WTF::makeUnexpected(CacheUnusable::Oversized);
 
     unsigned startOffset = startingOffsetForSelection(shadowBuffer, shadowRuns, selectionRange, options);
     if (auto result = findNextMatch(shadowBuffer, shadowRuns, startOffset, target, options, selectionRange))
@@ -177,30 +195,39 @@ std::optional<SimpleRange> CachedMatchFinder::findNextMatchInShadowIncludingAnce
         RefPtr parentShadow = host->containingShadowRoot();
         if (!parentShadow) {
             auto& cached = bufferForOptions(options);
+            if (cached.oversized)
+                return WTF::makeUnexpected(CacheUnusable::Oversized);
             unsigned docOffset = bufferOffsetForBoundaryPoint(cached.text, cached.runs, *afterHost, options);
             if (auto result = findNextMatch(cached.text, cached.runs, docOffset, target, options))
                 return result;
             if (options.contains(FindOption::WrapAround))
                 return findNextMatch(cached.text, cached.runs, 0, target, options);
-            return std::nullopt;
+            return std::optional<SimpleRange> { };
         }
 
-        std::tie(shadowBuffer, shadowRuns) = textForScope(*parentShadow, options);
+        if (auto built = textForScope(*parentShadow, options))
+            std::tie(shadowBuffer, shadowRuns) = *built;
+        else
+            return WTF::makeUnexpected(CacheUnusable::Oversized);
+
         unsigned parentOffset = bufferOffsetForBoundaryPoint(shadowBuffer, shadowRuns, *afterHost, options);
         if (auto result = findNextMatch(shadowBuffer, shadowRuns, parentOffset, target, options))
             return result;
         shadowRoot = parentShadow;
     }
 
-    return std::nullopt;
+    return std::optional<SimpleRange> { };
 }
 
-std::optional<SimpleRange> CachedMatchFinder::findMatchFrom(const std::optional<SimpleRange>& selectionRange, const String& target, FindOptions options)
+Expected<std::optional<SimpleRange>, CachedMatchFinder::CacheUnusable> CachedMatchFinder::findMatchFrom(const std::optional<SimpleRange>& selectionRange, const String& target, FindOptions options)
 {
     if (!isTextBufferCacheValid()) {
         if (!clearTextBufferCache())
-            return std::nullopt;
+            return std::optional<SimpleRange> { };
     }
+
+    if (bufferForOptions(options).oversized)
+        return makeUnexpected(CacheUnusable::Oversized);
 
     RefPtr shadowRoot = selectionRange ? selectionRange->startContainer().containingShadowRoot() : nullptr;
     if (shadowRoot && options.contains(FindOption::DoNotTraverseFlatTree))
@@ -221,18 +248,20 @@ std::optional<SimpleRange> CachedMatchFinder::findMatchFrom(const std::optional<
         return findNextMatch(cached.text, cached.runs, wrapOffset, target, options);
     }
 
-    return std::nullopt;
+    return std::optional<SimpleRange> { };
 }
 
-Vector<SimpleRange> CachedMatchFinder::findMatches(const std::optional<SimpleRange>& searchRange, const String& target, FindOptions options, std::optional<unsigned> limit)
+Expected<Vector<SimpleRange>, CachedMatchFinder::CacheUnusable> CachedMatchFinder::findMatches(const std::optional<SimpleRange>& searchRange, const String& target, FindOptions options, std::optional<unsigned> limit)
 {
     if (!isTextBufferCacheValid()) {
         if (!clearTextBufferCache())
-            return { };
+            return Vector<SimpleRange> { };
     } else if (isSearchResultCacheValid(target, options, limit) && m_matchCache)
         return *m_matchCache;
 
     auto& cached = bufferForOptions(options);
+    if (cached.oversized)
+        return makeUnexpected(CacheUnusable::Oversized);
 
     unsigned startOffset = searchRange ? bufferOffsetForBoundaryPoint(cached.text, cached.runs, searchRange->start, options) : 0;
     Vector<SimpleRange> results;
@@ -249,15 +278,17 @@ Vector<SimpleRange> CachedMatchFinder::findMatches(const std::optional<SimpleRan
     return results;
 }
 
-unsigned CachedMatchFinder::countMatches(const std::optional<SimpleRange>& searchRange, const String& target, FindOptions options, std::optional<unsigned> limit)
+Expected<unsigned, CachedMatchFinder::CacheUnusable> CachedMatchFinder::countMatches(const std::optional<SimpleRange>& searchRange, const String& target, FindOptions options, std::optional<unsigned> limit)
 {
     if (!isTextBufferCacheValid()) {
         if (!clearTextBufferCache())
-            return 0;
+            return 0u;
     } else if (isSearchResultCacheValid(target, options, limit) && m_countCache)
         return *m_countCache;
 
     auto& cached = bufferForOptions(options);
+    if (cached.oversized)
+        return makeUnexpected(CacheUnusable::Oversized);
 
     unsigned count { 0 };
     unsigned startOffset = searchRange ? bufferOffsetForBoundaryPoint(cached.text, cached.runs, searchRange->start, options) : 0;
@@ -352,22 +383,32 @@ CachedMatchFinder::TextRunCache& CachedMatchFinder::bufferForOptions(FindOptions
 {
     auto& cache = options.contains(FindOption::DoNotTraverseFlatTree) ? m_docBuffer : m_flatTreeBuffer;
     if (RefPtr document = m_document.get(); cache.dirty) {
-        std::tie(cache.text, cache.runs) = textForScope(*document, options);
+        if (auto built = textForScope(*document, options)) {
+            std::tie(cache.text, cache.runs) = WTF::move(*built);
+            cache.oversized = false;
+        } else {
+            cache.text = { };
+            cache.runs = { };
+            cache.oversized = true;
+        }
         cache.dirty = false;
     }
     return cache;
 }
 
-auto CachedMatchFinder::textForScope(ContainerNode& scope, FindOptions options) -> std::pair<String, Vector<TextRun>> {
+auto CachedMatchFinder::textForScope(ContainerNode& scope, FindOptions options) -> std::optional<std::pair<String, Vector<TextRun>>> {
     protect(scope.document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::TreatRevealedWhenFoundAsVisible });
     SimpleRange range = makeRangeSelectingNodeContents(scope);
     TextIterator it(range, findIteratorOptions(options));
 
-    StringBuilder builder;
+    StringBuilder builder { WTF::OverflowPolicy::RecordOverflow };
     Vector<TextRun> runs;
     for (; !it.atEnd(); it.advance()) {
+        if (auto limit = maximumRunCountForTesting(); limit && runs.size() >= *limit)
+            return std::nullopt;
         auto textRunRange = it.range();
-        runs.append(TextRun { static_cast<unsigned>(builder.length()), textRunRange });
+        if (!runs.tryAppend(TextRun { static_cast<unsigned>(builder.length()), textRunRange }))
+            return std::nullopt;
         auto text = it.text();
         if (text.is8Bit()) {
             for (auto character : text.span8())
@@ -376,9 +417,11 @@ auto CachedMatchFinder::textForScope(ContainerNode& scope, FindOptions options) 
             for (auto character : text.span16())
                 builder.append(foldQuoteMarkAndReplaceNoBreakSpace(character));
         }
+        if (builder.hasOverflowed())
+            return std::nullopt;
     }
 
-    return { builder.toString(), runs };
+    return std::pair { builder.toString(), WTF::move(runs) };
 }
 
 BoundaryPoint CachedMatchFinder::boundaryForOffset(const Vector<CachedMatchFinder::TextRun>& runs, unsigned position, BoundaryEdge boundaryEdge)

--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -27,6 +27,7 @@
 
 #include "FindOptions.h"
 #include "SimpleRange.h"
+#include <wtf/Expected.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -43,9 +44,13 @@ class CachedMatchFinder {
 public:
     explicit CachedMatchFinder(Document&);
 
-    std::optional<SimpleRange> findMatchFrom(const std::optional<SimpleRange>&, const String& target, FindOptions);
-    Vector<SimpleRange> findMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
-    unsigned countMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
+    enum class CacheUnusable : bool { Oversized };
+
+    Expected<std::optional<SimpleRange>, CacheUnusable> findMatchFrom(const std::optional<SimpleRange>&, const String& target, FindOptions);
+    Expected<Vector<SimpleRange>, CacheUnusable> findMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
+    Expected<unsigned, CacheUnusable> countMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
+
+    WEBCORE_EXPORT static void setMaximumRunCountForTesting(std::optional<unsigned>);
 
 private:
     struct TextRun {
@@ -57,15 +62,16 @@ private:
         String text;
         Vector<TextRun> runs;
         bool dirty { true };
+        bool oversized { false };
     };
 
     bool isTextBufferCacheValid() const;
     bool clearTextBufferCache();
     TextRunCache& bufferForOptions(FindOptions);
     bool isSearchResultCacheValid(const String&, FindOptions, std::optional<unsigned> limit) const;
-    static std::pair<String, Vector<TextRun>> textForScope(ContainerNode&, FindOptions);
+    static std::optional<std::pair<String, Vector<TextRun>>> textForScope(ContainerNode&, FindOptions);
     enum class SearchShouldContinue : bool { No, Yes };
-    std::optional<SimpleRange> findNextMatchInShadowIncludingAncestorTree(ShadowRoot&, const SimpleRange&, const String& target, FindOptions);
+    Expected<std::optional<SimpleRange>, CachedMatchFinder::CacheUnusable> findNextMatchInShadowIncludingAncestorTree(ShadowRoot&, const SimpleRange&, const String& target, FindOptions);
     static void performSearch(StringView, unsigned startOffset, const String& target, FindOptions, NOESCAPE const Function<SearchShouldContinue(size_t, size_t)>&);
     static std::optional<SimpleRange> findNextMatch(StringView, const Vector<TextRun>&, unsigned startOffset, const String& target, FindOptions, const std::optional<SimpleRange>& excludeRange = std::nullopt);
     static unsigned bufferOffsetForBoundaryPoint(StringView, const Vector<TextRun>&, const BoundaryPoint&, FindOptions);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4060,7 +4060,11 @@ std::optional<SimpleRange> Editor::findString(const String& target, FindOptions 
         if (!m_matchFinder)
             m_matchFinder = WTF::makeUnique<CachedMatchFinder>(document);
 
-        resultRange = m_matchFinder->findMatchFrom(referenceRange, target, options);
+        auto cachedResult = m_matchFinder->findMatchFrom(referenceRange, target, options);
+        if (cachedResult.has_value())
+            resultRange = *cachedResult;
+        else if (cachedResult.error() == CachedMatchFinder::CacheUnusable::Oversized)
+            resultRange = rangeOfString(target, referenceRange, options);
     }
 
     if (!resultRange)
@@ -4184,12 +4188,10 @@ unsigned Editor::countMatchesForText(const String& target, const std::optional<S
     if (!m_matchFinder)
         m_matchFinder = WTF::makeUnique<CachedMatchFinder>(document);
 
+    auto searchOptions = options - FindOption::Backwards;
     std::optional<unsigned> optionalLimit = limit ? std::make_optional(limit) : std::nullopt;
 
-    unsigned matchCount;
-    if (matches || markMatches) {
-        auto allMatches = m_matchFinder->findMatches(searchRange, target, options - FindOption::Backwards, optionalLimit);
-
+    auto collectAndMark = [&](const Vector<SimpleRange>& allMatches) {
         if (matches)
             matches->appendVector(allMatches);
 
@@ -4197,13 +4199,26 @@ unsigned Editor::countMatchesForText(const String& target, const std::optional<S
             for (const auto& match : allMatches)
                 addMarker(match, DocumentMarkerType::TextMatch);
         }
+    };
 
-        matchCount = allMatches.size();
+    if (matches || markMatches) {
+        auto cachedMatches = m_matchFinder->findMatches(searchRange, target, searchOptions, optionalLimit);
+        if (cachedMatches.has_value()) {
+            collectAndMark(*cachedMatches);
+            return cachedMatches->size();
+        }
+        ASSERT(cachedMatches.error() == CachedMatchFinder::CacheUnusable::Oversized);
     } else {
-        matchCount = m_matchFinder->countMatches(searchRange, target, options - FindOption::Backwards, optionalLimit);
+        auto cachedCount = m_matchFinder->countMatches(searchRange, target, searchOptions, optionalLimit);
+        if (cachedCount.has_value())
+            return *cachedCount;
+        ASSERT(cachedCount.error() == CachedMatchFinder::CacheUnusable::Oversized);
     }
 
-    return matchCount;
+    // The cached buffer was oversized; fall back to an uncached search.
+    auto allMatches = findAllPlainText(*searchRange, target, searchOptions, limit);
+    collectAndMark(allMatches);
+    return allMatches.size();
 }
 
 void Editor::setMarkedTextMatchesAreHighlighted(bool flag)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -49,6 +49,7 @@
 #include "CacheStorageConnection.h"
 #include "CacheStorageProvider.h"
 #include "CachedImage.h"
+#include "CachedMatchFinder.h"
 #include "CanvasBase.h"
 #include "CertificateInfo.h"
 #include "Chrome.h"
@@ -622,6 +623,8 @@ void Internals::resetToConsistentState(Page& page)
 {
     page.setPageScaleFactor(1, IntPoint(0, 0));
     page.setPagination(Pagination());
+
+    CachedMatchFinder::setMaximumRunCountForTesting(std::nullopt);
 
     page.setDefersLoading(false);
     page.setResourceCachingDisabledByWebInspector(false);
@@ -3350,6 +3353,11 @@ ExceptionOr<unsigned> Internals::countMatchesForText(const String& text, const V
 
     bool mark = markMatches == "mark"_s;
     return document->editor().countMatchesForText(text, std::nullopt, parsedOptions.releaseReturnValue(), 1000, mark, nullptr);
+}
+
+void Internals::setCachedFindMatchBufferLimitForTesting(unsigned maximumRunCount)
+{
+    CachedMatchFinder::setMaximumRunCountForTesting(maximumRunCount);
 }
 
 ExceptionOr<unsigned> Internals::countFindMatches(const String& text, const Vector<String>& findOptions)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -539,6 +539,7 @@ public:
     ExceptionOr<RefPtr<Range>> rangeOfString(const String&, RefPtr<Range>&&, const Vector<String>& findOptions);
     ExceptionOr<unsigned> countMatchesForText(const String&, const Vector<String>& findOptions, const String& markMatches);
     ExceptionOr<unsigned> countFindMatches(const String&, const Vector<String>& findOptions);
+    void setCachedFindMatchBufferLimitForTesting(unsigned maximumRunCount);
 #if ENABLE(VIDEO)
     ExceptionOr<Vector<double>> findCueMatches(const String&, const Vector<String>& findOptions);
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -669,6 +669,7 @@ enum ContentsFormat {
     Range? rangeOfString(DOMString text, Range? referenceRange, sequence<DOMString> findOptions);
     unsigned long countMatchesForText(DOMString text, sequence<DOMString> findOptions, DOMString markMatches);
     unsigned long countFindMatches(DOMString text, sequence<DOMString> findOptions);
+    undefined setCachedFindMatchBufferLimitForTesting(unsigned long maximumRunCount);
     [Conditional=VIDEO] sequence<unrestricted double> findCueMatches(DOMString text, sequence<DOMString> findOptions);
 
     DOMString autofillFieldName(Element formControlElement);


### PR DESCRIPTION
#### e3bc700a28feffa664c774e3347956273a3b4952
<pre>
Large pages can overflow the CachedMatchFinder buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=318124">https://bugs.webkit.org/show_bug.cgi?id=318124</a>
<a href="https://rdar.apple.com/179205821">rdar://179205821</a>

Reviewed by Megan Gardner.

Large pages are causing the CachedMatchFinder&apos;s buffer to overflow. To fix this,
I have added a check for this overflow, which sets an oversized flag on the buffer.
Then, if CachedMatchFinder&apos;s findMatchFrom, findMatches, or countMatches tries to use
a buffer that has been overflowed, it returns an unexpected
CachedMatchFinder::CacheUnusable, signalling they should fall back to the old implementation.

Test: editing/text-iterator/find-matches-oversized-buffer-fallback.html

* LayoutTests/editing/text-iterator/find-matches-oversized-buffer-fallback-expected.txt: Added.
* LayoutTests/editing/text-iterator/find-matches-oversized-buffer-fallback.html: Added.
* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::maximumRunCountForTesting):
(WebCore::CachedMatchFinder::setMaximumRunCountForTesting):
(WebCore::CachedMatchFinder::findNextMatchInShadowIncludingAncestorTree):
(WebCore::CachedMatchFinder::findMatchFrom):
(WebCore::CachedMatchFinder::findMatches):
(WebCore::CachedMatchFinder::countMatches):
(WebCore::CachedMatchFinder::bufferForOptions):
(WebCore::CachedMatchFinder::textForScope):
* Source/WebCore/editing/CachedMatchFinder.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::findString):
(WebCore::Editor::countMatchesForText):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::setCachedFindMatchBufferLimitForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/316401@main">https://commits.webkit.org/316401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb5dba15d4641d4d9fedbd6e34497702b2db3021

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181510 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129624 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3c2fae0-d5fd-4b49-a220-d5b3ab1572c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2da57b93-a2d9-49b7-a0d0-e117bc702039) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8625b2ec-2c9b-450b-a57e-157ad872f5a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35895 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34161 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30123 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146321 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184043 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142585 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38500 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46334 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30727 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110997 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37563 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118022 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44852 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8821 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->