### PR TITLE
[MediaStream] OverconstrainedError does not inherit from DOMException and has no code attribute

### DIFF
--- a/LayoutTests/fast/events/constructors/overconstrained-error-event-constructor-expected.txt
+++ b/LayoutTests/fast/events/constructors/overconstrained-error-event-constructor-expected.txt
@@ -10,15 +10,15 @@ PASS new OverconstrainedErrorEvent('eventType', { bubbles: false }).bubbles is f
 PASS new OverconstrainedErrorEvent('eventType', { bubbles: true }).bubbles is true
 PASS new OverconstrainedErrorEvent('eventType', { cancelable: false }).cancelable is false
 PASS new OverconstrainedErrorEvent('eventType', { cancelable: true }).cancelable is true
-PASS new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError() }).error.constraint is ""
-PASS new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError() }).error.message is ""
+PASS new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('') }).error.constraint is ""
+PASS new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('') }).error.message is ""
 PASS new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('width') }).error.constraint is "width"
 PASS new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('fred', 'unsupported constraint') }).error.message is "unsupported constraint"
 PASS new OverconstrainedErrorEvent('eventType', { error: null }).reason is undefined.
 PASS new OverconstrainedErrorEvent('eventType', { error: 'fake error' }) threw exception TypeError: Type error.
 PASS new OverconstrainedErrorEvent('eventType', { error: [] }) threw exception TypeError: Type error.
-PASS new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError() }).bubbles is true
-PASS new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError() }).cancelable is true
+PASS new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError('') }).bubbles is true
+PASS new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError('') }).cancelable is true
 PASS new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError('bogus') }).error.constraint is "bogus"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/constructors/overconstrained-error-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/overconstrained-error-event-constructor.html
@@ -29,8 +29,8 @@
         shouldBe("new OverconstrainedErrorEvent('eventType', { cancelable: true }).cancelable", "true");
 
         // error is passed.
-        shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError() }).error.constraint", "");
-        shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError() }).error.message", "");
+        shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('') }).error.constraint", "");
+        shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('') }).error.message", "");
         shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('width') }).error.constraint", "width");
         shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { error: new OverconstrainedError('fred', 'unsupported constraint') }).error.message", "unsupported constraint");
 
@@ -39,8 +39,8 @@
         shouldThrowErrorName("new OverconstrainedErrorEvent('eventType', { error: [] })", "TypeError");
 
         // All initializers are passed.
-        shouldBe("new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError() }).bubbles", "true");
-        shouldBe("new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError() }).cancelable", "true");
+        shouldBe("new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError('') }).bubbles", "true");
+        shouldBe("new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError('') }).cancelable", "true");
         shouldBeEqualToString("new OverconstrainedErrorEvent('eventType', { bubbles: true, cancelable: true, error: new OverconstrainedError('bogus') }).error.constraint", "bogus");
     })();
 

--- a/LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code-expected.txt
@@ -1,6 +1,6 @@
 
 PASS MediaStream.onaddtrack and onremovetrack IDL attributes (existence + default)
 PASS MediaStream.onaddtrack: addtrack event payload (when fired by UA or by script addTrack)
-FAIL OverconstrainedError.code is 0 (no legacy DOMException code mapping) assert_true: OverconstrainedError inherits from DOMException expected true got false
-FAIL OverconstrainedError raised by applyConstraints also has code 0 assert_equals: UA-raised OverconstrainedError.code is also 0 expected (number) 0 but got (undefined) undefined
+PASS OverconstrainedError.code is 0 (no legacy DOMException code mapping)
+PASS OverconstrainedError raised by applyConstraints also has code 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/idlharness.https.window-expected.txt
@@ -113,14 +113,10 @@ PASS MediaStreamTrackEvent interface: attribute track
 PASS MediaStreamTrackEvent must be primary interface of trackEvent
 PASS Stringification of trackEvent
 PASS MediaStreamTrackEvent interface: trackEvent must inherit property "track" with the proper type
-FAIL OverconstrainedError interface: existence and properties of interface object assert_equals: prototype of OverconstrainedError is not DOMException expected function "function DOMException() {
-    [native code]
-}" but got function "function () {
-    [native code]
-}"
-FAIL OverconstrainedError interface object length assert_equals: wrong value for OverconstrainedError.length expected 1 but got 0
+PASS OverconstrainedError interface: existence and properties of interface object
+PASS OverconstrainedError interface object length
 PASS OverconstrainedError interface object name
-FAIL OverconstrainedError interface: existence and properties of interface prototype object assert_equals: prototype of OverconstrainedError.prototype is not DOMException.prototype expected [stringifying object threw TypeError: The DOMException.name getter can only be used on instances of DOMException with type object] but got object "Error"
+PASS OverconstrainedError interface: existence and properties of interface prototype object
 PASS OverconstrainedError interface: existence and properties of interface prototype object's "constructor" property
 PASS OverconstrainedError interface: existence and properties of interface prototype object's @@unscopables property
 PASS OverconstrainedError interface: attribute constraint

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL Error of OverconstrainedError type inherit from DOMException assert_unreached: applyConstraints should have failed Reached unreachable code
-FAIL OverconstrainedError class inherits from DOMException assert_true: expected true got false
+PASS OverconstrainedError class inherits from DOMException
 

--- a/Source/WebCore/Modules/mediastream/OverconstrainedError.cpp
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedError.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016, 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,15 +26,32 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://w3c.github.io/mediacapture-main/#dom-overconstrainederror
+#include "config.h"
+#include "OverconstrainedError.h"
 
-[
-    Conditional=MEDIA_STREAM,
-    Exposed=Window,
-    JSGenerateToNativeObject,
-    SkipVTableValidation
-] interface OverconstrainedError : DOMException {
-    constructor(DOMString constraint, optional DOMString message = "");
+#if ENABLE(MEDIA_STREAM)
 
-    readonly attribute DOMString constraint;
-};
+namespace WebCore {
+
+OverconstrainedError::OverconstrainedError(const String& constraint, const String& message)
+    : DOMException(0, "OverconstrainedError"_s, message, Type::OverconstrainedError)
+    , m_constraint(constraint)
+{
+}
+
+OverconstrainedError::OverconstrainedError(MediaConstraintType invalidConstraint, const String& message)
+    : DOMException(0, "OverconstrainedError"_s, message, Type::OverconstrainedError)
+    , m_invalidConstraint(invalidConstraint)
+{
+}
+
+String OverconstrainedError::constraint() const
+{
+    if (m_constraint.isNull())
+        m_constraint = convertToString(m_invalidConstraint);
+    return m_constraint;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/Modules/mediastream/OverconstrainedError.h
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedError.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,13 +30,13 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "DOMException.h"
 #include "MediaConstraintType.h"
-#include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class OverconstrainedError  : public RefCounted<OverconstrainedError> {
+class OverconstrainedError final : public DOMException {
 public:
     static Ref<OverconstrainedError> create(const String& constraint, const String& message)
     {
@@ -48,34 +48,19 @@ public:
     }
 
     String constraint() const;
-    String message() const { return m_message; }
-    String name() const { return "OverconstrainedError"_s; }
-
-protected:
-    OverconstrainedError(const String& constraint, const String& message)
-        : m_constraint(constraint)
-        , m_message(message)
-    {
-    }
-    OverconstrainedError(MediaConstraintType invalidConstraint, const String& message)
-        : m_invalidConstraint(invalidConstraint)
-        , m_message(message)
-    {
-    }
 
 private:
+    OverconstrainedError(const String& constraint, const String& message);
+    OverconstrainedError(MediaConstraintType invalidConstraint, const String& message);
+
     mutable String m_constraint;
-    MediaConstraintType m_invalidConstraint;
-    String m_message;
+    MediaConstraintType m_invalidConstraint { MediaConstraintType::Unknown };
 };
 
-inline String OverconstrainedError::constraint() const
-{
-    if (m_constraint.isNull())
-        m_constraint = convertToString(m_invalidConstraint);
-    return m_constraint;
-}
-
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::OverconstrainedError)
+    static bool isType(const WebCore::DOMException& exception) { return exception.type() == WebCore::DOMException::Type::OverconstrainedError; }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -260,6 +260,7 @@ Modules/mediastream/MediaStreamTrackProcessor.cpp @cost:5
 Modules/mediastream/MediaTrackCapabilities.cpp
 Modules/mediastream/MediaTrackConstraints.cpp
 Modules/mediastream/NavigatorMediaDevices.cpp @cost:4
+Modules/mediastream/OverconstrainedError.cpp
 Modules/mediastream/OverconstrainedErrorEvent.cpp
 Modules/mediastream/PeerConnectionBackend.cpp @cost:5
 Modules/mediastream/RTCCertificate.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -7791,6 +7791,7 @@
 		070363DE181A1CDC00C074A5 /* AVVideoCaptureSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVVideoCaptureSource.h; sourceTree = "<group>"; };
 		070363DF181A1CDC00C074A5 /* AVVideoCaptureSource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVVideoCaptureSource.mm; sourceTree = "<group>"; };
 		0704A4031D6DE9F10086DCDB /* OverconstrainedError.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = OverconstrainedError.idl; sourceTree = "<group>"; };
+		0704A4041D6DE9F10086DCDB /* OverconstrainedError.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OverconstrainedError.cpp; sourceTree = "<group>"; };
 		0704A4051D6DE9F10086DCDB /* OverconstrainedError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OverconstrainedError.h; sourceTree = "<group>"; };
 		0704A4091D6DFC690086DCDB /* JSOverconstrainedError.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSOverconstrainedError.cpp; sourceTree = "<group>"; };
 		0704A40A1D6DFC690086DCDB /* JSOverconstrainedError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSOverconstrainedError.h; sourceTree = "<group>"; };
@@ -24088,6 +24089,7 @@
 				5EA725CC1ACABCB500EAD17B /* Navigator+MediaDevices.idl */,
 				5EA725CA1ACABCB500EAD17B /* NavigatorMediaDevices.cpp */,
 				5EA725CB1ACABCB500EAD17B /* NavigatorMediaDevices.h */,
+				0704A4041D6DE9F10086DCDB /* OverconstrainedError.cpp */,
 				0704A4051D6DE9F10086DCDB /* OverconstrainedError.h */,
 				0704A4031D6DE9F10086DCDB /* OverconstrainedError.idl */,
 				E3BF19E322AF2FA5009C9926 /* OverconstrainedErrorEvent.cpp */,

--- a/Source/WebCore/dom/DOMException.h
+++ b/Source/WebCore/dom/DOMException.h
@@ -62,7 +62,7 @@ public:
     static ASCIILiteral name(ExceptionCode ec) { return description(ec).name; }
     static ASCIILiteral message(ExceptionCode ec) { return description(ec).message; }
 
-    enum class Type : uint8_t { Default, WebTransportError, GPUPipelineError, RTCError };
+    enum class Type : uint8_t { Default, WebTransportError, GPUPipelineError, RTCError, OverconstrainedError };
     Type type() const { return m_type; }
 
 protected:


### PR DESCRIPTION
#### 525dd980ce78d4d809d726478919965cb2cd05f2
<pre>
[MediaStream] OverconstrainedError does not inherit from DOMException and has no code attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=318127">https://bugs.webkit.org/show_bug.cgi?id=318127</a>
<a href="https://rdar.apple.com/180728516">rdar://180728516</a>

Reviewed by Andy Estes.

The MediaCapture-Main specification defines OverconstrainedError as
`interface OverconstrainedError : DOMException`, with the `name`
&quot;OverconstrainedError&quot; and `code` of 0 (no legacy DOMException code
mapping). WebKit&apos;s implementation was a standalone RefCounted interface
that did not inherit from DOMException and exposed no `code` attribute,
which caused several spec-compliance failures, including
`new OverconstrainedError(&quot;x&quot;) instanceof DOMException` returning false
and `OverconstrainedError.length` being 0 instead of 1.

This patch makes OverconstrainedError inherit from DOMException, the
same pattern already used by RTCError, WebTransportError, and
GPUPipelineError. The two constructors now delegate to DOMException
with legacyCode = 0 and name &quot;OverconstrainedError&quot;, giving instances
the expected `.code`, `.name`, and DOMException prototype chain for
free. The IDL constructor signature is also tightened to match the
spec: `constructor(DOMString constraint, optional DOMString message = &quot;&quot;)`.

A new OverconstrainedError.cpp is added to host the constructors and
the lazy constraint() conversion (previously inline in the header),
and is wired into the unified-sources build and the Xcode project.

Layout test baselines are updated where the new behavior changes
PASS/FAIL state, and fast/events/constructors/overconstrained-error-event-constructor.html
is adjusted to pass the now-required `constraint` argument.

No new tests, existing tests updated.

* LayoutTests/fast/events/constructors/overconstrained-error-event-constructor-expected.txt:
* LayoutTests/fast/events/constructors/overconstrained-error-event-constructor.html:
* LayoutTests/fast/mediastream/mediastream-onaddtrack-and-overconstrainederror-code-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/idlharness.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/overconstrained_error.https-expected.txt:
* Source/WebCore/Modules/mediastream/OverconstrainedError.cpp: Copied from Source/WebCore/Modules/mediastream/OverconstrainedError.idl.
(WebCore::OverconstrainedError::OverconstrainedError):
(WebCore::OverconstrainedError::constraint const):
* Source/WebCore/Modules/mediastream/OverconstrainedError.h:
(isType):
(WebCore::OverconstrainedError::create): Deleted.
(WebCore::OverconstrainedError::message const): Deleted.
(WebCore::OverconstrainedError::name const): Deleted.
(WebCore::OverconstrainedError::OverconstrainedError): Deleted.
(WebCore::OverconstrainedError::constraint const): Deleted.
* Source/WebCore/Modules/mediastream/OverconstrainedError.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DOMException.h:

Canonical link: <a href="https://commits.webkit.org/316578@main">https://commits.webkit.org/316578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2d8ddad0acc5020d71999c97bd7925352ea894d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45887 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39305 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129524 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c8686c2-0735-4cb4-a2a5-df6c6f2ea049) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133784 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94376 "3 flakes 20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2796f54-50aa-4c47-9e9c-3fb78a9a7e19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114256 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2027b93-3778-4b80-b8b1-a592f316f91e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34075 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30023 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183942 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142500 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38632 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46234 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30651 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110897 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37486 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117922 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44752 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8745 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44152 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44384 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->