### PR TITLE
[Site Isolation] Positional back/forward child-frame lookup corrupts a sibling frameID, producing duplicate frameIDs in the BF tree

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2399,8 +2399,6 @@ webkit.org/b/317857 [ Debug ] http/tests/site-isolation/frame-index.html [ Skip 
 
 webkit.org/b/317884 imported/w3c/web-platform-tests/digital-credentials/get-non-fully-active.https.html [ Failure ]
 
-webkit.org/b/317799 [ Debug ] http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html [ Skip ]
-
 webkit.org/b/318150 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-shape-overflow.html [ ImageOnlyFailure ]
 webkit.org/b/318150 imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-border-shape.html [ ImageOnlyFailure ]
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -933,7 +933,7 @@ void WebBackForwardList::backForwardListCounts(CompletionHandler<void(WebBackFor
     completionHandler(rawCounts());
 }
 
-FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, uint64_t childFrameIndex)
+FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, WebCore::FrameIdentifier childFrameID, uint64_t childFrameIndex)
 {
     RefPtr targetItem = itemForID(itemID);
     if (!targetItem)
@@ -949,7 +949,11 @@ FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIde
         parentFrameItem = &targetItem->mainFrameItem();
     }
 
-    RefPtr childFrameItem = parentFrameItem->childItemAtIndex(childFrameIndex);
+    RefPtr childFrameItem = parentFrameItem->childItemForFrameID(childFrameID);
+    if (!childFrameItem) {
+        // The identifier is absent after session restore or cross-site child-frame recreation; fall back to position.
+        childFrameItem = parentFrameItem->childItemAtIndex(childFrameIndex);
+    }
     if (!childFrameItem)
         return nullptr;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -102,7 +102,7 @@ public:
     void backForwardAddItemShared(IPC::Connection&, Ref<FrameState>&&, LoadedWebArchive);
     void backForwardGoToItemShared(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
 
-    FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
+    FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier parentFrameID, WebCore::FrameIdentifier childFrameID, uint64_t childFrameIndex);
     void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
     void replaceFrameStateForChild(WebBackForwardListItem&, WebCore::FrameIdentifier, Ref<FrameState>&& newFrameState);

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -895,6 +895,7 @@ final class WebBackForwardList {
     func findFrameStateInItem(
         itemID: WebCore.BackForwardItemIdentifier,
         parentFrameID: WebCore.FrameIdentifier,
+        childFrameID: WebCore.FrameIdentifier,
         childFrameIndex: UInt64
     ) -> WebKit.FrameState? {
         guard let targetItem = itemForID(identifier: itemID) else {
@@ -906,7 +907,12 @@ final class WebBackForwardList {
         // This only works correctly for direct children of the main frame; nested frames
         // (e.g., subframe > nestedframe) will get the wrong FrameState.
         let parentFrameItem = targetItem.mainFrameItem().childItemForFrameID(parentFrameID) ?? targetItem.mainFrameItem()
-        guard let childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex) else {
+        var childFrameItem = parentFrameItem.childItemForFrameID(childFrameID)
+        if childFrameItem == nil {
+            // The identifier is absent after session restore or cross-site child-frame recreation; fall back to position.
+            childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex)
+        }
+        guard let childFrameItem else {
             return nil
         }
         return getFrameState(childFrameItem)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9297,7 +9297,7 @@ RefPtr<FrameState> WebPageProxy::frameStateForBackForwardChildFrame(WebFrameProx
     if (!index)
         return nullptr;
 
-    RefPtr frameState = backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), *index);
+    RefPtr frameState = backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), frame.frameID(), *index);
     if (!frameState)
         return nullptr;
 


### PR DESCRIPTION
#### bbef52230d06c1615a08fc6c75d6cbf2e1648f53
<pre>
[Site Isolation] Positional back/forward child-frame lookup corrupts a sibling frameID, producing duplicate frameIDs in the BF tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=318112">https://bugs.webkit.org/show_bug.cgi?id=318112</a>
<a href="https://rdar.apple.com/180926736">rdar://180926736</a>

Reviewed by Sihui Liu.

This is the capture-side root cause behind bug 318015, which only added a defensive guard in
the per-frame back/forward walk.

Under UseUIProcessForBackForwardItemLoading, when a child frame performs a back/forward
navigation, WebPageProxy::frameStateForBackForwardChildFrame looks up the child&apos;s stored
FrameState in the target back/forward item positionally: it takes the live frame&apos;s document-order
index (WebFrameProxy::indexInFrameTreeSiblings) and calls WebBackForwardList::findFrameStateInItem,
which fetches the BF child via WebBackForwardListFrameItem::childItemAtIndex(index).

But the BF item&apos;s children are stored in commit/append order (the order in which each iframe
recorded its initial history item), which can differ from the live frame tree&apos;s document order.
When a page has two sibling iframes and the second commits its initial history item before the
first (e.g. the second has a script and the first is empty), the BF children end up reversed
relative to the live tree.

With that ordering mismatch, the positional lookup returns the wrong sibling&apos;s FrameState.
frameStateForBackForwardChildFrame then sees frameState-&gt;frameID != live frame.frameID() and
&quot;corrects&quot; it by calling WebBackForwardList::updateFrameIdentifier(storedID -&gt; liveID), which walks
all back/forward entries and rewrites the first frame carrying storedID. That rewrites the
unaffected sibling&apos;s frameID onto the navigated frame&apos;s frameID, leaving two sibling frame items
with the same frameID in a back/forward entry. The duplicate then makes the per-frame walk dispatch
a second GoToBackForwardItem to the same live frame, clobbering the intended navigation -- the flaky
timeout that bug 318015 fixed defensively. On Debug it also fires the
HistoryItem::addChildItem duplicate-frameID assertion when the WebProcess reconstructs the
HistoryItem from the corrupted FrameState.

Fix: in findFrameStateInItem, match the child by the live frame&apos;s identifier first
(childItemForFrameID), and fall back to the positional lookup only when that identifier is absent --
i.e. the stored identifiers no longer match the live frames, which happens after session restore or
when a cross-site child frame is recreated (where updateFrameIdentifier then legitimately remaps the
regenerated identifier). In the common live case the identifier matches, so the wrong sibling can no
longer be selected and updateFrameIdentifier is no longer triggered spuriously. The change is
mirrored in the Swift (ENABLE_BACK_FORWARD_LIST_SWIFT) implementation.

Because the corruption is fixed at the source, the WebProcess never reconstructs a HistoryItem with
a duplicate frameID, so the bug-317799 Debug skip for the overlapping-navigations cluster test is
removed; the test passes on Debug with the fix.

Covered by existing tests (SiteIsolation.NavigateFrameWithSiblingsBackForward, previously flaky;
SiteIsolation.BackNavigationOverCrossSiteIframeWithoutBFCache; and the session-restore back/forward
tests that exercise the positional fallback) and by
http/wpt/site-isolation/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html
on Debug. Verified on both the C++ and Swift back/forward list implementations: the
duplicate-frameID corruption no longer appears across many iterations (it reproduced roughly one run
in ten to twenty-five before), and the Debug assertion fires without the fix and is quiet with it.

* LayoutTests/platform/mac-wk2/TestExpectations: Remove the bug-317799 Debug skip.
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::findFrameStateInItem):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.swift:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::frameStateForBackForwardChildFrame):

Canonical link: <a href="https://commits.webkit.org/316109@main">https://commits.webkit.org/316109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1f2dfc81bc850e22606452be5dfba8c0d11a3d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128604 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113774 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35136 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33451 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28948 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182853 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141748 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44470 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141558 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45159 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109864 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36825 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117050 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43670 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8222 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43074 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43205 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->