### PR TITLE
Add unprefixed `box-decoration-break` CSS property

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1656,6 +1656,20 @@ CSSUnprefixedBackdropFilterEnabled:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
 
+CSSUnprefixedBoxDecorationBreakEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS Unprefixed box-decoration-break"
+  humanReadableDescription: "Enable unprefixed box-decoration-break CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSWordBreakAutoPhraseEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10182,10 +10182,25 @@
                 "slice"
             ],
             "codegen-properties": {
+                "cascade-alias": "box-decoration-break",
+                "skip-style-builder": true,
+                "parser-grammar": "<<values>>"
+            },
+            "status": "non-standard"
+        },
+        "box-decoration-break": {
+            "animation-type": "discrete",
+            "initial": "slice",
+            "values": [
+                "clone",
+                "slice"
+            ],
+            "codegen-properties": {
                 "computed-style-storage-path": ["m_nonInheritedData", "boxData"],
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "BoxDecorationBreak",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "settings-flag": "cssUnprefixedBoxDecorationBreakEnabled"
             },
             "status": {
                 "status": "experimental"


### PR DESCRIPTION
#### a1b1bf8b0702
<pre>
Add unprefixed `box-decoration-break` CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=318129">https://bugs.webkit.org/show_bug.cgi?id=318129</a>
<a href="https://rdar.apple.com/problem/180951474">rdar://problem/180951474</a>

Reviewed by NOBODY (OOPS!).

The unprefixed property is behind the
`CSSUnprefixedBoxDecorationBreakEnabled` flag.

The existing prefixed property now uses `cascade-alias` to point at
the unprefixed one.

* Source/WebCore/css/CSSProperties.json:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1b1bf8b070242af51b622fbf046be586c393f76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180193 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128530 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c58c9faa-2269-49e7-ac50-a977d199e815) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172680 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46012 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44375 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133242 "Found 10 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html imported/w3c/web-platform-tests/css/css-break/inheritance.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-computed.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-valid.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html svg/css/getComputedStyle-basic.xhtml (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94022 "1 flakes 21 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01fd7bbd-8af6-4523-a279-433f69effda1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173773 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36457 "Found 3 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html svg/css/getComputedStyle-basic.xhtml (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113730 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07833e55-c92c-46fd-b034-3c6b65d236cf) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35080 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-break/inheritance.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-computed.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-valid.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-constraint-validation.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33393 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28873 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2092 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145537 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33077 "Found 10 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html imported/w3c/web-platform-tests/css/css-break/inheritance.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-computed.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-valid.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html svg/css/getComputedStyle-basic.xhtml (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182779 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32070 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Passed JSC tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35574 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37568 "Found 10 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html imported/w3c/web-platform-tests/css/css-break/inheritance.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-computed.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-valid.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html svg/css/getComputedStyle-basic.xhtml (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141697 "Found 10 new test failures: fast/css/getComputedStyle/computed-style.html imported/w3c/web-platform-tests/css/css-break/inheritance.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-computed.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-valid.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html inspector/animation/lifecycle-css-animation.html svg/css/getComputedStyle-basic.xhtml (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44396 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45085 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30063 "Found 10 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html imported/w3c/web-platform-tests/css/css-break/inheritance.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-computed.html imported/w3c/web-platform-tests/css/css-break/parsing/box-decoration-break-valid.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001.html imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001.html svg/css/getComputedStyle-basic.xhtml (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109789 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36777 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116976 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203493 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43596 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8167 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54487 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43000 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->