### PR TITLE
Add FloatQuad::intersectsQuad to test intersection between two quads

### DIFF
--- a/Source/WebCore/platform/graphics/FloatQuad.cpp
+++ b/Source/WebCore/platform/graphics/FloatQuad.cpp
@@ -33,7 +33,9 @@
 #include "FloatQuad.h"
 
 #include "GeometryUtilities.h"
+
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <wtf/MathExtras.h>
@@ -224,6 +226,33 @@ bool FloatQuad::intersectsEllipse(const FloatPoint& center, const FloatSize& rad
     FloatPoint originPoint;
     return transformedQuad.intersectsCircle(originPoint, radii.height() * radii.width());
 
+}
+
+// Returns positive if point is to the right of edgeStart→edgeEnd, negative if to the left, zero if on the line.
+static inline float sideOf(FloatPoint edgeStart, FloatPoint edgeEnd, FloatPoint point)
+{
+    FloatSize edge = edgeEnd - edgeStart;
+    FloatSize toPoint = point - edgeStart;
+    return toPoint.height() * edge.width() - edge.height() * toPoint.width();
+}
+
+bool FloatQuad::intersectsQuad(const FloatQuad& other) const
+{
+    const std::array<FloatPoint, 4> thisVertices = { m_p1, m_p2, m_p3, m_p4 };
+    const std::array<FloatPoint, 4> otherVertices = { other.m_p1, other.m_p2, other.m_p3, other.m_p4 };
+
+    for (int edgeA = 0; edgeA < 4; ++edgeA) {
+        FloatPoint aStart = thisVertices[edgeA], aEnd = thisVertices[(edgeA + 1) % 4];
+        for (int edgeB = 0; edgeB < 4; ++edgeB) {
+            FloatPoint bStart = otherVertices[edgeB], bEnd = otherVertices[(edgeB + 1) % 4];
+            // Edges cross if each one's endpoints land on opposite sides of the other edge
+            if ((sideOf(bStart, bEnd, aStart) > 0) != (sideOf(bStart, bEnd, aEnd) > 0)
+                && (sideOf(aStart, aEnd, bStart) > 0) != (sideOf(aStart, aEnd, bEnd) > 0))
+                return true;
+        }
+    }
+    // Check if quad is entirely inside the other
+    return containsPoint(other.m_p1) || other.containsPoint(m_p1);
 }
 
 bool FloatQuad::isCounterclockwise() const

--- a/Source/WebCore/platform/graphics/FloatQuad.h
+++ b/Source/WebCore/platform/graphics/FloatQuad.h
@@ -105,6 +105,8 @@ public:
     bool NODELETE intersectsCircle(const FloatPoint& center, float radius) const;
     bool NODELETE intersectsEllipse(const FloatPoint& center, const FloatSize& radii) const;
 
+    WEBCORE_EXPORT bool intersectsQuad(const FloatQuad&) const;
+
     // The center of the quad. If the quad is the result of a affine-transformed rectangle this is the same as the original center transformed.
     FloatPoint center() const
     {

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -219,6 +219,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/Decimal.cpp
         Tests/WebCore/FileMonitor.cpp
         Tests/WebCore/FloatPointTests.cpp
+        Tests/WebCore/FloatQuadTests.cpp
         Tests/WebCore/FloatRectTests.cpp
         Tests/WebCore/FloatSegmentTest.cpp
         Tests/WebCore/FloatSizeTests.cpp

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp
@@ -190,13 +190,42 @@ TEST(FloatQuad, BoundingBoxSaturateInf)
 
 TEST(FloatQuad, BoundingBoxSaturateLarge)
 {
-    constexpr double large = std::numeric_limits<float>::max() * 4;
+    const double large = std::numeric_limits<float>::max() * 4;
     FloatQuad quad(FloatPoint(-large, 3), FloatPoint(5, large), FloatPoint(11, 13), FloatPoint(17, 19));
     FloatRect rect = quad.boundingBox();
     ASSERT_EQ(rect.x(), std::numeric_limits<int>::min());
     ASSERT_EQ(rect.y(), 3.0f);
     ASSERT_EQ(rect.width(), 17.0f - std::numeric_limits<int>::min());
     ASSERT_EQ(rect.height(), static_cast<float>(std::numeric_limits<int>::max()) - 3.0f);
+}
+
+TEST(FloatQuad, IntersectsQuad)
+{
+    // Two overlapping axis-aligned quads.
+    FloatQuad quadA(FloatPoint(0, 0), FloatPoint(10, 0), FloatPoint(10, 10), FloatPoint(0, 10));
+    FloatQuad quadB(FloatPoint(5, 5), FloatPoint(15, 5), FloatPoint(15, 15), FloatPoint(5, 15));
+    EXPECT_TRUE(quadA.intersectsQuad(quadB));
+
+    // Two non-overlapping axis-aligned quads.
+    FloatQuad quadC(FloatPoint(0, 0), FloatPoint(10, 0), FloatPoint(10, 10), FloatPoint(0, 10));
+    FloatQuad quadD(FloatPoint(20, 20), FloatPoint(30, 20), FloatPoint(30, 30), FloatPoint(20, 30));
+    EXPECT_FALSE(quadC.intersectsQuad(quadD));
+
+    // One quad entirely inside the other (no edge crossings, tests containsPoint fallback).
+    FloatQuad outer(FloatPoint(0, 0), FloatPoint(20, 0), FloatPoint(20, 20), FloatPoint(0, 20));
+    FloatQuad inner(FloatPoint(5, 5), FloatPoint(15, 5), FloatPoint(15, 15), FloatPoint(5, 15));
+    EXPECT_TRUE(outer.intersectsQuad(inner));
+    EXPECT_TRUE(inner.intersectsQuad(outer));
+
+    // Two rotated quads crossing in an X shape.
+    FloatQuad diagA(FloatPoint(0, 5), FloatPoint(5, 0), FloatPoint(10, 5), FloatPoint(5, 10));
+    FloatQuad diagB(FloatPoint(3, 0), FloatPoint(7, 0), FloatPoint(7, 10), FloatPoint(3, 10));
+    EXPECT_TRUE(diagA.intersectsQuad(diagB));
+
+    // Two rotated quads that don't intersect.
+    FloatQuad diagC(FloatPoint(0, 0), FloatPoint(4, 0), FloatPoint(4, 4), FloatPoint(0, 4));
+    FloatQuad diagD(FloatPoint(10, 10), FloatPoint(14, 10), FloatPoint(14, 14), FloatPoint(10, 14));
+    EXPECT_FALSE(diagC.intersectsQuad(diagD));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b39363a17b0e45272c72444cabd9bb08599766e5
<pre>
Add FloatQuad::intersectsQuad to test intersection between two quads
<a href="https://bugs.webkit.org/show_bug.cgi?id=318137">https://bugs.webkit.org/show_bug.cgi?id=318137</a>
<a href="https://rdar.apple.com/180956416">rdar://180956416</a>

Reviewed by Simon Fraser.

Adds intersectsQuad to FloatQuad for testing whether two convex quads overlap.
The method checks all 16 pairs of edges (4 from each quad) for segment
intersection using a cross-product sign test, two edges cross if each edge&apos;s
endpoints fall on opposite sides of the other edge. If no edges intersect, it
falls back to containsPoint to handle the case where one quad is entirely
inside the other.

5 new tests written in FloatQuadTests.cpp

* Source/WebCore/platform/graphics/FloatQuad.cpp:
(WebCore::sideOf):
(WebCore::FloatQuad::intersectsQuad const):
* Source/WebCore/platform/graphics/FloatQuad.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp:
(TestWebKitAPI::TEST(FloatQuad, BoundingBoxSaturateLarge)):
(TestWebKitAPI::TEST(FloatQuad, IntersectsQuad)):

Canonical link: <a href="https://commits.webkit.org/316291@main">https://commits.webkit.org/316291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/215ba73eaa401e096c82c4b4cda12839dfad201f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171525 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45453 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133579 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35473 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33735 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183497 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142132 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45110 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38403 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45802 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30384 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110439 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37254 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117492 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44307 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8480 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->