### PR TITLE
Fire async load event to prevent guessing a cross-origin iframe's URL

### DIFF
--- a/LayoutTests/http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak-expected.txt
+++ b/LayoutTests/http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak-expected.txt
@@ -1,0 +1,11 @@
+Tests that a cross-origin parent cannot use iframe.onload timing to infer an iframe's post-redirect URL.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Probing with a different URL fired iframe.onload (cross-document navigation).
+PASS Probing with the iframe's post-redirect URL was observably indistinguishable from probing with any other URL (no oracle).
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak.html
+++ b/LayoutTests/http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that a cross-origin parent cannot use iframe.onload timing to infer an iframe's post-redirect URL.");
+jsTestIsAsync = true;
+
+const REDIRECT_TARGET = "http://localhost:8000/navigation/resources/success.html";
+const ENTRY           = "http://localhost:8000/resources/redirect.py?code=302&url=" + encodeURIComponent(REDIRECT_TARGET);
+// Same file as REDIRECT_TARGET but a different URL, so probing with it triggers a
+// cross-document navigation (the URL minus fragment differs).
+const SIBLING         = REDIRECT_TARGET + "?sibling";
+
+const iframe = document.createElement("iframe");
+document.body.appendChild(iframe);
+
+function loadEntry() {
+    return new Promise(resolve => {
+        // clear subsequent iframe onloads
+        iframe.onload = () => { iframe.onload = null; resolve(); };
+        // add some randomness to the URL each time loadEntry 
+        // is called to force a fresh navigation
+        iframe.src = ENTRY + "&_=" + Math.random();
+    });
+}
+
+// Oracle which tells the attacker if the guess URL is correct. 
+// If the guess matches the iframe's URL, then the navigation is
+// treated as same-document and an attacker can observe that no onload 
+// event fires (the 500ms timer wins and promise resolves to true).
+// If the guess is wrong, the navigation is cross-document which will fire
+// and onload event (promise resolves to false).
+function probe(guess) {
+    return new Promise(resolve => {
+        iframe.onload = null;
+        for (let i = 0; i < 5; ++i)
+            iframe.src = guess + "#" + Math.random();
+        const timer = setTimeout(() => { iframe.onload = null; resolve(true); }, 500);
+        iframe.onload = () => {
+            clearTimeout(timer);
+            iframe.onload = null;
+            resolve(false);
+        };
+    });
+}
+
+(async function() {
+    // Sanity: probing with an unrelated URL is a cross-document navigation; load fires asynchronously
+    // after the writes finish, so the handler-last pattern still catches it.
+    await loadEntry();
+    const oracleClaimsSiblingMatches = await probe(SIBLING);
+    if (!oracleClaimsSiblingMatches)
+        testPassed("Probing with a different URL fired iframe.onload (cross-document navigation).");
+    else
+        testFailed("Sanity check failed: cross-document navigation did not fire iframe.onload.");
+
+    // The leak: probing with the iframe's current post-redirect URL should also let the parent observe load.
+    // Without the fix, WebKit fires the load synchronously during the same-document fragment writes,
+    // before the handler is installed, so the handler is never called and the 500ms timer wins. That
+    // asymmetry is the cross-origin URL inference primitive.
+    await loadEntry();
+    const oracleClaimsRedirectTargetMatches = await probe(REDIRECT_TARGET);
+    if (!oracleClaimsRedirectTargetMatches)
+        testPassed("Probing with the iframe's post-redirect URL was observably indistinguishable from probing with any other URL (no oracle).");
+    else
+        testFailed("Probing with the iframe's post-redirect URL did NOT fire iframe.onload within 500ms -- a cross-origin parent can use this asymmetry to learn the iframe's post-redirect URL.");
+
+    finishJSTest();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload.html
+++ b/LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload.html
@@ -10,12 +10,15 @@ jsTestIsAsync = true;
 let onloadCount = 0;
 
 window.addEventListener("message", () => {
-    if (onloadCount == 2)
-        testPassed("onload fired twice.");
-    else
-        testFailed("onload fired " + onloadCount + " time(s).");
+    // Wait for the async synthetic onload from the fragment nav.
+    setTimeout(() => {
+        if (onloadCount == 2)
+            testPassed("onload fired twice.");
+        else
+            testFailed("onload fired " + onloadCount + " time(s).");
 
-    finishJSTest();
+        finishJSTest();
+    }, 200);
 });
 
 function onloadFired() {

--- a/LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload.html
+++ b/LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload.html
@@ -14,12 +14,15 @@ window.onload = function() {
 let onloadCount = 0;
 
 window.addEventListener('message', function (e) {
-    if (onloadCount == 2)
-        testPassed("onload fired 2 times.");
-    else
-        testFailed("onload fired " + onloadCount + " time(s).");
-    
-    finishJSTest();
+    // Wait for the async synthetic onload from the fragment nav.
+    setTimeout(() => {
+        if (onloadCount == 2)
+            testPassed("onload fired 2 times.");
+        else
+            testFailed("onload fired " + onloadCount + " time(s).");
+
+        finishJSTest();
+    }, 200);
 });
 
 function onloadFired() {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -389,6 +389,7 @@ FrameLoader::FrameLoader(LocalFrame& frame, CompletionHandler<UniqueRef<LocalFra
     , m_state(FrameState::Provisional)
     , m_loadType(FrameLoadType::Standard)
     , m_checkTimer(*this, &FrameLoader::checkTimerFired)
+    , m_crossOriginParentSyntheticSameDocLoadEventTimer(*this, &FrameLoader::crossOriginParentSyntheticSameDocLoadEventTimerFired)
     , m_documentPrefetcher(DocumentPrefetcher::create(frame))
 {
 }
@@ -783,6 +784,7 @@ void FrameLoader::clear(RefPtr<Document>&& newDocument, bool clearWindowProperti
     protect(frame->navigationScheduler())->clear();
 
     m_checkTimer.stop();
+    m_crossOriginParentSyntheticSameDocLoadEventTimer.stop();
     m_shouldCallCheckCompleted = false;
     m_shouldCallCheckLoadComplete = false;
 
@@ -1034,6 +1036,19 @@ void FrameLoader::checkCompleted()
 void FrameLoader::checkTimerFired()
 {
     checkCompletenessNow();
+}
+
+void FrameLoader::startCrossOriginParentSyntheticSameDocLoadEventTimer()
+{
+    static constexpr Seconds crossOriginParentSyntheticSameDocLoadEventDelay { 100_ms };
+    if (m_crossOriginParentSyntheticSameDocLoadEventTimer.isActive())
+        m_crossOriginParentSyntheticSameDocLoadEventTimer.stop();
+    m_crossOriginParentSyntheticSameDocLoadEventTimer.startOneShot(crossOriginParentSyntheticSameDocLoadEventDelay);
+}
+
+void FrameLoader::crossOriginParentSyntheticSameDocLoadEventTimerFired()
+{
+    protect(m_frame)->dispatchLoadEventToParent();
 }
 
 void FrameLoader::checkCompletenessNow()
@@ -1418,12 +1433,14 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
         m_client->dispatchDidChangeLocationWithinPage();
     }
 
+    // Asynchronously dispatch a synthetic load event on the iframe owner so a cross-origin
+    // parent cannot distinguish same-doc from cross-doc navigations by load-event timing.
     RefPtr parentFrame = m_frame->tree().parent();
     RefPtr localParentFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
     if (parentFrame
         && (document->processingLoadEvent() || document->loadEventFinished())
         && (!localParentFrame || !protect(document->securityOrigin())->isSameOriginAs(protect(protect(localParentFrame->document())->securityOrigin()))))
-        protect(m_frame)->dispatchLoadEventToParent();
+        startCrossOriginParentSyntheticSameDocLoadEventTimer();
 
     // LocalFrameLoaderClient::didFinishLoad() tells the internal load delegate the load finished with no error
     m_client->didFinishLoad();
@@ -2246,6 +2263,7 @@ void FrameLoader::stopAllLoadersAndCheckCompleteness()
         return;
 
     m_checkTimer.stop();
+    m_crossOriginParentSyntheticSameDocLoadEventTimer.stop();
     m_checkingLoadCompleteForDetachment = true;
     checkCompletenessNow();
     m_checkingLoadCompleteForDetachment = false;
@@ -3400,6 +3418,7 @@ void FrameLoader::frameDetached()
         m_checkTimer.stop();
         checkCompletenessNow();
     }
+    m_crossOriginParentSyntheticSameDocLoadEventTimer.stop();
 
     if (frame->document()->backForwardCacheState() != Document::InBackForwardCache)
         stopAllLoadersAndCheckCompleteness();
@@ -4206,6 +4225,7 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
         if (navigationPolicyDecision == NavigationPolicyDecision::LoadWillContinueInAnotherProcess) {
             stopAllLoaders();
             m_checkTimer.stop();
+            m_crossOriginParentSyntheticSameDocLoadEventTimer.stop();
         }
 
         setPolicyDocumentLoader(nullptr, navigationPolicyDecision == NavigationPolicyDecision::LoadWillContinueInAnotherProcess ? LoadWillContinueInAnotherProcess::Yes : LoadWillContinueInAnotherProcess::No);

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -400,6 +400,9 @@ private:
     void checkTimerFired();
     void checkCompletenessNow();
 
+    void startCrossOriginParentSyntheticSameDocLoadEventTimer();
+    void crossOriginParentSyntheticSameDocLoadEventTimerFired();
+
     void loadSameDocumentItem(HistoryItem&);
     void loadDifferentDocumentItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, FormSubmissionCacheLoadPolicy, ShouldTreatAsContinuingLoad, ShouldRestoreFromBackForwardCache = ShouldRestoreFromBackForwardCache::Unspecified, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
 
@@ -539,6 +542,7 @@ private:
     URL m_submittedFormURL;
 
     Timer m_checkTimer;
+    Timer m_crossOriginParentSyntheticSameDocLoadEventTimer;
     bool m_shouldCallCheckCompleted { false };
     bool m_shouldCallCheckLoadComplete { false };
 


### PR DESCRIPTION
#### d7c0b5ae247bd01a12f6741b142f8e6b5aeaeda8
<pre>
Fire async load event to prevent guessing a cross-origin iframe&apos;s URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=316653">https://bugs.webkit.org/show_bug.cgi?id=316653</a>
<a href="https://rdar.apple.com/179100444">rdar://179100444</a>

Reviewed by Charlie Wolfe.

Currently, the URL of a cross-origin iframe can be guessed based
on the timing of a load event of a same-document navigation.

Before this patch, WebKit fires a synthetic load event when a
cross-origin frame is navigated to the same-document (see
FrameLoader::loadInSameDocument from <a href="https://commits.webkit.org/259384@main">https://commits.webkit.org/259384@main</a> ).

However, this load event fires immediately and synchronously.
So from JS, the timing of this immediate load event could be noticed
and used as an oracle to determine if a cross-origin iframe is a the
same URL as the navigation destination.

This patch adds a delayed timer before firing the load event
when a cross-origin parent initiates a same-document navigation.

This fix is similar to what is described in <a href="https://chromium-review.googlesource.com/c/chromium/src/+/7560041">https://chromium-review.googlesource.com/c/chromium/src/+/7560041</a>

Test: http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak.html

* LayoutTests/http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak-expected.txt: Added.
* LayoutTests/http/tests/navigation/cross-origin-iframe-fragment-navigation-onload-url-leak.html: Added.
* LayoutTests/http/tests/navigation/cross-origin-iframe-location-hash-reexecute-onload.html:
    Added delay to wait for delayed load
* LayoutTests/http/tests/navigation/cross-origin-navigation-fires-onload.html:
    Added delay to wait for delayed load
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameLoader):
    Initialize timer
(WebCore::FrameLoader::clear):
    Stop timer
(WebCore::FrameLoader::startCrossOriginParentSyntheticSameDocLoadEventTimer):
    Start a new timer and cancel an existing one, if any.
(WebCore::FrameLoader::crossOriginParentSyntheticSameDocLoadEventTimerFired):
    Dispatch load event when timer fires
(WebCore::FrameLoader::loadInSameDocument):
    Start timer
(WebCore::FrameLoader::stopAllLoadersAndCheckCompleteness):
    Stop timer
(WebCore::FrameLoader::frameDetached):
    Stop timer
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
    Stop timer
* Source/WebCore/loader/FrameLoader.h:

Canonical link: <a href="https://commits.webkit.org/316098@main">https://commits.webkit.org/316098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7987f6dacaab8a7a430e8f2066b78dbc2fb59c0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128567 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/145e3333-8dec-48cf-ad17-cd7ddfecaccf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133257 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97a53bfb-0488-4039-ae54-10b944124916) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113744 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c026f8e-611b-42a3-b9ea-87c22670dda5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35105 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28910 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182816 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141719 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38165 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45122 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109827 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36799 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117013 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43633 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8189 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43037 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43279 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->