### PR TITLE
[JSC][Temporal] Polish Temporal.PlainDate: spec alignment, era and date-add fixes

### DIFF
--- a/JSTests/stress/temporal-non-iso-era-codes.js
+++ b/JSTests/stress/temporal-non-iso-era-codes.js
@@ -1,0 +1,61 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+
+// Per icu4x components/calendar/src/cal/{coptic,ethiopian,indian,...}.rs.
+const expectedEras = [
+    ["coptic", "am"],
+    ["ethiopic", "am"],
+    ["ethioaa", "aa"],
+    ["indian", "shaka"],
+    ["persian", "ap"],
+    ["roc", "roc"],
+    ["hebrew", "am"],
+    ["buddhist", "be"],
+    ["gregory", "ce"],
+    ["islamic-umalqura", "ah"],
+    ["islamic-civil", "ah"],
+    ["islamic-tbla", "ah"],
+];
+
+for (const [cal, expected] of expectedEras) {
+    const d = new Temporal.PlainDate(2024, 1, 15, cal);
+    shouldBe(d.era, expected, `${cal}.era`);
+}
+
+// Japanese era depends on the date; spot-check the current Reiwa era.
+shouldBe(new Temporal.PlainDate(2024, 1, 15, "japanese").era, "reiwa", "japanese (2024).era");
+shouldBe(new Temporal.PlainDate(1990, 1, 15, "japanese").era, "heisei", "japanese (1990).era");
+shouldBe(new Temporal.PlainDate(1980, 1, 15, "japanese").era, "showa", "japanese (1980).era");
+
+// ISO calendar must not have an era.
+shouldBe(new Temporal.PlainDate(2024, 1, 15).era, undefined, "iso8601.era");
+
+// Reverse direction: PlainDate.from() with era field must accept the canonical era code.
+const fromCoptic = Temporal.PlainDate.from({ era: "am", eraYear: 1740, month: 9, day: 1, calendar: "coptic" });
+shouldBe(fromCoptic.era, "am", "from({era:'am'}) coptic round-trip");
+
+const fromIndian = Temporal.PlainDate.from({ era: "shaka", eraYear: 1945, month: 1, day: 15, calendar: "indian" });
+shouldBe(fromIndian.era, "shaka", "from({era:'shaka'}) indian round-trip");
+
+// Wrong era code must throw.
+let threw = false;
+try {
+    Temporal.PlainDate.from({ era: "ce", eraYear: 1740, month: 9, day: 1, calendar: "coptic" });
+} catch (e) {
+    threw = e instanceof RangeError;
+}
+if (!threw)
+    throw new Error("coptic.from with era='ce' should throw RangeError");
+
+threw = false;
+try {
+    Temporal.PlainDate.from({ era: "saka", eraYear: 1945, month: 1, day: 15, calendar: "indian" });
+} catch (e) {
+    threw = e instanceof RangeError;
+}
+if (!threw)
+    throw new Error("indian.from with era='saka' should throw RangeError");

--- a/JSTests/stress/temporal-plain-date-add-time-rollover.js
+++ b/JSTests/stress/temporal-plain-date-add-time-rollover.js
@@ -1,0 +1,57 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+
+const cases = [
+    // [calendar, expected after +24h]
+    ["iso8601"],
+    ["hebrew"],
+    ["gregory"],
+    ["japanese"],
+    ["islamic-umalqura"],
+    ["chinese"],
+    ["coptic"],
+    ["ethiopic"],
+    ["persian"],
+];
+
+for (const [cal] of cases) {
+    const base = new Temporal.PlainDate(2024, 1, 15, cal);
+    const plus24h = base.add({ hours: 24 });
+    const plus1d = base.add({ days: 1 });
+    shouldBe(plus24h.toString(), plus1d.toString(), `${cal}: add({hours: 24}) ≡ add({days: 1})`);
+}
+
+// Time-rollover should also work for subtract (negate-then-rollover).
+for (const [cal] of cases) {
+    const base = new Temporal.PlainDate(2024, 1, 15, cal);
+    const minus24h = base.subtract({ hours: 24 });
+    const minus1d = base.subtract({ days: 1 });
+    shouldBe(minus24h.toString(), minus1d.toString(), `${cal}: subtract({hours: 24}) ≡ subtract({days: 1})`);
+}
+
+// 48h must roll to 2 days, not be ignored.
+for (const [cal] of cases) {
+    const base = new Temporal.PlainDate(2024, 1, 15, cal);
+    const plus48h = base.add({ hours: 48 });
+    const plus2d = base.add({ days: 2 });
+    shouldBe(plus48h.toString(), plus2d.toString(), `${cal}: add({hours: 48}) ≡ add({days: 2})`);
+}
+
+// Mixed: 1 day + 24 hours = 2 days.
+for (const [cal] of cases) {
+    const base = new Temporal.PlainDate(2024, 1, 15, cal);
+    const mixed = base.add({ days: 1, hours: 24 });
+    const total = base.add({ days: 2 });
+    shouldBe(mixed.toString(), total.toString(), `${cal}: add({days: 1, hours: 24}) ≡ add({days: 2})`);
+}
+
+// Sub-day amounts that don't accumulate to a full day stay on the same date.
+for (const [cal] of cases) {
+    const base = new Temporal.PlainDate(2024, 1, 15, cal);
+    const subDay = base.add({ hours: 23, minutes: 59, seconds: 59 });
+    shouldBe(subDay.toString(), base.toString(), `${cal}: sub-day duration stays on same date`);
+}

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -47,6 +47,8 @@ namespace JSC {
 
 std::optional<CalendarID> isBuiltinCalendar(StringView string)
 {
+    // FIXME: bare "islamic" is accepted via ICU's keyword set but V8/temporal_rs reject it;
+    // canonicalize to "islamic-civil" (CLDR alias) or filter out.
     const auto& calendars = intlAvailableCalendars();
     for (unsigned index = 0; index < calendars.size(); ++index) {
         if (WTF::equalIgnoringASCIICase(calendars[index], string))
@@ -487,7 +489,7 @@ ISO8601::PlainDate isoDateFromFields(JSGlobalObject* globalObject, TemporalDateF
         day = std::min<uint32_t>(day, ISO8601::daysInMonth(year, month));
     }
 
-    auto plainDate = TemporalPlainDate::toPlainDate(globalObject, ISO8601::Duration(year, month, 0LL, day, 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0)));
+    auto plainDate = TemporalPlainDate::validateAndCreateISODateRecord(globalObject, ISO8601::Duration(year, month, 0LL, day, 0LL, 0LL, 0LL, 0LL, Int128(0), Int128(0)));
     RETURN_IF_EXCEPTION(scope, { });
 
     bool valid = true;
@@ -506,18 +508,6 @@ ISO8601::PlainDate isoDateFromFields(JSGlobalObject* globalObject, TemporalDateF
     }
 
     return plainDate;
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal-adddurationtodate
-// AddDurationToDate ( operation, temporalDate, temporalDurationLike, options )
-ISO8601::PlainDate addDurationToDate(JSGlobalObject* globalObject, const ISO8601::PlainDate& plainDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto dateDuration = TemporalDuration::toDateDurationRecordWithoutTime(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
-    RELEASE_AND_RETURN(scope, isoDateAdd(globalObject, plainDate, dateDuration, overflow));
 }
 
 ISO8601::PlainDate isoDateAdd(JSGlobalObject* globalObject, const ISO8601::PlainDate& plainDate, const ISO8601::Duration& duration, TemporalOverflow overflow)

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.h
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.h
@@ -48,7 +48,6 @@ ISO8601::PlainDate isoDateFromFields(JSGlobalObject*, TemporalDateFormat, int32_
 template<DifferenceOperation>
 ISO8601::Duration differenceTemporalPlainYearMonth(JSGlobalObject*, const ISO8601::PlainYearMonth&, const ISO8601::PlainYearMonth&, unsigned, TemporalUnit, TemporalUnit, RoundingMode, CalendarID = iso8601CalendarID());
 
-ISO8601::PlainDate addDurationToDate(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 ISO8601::PlainDate isoDateAdd(JSGlobalObject*, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 ISO8601::PlainDate calendarDateAdd(JSGlobalObject*, CalendarID, const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
 ISO8601::Duration calendarDateUntil(CalendarID, const ISO8601::PlainDate&, const ISO8601::PlainDate&, TemporalUnit);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.cpp
@@ -94,8 +94,9 @@ String TemporalPlainDate::toString() const
     return makeString(base, "[u-ca="_s, TemporalCore::calendarIDToString(m_calendarID), ']');
 }
 
-
-ISO8601::PlainDate TemporalPlainDate::toPlainDate(JSGlobalObject* globalObject, const ISO8601::Duration& duration)
+// IsValidISODate + CreateISODateRecord
+// https://tc39.es/proposal-temporal/#sec-temporal-isvalidisodate
+ISO8601::PlainDate TemporalPlainDate::validateAndCreateISODateRecord(JSGlobalObject* globalObject, const ISO8601::Duration& duration)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -110,12 +111,14 @@ ISO8601::PlainDate TemporalPlainDate::toPlainDate(JSGlobalObject* globalObject, 
     }
     int32_t year = static_cast<int32_t>(yearDouble);
 
+    // IsValidISODate Step 1: If month < 1 or month > 12, return false.
     if (!(monthDouble >= 1 && monthDouble <= 12)) [[unlikely]] {
         throwRangeError(globalObject, scope, "month is out of range"_s);
         return { };
     }
     uint32_t month = static_cast<uint32_t>(monthDouble);
 
+    // IsValidISODate Steps 2-3: reject day outside [1, ISODaysInMonth(year, month)].
     double daysInMonth = ISO8601::daysInMonth(year, month);
     if (!(dayDouble >= 1 && dayDouble <= daysInMonth)) [[unlikely]] {
         throwRangeError(globalObject, scope, "day is out of range"_s);
@@ -123,87 +126,41 @@ ISO8601::PlainDate TemporalPlainDate::toPlainDate(JSGlobalObject* globalObject, 
     }
     uint32_t day = static_cast<uint32_t>(dayDouble);
 
+    // CreateISODateRecord ( year, month, day ): Return ISO Date Record { [[Year]], [[Month]], [[Day]] }.
     return ISO8601::PlainDate(year, month, day);
 }
 
-// CreateTemporalDate ( years, months, days )
+static bool isValidPlainDateOrThrow(JSGlobalObject* globalObject, const ISO8601::PlainDate& plainDate)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
+        throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
+        return false;
+    }
+    return true;
+}
+
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporaldate
 TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
+    if (!isValidPlainDateOrThrow(globalObject, plainDate))
         return { };
-    }
-
-    return TemporalPlainDate::create(vm, structure, WTF::move(plainDate));
+    // Steps 2-6: OrdinaryCreateFromConstructor + [[ISODate]] + [[Calendar]].
+    return TemporalPlainDate::create(globalObject->vm(), structure, WTF::move(plainDate));
 }
 
 TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, String&& calendarId)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
+    if (!isValidPlainDateOrThrow(globalObject, plainDate))
         return { };
-    }
-
-    return TemporalPlainDate::create(vm, structure, WTF::move(plainDate), WTF::move(calendarId));
+    return TemporalPlainDate::create(globalObject->vm(), structure, WTF::move(plainDate), WTF::move(calendarId));
 }
 
 TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, CalendarID calendarID)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), 12, 0, 0, 0, 0, 0)) [[unlikely]] {
-        throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
+    if (!isValidPlainDateOrThrow(globalObject, plainDate))
         return { };
-    }
-
-    return TemporalPlainDate::create(vm, structure, WTF::move(plainDate), calendarID);
-}
-
-TemporalPlainDate* TemporalPlainDate::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::Duration&& duration)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto plainDate = toPlainDate(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, TemporalPlainDate::tryCreateIfValid(globalObject, structure,  WTF::move(plainDate)));
-}
-
-String TemporalPlainDate::toString(JSGlobalObject* globalObject, JSValue optionsValue) const
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSObject* options = intlGetOptionsObject(globalObject, optionsValue);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (!options)
-        return toString();
-
-    String calOpt = temporalShowCalendarName(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    auto base = ISO8601::temporalDateToString(m_plainDate);
-    auto calId = calendarIDAsString();
-    if (calOpt == "never"_s)
-        return base;
-    if (calOpt == "always"_s)
-        return makeString(base, "[u-ca="_s, calId, ']');
-    if (calOpt == "critical"_s)
-        return makeString(base, "[!u-ca="_s, calId, ']');
-    // "auto": show calendar annotation only for non-ISO calendars.
-    if (calendarID() != iso8601CalendarID())
-        return makeString(base, "[u-ca="_s, calId, ']');
-    return base;
+    return TemporalPlainDate::create(globalObject->vm(), structure, WTF::move(plainDate), calendarID);
 }
 
 static TemporalPlainDate* fromImpl(JSGlobalObject*, JSValue, Variant<JSObject*, TemporalOverflow>);
@@ -501,7 +458,7 @@ TemporalPlainDate::mergeDateFields(JSGlobalObject* globalObject, JSObject* tempo
     TemporalOverflow overflow = toTemporalOverflow(globalObject, optionsValue);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Duplicate code from TemporalPlainDate::toPlainDate so we can convert from
+    // Duplicate code from TemporalPlainDate::validateAndCreateISODateRecord so we can convert from
     // double to int32_t / unsigned here
     if (year && !ISO8601::isYearWithinLimits(*year)) [[unlikely]] {
         throwRangeError(globalObject, scope, "year is out of range"_s);
@@ -696,26 +653,40 @@ static Int128 getUTCEpochNanoseconds(ISO8601::PlainDate isoDate)
     return TemporalCore::getUTCEpochNanoseconds(isoDate, ISO8601::PlainTime());
 }
 
-ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject* globalObject, DifferenceOperation op, TemporalPlainDate* other, TemporalUnit smallestUnit, TemporalUnit largestUnit, RoundingMode roundingMode, double increment)
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaindate
+// Step 1 (ToTemporalDate) done by the prototype host fn via TemporalPlainDate::from().
+// Uses spec's flip-mode + negate-at-end pattern for Since (unlike PlainTime's operand-swap).
+template<DifferenceOperation op>
+ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject* globalObject, TemporalPlainDate* other, JSValue optionsValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: CalendarEquals — calendars must match.
+    // Step 2: If CalendarEquals is false, throw RangeError.
     if (m_calendarID != other->m_calendarID) [[unlikely]] {
         throwRangeError(globalObject, scope, "cannot compute difference between dates with different calendars"_s);
         return { };
     }
 
-    // Step 2: if dates equal, return zero duration.
+    // Step 3: settings = ? GetDifferenceSettings(operation, options, ~date~, «», ~day~, ~day~).
+    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Date, TemporalUnit::Day, TemporalUnit::Day, op);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 4: If CompareISODate = 0, return zero duration.
     if (!TemporalCore::isoDateCompare(plainDate(), other->plainDate()))
         return ISO8601::Duration();
+
+    // Step 5: dateDifference = CalendarDateUntil(calendar, this, other, largestUnit).
     ISO8601::Duration dateDiff;
     if (!TemporalCore::calendarIsISO(m_calendarID))
         dateDiff = calendarDateUntil(m_calendarID, plainDate(), other->plainDate(), largestUnit);
     else
         dateDiff = TemporalCore::calendarDateUntil(plainDate(), other->plainDate(), largestUnit);
+
+    // Step 6: duration = CombineDateAndTimeDuration(dateDifference, 0).
     ISO8601::InternalDuration duration = ISO8601::InternalDuration::combineDateAndTimeDuration(dateDiff, 0);
+
+    // Step 7: If smallestUnit ≠ ~day~ or increment ≠ 1, RoundRelativeDuration.
     if (smallestUnit != TemporalUnit::Day || increment != 1) {
         auto isoDate = plainDate();
         Int128 originEpochNs = getUTCEpochNanoseconds(isoDate);
@@ -729,45 +700,36 @@ ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate(JSGlobalObject*
             return { };
         }
     }
+
+    // Step 8: result = ! TemporalDurationFromInternal(duration, ~day~).
     auto durResult = TemporalCore::temporalDurationFromInternal(duration, TemporalUnit::Day);
     if (!durResult) [[unlikely]] {
         throwTemporalError(globalObject, scope, durResult.error());
         return { };
     }
     ISO8601::Duration result = *durResult;
-    if (op == DifferenceOperation::Since)
+
+    // Step 9: If since, negate result. Step 10: Return result.
+    if constexpr (op == DifferenceOperation::Since)
         result = -result;
     return result;
 }
 
+template ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate<DifferenceOperation::Until>(JSGlobalObject*, TemporalPlainDate*, JSValue);
+template ISO8601::Duration TemporalPlainDate::differenceTemporalPlainDate<DifferenceOperation::Since>(JSGlobalObject*, TemporalPlainDate*, JSValue);
+
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.until
+// Step 3: Return ? DifferenceTemporalPlainDate(~until~, this, other, options).
 ISO8601::Duration TemporalPlainDate::until(JSGlobalObject* globalObject, TemporalPlainDate* other, JSValue optionsValue)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 3-4: GetDifferenceSettings.
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Date, TemporalUnit::Day, TemporalUnit::Day);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Steps 5-9: DifferenceTemporalPlainDate.
-    RELEASE_AND_RETURN(scope, differenceTemporalPlainDate(globalObject,
-        DifferenceOperation::Until, other, smallestUnit, largestUnit, roundingMode, increment));
+    return differenceTemporalPlainDate<DifferenceOperation::Until>(globalObject, other, optionsValue);
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.since
+// Step 3: Return ? DifferenceTemporalPlainDate(~since~, this, other, options).
 ISO8601::Duration TemporalPlainDate::since(JSGlobalObject* globalObject, TemporalPlainDate* other, JSValue optionsValue)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 3-4: GetDifferenceSettings(~since~, ...).
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::Date, TemporalUnit::Day, TemporalUnit::Day, DifferenceOperation::Since);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Steps 5-9: DifferenceTemporalPlainDate.
-    RELEASE_AND_RETURN(scope, differenceTemporalPlainDate(globalObject,
-        DifferenceOperation::Since, other, smallestUnit, largestUnit, roundingMode, increment));
+    return differenceTemporalPlainDate<DifferenceOperation::Since>(globalObject, other, optionsValue);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -47,12 +47,11 @@ public:
     static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&);
     static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, String&& calendarId);
     static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, CalendarID);
-    static TemporalPlainDate* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::Duration&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
 
-    static ISO8601::PlainDate toPlainDate(JSGlobalObject*, const ISO8601::Duration&);
+    static ISO8601::PlainDate validateAndCreateISODateRecord(JSGlobalObject*, const ISO8601::Duration&);
     static std::tuple<int32_t, unsigned, unsigned, std::optional<ParsedMonthCode>, TemporalOverflow, TemporalAnyProperties>
     mergeDateFields(JSGlobalObject*, JSObject*, JSValue, int32_t, uint32_t, uint32_t);
     static std::optional<int32_t> toDay(JSGlobalObject*, JSObject*);
@@ -79,7 +78,6 @@ public:
     uint8_t weekOfYear() const { return ISO8601::weekOfYear(m_plainDate); }
     int32_t yearOfWeek() const { return ISO8601::yearOfWeek(m_plainDate); }
 
-    String toString(JSGlobalObject*, JSValue options) const;
     String toString() const;
 
     ISO8601::Duration until(JSGlobalObject*, TemporalPlainDate*, JSValue options);
@@ -90,12 +88,8 @@ private:
     TemporalPlainDate(VM&, Structure*, ISO8601::PlainDate&&, String&&);
     DECLARE_DEFAULT_FINISH_CREATION;
 
-    template<typename CharacterType>
-    static std::optional<ISO8601::PlainDate> parse(StringParsingBuffer<CharacterType>&);
-    static ISO8601::PlainDate fromObject(JSGlobalObject*, JSObject*);
-
-    ISO8601::Duration differenceTemporalPlainDate(JSGlobalObject*, DifferenceOperation,
-        TemporalPlainDate*, TemporalUnit, TemporalUnit, RoundingMode, double);
+    template<DifferenceOperation>
+    ISO8601::Duration differenceTemporalPlainDate(JSGlobalObject*, TemporalPlainDate*, JSValue optionsValue);
 
     ISO8601::PlainDate m_plainDate;
     CalendarID m_calendarID { 0 };

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateConstructor.cpp
@@ -92,8 +92,11 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainDateStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 2-4: y/m/d = ToIntegerWithTruncation(isoYear/isoMonth/isoDay).
-    // ToIntegerWithTruncation throws RangeError for NaN or ±Infinity.
+    // Steps 2-4: y/m/d = ? ToIntegerWithTruncation(isoYear/isoMonth/isoDay).
+    //   ToIntegerWithTruncation: NaN → 0, ±Infinity → throw RangeError.
+    //   When called with fewer than 3 args the missing arg is undefined → 0.
+    //   We skip the conversion entirely for missing args (Duration default is 0); the
+    //   downstream IsValidISODate check then rejects month=0, matching spec behavior.
     ISO8601::Duration duration { };
     auto argumentCount = callFrame->argumentCount();
 
@@ -137,9 +140,10 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDate, (JSGlobalObject* globalObje
         }
     }
 
-    // Steps 8-10: IsValidISODate + CreateISODateRecord + CreateTemporalDate.
-    auto plainDate = TemporalPlainDate::toPlainDate(globalObject, duration);
+    // Steps 8-9: IsValidISODate + CreateISODateRecord.
+    auto plainDate = TemporalPlainDate::validateAndCreateISODateRecord(globalObject, duration);
     RETURN_IF_EXCEPTION(scope, { });
+    // Step 10: Return ? CreateTemporalDate(isoDate, calendar, NewTarget).
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), calendarId)));
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -153,10 +153,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainMonthDay, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* temporalDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!temporalDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toPlainMonthDay called on value that's not a PlainDate"_s);
 
+    // Steps 3-6: ISODateToFields + ? CalendarMonthDayFromFields + CreateTemporalMonthDay.
     if (!TemporalCore::calendarIsISO(temporalDate->calendarID())) {
         auto resolved = TemporalCore::plainMonthDayFromISODate(temporalDate->calendarID(), temporalDate->plainDate(), TemporalOverflow::Constrain);
         if (!resolved) [[unlikely]] {
@@ -169,6 +171,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainMonthDay, (JSGloba
         return JSValue::encode(result);
     }
 
+    // ISO: encode month-day with reference year 1972 (leap year, so Feb 29 fits).
     ISO8601::PlainDate dateToUse(1972, temporalDate->plainDate().month(), temporalDate->plainDate().day());
     auto* mdResult = TemporalPlainMonthDay::tryCreateIfValid(globalObject, globalObject->plainMonthDayStructure(), WTF::move(dateToUse));
     RETURN_IF_EXCEPTION(scope, { });
@@ -181,10 +184,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainYearMonth, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* temporalDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!temporalDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toPlainYearMonth called on value that's not a PlainDate"_s);
 
+    // Steps 3-6: ISODateToFields + ? CalendarYearMonthFromFields + CreateTemporalYearMonth.
     if (!TemporalCore::calendarIsISO(temporalDate->calendarID())) {
         auto resolved = TemporalCore::plainYearMonthFromISODate(temporalDate->calendarID(), temporalDate->plainDate());
         if (!resolved) [[unlikely]] {
@@ -196,27 +201,28 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainYearMonth, (JSGlob
         return JSValue::encode(result);
     }
 
+    // ISO: encode year-month with day=1.
     ISO8601::PlainDate dateToUse(temporalDate->plainDate().year(), temporalDate->plainDate().month(), 1);
     auto* ymResult = TemporalPlainYearMonth::tryCreateIfValid(globalObject, globalObject->plainYearMonthStructure(), WTF::move(dateToUse));
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(ymResult);
 }
 
+// AddDurationToDate ( operation, temporalDate, temporalDurationLike, options )
 // https://tc39.es/proposal-temporal/#sec-temporal-adddurationtodate
-// Caller handles steps 1 (ToTemporalDuration), 2 (ToISO8601Duration), 3 (negate if subtract),
-// and 4 (ToDateDurationRecordWithoutTime — time fields ignored by CalendarDateAdd).
+// Caller handles Steps 1-3 (calendar binding, ToTemporalDuration, negate-if-subtract via `-duration`).
 static EncodedJSValue addDurationToPlainDate(JSGlobalObject* globalObject, ThrowScope& scope, TemporalPlainDate* plainDate, const ISO8601::Duration& duration, JSValue optionsArg)
 {
+    // Step 4: dateDuration = ToDateDurationRecordWithoutTime — rolls 24h → 1 day.
+    auto dateDuration = TemporalDuration::toDateDurationRecordWithoutTime(globalObject, duration);
+    RETURN_IF_EXCEPTION(scope, { });
+
     // Steps 5-6: GetOptionsObject + GetTemporalOverflowOption.
     TemporalOverflow overflow = toTemporalOverflow(globalObject, optionsArg);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 7: CalendarDateAdd(calendar, temporalDate.[[ISODate]], dateDuration, overflow).
-    ISO8601::PlainDate result;
-    if (plainDate->calendarID() != iso8601CalendarID())
-        result = calendarDateAdd(globalObject, plainDate->calendarID(), plainDate->plainDate(), duration, overflow);
-    else
-        result = addDurationToDate(globalObject, plainDate->plainDate(), duration, overflow);
+    // Step 7: result = ? CalendarDateAdd(calendar, isoDate, dateDuration, overflow).
+    auto result = calendarDateAdd(globalObject, plainDate->calendarID(), plainDate->plainDate(), dateDuration, overflow);
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 8: Return ! CreateTemporalDate(result, calendar).
@@ -229,10 +235,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncAdd, (JSGlobalObject* glo
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.add called on value that's not a PlainDate"_s);
 
+    // Step 3: Return ? AddDurationToDate(~add~, this, temporalDurationLike, options).
+    //   Inner Step 2: ? ToTemporalDuration.
     auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDate(globalObject, scope, plainDate, duration, callFrame->argument(1));
@@ -244,10 +253,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSubtract, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.subtract called on value that's not a PlainDate"_s);
 
+    // Step 3: Return ? AddDurationToDate(~subtract~, …). `-duration` ≡ CreateNegatedTemporalDuration.
     auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDate(globalObject, scope, plainDate, -duration, callFrame->argument(1));
@@ -259,21 +270,23 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWith, (JSGlobalObject* gl
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Steps 1-2: RequireInternalSlot.
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.with called on value that's not a PlainDate"_s);
 
     // Step 3: If ? IsPartialTemporalObject(temporalDateLike) is false, throw TypeError.
-    // IsPartialTemporalObject requires an object with no calendar/timeZone property.
-    JSValue temporalDateLike  = callFrame->argument(0);
+    //   isObject() handles the non-Object case; Temporal.* / calendar / timeZone rejection
+    //   is enforced inside plainDate->with() via rejectObjectWithCalendarOrTimeZone.
+    JSValue temporalDateLike = callFrame->argument(0);
     if (!temporalDateLike.isObject()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "First argument to Temporal.PlainDate.prototype.with must be an object"_s);
 
-    // Step 4: calendar = plainDate.[[Calendar]]. Steps 5-11 in plainDate->with().
+    // Steps 4-10: PrepareCalendarFields + CalendarMergeFields + CalendarDateFromFields inside plainDate->with().
     auto result = plainDate->with(globalObject, asObject(temporalDateLike), callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 11: Return ! CreateTemporalDate(isoDate, calendar).
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDate::tryCreateIfValid(globalObject, globalObject->plainDateStructure(), WTF::move(result), plainDate->calendarID())));
 }
 
@@ -283,10 +296,13 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncUntil, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.until called on value that's not a PlainDate"_s);
 
+    // Step 3: Return ? DifferenceTemporalPlainDate(~until~, this, other, options).
+    //   Inner Step 1 (ToTemporalDate) handled by from().
     auto* other = TemporalPlainDate::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -302,10 +318,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncSince, (JSGlobalObject* g
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.since called on value that's not a PlainDate"_s);
 
+    // Step 3: Return ? DifferenceTemporalPlainDate(~since~, this, other, options).
     auto* other = TemporalPlainDate::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -321,17 +339,20 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncEquals, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.equals called on value that's not a PlainDate"_s);
 
+    // Step 3: Set other to ? ToTemporalDate(other).
     auto* other = TemporalPlainDate::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 4: If CompareISODate ≠ 0, return false. operator!= ≡ CompareISODate ≠ 0.
     if (plainDate->plainDate() != other->plainDate())
         return JSValue::encode(jsBoolean(false));
 
-    // CalendarEquals: compare calendar IDs.
+    // Steps 5-6: If CalendarEquals is false return false; else true.
     return JSValue::encode(jsBoolean(plainDate->calendarID() == other->calendarID()));
 }
 
@@ -424,10 +445,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime, (JSGloba
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toPlainDateTime called on value that's not a PlainDate"_s);
 
+    // Steps 3-4: time = (temporalTime undef) ? MidnightTimeRecord : ? ToTemporalTime(temporalTime).[[Time]].
     JSValue itemValue = callFrame->argument(0);
     ISO8601::PlainTime plainTime;
     if (!itemValue.isUndefined()) {
@@ -436,6 +459,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime, (JSGloba
         plainTime = pt->plainTime();
     }
 
+    // Steps 5-6: CombineISODateAndTimeRecord + CreateTemporalDateTime.
     auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDate->plainDate(), WTF::move(plainTime));
     RETURN_IF_EXCEPTION(scope, { });
     if (result && plainDate->calendarID() != iso8601CalendarID())
@@ -449,11 +473,38 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToString, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toString called on value that's not a PlainDate"_s);
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, plainDate->toString(globalObject, callFrame->argument(0)))));
+    // Step 3: resolvedOptions = ? GetOptionsObject(options).
+    JSObject* options = intlGetOptionsObject(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!options)
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, plainDate->toString())));
+
+    // Step 4: showCalendar = ? GetTemporalShowCalendarNameOption(resolvedOptions).
+    String calOpt = temporalShowCalendarName(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 5: Return TemporalDateToString(plainDate, showCalendar). Inlined:
+    //   never    → bare ISO; always → [u-ca=<id>]; critical → [!u-ca=<id>]; auto → annotate iff non-ISO.
+    auto base = ISO8601::temporalDateToString(plainDate->plainDate());
+    auto calId = plainDate->calendarIDAsString();
+    String result;
+    if (calOpt == "never"_s)
+        result = base;
+    else if (calOpt == "always"_s)
+        result = makeString(base, "[u-ca="_s, calId, ']');
+    else if (calOpt == "critical"_s)
+        result = makeString(base, "[!u-ca="_s, calId, ']');
+    else if (plainDate->calendarID() != iso8601CalendarID())
+        result = makeString(base, "[u-ca="_s, calId, ']');
+    else
+        result = base;
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, result)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindate.prototype.tojson
@@ -462,23 +513,28 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToJSON, (JSGlobalObject* 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toJSON called on value that's not a PlainDate"_s);
 
+    // Step 3: Return TemporalDateToString(this, ~auto~).
     return JSValue::encode(jsString(vm, plainDate->toString()));
 }
 
 // https://tc39.es/proposal-temporal/#sup-temporal.plaindate.prototype.tolocalestring
+// (The Temporal proposal's i18n supplement; staged for inclusion in ECMA-402.)
 JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToLocaleString, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue());
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.toLocaleString called on value that's not a PlainDate"_s);
 
+    // Step 3: dateFormat = ? CreateDateTimeFormat(%Intl.DateTimeFormat%, locales, options, ~date~, ~date~).
     JSValue locales = callFrame->argument(0);
     JSValue options = callFrame->argument(1);
     IntlDateTimeFormat* formatter;
@@ -490,6 +546,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToLocaleString, (JSGlobal
     }
     RETURN_IF_EXCEPTION(scope, { });
 
+    // Step 4: Return ? FormatDateTime(dateFormat, plainDate).
     RELEASE_AND_RETURN(scope, JSValue::encode(formatter->format(globalObject, callFrame->thisValue())));
 }
 
@@ -499,6 +556,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncValueOf, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: Throw a TypeError exception.
     return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.valueOf must not be called. To compare PlainDate values, use Temporal.PlainDate.compare"_s);
 }
 
@@ -778,14 +836,15 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncWithCalendar, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDate = dynamicDowncast<TemporalPlainDate>(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
     if (!plainDate) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDate.prototype.withCalendar called on value that's not a PlainDate"_s);
 
-    // Step 3: ToTemporalCalendarIdentifier(calendarLike).
+    // Step 3: calendar = ? ToTemporalCalendarIdentifier(calendarLike).
     auto newCalendarID = toTemporalCalendarIdentifier(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
-    // Step 4: CreateTemporalDate(this.[[ISODate]], calendar).
+    // Step 4: Return ! CreateTemporalDate(this.[[ISODate]], calendar).
     auto* result = TemporalPlainDate::create(vm, globalObject->plainDateStructure(), plainDate->plainDate());
     result->setCalendarID(newCalendarID);
     return JSValue::encode(result);

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -85,20 +85,6 @@ TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* g
     return TemporalPlainDateTime::create(vm, structure, WTF::move(plainDate), WTF::move(plainTime));
 }
 
-TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::Duration&& duration)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto plainDate = TemporalPlainDate::toPlainDate(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), WTF::move(plainTime)));
-}
-
 static TemporalPlainDateTime* fromImpl(JSGlobalObject*, JSValue, JSObject*);
 
 // Implements ToTemporalDateTime core (steps 2-3); step 1 options handled by caller.

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -44,7 +44,6 @@ public:
     static TemporalPlainDateTime* create(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&);
     static TemporalPlainDateTime* create(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID);
     static TemporalPlainDateTime* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&);
-    static TemporalPlainDateTime* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::Duration&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -30,8 +30,10 @@
 #include "JSCInlines.h"
 #include "PlainDateTimeCore.h"
 #include "TemporalCalendar.h"
+#include "TemporalPlainDate.h"
 #include "TemporalPlainDateTime.h"
 #include "TemporalPlainDateTimePrototype.h"
+#include "TemporalPlainTime.h"
 
 namespace JSC {
 
@@ -129,8 +131,16 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
         }
     }
 
-    // Steps 14-19: IsValidISODate + IsValidTime + CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(duration));
+    // Steps 14-15: IsValidISODate + CreateISODateRecord.
+    auto plainDate = TemporalPlainDate::validateAndCreateISODateRecord(globalObject, duration);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Steps 16-17: IsValidTime + CreateTimeRecord.
+    auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, duration);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Steps 18-19: CombineISODateAndTimeRecord + ? CreateTemporalDateTime.
+    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), WTF::move(plainTime));
     RETURN_IF_EXCEPTION(scope, { });
     if (result && calId != iso8601CalendarID())
         result->setCalendarID(calId);

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -271,13 +271,13 @@ static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32
     if (calendarId == rocCalendarID())
         return !icuEra ? "broc"_s : "roc"_s;
     if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
-        return !icuEra ? "bce"_s : "ce"_s;
+        return "am"_s;
     if (calendarId == ethioaaCalendarID())
         return "aa"_s;
     if (calendarId == hebrewCalendarID())
         return "am"_s;
     if (calendarId == indianCalendarID())
-        return "saka"_s;
+        return "shaka"_s;
     if (calendarId == persianCalendarID())
         return "ap"_s;
     if (calendarIsIslamic(calendarId))
@@ -398,19 +398,14 @@ static std::optional<int32_t> mapTemporalEraToICUEra(CalendarID calendarId, Stri
             return 1;
         return std::nullopt;
     }
-    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID()) {
-        if (era == "bce"_s)
-            return 0;
-        if (era == "ce"_s)
-            return 1;
-        return std::nullopt;
-    }
+    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
+        return era == "am"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == ethioaaCalendarID())
         return era == "aa"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == hebrewCalendarID())
         return era == "am"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == indianCalendarID())
-        return era == "saka"_s ? std::optional<int32_t>(0) : std::nullopt;
+        return era == "shaka"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarId == persianCalendarID())
         return era == "ap"_s ? std::optional<int32_t>(0) : std::nullopt;
     if (calendarIsIslamic(calendarId))


### PR DESCRIPTION
#### c9647b14e97b537ef936327ab0e821f6b3c74e56
<pre>
[JSC][Temporal] Polish Temporal.PlainDate: spec alignment, era and date-add fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318138">https://bugs.webkit.org/show_bug.cgi?id=318138</a>
<a href="https://rdar.apple.com/180958190">rdar://180958190</a>

Reviewed by Yusuke Suzuki.

Annotate every Temporal.PlainDate operation against the Stage 4
spec; rename toPlainDate to validateAndCreateISODateRecord.

Two real bugs fixed:

* Non-ISO PlainDate.add({hours: 24}) was a no-op. AddDurationToDate
Step 4 (ToDateDurationRecordWithoutTime — rolls 24h into one day)
was only applied on the ISO path. Hoisted so both branches roll
time fields; delete the now-unused addDurationToDate helper.
* Era codes for coptic/ethiopic (&quot;ce&quot;/&quot;bce&quot; -&gt; &quot;am&quot;) and indian
(&quot;saka&quot; -&gt; &quot;shaka&quot;) diverged from temporal_rs / icu4x. Fixed in
both forward and reverse maps.

Refactors: differenceTemporalPlainDate becomes a DifferenceOperation
template taking JSValue options; until()/since() are one-liners. Dead
Duration-taking tryCreateIfValid overloads, parse&lt;&gt;, and fromObject
removed. Single-caller toString(JSValue) inlined into its prototype
host function.

Added a FIXME notes that bare &quot;islamic&quot; is still accepted on JSC but rejected on
V8 — deferred to the Calendar internals phase.

Tests:
JSTests/stress/temporal-non-iso-era-codes.js
JSTests/stress/temporal-plain-date-add-time-rollover.js

Canonical link: <a href="https://commits.webkit.org/316092@main">https://commits.webkit.org/316092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b6283c64007f620fb26b45bb5027396366cf05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128554 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e50b402f-4f5e-4b51-8df9-730345fd4585) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c55a54d9-4b4b-4cc5-a8b1-1e7254b226b9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113736 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42b17e27-0a30-465b-b7d6-6ea317e24f5e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33408 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28897 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2102 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182803 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32095 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141709 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44420 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141519 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45109 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109814 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36787 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117000 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203517 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43620 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8177 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54491 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43266 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43155 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->