### PR TITLE
[Site Isolation] Enter fullscreen animation begin needs coordinate transformation with site isolation on

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,8 +1,10 @@
 supportsFullScreen() == true
 enterFullScreenForElement()
 beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {800, 600}
+beganEnterFullScreen() - initialRect.origin: {8, 442}, finalRect.origin: {-8, -442}
 exitFullScreenForElement()
 beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
+beganExitFullScreen() - initialRect.origin: {-8, -442}, finalRect.origin: {8, 442}
 
 Size after entering fullscreen: 600x800
 iframe border style after transition: 0px none rgb(0, 0, 0)

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -4,6 +4,7 @@
         testRunner.waitUntilDone();
         testRunner.dumpAsText()
         testRunner.dumpFullScreenCallbacks();
+        testRunner.dumpFullScreenOrigin();
     }
     addEventListener("message", (event) => {
         document.getElementById("mylog").innerHTML += event.data + "<br>";

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -228,6 +228,17 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
     if (!client)
         co_return false;
 
+    RefPtr page = m_page.get();
+    if (!page)
+        co_return false;
+
+    RefPtr webFrame = WebFrameProxy::webFrame(frameID);
+    if (!webFrame)
+        co_return false;
+
+    if (auto coordinates = co_await page->convertPointToMainFrameCoordinates({ 0, 0 }, webFrame->rootFrame()->frameID()))
+        m_rootFrameOriginInMainFrameCoordinates = IntPoint(*coordinates);
+
     bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
         client->enterFullScreen(mediaDetails.mediaDimensions, WTF::move(completionHandler));
     } };
@@ -236,21 +247,37 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
     if (!success)
         co_return false;
     m_fullscreenState = FullscreenState::EnteringFullscreen;
-    if (RefPtr page = m_page.get())
-        page->fullscreenClient().willEnterFullscreen(page.get());
+    page->fullscreenClient().willEnterFullscreen(page.get());
 
-    co_await AwaitableFromCompletionHandler<void> { [this, protectedThis = Ref { *this }, frameID] (auto completionHandler) {
+    auto needsPresentationUpdate = co_await AwaitableFromCompletionHandler<NeedsPresentationUpdate> { [this, protectedThis = Ref { *this }, frameID] (auto completionHandler) {
         enterFullScreenForOwnerElementsInOtherProcesses(frameID, WTF::move(completionHandler));
     } };
 
-    if (RefPtr page = m_page.get(); page && protect(page->preferences())->siteIsolationEnabled())
+    if (needsPresentationUpdate == NeedsPresentationUpdate::Yes) {
+        ASSERT(protect(page->preferences())->siteIsolationEnabled());
         co_await page->nextPresentationUpdate();
+    }
 
     co_return true;
 }
 
-void WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses(FrameIdentifier frameID, CompletionHandler<void()>&& completionHandler)
+void WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses(FrameIdentifier frameID, CompletionHandler<void(NeedsPresentationUpdate)>&& completionHandler)
 {
+    class CallbackAggregator : public RefCounted<CallbackAggregator> {
+    public:
+        static Ref<CallbackAggregator> create(CompletionHandler<void(NeedsPresentationUpdate)>&& completionHandler) { return adoptRef(*new CallbackAggregator(WTF::move(completionHandler))); }
+        void requirePresentationUpdate() { m_result = NeedsPresentationUpdate::Yes; }
+        ~CallbackAggregator()
+        {
+            m_completionHandler(m_result);
+        }
+    private:
+        CallbackAggregator(CompletionHandler<void(NeedsPresentationUpdate)>&& completionHandler)
+            : m_completionHandler(WTF::move(completionHandler)) { }
+        CompletionHandler<void(NeedsPresentationUpdate)> m_completionHandler;
+        NeedsPresentationUpdate m_result { NeedsPresentationUpdate::No };
+    };
+
     Ref aggregator = CallbackAggregator::create(WTF::move(completionHandler));
 
     RefPtr webFrame = WebFrameProxy::webFrame(frameID);
@@ -269,6 +296,7 @@ void WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses(
         auto addResult = processes.add(ancestor->process().coreProcessIdentifier());
         if (addResult.isNewEntry) {
             Ref process = ancestor->process();
+            aggregator->requirePresentationUpdate();
             process->sendWithAsyncReply(Messages::WebFullScreenManager::EnterFullScreenForOwnerElements(currentFrame->frameID()), [aggregator] { }, page->webPageIDInProcess(process));
         }
     }
@@ -359,20 +387,44 @@ void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(
 }
 #endif
 
-Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(IntRect initialFrame, IntRect finalFrame)
+std::optional<std::pair<IntRect, IntRect>> WebFullScreenManagerProxy::convertFromRootViewToScreenCoordinates(std::pair<IntRect, IntRect> rectsInRootViewCoordinates)
+{
+    CheckedPtr client = m_client;
+    if (!client)
+        return std::nullopt;
+
+    RefPtr page = m_page.get();
+    if (!page)
+        return std::nullopt;
+
+    auto rectsInMainFrameCoordinates = rectsInRootViewCoordinates;
+    rectsInMainFrameCoordinates.first.moveBy(m_rootFrameOriginInMainFrameCoordinates);
+
+    return { {
+        IntRect(client->convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen(*page, IntRect(rectsInMainFrameCoordinates.first))),
+        IntRect(page->syncRootViewToScreen(IntRect(rectsInMainFrameCoordinates.second)))
+    } };
+}
+
+Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(FrameIdentifier frameID, IntRect initialFrameInRootViewCoordinates, IntRect finalFrameInRootViewCoordinates)
 {
     RefPtr page = m_page.get();
     if (!page)
         co_return false;
 
-    co_await page->nextPresentationUpdate();
-
     CheckedPtr client = m_client;
     if (!client)
         co_return false;
 
+    auto rectsInScreenCoordinates = convertFromRootViewToScreenCoordinates({ initialFrameInRootViewCoordinates, finalFrameInRootViewCoordinates });
+    if (!rectsInScreenCoordinates)
+        co_return false;
+    auto [initialFrameInScreenCoordinates, finalFrameInScreenCoordinates] = *rectsInScreenCoordinates;
+
+    co_await page->nextPresentationUpdate();
+
     bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
-        client->beganEnterFullScreen(initialFrame, finalFrame, WTF::move(completionHandler));
+        client->beganEnterFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));
     } };
     if (!success)
         co_return false;
@@ -382,14 +434,19 @@ Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(IntRect initialF
     } };
 }
 
-Awaitable<void> WebFullScreenManagerProxy::beganExitFullScreen(FrameIdentifier frameID, IntRect initialFrame, IntRect finalFrame)
+Awaitable<void> WebFullScreenManagerProxy::beganExitFullScreen(FrameIdentifier frameID, IntRect initialFrameInRootViewCoordinates, IntRect finalFrameInRootViewCoordinates)
 {
     CheckedPtr client = m_client;
     if (!client)
         co_return;
 
+    auto rectsInScreenCoordinates = convertFromRootViewToScreenCoordinates({ finalFrameInRootViewCoordinates, initialFrameInRootViewCoordinates });
+    if (!rectsInScreenCoordinates)
+        co_return;
+    auto [finalFrameInScreenCoordinates, initialFrameInScreenCoordinates] = *rectsInScreenCoordinates;
+
     co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
-        client->beganExitFullScreen(initialFrame, finalFrame, WTF::move(completionHandler));
+        client->beganExitFullScreen(initialFrameInScreenCoordinates, finalFrameInScreenCoordinates, WTF::move(completionHandler));
     } };
 
     m_fullscreenState = FullscreenState::NotInFullscreen;
@@ -452,6 +509,11 @@ WTFLogChannel& WebFullScreenManagerProxy::logChannel() const
     return WebKit2LogFullscreen;
 }
 #endif
+
+WebCore::IntRect WebFullScreenManagerProxyClient::convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen(WebPageProxy& page, WebCore::IntRect rect) const
+{
+    return page.syncRootViewToScreen(rect);
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -71,6 +71,7 @@ public:
     virtual void exitFullScreen(CompletionHandler<void()>&&) = 0;
     virtual void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) = 0;
     virtual void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) = 0;
+    virtual WebCore::IntRect convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen(WebPageProxy&, WebCore::IntRect) const;
 
     virtual bool lockFullscreenOrientation(WebCore::ScreenOrientationType) { return false; }
     virtual void unlockFullscreenOrientation() { }
@@ -104,7 +105,8 @@ public:
     void detachFromClient();
     void NODELETE attachToNewClient(WebFullScreenManagerProxyClient&);
 
-    void enterFullScreenForOwnerElementsInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
+    enum class NeedsPresentationUpdate : bool { No, Yes };
+    void enterFullScreenForOwnerElementsInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void(NeedsPresentationUpdate)>&&);
     void exitFullScreenInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
 
     enum class FullscreenState : uint8_t {
@@ -134,10 +136,12 @@ private:
     void updateImageSource(FullScreenMediaDetails&&);
 #endif
     Awaitable<void> exitFullScreen();
-    Awaitable<bool> beganEnterFullScreen(WebCore::IntRect initialFrame, WebCore::IntRect finalFrame);
-    Awaitable<void> beganExitFullScreen(WebCore::FrameIdentifier, WebCore::IntRect initialFrame, WebCore::IntRect finalFrame);
+    Awaitable<bool> beganEnterFullScreen(WebCore::FrameIdentifier, WebCore::IntRect initialFrameInRootViewCoordinates, WebCore::IntRect finalFrameInRootViewCoordinates);
+    Awaitable<void> beganExitFullScreen(WebCore::FrameIdentifier, WebCore::IntRect initialFrameInRootViewCoordinates, WebCore::IntRect finalFrameInRootViewCoordinates);
     void callCloseCompletionHandlers();
     template<typename M> void sendToWebProcess(M&&);
+
+    std::optional<std::pair<WebCore::IntRect, WebCore::IntRect>> convertFromRootViewToScreenCoordinates(std::pair<WebCore::IntRect, WebCore::IntRect> rectsInRootViewCoordinates);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
@@ -159,6 +163,7 @@ private:
 #endif // QUICKLOOK_FULLSCREEN
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
     WeakPtr<WebProcessProxy> m_fullScreenProcess;
+    WebCore::IntPoint m_rootFrameOriginInMainFrameCoordinates;
 
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -33,7 +33,7 @@ messages -> WebFullScreenManagerProxy {
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif
     ExitFullScreen() -> ()
-    BeganEnterFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> (bool success)
+    BeganEnterFullScreen(WebCore::FrameIdentifier frameID, WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> (bool success)
     BeganExitFullScreen(WebCore::FrameIdentifier frameID, WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> ()
     Close()
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15387,6 +15387,13 @@ void WebPageProxy::convertRectsToMainFrameCoordinates(Vector<WebCore::FloatRect>
     });
 }
 
+Awaitable<std::optional<WebCore::FloatPoint>> WebPageProxy::convertPointToMainFrameCoordinates(WebCore::FloatPoint point, std::optional<WebCore::FrameIdentifier> frameID)
+{
+    co_return co_await AwaitableFromCompletionHandler<std::optional<WebCore::FloatPoint>> { [protectedThis = Ref { *this }, point, frameID] (auto completionHandler) {
+        protectedThis->convertPointToMainFrameCoordinates(point, frameID, WTF::move(completionHandler));
+    } };
+}
+
 Awaitable<std::optional<WebCore::FloatRect>> WebPageProxy::convertRectToMainFrameCoordinates(WebCore::FloatRect rect, std::optional<WebCore::FrameIdentifier> frameID)
 {
     co_return co_await AwaitableFromCompletionHandler<std::optional<WebCore::FloatRect>> { [protectedThis = Ref { *this }, rect, frameID] (auto completionHandler) {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2871,6 +2871,7 @@ public:
     void convertRectToMainFrameCoordinates(WebCore::FloatRect, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(std::optional<WebCore::FloatRect>)>&&);
     void convertRectsToMainFrameCoordinates(Vector<WebCore::FloatRect>, std::optional<WebCore::FrameIdentifier>, CompletionHandler<void(std::optional<Vector<WebCore::FloatRect>>)>&&);
     Awaitable<std::optional<WebCore::FloatRect>> convertRectToMainFrameCoordinates(WebCore::FloatRect, std::optional<WebCore::FrameIdentifier>);
+    Awaitable<std::optional<WebCore::FloatPoint>> convertPointToMainFrameCoordinates(WebCore::FloatPoint, std::optional<WebCore::FrameIdentifier>);
     void hitTestAtPoint(WebCore::FrameIdentifier, WebCore::FloatPoint, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -231,6 +231,7 @@ private:
     void exitFullScreen(CompletionHandler<void()>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
+    WebCore::IntRect convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen(WebPageProxy&, WebCore::IntRect) const override;
 #endif
 
     void navigationGestureDidBegin() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -911,6 +911,15 @@ void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntR
         return completionHandler();
 }
 
+WebCore::IntRect PageClientImpl::convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen(WebPageProxy& page, WebCore::IntRect mainFrameCoordinates) const
+{
+    if (RetainPtr fullScreenWindowController = protect(m_impl)->fullScreenWindowController()) {
+        if (auto screenCoordinates = [fullScreenWindowController convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen:mainFrameCoordinates])
+            return *screenCoordinates;
+    }
+    return page.syncRootViewToScreen(mainFrameCoordinates);
+}
+
 #endif // ENABLE(FULLSCREEN_API)
 
 void PageClientImpl::navigationGestureDidBegin()

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -86,6 +86,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 - (void)close;
 - (void)beganEnterFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame completionHandler:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)beganExitFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame completionHandler:(CompletionHandler<void()>&&)completionHandler;
+- (std::optional<WebCore::IntRect>)convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen:(WebCore::IntRect)mainFrameCoordinates;
 
 - (void)videoControlsManagerDidChange;
 

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -636,6 +636,28 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         manager->requestExitFullScreen();
 }
 
+- (std::optional<WebCore::IntRect>)convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen:(WebCore::IntRect)mainFrameCoordinates
+{
+    // This is like PageClientImpl::rootViewToScreen but with two important differences:
+    // 1. We use _webViewPlaceholder instead of the WKWebView because at this point the
+    //    WKWebView has been put at the screen origin, which can't be used for coordinate
+    //    transformations.
+    // 2. _webViewPlaceholder is non-flipped so we need to flip the Y coordinate before
+    //    converting to window coordinates.
+
+    NSRect tempRect = mainFrameCoordinates;
+    RetainPtr view = _webViewPlaceholder;
+    if (![view window])
+        return std::nullopt;
+
+    tempRect.origin.y = NSHeight([view bounds]) - NSMaxY(tempRect);
+
+    tempRect = [view convertRect:tempRect toView:nil];
+    tempRect.origin = [retainPtr([view window]) convertPointToScreen:tempRect.origin];
+
+    return WebCore::enclosingIntRect(tempRect);
+}
+
 - (void)beganExitFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame completionHandler:(CompletionHandler<void()>&&)completionHandler
 {
     if (_fullScreenState != WaitingToExitFullScreen)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -81,7 +81,7 @@ using namespace WebCore;
 
 using WebCore::FloatSize;
 
-static WebCore::IntRect screenRectOfContents(WebCore::Element& element)
+static WebCore::IntRect rootViewRectOfContents(WebCore::Element& element)
 {
     CheckedPtr renderer = element.renderer();
     if (!renderer)
@@ -103,7 +103,7 @@ static WebCore::IntRect screenRectOfContents(WebCore::Element& element)
     auto viewportRect = snappedIntRect(frameView->layoutViewportRect());
     contentsRect.intersect(viewportRect);
 
-    return frameView->contentsToScreen(contentsRect);
+    return frameView->contentsToRootView(contentsRect);
 }
 
 Ref<WebFullScreenManager> WebFullScreenManager::create(WebPage& page)
@@ -447,7 +447,7 @@ void WebFullScreenManager::performEnterFullScreen()
     }
 #endif
 
-    m_initialFrame = screenRectOfContents(*element);
+    m_initialFrameInRootViewCoordinates = rootViewRectOfContents(*element);
 
 #if ENABLE(VIDEO)
     updateMainVideoElement();
@@ -573,9 +573,20 @@ void WebFullScreenManager::willEnterFullScreen(Element& element, CompletionHandl
     m_page->hidePageBanners();
 #endif
     protect(element.document())->updateLayout();
-    m_finalFrame = screenRectOfContents(element);
+    m_finalFrameInRootViewCoordinates = rootViewRectOfContents(element);
 
-    m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::BeganEnterFullScreen(m_initialFrame, m_finalFrame), [this, protectedThis = Ref { *this }, mode, completionHandler = WTF::move(didEnterFullscreenCallback)] (bool success) mutable {
+    RefPtr frame = element.document().frame();
+    if (!frame) {
+        didEnterFullscreenCallback(false);
+        return;
+    }
+
+    m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::BeganEnterFullScreen(frame->frameID(), m_initialFrameInRootViewCoordinates, m_finalFrameInRootViewCoordinates), [
+        this,
+        protectedThis = Ref { *this },
+        mode,
+        completionHandler = WTF::move(didEnterFullscreenCallback)
+    ] (bool success) mutable {
         if (!success && mode != WebCore::HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
             completionHandler(false);
             return;
@@ -654,7 +665,7 @@ void WebFullScreenManager::willExitFullScreen(CompletionHandler<void()>&& comple
     setPIPStandbyElement(nullptr);
 #endif
 
-    m_finalFrame = screenRectOfContents(*element);
+    m_finalFrameInRootViewCoordinates = rootViewRectOfContents(*element);
     if (!protect(protect(element->document())->fullscreen())->willExitFullscreen()) {
         close();
         return completionHandler();
@@ -664,7 +675,7 @@ void WebFullScreenManager::willExitFullScreen(CompletionHandler<void()>&& comple
 #endif
     // FIXME: The order of these frames is switched, but that is kept for historical reasons.
     // It should probably be fixed to be consistent at some point.
-    m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::BeganExitFullScreen(*m_elementFrameIdentifier, m_finalFrame, m_initialFrame), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] mutable {
+    m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::BeganExitFullScreen(*m_elementFrameIdentifier, m_finalFrameInRootViewCoordinates, m_initialFrameInRootViewCoordinates), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] mutable {
         didExitFullScreen(WTF::move(completionHandler));
     });
 }

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -105,8 +105,8 @@ protected:
     void setFullscreenInsets(const WebCore::FloatBoxExtent&);
     void setFullscreenAutoHideDuration(Seconds);
 
-    WebCore::IntRect m_initialFrame;
-    WebCore::IntRect m_finalFrame;
+    WebCore::IntRect m_initialFrameInRootViewCoordinates;
+    WebCore::IntRect m_finalFrameInRootViewCoordinates;
     WebCore::IntPoint m_scrollPosition;
     const Ref<WebPage> m_page;
     RefPtr<WebCore::Element> m_element;

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -666,6 +666,20 @@ void TestController::beganEnterFullScreen(WKPageRef page, WKRect initialFrame, W
             "}\n"_s
         ));
     }
+
+    if (m_dumpFullScreenOrigin) {
+        protectedCurrentInvocation()->outputText(makeString(
+            "beganEnterFullScreen() - initialRect.origin: {"_s,
+            (initialFrame.origin.x - finalFrame.origin.x),
+            ", "_s,
+            (initialFrame.origin.y - finalFrame.origin.y),
+            "}, finalRect.origin: {"_s,
+            (finalFrame.origin.x - initialFrame.origin.x),
+            ", "_s,
+            (finalFrame.origin.y - initialFrame.origin.y),
+            "}\n"_s
+        ));
+    }
 }
 
 void TestController::exitFullScreen(WKPageRef page, const void* clientInfo)
@@ -696,6 +710,20 @@ void TestController::beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect 
         finalFrame.size.width,
         ", "_s,
         finalFrame.size.height,
+        "}\n"_s
+        ));
+    }
+
+    if (m_dumpFullScreenOrigin) {
+        protectedCurrentInvocation()->outputText(makeString(
+        "beganExitFullScreen() - initialRect.origin: {"_s,
+        (initialFrame.origin.x - finalFrame.origin.x),
+        ", "_s,
+        (initialFrame.origin.y - finalFrame.origin.y),
+        "}, finalRect.origin: {"_s,
+        (finalFrame.origin.x - initialFrame.origin.x),
+        ", "_s,
+        (finalFrame.origin.y - initialFrame.origin.y),
         "}\n"_s
         ));
     }
@@ -1670,6 +1698,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     m_hasResourceLoadClient = false;
     m_dumpResourceLoadCallbacks = false;
 
+    m_dumpFullScreenOrigin = false;
     m_waitBeforeFinishingFullscreenExit = false;
     m_scrollDuringEnterFullscreen = false;
     if (m_finishExitFullscreenHandler)
@@ -2245,6 +2274,7 @@ if (window.testRunner) {
     testRunner.setBlockAllPlugins = value => post(['SetBlockAllPlugins', value]);
     testRunner.stopLoading = () => post(['StopLoading']);
     testRunner.dumpFullScreenCallbacks = () => post(['DumpFullScreenCallbacks']);
+    testRunner.dumpFullScreenOrigin = () => post(['DumpFullScreenOrigin']);
     testRunner.displayAndTrackRepaints = () => post(['DisplayAndTrackRepaints']);
     testRunner.clearBackForwardList = () => post(['ClearBackForwardList']);
     testRunner.addChromeInputField = async (callback) => { await post(['AddChromeInputField']); callback?.(); }; // NOLINT
@@ -2827,6 +2857,11 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
 
     if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenCallbacks")) {
         dumpFullScreenCallbacks();
+        return completionHandler(nullptr);
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "DumpFullScreenOrigin")) {
+        dumpFullScreenOrigin();
         return completionHandler(nullptr);
     }
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -224,6 +224,7 @@ public:
     void dumpResourceResponseMIMETypes(String&&);
     void dumpPolicyDelegateCallbacks() { m_dumpPolicyDelegateCallbacks = true; }
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
+    void dumpFullScreenOrigin() { m_dumpFullScreenOrigin = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
     void scrollDuringEnterFullscreen() { m_scrollDuringEnterFullscreen = true; }
     void finishFullscreenExit();
@@ -923,6 +924,7 @@ private:
     String m_resourceResponseMIMETypesToDump;
     bool m_dumpFullScreenCallbacks { false };
     bool m_dumpAllHTTPRedirectedResponseHeaders { false };
+    bool m_dumpFullScreenOrigin { false };
     bool m_waitBeforeFinishingFullscreenExit { false };
     bool m_scrollDuringEnterFullscreen { false };
     bool m_useWorkQueue { false };


### PR DESCRIPTION
#### 545bccd54800338a09aa33bed6aecafc07ca7380
<pre>
[Site Isolation] Enter fullscreen animation begin needs coordinate transformation with site isolation on
<a href="https://bugs.webkit.org/show_bug.cgi?id=318149">https://bugs.webkit.org/show_bug.cgi?id=318149</a>
<a href="https://rdar.apple.com/153776866">rdar://153776866</a>

Reviewed by Andy Estes.

This was attempted once before in 301065@main but it was reverted in 302010@main because it changed what
coordinates are used for fullscreen transitions.  This happened because the prior approach was to transform
the coordinates in WebFullScreenManagerProxy::enterFullScreen and use them in
WebFullScreenManagerProxy::beganEnterFullScreen, but in order to do that we changed the time when the initial
and final coordinates were gathered and stored.  In a process that has multiple IPC roundtrips to give the
page a chance to change to the new size then transition to the new size, this timing change broke things.

In this PR, I take a different approach.  I don&apos;t change when I gather or store the coordinates, but I
change what coordinate space they are in.  Instead of converting to screen space in the web content process,
I convert to root frame coordinate space in the web content process, then in the UI process I take those
coordinates and convert them to main frame space then to screen space.  This would be easier, but when I&apos;m
doing those transformations the window has already been detached so I can&apos;t use WebPageProxy::syncRootViewToScreen
because that uses the wrong window and therefore gives me the wrong coordinates.  Instead, I introduce a new
utility, convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen, that uses the old window to do the
same coordinate transformation.  I verified that the coordinates before and after this change are identical.

The only remaining tricky part once I got that working was to get it working with site isolation.  At the
point in time when I would like to convert iframe coordinates to main frame coordinates, the frame coordinates
have already been changed by enterFullScreenForOwnerElementsInOtherProcesses so WebPageProxy&apos;s
geometry conversion utilities like convertRectToMainFrameCoordinates are also giving the wrong values.  The
page has already changed in multiple processes, so the ability to transform coordinates from iframe space
to main frame space has been destroyed.  To make it work I use a cached value of m_rootFrameOriginInMainFrameCoordinates
that I stored from convertPointToMainFrameCoordinates before enterFullScreenForOwnerElementsInOtherProcesses
was called to transform the coordinates.  This is somewhat equivalent to our previous approach of using a
web process&apos;s cached values of the location of its window in the screen.

While I was reorganizing things around enterFullScreenForOwnerElementsInOtherProcesses, I realized that
the condition in which we need a call to nextPresentationUpdate after it was not when site isolation is enabled,
but rather when WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses sends IPC to other
processes to tell them to update their geometry for entering fullscreen.  We need the nextPresentationUpdate call
in that case because we need the geometry changes to percolate down the frame tree scattered across multiple
web content processes.

The test and infrastructure is taken from Nipun&apos;s earlier work, 301065@main.

* LayoutTests/http/tests/site-isolation/fullscreen-expected.txt:
* LayoutTests/http/tests/site-isolation/fullscreen.html:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses):
(WebKit::WebFullScreenManagerProxy::convertFromRootViewToScreenCoordinates):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
(WebKit::WebFullScreenManagerProxyClient::convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen const):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::convertPointToMainFrameCoordinates):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen const):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController convertMainFrameCoordinatesInFullscreenPlaceholderViewToScreen:]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::rootViewRectOfContents):
(WebKit::WebFullScreenManager::performEnterFullScreen):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::screenRectOfContents): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::beganEnterFullScreen):
(WTR::TestController::beganExitFullScreen):
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/TestController.h:
(WTR::TestController::dumpFullScreenOrigin):

Canonical link: <a href="https://commits.webkit.org/316670@main">https://commits.webkit.org/316670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e94e86a1823e4f2209048cb73dcd85ba5bd0b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129529 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f40c40b3-a736-429e-a558-ec077bdae058) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94378 "19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc596ce8-33d8-4f6b-bb37-fb0c000644e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154298 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114279 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/420c2a75-a378-464a-9074-85bcd9dd0857) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35819 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34079 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30028 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183947 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142503 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46239 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30654 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110902 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37492 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117927 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44757 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8748 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44157 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44216 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->