### PR TITLE
Support browser.tabs.move(...) WebExtension API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -86,6 +86,23 @@ WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
 - (void)_webExtensionController:(WKWebExtensionController *)controller didCreateBackgroundWebView:(WKWebView *)webView forExtensionContext:(WKWebExtensionContext *)context;
 
 /*!
+ @abstract Called when an extension context requests one or more tabs be moved to a new position.
+ @param controller The web extension controller that is managing the extension.
+ @param tabs The tabs to move, in the order they should appear at the destination.
+ @param index The zero-based index position to move the tabs to within the destination window. The first tab is
+ moved to this index and the remaining tabs follow it in order. If \c index is greater than or equal to the number
+ of tabs in the destination window, the tabs should be moved to the last position.
+ @param window The destination window. All of the provided tabs are currently in this window, or are being moved into it.
+ @param extensionContext The context in which the web extension is running.
+ @param completionHandler A block that must be called upon completion. It takes a single error argument,
+ which should be provided if any errors occurred.
+ @discussion This method should be implemented by the app to handle requests to move tabs, e.g. via `browser.tabs.move()`. The app is
+ responsible for the final placement, including honoring any constraints such as keeping pinned tabs ahead of unpinned tabs.
+ The provided tabs are always in a single destination window, so an app may move them together as one selection.
+ */
+- (void)_webExtensionController:(WKWebExtensionController *)controller moveTabs:(NSArray<id <WKWebExtensionTab>> *)tabs toIndex:(NSUInteger)index inWindow:(id <WKWebExtensionWindow>)window forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(webExtensionController(_:move:toIndex:in:for:completionHandler:));
+
+/*!
  @abstract Called when a sidebar is requested to be opened.
  @param controller The web extension controller initiating the request.
  @param sidebar The sidebar which should be displayed.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -49,8 +49,11 @@
 #import <WebCore/ImageUtilities.h>
 #import <wtf/Box.h>
 #import <wtf/CallbackAggregator.h>
+#import <wtf/MathExtras.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/OrderedHashMap.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 
@@ -573,6 +576,123 @@ void WebExtensionContext::tabsSetZoom(WebPageProxyIdentifier webPageProxyIdentif
     }
 
     tab->setZoomFactor(zoomFactor, WTF::move(completionHandler));
+}
+
+void WebExtensionContext::tabsMove(Vector<WebExtensionTabIdentifier> tabIdentifiers, std::optional<WebExtensionWindowIdentifier> windowIdentifier, double targetIndex, CompletionHandler<void(Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&&)>&& completionHandler)
+{
+    static NSString * const apiName = @"tabs.move()";
+
+    RefPtr extensionController = this->extensionController();
+    if (!extensionController) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the extension is not loaded"));
+        return;
+    }
+
+    auto *delegate = extensionController->delegate();
+    if (![delegate respondsToSelector:@selector(_webExtensionController:moveTabs:toIndex:inWindow:forExtensionContext:completionHandler:)]) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
+        return;
+    }
+
+    Vector<Ref<WebExtensionTab>> tabs;
+    tabs.reserveInitialCapacity(tabIdentifiers.size());
+
+    for (auto& tabIdentifier : tabIdentifiers) {
+        if (RefPtr tab = getTab(tabIdentifier))
+            tabs.append(tab.releaseNonNull());
+        else {
+            completionHandler(toWebExtensionError(apiName, nullString(), makeString("tab '"_s, tabIdentifier.toUInt64(), "' was not found"_s)));
+            return;
+        }
+    }
+
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE RefPtr<WebExtensionWindow> window = windowIdentifier
+        .transform([this](auto& windowId) { return getWindow(windowId); })
+        .value_or(nullptr);
+    if (windowIdentifier && !window) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"window not found"));
+        return;
+    }
+
+    // Tabs can only be moved to and from normal windows.
+    if (window && window->type() != WebExtensionWindow::Type::Normal) {
+        completionHandler(toWebExtensionError(apiName, nullString(), @"the destination window is not a normal window"));
+        return;
+    }
+
+    for (Ref tab : tabs) {
+        RefPtr tabWindow = tab->window();
+
+        if (tabWindow && tabWindow->type() != WebExtensionWindow::Type::Normal) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"it is not possible to move a tab that is not in a normal window"));
+            return;
+        }
+
+        if (window && tab->isPrivate() != window->isPrivate()) {
+            completionHandler(toWebExtensionError(apiName, nullString(), @"it is not possible to move tabs between private and non-private windows"));
+            return;
+        }
+    }
+
+    Ref callbackAggregator = EagerCallbackAggregator<void(Expected<void, WebExtensionError>)>::create([protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), tabs](Expected<void, WebExtensionError>&& result) mutable {
+        if (!result) {
+            completionHandler(makeUnexpected(result.error()));
+            return;
+        }
+
+        completionHandler(tabs.map([](auto& tab) {
+            return tab->parameters();
+        }));
+    }, { });
+
+    SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE auto moveTabsToIndexInWindow = [=, this, extensionController = WTF::move(extensionController)](NSArray<WKWebExtensionTab *> *tabs, WebExtensionWindow& window) {
+        uint64_t resolvedIndex = targetIndex < 0 ? window.tabs().size() : clampTo<uint64_t>(targetIndex);
+
+        auto *windowDelegate = window.delegate();
+        if (!windowDelegate) {
+            callbackAggregator.get()(toWebExtensionError(apiName, nullString(), @"an internal error occurred"));
+            return false;
+        }
+
+        [delegate _webExtensionController:extensionController->wrapper() moveTabs:tabs toIndex:resolvedIndex inWindow:windowDelegate forExtensionContext:wrapper() completionHandler:makeBlockPtr([callbackAggregator](NSError *error) mutable {
+            if (error)
+                callbackAggregator.get()(toWebExtensionError(apiName, nullString(), error.localizedDescription));
+        }).get()];
+
+        return true;
+    };
+
+    if (window) {
+        auto *tabDelegates = createNSArray(tabs, [](auto& tab) {
+            return tab->delegate();
+        }).get();
+        moveTabsToIndexInWindow(tabDelegates, *window);
+        return;
+    }
+
+    OrderedHashMap<Ref<WebExtensionWindow>, Vector<Ref<WebExtensionTab>>> tabsByWindow;
+    for (Ref tab : tabs) {
+        RefPtr tabWindow = tab->window();
+        if (!tabWindow) {
+            callbackAggregator.get()(toWebExtensionError(apiName, nullString(), @"the tab is not in a window"));
+            return;
+        }
+
+        Ref destinationWindow = tabWindow.releaseNonNull();
+        auto& tabsForWindow = tabsByWindow.ensure(destinationWindow, [] {
+            return Vector<Ref<WebExtensionTab>> { };
+        }).iterator->value;
+        tabsForWindow.append(WTF::move(tab));
+    }
+
+    for (auto& [destinationWindow, groupedTabs] : tabsByWindow) {
+        auto *tabDelegates = createNSArray(groupedTabs, [](auto& tab) {
+            return tab->delegate();
+        }).get();
+
+        if (!moveTabsToIndexInWindow(tabDelegates, destinationWindow.get()))
+            return;
+    }
 }
 
 void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdentifiers, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -994,6 +994,7 @@ private:
     void tabsConnect(WebExtensionTabIdentifier, WebExtensionPortChannelIdentifier, String name, const WebExtensionMessageTargetParameters&, const WebExtensionMessageSenderParameters&, bool userGesture, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void tabsGetZoom(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<double, WebExtensionError>&&)>&&);
     void tabsSetZoom(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, double, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
+    void tabsMove(Vector<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>, double, CompletionHandler<void(Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&&)>&&);
     void tabsRemove(Vector<WebExtensionTabIdentifier>, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void tabsExecuteScript(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, const WebExtensionScriptInjectionParameters&, bool userGesture, CompletionHandler<void(Expected<Vector<WebExtensionScriptInjectionResultParameters>, WebExtensionError>&&)>&&);
     void tabsInsertCSS(WebPageProxyIdentifier, std::optional<WebExtensionTabIdentifier>, const WebExtensionScriptInjectionParameters&, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -53,7 +53,7 @@ messages -> WebExtensionContext {
     [Validator=isAlarmsMessageAllowed] AlarmsGetAll() -> (Vector<WebKit::WebExtensionAlarmParameters> alarms)
     [Validator=isAlarmsMessageAllowed] AlarmsClearAll() -> ()
 
-    #if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
+#if ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
     // Bookmarks APIs
     [Validator=isBookmarksMessageAllowed] BookmarksCreate(std::optional<String> parentId, std::optional<uint64_t> index, std::optional<String> url, std::optional<String> title) -> (Expected<WebKit::WebExtensionBookmarksParameters, WebKit::WebExtensionError> result)
     [Validator=isBookmarksMessageAllowed] BookmarksGetTree() -> (Expected<Vector<WebKit::WebExtensionBookmarksParameters>, WebKit::WebExtensionError> result)
@@ -180,6 +180,7 @@ messages -> WebExtensionContext {
     [Validator=isLoadedAndPrivilegedMessage] TabsConnect(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionPortChannelIdentifier channelIdentifier, String name, struct WebKit::WebExtensionMessageTargetParameters targetParameters, struct WebKit::WebExtensionMessageSenderParameters senderParameters, bool userGesture) -> (Expected<void, WebKit::WebExtensionError> result)
     [Validator=isLoadedAndPrivilegedMessage] TabsGetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier) -> (Expected<double, WebKit::WebExtensionError> result)
     [Validator=isLoadedAndPrivilegedMessage] TabsSetZoom(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, double zoomFactor) -> (Expected<void, WebKit::WebExtensionError> result)
+    [Validator=isLoadedAndPrivilegedMessage] TabsMove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers, std::optional<WebKit::WebExtensionWindowIdentifier> windowIdentifier, double index) -> (Expected<Vector<WebKit::WebExtensionTabParameters>, WebKit::WebExtensionError> result)
     [Validator=isLoadedAndPrivilegedMessage] TabsRemove(Vector<WebKit::WebExtensionTabIdentifier> tabIdentifiers) -> (Expected<void, WebKit::WebExtensionError> result)
     [Validator=isLoadedAndPrivilegedMessage] TabsExecuteScript(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters, bool userGesture) -> (Expected<Vector<WebKit::WebExtensionScriptInjectionResultParameters>, WebKit::WebExtensionError> result)
     [Validator=isLoadedAndPrivilegedMessage] TabsInsertCSS(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<WebKit::WebExtensionTabIdentifier> tabIdentifier, WebKit::WebExtensionScriptInjectionParameters parameters) -> (Expected<void, WebKit::WebExtensionError> result)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -126,6 +126,42 @@ static inline size_t clampIndex(double index)
     return static_cast<size_t>(std::max(0.0, std::min(index, static_cast<double>(JSC::maxSafeInteger()))));
 }
 
+// Parses a tab identifier or array of tab identifiers into a validated list of WebExtensionTabIdentifiers.
+static bool parseTabIdentifiers(NSObject *tabIDs, Vector<WebExtensionTabIdentifier>& identifiers, NSString *sourceKey, NSString **outExceptionString)
+{
+    if (!validateObject(tabIDs, sourceKey, [NSOrderedSet orderedSetWithObjects:NSNumber.class, @[ NSNumber.class ], nil], outExceptionString))
+        return false;
+
+    auto appendIdentifier = [&](NSNumber *tabID) -> bool {
+        auto tabIdentifier = toWebExtensionTabIdentifier(tabID.doubleValue);
+        if (!isValid(tabIdentifier)) {
+            *outExceptionString = toErrorString(nullString(), sourceKey, makeString("'"_s, String(tabID.description), "' is not a tab identifier"_s)).createNSString().autorelease();
+            return false;
+        }
+
+        identifiers.append(tabIdentifier.value());
+        return true;
+    };
+
+    if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs))
+        return appendIdentifier(tabID);
+
+    if (NSArray *tabIDArray = dynamic_objc_cast<NSArray>(tabIDs)) {
+        identifiers.reserveInitialCapacity(tabIDArray.count);
+
+        for (NSNumber *tabID in tabIDArray) {
+            if (!appendIdentifier(tabID))
+                return false;
+        }
+    } else {
+        // This should be unreachable if validateObject passed above, but handle it anyways
+        *outExceptionString = toErrorString(nullString(), sourceKey, makeString("an internal error occurred"_s)).createNSString().autorelease();
+        return false;
+    }
+
+    return true;
+}
+
 bool WebExtensionAPITabs::parseTabCreateOptions(NSDictionary *options, WebExtensionTabParameters& parameters, NSString *sourceKey, NSString **outExceptionString)
 {
     if (!parseTabUpdateOptions(options, parameters, sourceKey, outExceptionString))
@@ -688,36 +724,72 @@ void WebExtensionAPITabs::update(WebPageProxyIdentifier webPageProxyIdentifier, 
     }, extensionContext().identifier());
 }
 
+void WebExtensionAPITabs::move(NSObject *tabIDs, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+{
+    // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move
+
+    Vector<WebExtensionTabIdentifier> identifiers;
+    if (!parseTabIdentifiers(tabIDs, identifiers, @"tabIDs", outExceptionString))
+        return;
+
+    if (identifiers.isEmpty()) {
+        *outExceptionString = toErrorString(nullString(), @"tabIDs", "no tabs were specified"_s).createNSString().autorelease();
+        return;
+    }
+
+    static NSDictionary<NSString *, id> *types = @{
+        windowIdKey: NSNumber.class,
+        indexKey: NSNumber.class,
+    };
+
+    if (!validateDictionary(properties, @"properties", @[ indexKey ], types, outExceptionString))
+        return;
+
+    std::optional<WebExtensionWindowIdentifier> windowIdentifier;
+    if (NSNumber *windowId = objectForKey<NSNumber>(properties, windowIdKey)) {
+        windowIdentifier = toWebExtensionWindowIdentifier(windowId.doubleValue);
+
+        if (!windowIdentifier || !isValid(windowIdentifier.value())) {
+            *outExceptionString = toErrorString(nullString(), windowIdKey, makeString("'"_s, String(windowId.description), "' is not a window identifier"_s)).createNSString().autorelease();
+            return;
+        }
+    }
+
+    double index = objectForKey<NSNumber>(properties, indexKey).doubleValue;
+
+    double integral;
+    if (std::modf(index, &integral) != 0.0) {
+        *outExceptionString = toErrorString(nullString(), indexKey, "it must be an integer"_s).createNSString().autorelease();
+        return;
+    }
+
+    if (index < -1) {
+        *outExceptionString = toErrorString(nullString(), indexKey, "it must be -1 or greater"_s).createNSString().autorelease();
+        return;
+    }
+
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsMove(WTF::move(identifiers), windowIdentifier, index), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<Vector<WebExtensionTabParameters>, WebExtensionError>&& result) {
+        if (!result) {
+            callback->reportError(result.error().createNSString().get());
+            return;
+        }
+
+        auto& movedTabs = result.value();
+
+        if (movedTabs.size() == 1)
+            callback->call(toJSValueRef(callback->globalContext(), toWebAPI(movedTabs[0])));
+        else
+            callback->call(toJSValueRef(callback->globalContext(), toWebAPI(movedTabs)));
+    }, extensionContext().identifier());
+}
+
 void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove
 
-    if (!validateObject(tabIDs, @"tabIDs", [NSOrderedSet orderedSetWithObjects:NSNumber.class, @[ NSNumber.class ], nil], outExceptionString))
-        return;
-
     Vector<WebExtensionTabIdentifier> identifiers;
-
-    if (NSNumber *tabID = dynamic_objc_cast<NSNumber>(tabIDs)) {
-        auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
-        if (!isValid(tabIdentifer)) {
-            *outExceptionString = toErrorString(nullString(), @"tabIDs", makeString("'"_s, String([tabID description]), "' is not a tab identifier"_s)).createNSString().autorelease();
-            return;
-        }
-
-        identifiers.append(tabIdentifer.value());
-    } else if (NSArray *tabIDArray = dynamic_objc_cast<NSArray>(tabIDs)) {
-        identifiers.reserveInitialCapacity(tabIDArray.count);
-
-        for (NSNumber *tabID in tabIDArray) {
-            auto tabIdentifer = toWebExtensionTabIdentifier(tabID.doubleValue);
-            if (!isValid(tabIdentifer)) {
-                *outExceptionString = toErrorString(nullString(), @"tabIDs", makeString("'"_s, String([tabID description]), "' is not a tab identifier"_s)).createNSString().autorelease();
-                return;
-            }
-
-            identifiers.append(tabIdentifer.value());
-        }
-    }
+    if (!parseTabIdentifiers(tabIDs, identifiers, @"tabIDs", outExceptionString))
+        return;
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemove(WTF::move(identifiers)), [protectedThis = Ref { *this }, callback = WTF::move(callback)](Expected<void, WebExtensionError>&& result) {
         if (!result) {

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -62,6 +62,7 @@ public:
 
     void duplicate(double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void update(WebPageProxyIdentifier, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void move(NSObject *tabIDs, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void reload(WebPageProxyIdentifier, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
@@ -39,6 +39,7 @@
 
     [RaisesException] void duplicate(double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);
     [RaisesException, NeedsPageIdentifier] void update([Optional] double tabID, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
+    [RaisesException] void move([NSObject] any tabIDs, [NSDictionary] any properties, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any tabIDs, [Optional, CallbackHandler] function callback);
 
     [RaisesException, NeedsPageIdentifier] void reload([Optional] double tabID, [Optional, NSDictionary] any properties, [Optional, CallbackHandler] function callback);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h
@@ -52,6 +52,7 @@
 #endif
 
 @property (nonatomic, copy) void (^openNewTab)(WKWebExtensionTabConfiguration *, WKWebExtensionContext *, void (^)(id<WKWebExtensionTab>, NSError *));
+@property (nonatomic, copy) void (^moveTabs)(NSArray<id <WKWebExtensionTab>> *, NSUInteger index, id <WKWebExtensionWindow> window, WKWebExtensionContext *, void (^)(NSError *));
 @property (nonatomic, copy) void (^openOptionsPage)(WKWebExtensionContext *, void (^)(NSError *));
 
 @property (nonatomic, copy) void (^promptForPermissions)(id <WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<WKWebExtensionPermission> *, NSDate *));

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm
@@ -32,6 +32,7 @@
 #import <WebKit/WKWebExtensionController.h>
 #import <WebKit/WKWebExtensionMatchPattern.h>
 #import <WebKit/WKWebExtensionPermission.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @implementation TestWebExtensionsDelegate
 
@@ -80,6 +81,33 @@
     [controller didOpenTab:newTab.get()];
 
     completionHandler(newTab.get(), nil);
+}
+
+- (void)_webExtensionController:(WKWebExtensionController *)controller moveTabs:(NSArray<id<WKWebExtensionTab>> *)tabs toIndex:(NSUInteger)index inWindow:(id<WKWebExtensionWindow>)window forExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError *))completionHandler
+{
+    if (_moveTabs)
+        return _moveTabs(tabs, index, window, extensionContext, completionHandler);
+
+    auto *destinationWindow = dynamic_objc_cast<TestWebExtensionWindow>(window);
+    if (!destinationWindow) {
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"tabs.move() destination window is missing" }]);
+        return;
+    }
+
+    NSUInteger placementIndex = index;
+    for (id<WKWebExtensionTab> tab : tabs) {
+        auto *testTab = dynamic_objc_cast<TestWebExtensionTab>(tab);
+        BOOL alreadyInDestination = testTab.window == destinationWindow;
+        NSUInteger lastValidIndex = alreadyInDestination ? destinationWindow.tabs.count - 1 : destinationWindow.tabs.count;
+        NSUInteger clampedIndex = std::min(placementIndex, lastValidIndex);
+
+        [destinationWindow moveTab:testTab toIndex:clampedIndex];
+
+        // The next tab in the batch follows this one.
+        placementIndex = [destinationWindow.tabs indexOfObject:testTab] + 1;
+    }
+
+    completionHandler(nil);
 }
 
 - (void)webExtensionController:(WKWebExtensionController *)controller openOptionsPageForExtensionContext:(WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError *))completionHandler

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -1203,6 +1203,380 @@ TEST(WKWebExtensionAPITabs, RemoveMultipleInvalidTabs)
     [manager run];
 }
 
+TEST(WKWebExtensionAPITabs, MoveSingleTabInSingleWindow)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const win = (await browser.windows.getAll({ populate: true }))[0]",
+        @"const tabIds = win.tabs.map(tab => tab.id)",
+        @"browser.test.assertEq(win.tabs.length, 3, 'There should be 3 tabs')",
+
+        // Move the first tab to the end of the window...
+        @"const moved = await browser.tabs.move(tabIds[0], { index: 2 })",
+
+        @"browser.test.assertFalse(Array.isArray(moved), 'Moving a single tab should resolve with a Tab object, not an array')",
+        @"browser.test.assertEq(moved.id, tabIds[0], 'The moved tab should be returned')",
+        @"browser.test.assertEq(moved.index, 2, 'The moved tab should now be at index 2')",
+
+        @"const movedOrder = (await browser.tabs.query({ windowId: win.id })).map(tab => tab.id)",
+        @"browser.test.assertEq(JSON.stringify(movedOrder), JSON.stringify([tabIds[1], tabIds[2], tabIds[0]]), 'Tab order should reflect the move')",
+
+        // ...then move it back to the front.
+        @"const movedBack = await browser.tabs.move(tabIds[0], { index: 0 })",
+        @"browser.test.assertEq(movedBack.index, 0, 'The tab should move back to index 0')",
+
+        @"const restoredOrder = (await browser.tabs.query({ windowId: win.id })).map(tab => tab.id)",
+        @"browser.test.assertEq(JSON.stringify(restoredOrder), JSON.stringify([tabIds[0], tabIds[1], tabIds[2]]), 'Tab order should be restored')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+    [manager.get().defaultWindow openNewTab];
+
+    EXPECT_EQ(manager.get().defaultWindow.tabs.count, 3lu);
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPITabs, MoveSingleTabToEndOfWindow)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const win = (await browser.windows.getAll({ populate: true }))[0]",
+        @"const tabIds = win.tabs.map(tab => tab.id)",
+
+        @"const moved = await browser.tabs.move(tabIds[0], { index: -1 })",
+        @"browser.test.assertEq(moved.index, tabIds.length - 1, 'index:-1 should move the tab to the last position')",
+
+        @"const order = (await browser.tabs.query({ windowId: win.id })).map(tab => tab.id)",
+        @"browser.test.assertEq(order[order.length - 1], tabIds[0], 'The moved tab should be last')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+    [manager.get().defaultWindow openNewTab];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPITabs, MoveOverflowIndexClampsToEnd)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const win = (await browser.windows.getAll({ populate: true }))[0]",
+        @"const tabIds = win.tabs.map(tab => tab.id)",
+
+        @"const moved = await browser.tabs.move(tabIds[0], { index: 9999 })",
+        @"browser.test.assertEq(moved.index, tabIds.length - 1, 'An out-of-range index should clamp to the last position')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+    [manager.get().defaultWindow openNewTab];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPITabs, MoveToCurrentIndexReturnsTab)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const win = (await browser.windows.getAll({ populate: true }))[0]",
+        @"const tabId = win.tabs[1].id",
+
+        @"const moved = await browser.tabs.move(tabId, { index: 1 })",
+        @"browser.test.assertFalse(Array.isArray(moved), 'A no-op move should still resolve with a Tab object')",
+        @"browser.test.assertEq(moved.id, tabId, 'The tab should be returned even when its position is unchanged')",
+        @"browser.test.assertEq(moved.index, 1, 'The tab should remain at its index')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+    [manager.get().defaultWindow openNewTab];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPITabs, MoveMultipleTabsReturnsArray)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const source = windows[0]",
+        @"const destination = windows[1]",
+        @"const movingIds = [source.tabs[0].id, source.tabs[1].id]",
+
+        @"const moved = await browser.tabs.move(movingIds, { windowId: destination.id, index: 0 })",
+
+        @"browser.test.assertTrue(Array.isArray(moved), 'Moving multiple tabs should resolve with an array')",
+        @"browser.test.assertEq(moved.length, 2, 'There should be one returned entry per moved tab')",
+        @"for (const tab of moved)",
+        @"  browser.test.assertEq(tab.windowId, destination.id, 'Each moved tab should report the destination window')",
+
+        @"const destIds = (await browser.tabs.query({ windowId: destination.id })).map(tab => tab.id)",
+        // The moved tabs should occupy index 0 and 1, in the order they were given.
+        @"browser.test.assertEq(destIds[0], movingIds[0], 'The first moved tab should be at the destination index')",
+        @"browser.test.assertEq(destIds[1], movingIds[1], 'The second moved tab should follow the first, preserving order')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+    [manager.get().defaultWindow openNewTab];
+
+    auto *destination = [manager openNewWindow];
+    [destination openNewTab];
+
+    EXPECT_EQ(manager.get().defaultWindow.tabs.count, 3lu);
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveWithoutWindowIdGroupsTabsByWindow)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const first = windows[0]",
+        @"const second = windows[1]",
+
+        // Take the last tab of each window. With no windowId, each tab should move to index 0 within its own current window
+        @"const firstMovingId = first.tabs[first.tabs.length - 1].id",
+        @"const secondMovingId = second.tabs[second.tabs.length - 1].id",
+
+        @"const moved = await browser.tabs.move([firstMovingId, secondMovingId], { index: 0 })",
+
+        @"browser.test.assertTrue(Array.isArray(moved), 'Moving multiple tabs should resolve with an array')",
+        @"browser.test.assertEq(moved.length, 2, 'Both tabs should be returned')",
+
+        @"const movedFirst = moved.find(tab => tab.id === firstMovingId)",
+        @"const movedSecond = moved.find(tab => tab.id === secondMovingId)",
+        @"browser.test.assertEq(movedFirst.windowId, first.id, 'A tab moved without a windowId should stay in its own window')",
+        @"browser.test.assertEq(movedSecond.windowId, second.id, 'A tab moved without a windowId should stay in its own window')",
+        @"browser.test.assertEq(movedFirst.index, 0, 'The tab should move to the front of its own window')",
+        @"browser.test.assertEq(movedSecond.index, 0, 'The tab should move to the front of its own window')",
+
+        @"const firstOrder = (await browser.tabs.query({ windowId: first.id })).map(tab => tab.id)",
+        @"const secondOrder = (await browser.tabs.query({ windowId: second.id })).map(tab => tab.id)",
+        @"browser.test.assertEq(firstOrder[0], firstMovingId, 'The moved tab should be first in its window')",
+        @"browser.test.assertEq(secondOrder[0], secondMovingId, 'The moved tab should be first in its window')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+
+    auto *secondWindow = [manager openNewWindow];
+    [secondWindow openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveToAnotherWindow)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const source = windows[0]",
+        @"const destination = windows[1]",
+        @"const movingId = source.tabs[0].id",
+
+        @"const moved = await browser.tabs.move(movingId, { windowId: destination.id, index: -1 })",
+        @"browser.test.assertEq(moved.windowId, destination.id, 'The tab should report the destination window')",
+
+        @"const destIds = (await browser.tabs.query({ windowId: destination.id })).map(tab => tab.id)",
+        @"browser.test.assertEq(destIds[destIds.length - 1], movingId, 'index:-1 should append the tab to the end of the destination window')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().defaultWindow openNewTab];
+
+    auto *destination = [manager openNewWindow];
+    [destination openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveToOrFromPopupWindowFails)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const normal = windows.find(window => window.type === 'normal')",
+        @"const popup = windows.find(window => window.type === 'popup')",
+
+        // Tabs can only be moved to and from normal windows, in either direction.
+        @"await browser.test.assertRejects(browser.tabs.move(normal.tabs[0].id, { windowId: popup.id, index: 0 }), /the destination window is not a normal window/i, 'Moving a tab into a popup window should fail')",
+        @"await browser.test.assertRejects(browser.tabs.move(popup.tabs[0].id, { index: 0 }), /it is not possible to move a tab that is not in a normal window/i, 'Moving a tab out of a popup window should fail')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    auto *popup = [manager openNewWindow];
+    popup.windowType = WKWebExtensionWindowTypePopup;
+    [popup openNewTab];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveBetweenPrivateAndNonPrivateFails)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const normal = windows.find(window => !window.incognito)",
+        @"const privateWindow = windows.find(window => window.incognito)",
+        @"const normalTabId = normal.tabs[0].id",
+        @"const privateTabId = privateWindow.tabs[0].id",
+
+        @"await browser.test.assertRejects(browser.tabs.move(normalTabId, { windowId: privateWindow.id, index: 0 }), /private and non-private windows/i)",
+        @"await browser.test.assertRejects(browser.tabs.move(privateTabId, { windowId: normal.id, index: 0 }), /private and non-private windows/i)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    manager.get().context.hasAccessToPrivateData = YES;
+
+    [manager openNewWindowUsingPrivateBrowsing:YES];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveDelegateErrorIsPropagated)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const win = (await browser.windows.getAll({ populate: true }))[0]",
+        @"const tabId = win.tabs[0].id",
+
+        @"await browser.test.assertRejects(browser.tabs.move(tabId, { index: 0 }), /simulated move failure/i, 'An error returned by the move delegate should reject the promise')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    manager.get().internalDelegate.moveTabs = ^(NSArray<id<WKWebExtensionTab>> *tabs, NSUInteger index, id<WKWebExtensionWindow> window, WKWebExtensionContext *context, void (^completionHandler)(NSError *)) {
+        completionHandler([NSError errorWithDomain:@"TestWebExtensionErrorDomain" code:1 userInfo:@{ NSLocalizedDescriptionKey: @"simulated move failure" }]);
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveMultiWindowGroupErrorIsPropagated)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const first = windows[0]",
+        @"const second = windows[1]",
+
+        // One tab from each window, no windowId, so the move splits into two per-window delegate calls.
+        @"const movingIds = [first.tabs[0].id, second.tabs[0].id]",
+
+        @"await browser.test.assertRejects(browser.tabs.move(movingIds, { index: 0 }), /one group failed/i, 'An error from one window group should reject the whole move')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    auto *erroringWindow = [manager openNewWindow];
+
+    // Fail only the second window's group; the first window's group succeeds. The aggregated result must
+    // still reject, surfacing the failing group's error.
+    __block NSUInteger moveCallCount = 0;
+    manager.get().internalDelegate.moveTabs = ^(NSArray<id<WKWebExtensionTab>> *tabs, NSUInteger index, id<WKWebExtensionWindow> window, WKWebExtensionContext *context, void (^completionHandler)(NSError *)) {
+        ++moveCallCount;
+
+        if (window == erroringWindow) {
+            completionHandler([NSError errorWithDomain:@"TestWebExtensionErrorDomain" code:1 userInfo:@{ NSLocalizedDescriptionKey: @"one group failed" }]);
+            return;
+        }
+
+        completionHandler(nil);
+    };
+
+    [manager loadAndRun];
+
+    EXPECT_EQ(moveCallCount, 2lu);
+}
+
+TEST(WKWebExtensionAPITabs, MovePrivateTabsAllowed)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const windows = await browser.windows.getAll({ populate: true })",
+        @"const privateWindows = windows.filter(window => window.incognito)",
+        @"browser.test.assertEq(privateWindows.length, 2, 'There should be two private windows')",
+
+        @"const source = privateWindows[0]",
+        @"const destination = privateWindows[1]",
+
+        // A private tab can move within its own private window (no windowId).
+        @"const withinId = source.tabs[source.tabs.length - 1].id",
+        @"const movedWithin = await browser.tabs.move(withinId, { index: 0 })",
+        @"browser.test.assertEq(movedWithin.windowId, source.id, 'A private tab should move within its own private window')",
+        @"browser.test.assertEq(movedWithin.index, 0, 'The private tab should move to the front of its window')",
+
+        // A private tab can move to another private window.
+        @"const crossId = source.tabs[0].id",
+        @"const movedCross = await browser.tabs.move(crossId, { windowId: destination.id, index: -1 })",
+        @"browser.test.assertEq(movedCross.windowId, destination.id, 'A private tab should be allowed to move to another private window')",
+        @"browser.test.assertEq(movedCross.index, 1, 'The private tab should be appended to the end of the destination window')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::parseExtension(tabsManifest, @{ @"background.js": backgroundScript });
+
+    manager.get().context.hasAccessToPrivateData = YES;
+
+    auto *source = [manager openNewWindowUsingPrivateBrowsing:YES];
+    [source openNewTab];
+
+    [manager openNewWindowUsingPrivateBrowsing:YES];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPITabs, MoveErrors)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const win = (await browser.windows.getAll({ populate: true }))[0]",
+        @"const tabId = win.tabs[0].id",
+
+        @"browser.test.assertThrows(() => browser.tabs.move(0, { index: 0 }), /'tabIDs' value is invalid, because '0' is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move([tabId, 0], { index: 0 }), /'tabIDs' value is invalid, because '0' is not a tab identifier/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move([], { index: 0 }), /'tabIDs' value is invalid, because no tabs were specified/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId), /a required argument is missing/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId, null), /'properties' value is invalid, because an object is expected/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId, { }), /'properties' value is invalid, because it is missing required keys: 'index'/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId, { index: 'two' }), /'index' is expected to be a number, but a string was provided/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId, { index: 1.5 }), /'index' value is invalid, because it must be an integer/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId, { index: -2 }), /'index' value is invalid, because it must be -1 or greater/i)",
+        @"browser.test.assertThrows(() => browser.tabs.move(tabId, { index: 0, windowId: -5 }), /'windowId' value is invalid, because '-5' is not a window identifier/i)",
+
+        @"await browser.test.assertRejects(browser.tabs.move(9999, { index: 0 }), /tab '9999' was not found/i)",
+        @"await browser.test.assertRejects(browser.tabs.move(tabId, { index: 0, windowId: 9999 }), /window not found/i)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
+}
+
 TEST(WKWebExtensionAPITabs, CreatedEvent)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### 9d9c4e42c34d0f8ae2db0bc6f2849371e101aa85
<pre>
Support browser.tabs.move(...) WebExtension API
<a href="https://rdar.apple.com/173603894">rdar://173603894</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318148">https://bugs.webkit.org/show_bug.cgi?id=318148</a>

Reviewed by Timothy Hatcher.

This patch adds WebKit support for the `browser.tabs.move` WebExtension API. To that end, add
`webExtensionController:moveTabs:toIndex:inWindow:forExtensionContext:completionHandler:` delegate
method on WKWebExtensionControllerDelegate to perform the actual move. Tabs are moved in per-window
batches. Per the API&apos;s documentation, if a window is specified then all listed tabs are moved to
that window (in one delegate call). If no window is specified, tabs are moved to that index in the
window where they already are (one delegate call per window).

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsMove):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
    Drive-by: Fix indentation
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::parseTabIdentifiers):
(WebKit::WebExtensionAPITabs::move):
(WebKit::WebExtensionAPITabs::remove):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate _webExtensionController:moveTabs:toIndex:inWindow:forExtensionContext:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveSingleTabInSingleWindow)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveSingleTabToEndOfWindow)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveOverflowIndexClampsToEnd)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveToCurrentIndexReturnsTab)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveMultipleTabsReturnsArray)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveWithoutWindowIdGroupsTabsByWindow)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveToAnotherWindow)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveToOrFromPopupWindowFails)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveBetweenPrivateAndNonPrivateFails)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveDelegateErrorIsPropagated)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveMultiWindowGroupErrorIsPropagated)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MovePrivateTabsAllowed)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, MoveErrors)):

Canonical link: <a href="https://commits.webkit.org/316366@main">https://commits.webkit.org/316366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b2a8c1e46ebefafa19cfcf2f9393c4c491abe09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129517 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72234d52-bd18-433c-a36c-89b69049da93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133779 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0782fad6-beea-4c98-a974-b37b3cbf76de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114251 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9c45d4a-10c0-41ac-81ff-e45786247233) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34069 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30016 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183935 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142494 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45547 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38469 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46227 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110888 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37480 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117915 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44745 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8737 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44145 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44377 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44204 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->