### PR TITLE
Remove duplicate (&layer == &m_owningLayer) condition in RenderLayerBacking::paintIntoLayer

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4176,14 +4176,11 @@ void RenderLayerBacking::paintIntoLayer(const GraphicsLayer* graphicsLayer, Grap
         RenderLayer::LayerPaintingInfo paintingInfo(&m_owningLayer, paintDirtyRect, paintBehavior, -m_subpixelOffsetFromRenderer);
         paintingInfo.regionContext = regionContext;
 
-        // Limit the owning SVG layer's DOM-order child walk to the part of the flat list this GraphicsLayer
-        // owns: the primary segment for the primary layer, the matching segment for each overlay. std::nullopt (no segments)
-        // leaves the common path unchanged. Only m_owningLayer has a flat list.
-        std::optional<WTF::Range<unsigned>> svgPaintOrderItemRange;
-        if (&layer == &m_owningLayer)
-            svgPaintOrderItemRange = svgSegmentRangeForGraphicsLayer(*graphicsLayer);
-
         if (&layer == &m_owningLayer) {
+            // Limit the owning SVG layer's DOM-order child walk to the part of the flat list this GraphicsLayer
+            // owns: the primary segment for the primary layer, the matching segment for each overlay. std::nullopt (no segments)
+            // leaves the common path unchanged. Only m_owningLayer has a flat list.
+            auto svgPaintOrderItemRange = svgSegmentRangeForGraphicsLayer(*graphicsLayer);
             {
                 bool shouldResetCompositeMode = false;
                 if (m_shouldPaintUsingCompositeCopy && context.compositeMode() == CompositeMode { CompositeOperator::SourceOver, BlendMode::Normal }) {


### PR DESCRIPTION
#### 25db7a2d394b2a850d56037f38de03fd0181fb87
<pre>
Remove duplicate (&amp;layer == &amp;m_owningLayer) condition in RenderLayerBacking::paintIntoLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=318153">https://bugs.webkit.org/show_bug.cgi?id=318153</a>
<a href="https://rdar.apple.com/180962809">rdar://180962809</a>

Reviewed by Nikolas Zimmermann and Simon Fraser.

paintOneLayer() evaluated `&amp;layer == &amp;m_owningLayer` twice back-to-back: once
to conditionally assign svgPaintOrderItemRange, and again to open the block
that actually consumes it. The std::optional was declared in the outer scope
solely to bridge the two checks.

svgPaintOrderItemRange is only read inside the second block (the
paintLayerContents() calls), so fold the assignment into that block and scope
the variable there. This evaluates the condition once and narrows the
variable&apos;s lifetime. No change in behavior.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintIntoLayer):

Canonical link: <a href="https://commits.webkit.org/316111@main">https://commits.webkit.org/316111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e0f000501a9f29b5a16f5253358bd7a54bcb5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8127a6c2-73ca-4354-81e7-f33b942df55c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133294 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b27bd67-6b28-4ad7-84d3-8be25f92c3e9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113775 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bec7bc17-bac8-4403-8eb4-89ec814ba1cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35138 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33452 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28951 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145596 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182856 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141750 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44473 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141560 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38187 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45162 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109867 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36829 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117053 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43673 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8227 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43077 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->