### PR TITLE
[GFC] fit-content grid items should contribute min-content instead of used minimum size when sizing tracks.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -506,7 +506,7 @@ bool preferredSizeBehavesAsAuto(const Style::PreferredSize& preferredSize)
 
 bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize& preferredSize)
 {
-    return preferredSize.isStretch() || preferredSize.isFitContent() || preferredSize.isPercentOrCalculated();
+    return preferredSize.isStretch() || preferredSize.isPercentOrCalculated();
 }
 
 }


### PR DESCRIPTION
#### 6db96cd11f963bfa6a9874768309a175de3049cd
<pre>
[GFC] fit-content grid items should contribute min-content instead of used minimum size when sizing tracks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318159">https://bugs.webkit.org/show_bug.cgi?id=318159</a>
&lt;<a href="https://rdar.apple.com/180968579">rdar://180968579</a>&gt;

Reviewed by Sammy Gill.

315911@main incorrectly included preferredSize.isFitContent() in
GridLayoutUtils::preferredSizeDependsOnContainingBlockSize(), causing
grid items with fit-content to incorrectly contribute used minimum size
instead of min-content size when sizing tracks.

Note that our avoidance reasons are only allowing grids with auto and
fixed grid item widths to run through GFC.

<a href="https://searchfox.org/wubkat/source/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp#226">https://searchfox.org/wubkat/source/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp#226</a>

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::preferredSizeDependsOnContainingBlockSize):

Canonical link: <a href="https://commits.webkit.org/316202@main">https://commits.webkit.org/316202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2240ba02164c336a3fe3ee018a2a83f7d0964c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128595 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/380b797c-4f7c-4b38-8d95-d6d7ed438e19) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133282 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94053 "2 flakes 18 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db66d83a-5005-43b0-b360-2a54e85b42fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113766 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/255d0385-27ad-428a-8623-e775812e69a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35124 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33442 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182844 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141743 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44461 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141553 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45150 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109855 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26074 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36820 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117041 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43661 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8225 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43196 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->