### PR TITLE
Background of composited root element is not re-painted when background of <body> changes

### DIFF
--- a/LayoutTests/fast/body-propagation/background-color/009-expected.html
+++ b/LayoutTests/fast/body-propagation/background-color/009-expected.html
@@ -1,0 +1,25 @@
+<!doctype html>
+
+<style>
+  body {
+    margin: 100px;
+    border: 1px black solid;
+    color: white;
+    background-color: green;
+  }
+
+  #fixedpos-text {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    border: 1px black solid;
+  }
+</style>
+
+<body>
+
+<div id="fixedpos-text">Fixed-positioned with negative z-order</div>
+<p>Body element. The page background should be all green with no red.</p>
+
+</body>

--- a/LayoutTests/fast/body-propagation/background-color/009.html
+++ b/LayoutTests/fast/body-propagation/background-color/009.html
@@ -1,0 +1,51 @@
+<!doctype html>
+
+<title>Body background is propagated when an element is fixed-positioned with negative z-order</title>
+
+<style>
+  body {
+    margin: 100px;
+    border: 1px black solid;
+    color: white;
+    background-color: red;
+  }
+
+  #fixedpos-text {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    border: 1px black solid;
+  }
+</style>
+
+<body id="body">
+
+<div id="fixedpos-text">Fixed-positioned with negative z-order</div>
+<p>Body element. The page background should be all green with no red.</p>
+
+<script>
+  function rafPromise() {
+    return new Promise(r => requestAnimationFrame(r));
+  }
+
+  onload = async () => {
+    if (window.testRunner) {
+      testRunner.dontForceRepaint();
+      testRunner.waitUntilDone();
+    }
+
+    await rafPromise();
+    await rafPromise();
+
+    body.style.backgroundColor = "green";
+
+    await rafPromise();
+    await rafPromise();
+
+    if (window.testRunner)
+      testRunner.notifyDone();
+  };
+</script>
+
+</body>

--- a/LayoutTests/fast/body-propagation/background-color/010-expected.html
+++ b/LayoutTests/fast/body-propagation/background-color/010-expected.html
@@ -1,0 +1,25 @@
+<!doctype html>
+
+<style>
+  body {
+    margin: 100px;
+    border: 1px black solid;
+    color: white;
+    background-color: green;
+  }
+
+  #fixedpos-text {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    border: 1px black solid;
+  }
+</style>
+
+<body>
+
+<div id="fixedpos-text">Fixed-positioned with negative z-order</div>
+<p>Body element. The page background should be all green with no red.</p>
+
+</body>

--- a/LayoutTests/fast/body-propagation/background-color/010.html
+++ b/LayoutTests/fast/body-propagation/background-color/010.html
@@ -1,0 +1,58 @@
+<!doctype html>
+
+<title>body background is controlled by @prefers-color-scheme, it's propagated to root when an element is fixed-positioned with negative z-order</title>
+
+<style>
+  body {
+    margin: 100px;
+    border: 1px black solid;
+    color: white;
+    background-color: red;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    body {
+      background-color: green;
+    }
+  }
+
+  #fixedpos-text {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    border: 1px black solid;
+  }
+</style>
+
+<body>
+
+<div id="fixedpos-text">Fixed-positioned with negative z-order</div>
+<p>Body element. The page background should be all green with no red.</p>
+
+<script>
+  function rafPromise() {
+    return new Promise(r => requestAnimationFrame(r));
+  }
+
+  onload = async () => {
+    if (window.testRunner) {
+      testRunner.dontForceRepaint();
+      testRunner.waitUntilDone();
+    }
+
+    await rafPromise();
+    await rafPromise();
+
+    if (window.testRunner);
+      testRunner.setUseDarkAppearanceForTesting(true);
+
+    await rafPromise();
+    await rafPromise();
+
+    if (window.testRunner)
+      testRunner.notifyDone();
+  };
+</script>
+
+</body>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -117,8 +117,11 @@ bool BackgroundPainter::paintsOwnBackground(const RenderBoxModelObject& renderer
         return true;
     if (renderer.shouldApplyAnyContainment())
         return true;
-    // The <body> only paints its background if the root element has defined a background independent of the body,
-    // or if the <body>'s parent is not the document element's renderer (e.g. inside SVG foreignObject).
+
+    // Per CSS Backgrounds spec, the background of <body> is used as the root background,
+    // hence it'll be painted by the root background painter. <body> only paints its background
+    // if the root element has defined a background independent of the body, or if the <body>'s
+    // parent is not the document element's renderer (e.g. inside SVG foreignObject).
     auto documentElementRenderer = renderer.document().documentElement()->renderer();
     return !documentElementRenderer || documentElementRenderer->shouldApplyAnyContainment() || documentElementRenderer->hasBackground() || documentElementRenderer != renderer.parent();
 }

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -485,6 +485,19 @@ bool RenderView::shouldRepaint(const LayoutRect& rect) const
 
 void RenderView::repaintRootContents()
 {
+    // The contents background could come from the root (document element) renderer.
+    // If the root is not composited, repainting this RenderView should repaint it and
+    // its background. But if it's composited, then the background doesn't get repainted
+    // unless we explicitly repaint its layers.
+    if (RefPtr rootElement = protect(document())->documentElement()) {
+        if (CheckedPtr rootRenderer = dynamicDowncast<RenderLayerModelObject>(rootElement->renderer())) {
+            // Only repaint if its has its own backing. Otherwise, it paints into its
+            // ancestor layer (this RenderView), which we're repainting anyway.
+            if (CheckedPtr rootLayer = rootRenderer->layer(); rootLayer && compositedWithOwnBackingStore(*rootLayer))
+                rootLayer->setBackingNeedsRepaint(GraphicsLayerShouldClipToLayer::DoNotClip);
+        }
+    }
+
     if (layer()->isComposited()) {
         layer()->setBackingNeedsRepaint(GraphicsLayerShouldClipToLayer::DoNotClip);
         return;


### PR DESCRIPTION
#### 0637bedae75eb3bea1f33827d6a576c193134371
<pre>
Background of composited root element is not re-painted when background of &lt;body&gt; changes
<a href="https://rdar.apple.com/177975964">rdar://177975964</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315512">https://bugs.webkit.org/show_bug.cgi?id=315512</a>

Reviewed by Simon Fraser and Alan Baradlay.

Per CSS Backgrounds spec [1], the background of &lt;body&gt; is used as the background of the root
element (e.g &lt;html&gt;). When the background of &lt;body&gt; changes, RenderBox::styleWillChange handles
this by repainting the RenderView:

void RenderBox::styleWillChange(Style::Difference diff, const Style::ComputedStyle&amp; newStyle)
{
    s_hadNonVisibleOverflow = hasNonVisibleOverflow();

    const Style::ComputedStyle* oldStyle = hasInitializedStyle() ? &amp;style() : nullptr;
    if (oldStyle) {
        if (diff &gt;= Style::DifferenceResult::Repaint &amp;&amp; (isDocumentElementRenderer() || isBody())) {
----&gt;       view().repaintRootContents();
            if (Style::hasEntirelyFixedBackground(oldStyle-&gt;backgroundLayers()) != Style::hasEntirelyFixedBackground(newStyle.backgroundLayers()))
                view().compositor().rootLayerConfigurationChanged();
        }
        [...]
}

But this only repaints the RenderView, not the root. It might just so happen to re-paint
its contents because the repaint region of RenderView covers it. BUT, if it&apos;s composited
(e.g an element is fixed-positioned and has negative z-index, forcing creation of background
and content layers), then its layers doesn&apos;t get repainted. This may include the background
layer, which is the document&apos;s background.

Fix this by making RenderView::repaintRootContents repaint the root layer too if
it&apos;s composited.

[1]: <a href="https://drafts.csswg.org/css-backgrounds/#body-background">https://drafts.csswg.org/css-backgrounds/#body-background</a>

Tests: fast/body-propagation/background-color/009.html
       fast/body-propagation/background-color/010.html

* LayoutTests/fast/body-propagation/background-color/009-expected.html: Added.
* LayoutTests/fast/body-propagation/background-color/009.html: Added.
* LayoutTests/fast/body-propagation/background-color/010-expected.html: Added.
* LayoutTests/fast/body-propagation/background-color/010.html: Added.
    - Add tests that change the background color of &lt;body&gt; in two ways: by modifying the
      style directly, and by changing the light/dark appearance. Unfortunately the tests
      rely on testRunner.dontForceRepaint(), so they can&apos;t be upstreamed to WPT.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintsOwnBackground):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::repaintRootContents):

Canonical link: <a href="https://commits.webkit.org/316415@main">https://commits.webkit.org/316415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f40632b3cd0ee318e3c1e258e99a3c74f235d86d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129466 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6af4b7b-88f7-4dd3-88ad-51c7a03358b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133742 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/799135db-ea35-4d54-9dd3-0daae0185b1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8760e74c-e0e0-4aa6-9a49-2525026137dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29965 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183883 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142452 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38503 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46176 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30600 "Too many flaky failures: http/tests/contentextensions/sync-xhr-blocked.html, http/tests/cookies/same-site/user-load-cross-site-redirect.py, http/tests/media/media-document.html, http/tests/navigation/post-redirect-get-reload.py, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/cached-cross-origin-preloaded-css-stylesheet.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/object-redirect-blocked2.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/site-isolation/frame-index.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110834 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37437 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117864 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44694 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8695 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44094 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44153 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->