### PR TITLE
[iOS] Remove support for AVMediaSource from MediaDeviceRoute

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -39,7 +39,7 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
-OBJC_CLASS WebMediaSourceObserver;
+OBJC_CLASS WebPlaybackControlObserver;
 
 namespace WebCore {
 
@@ -91,9 +91,9 @@ public:
     virtual void timeRangeDidChange(MediaDeviceRoute&) { }
     virtual void readyDidChange(MediaDeviceRoute&) { }
     virtual void bufferingDidChange(MediaDeviceRoute&) { }
-    virtual void playbackErrorDidChange(MediaDeviceRoute&) { }
+    virtual void errorDidChange(MediaDeviceRoute&) { }
     virtual void audioOptionsDidChange(MediaDeviceRoute&) { }
-    virtual void currentPlaybackPositionDidChange(MediaDeviceRoute&) { }
+    virtual void playbackPositionDidChange(MediaDeviceRoute&) { }
     virtual void playingDidChange(MediaDeviceRoute&) { }
     virtual void playbackSpeedDidChange(MediaDeviceRoute&) { }
     virtual void scanSpeedDidChange(MediaDeviceRoute&) { }
@@ -120,16 +120,16 @@ public:
     MediaTimeRange timeRange() const;
     bool ready() const;
     bool buffering() const;
-    std::optional<MediaPlaybackSourceError> playbackError() const;
+    std::optional<MediaPlaybackSourceError> error() const;
     Vector<MediaSelectionOption> audioOptions() const;
-    MediaTime currentPlaybackPosition() const;
+    MediaTime playbackPosition() const;
     bool playing() const;
     float playbackSpeed() const;
     float scanSpeed() const;
     bool muted() const;
     float volume() const;
 
-    void setCurrentPlaybackPosition(MediaTime);
+    void setPlaybackPosition(MediaTime);
     void setPlaying(bool);
     void setPlaybackSpeed(float);
     void setScanSpeed(float);
@@ -141,7 +141,7 @@ private:
 
     WTF::UUID m_identifier;
     RetainPtr<WebMediaDevicePlatformRoute> m_platformRoute;
-    RetainPtr<WebMediaSourceObserver> m_mediaSourceObserver;
+    RetainPtr<WebPlaybackControlObserver> m_playbackControlObserver;
     WeakPtr<MediaDeviceRouteClient> m_client;
 #if HAVE(AVROUTING_FRAMEWORK)
     RetainPtr<WebMediaDevicePlatformRouteSession> m_routeSession;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -36,14 +36,16 @@
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
-#define FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
+#define FOR_EACH_READONLY_KEY_PATH(Macro) \
     Macro(timeRange, TimeRange, MediaTimeRange) \
     Macro(ready, Ready, bool) \
     Macro(buffering, Buffering, bool) \
     Macro(audioOptions, AudioOptions, Vector<MediaSelectionOption>) \
+    Macro(error, Error, std::optional<MediaPlaybackSourceError>) \
+    Macro(playbackPosition, PlaybackPosition, MediaTime) \
 \
 
-#define FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_READWRITE_KEY_PATH(Macro) \
     Macro(playing, Playing, bool) \
     Macro(playbackSpeed, PlaybackSpeed, float) \
     Macro(scanSpeed, ScanSpeed, float) \
@@ -51,43 +53,16 @@
     Macro(volume, Volume, float) \
 \
 
-#define FOR_EACH_COMMON_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_KEY_PATH(Macro) \
+    FOR_EACH_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_READWRITE_KEY_PATH(Macro) \
 \
 
-#define FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
-    Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
-\
-
-#define FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
-    Macro(currentPlaybackPosition, CurrentPlaybackPosition, MediaTime) \
-\
-
-#define FOR_EACH_MEDIA_SOURCE_KEY_PATH(Macro) \
-    FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
-\
-
-#define FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_KEY_PATH(Macro) \
-\
-
-#define ADD_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_mediaSource addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebMediaSourceObserverContext]; \
-\
-
-#define REMOVE_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_mediaSource removeObserver:self forKeyPath:@#KeyPath context:WebMediaSourceObserverContext]; \
-\
-
-#define ADD_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_playbackControl addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebPlaybackControlObserverContext]; \
 \
 
-#define REMOVE_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_playbackControl removeObserver:self forKeyPath:@#KeyPath context:WebPlaybackControlObserverContext]; \
 \
 
@@ -108,37 +83,30 @@
 #define DEFINE_GETTER(KeyPath, SetterSuffix, Type) \
     Type MediaDeviceRoute::KeyPath() const \
     { \
-        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
-            return convert(playbackControl.get().KeyPath); \
-        return convert([m_mediaSourceObserver mediaSource].KeyPath); \
+        return convert([m_playbackControlObserver playbackControl].KeyPath); \
     } \
 \
 
 #define DEFINE_SETTER(KeyPath, SetterSuffix, Type) \
     void MediaDeviceRoute::set##SetterSuffix(Type KeyPath) \
     { \
-        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
-            return [playbackControl set##SetterSuffix:convert(WTF::move(KeyPath))]; \
-        [[m_mediaSourceObserver mediaSource] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
+        [[m_playbackControlObserver playbackControl] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
     } \
 \
 
 NS_ASSUME_NONNULL_BEGIN
 
-static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
 static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverContext;
 
-@interface WebMediaSourceObserver : NSObject
+@interface WebPlaybackControlObserver : NSObject
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route NS_DESIGNATED_INITIALIZER;
-@property (nonatomic, nullable, strong) AVMediaSource *mediaSource;
 @property (nonatomic, nullable, strong) AVPlaybackControl *playbackControl;
 @end
 
-@implementation WebMediaSourceObserver {
+@implementation WebPlaybackControlObserver {
     WeakPtr<WebCore::MediaDeviceRoute> _route;
-    RetainPtr<AVMediaSource> _mediaSource;
     RetainPtr<AVPlaybackControl> _playbackControl;
 }
 
@@ -151,23 +119,6 @@ static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverCont
     return self;
 }
 
-- (AVMediaSource * _Nullable)mediaSource
-{
-    return _mediaSource.get();
-}
-
-- (void)setMediaSource:(AVMediaSource * _Nullable)mediaSource
-{
-    if (mediaSource)
-        self.playbackControl = nil;
-
-    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
-
-    _mediaSource = mediaSource;
-
-    FOR_EACH_MEDIA_SOURCE_KEY_PATH(ADD_MEDIA_SOURCE_OBSERVER)
-}
-
 - (AVPlaybackControl * _Nullable)playbackControl
 {
     return _playbackControl.get();
@@ -175,60 +126,29 @@ static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverCont
 
 - (void)setPlaybackControl:(AVPlaybackControl * _Nullable)playbackControl
 {
-    if (playbackControl)
-        self.mediaSource = nil;
-
-    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
 
     _playbackControl = playbackControl;
 
-    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(ADD_PLAYBACK_CONTROL_OBSERVER)
-    ADD_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
-    ADD_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+    FOR_EACH_KEY_PATH(ADD_OBSERVER)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context
 {
-    if (context != WebMediaSourceObserverContext && context != WebPlaybackControlObserverContext) {
+    if (context != WebPlaybackControlObserverContext) {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
 
     dispatch_async(mainDispatchQueueSingleton(), ^{
-        if (context == WebMediaSourceObserverContext) {
-            FOR_EACH_MEDIA_SOURCE_KEY_PATH(OBSERVE_VALUE)
-            ASSERT_NOT_REACHED();
-            return;
-        }
-
-        if ([keyPath isEqualToString:@"error"]) {
-            if (RefPtr route = _route.get()) {
-                if (RefPtr client = route->client())
-                    client->playbackErrorDidChange(*route);
-            }
-            return;
-        }
-        if ([keyPath isEqualToString:@"playbackPosition"]) {
-            if (RefPtr route = _route.get()) {
-                if (RefPtr client = route->client())
-                    client->currentPlaybackPositionDidChange(*route);
-            }
-            return;
-        }
-
-        FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(OBSERVE_VALUE)
+        FOR_EACH_KEY_PATH(OBSERVE_VALUE)
         ASSERT_NOT_REACHED();
     });
 }
 
 - (void)dealloc
 {
-    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
-    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
     [super dealloc];
 }
 
@@ -258,6 +178,11 @@ static CMTime convert(MediaTime time)
 static MediaTime convert(CMTime time)
 {
     return PAL::toMediaTime(time);
+}
+
+static MediaTime convert(AVPlaybackUserInterfacePlaybackPosition *playbackPosition)
+{
+    return convert(playbackPosition.position);
 }
 
 static MediaTimeRange convert(CMTimeRange timeRange)
@@ -301,7 +226,7 @@ Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *plat
 MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
     : m_identifier { WTF::UUID::createVersion4() }
     , m_platformRoute { platformRoute }
-    , m_mediaSourceObserver { adoptNS([[WebMediaSourceObserver alloc] initWithRoute:*this]) }
+    , m_playbackControlObserver { adoptNS([[WebPlaybackControlObserver alloc] initWithRoute:*this]) }
 {
 }
 
@@ -315,29 +240,10 @@ WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
     return m_platformRoute.get();
 }
 
-std::optional<MediaPlaybackSourceError> MediaDeviceRoute::playbackError() const
+void MediaDeviceRoute::setPlaybackPosition(MediaTime playbackPosition)
 {
-    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
-        return convert(playbackControl.get().error);
-    return convert([m_mediaSourceObserver mediaSource].playbackError);
-}
-
-MediaTime MediaDeviceRoute::currentPlaybackPosition() const
-{
-    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
-        return convert(playbackControl.get().playbackPosition.position);
-    return convert([m_mediaSourceObserver mediaSource].currentPlaybackPosition);
-}
-
-void MediaDeviceRoute::setCurrentPlaybackPosition(MediaTime currentPlaybackPosition)
-{
-    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) {
-        // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
-        [playbackControl seekToPosition:convert(WTF::move(currentPlaybackPosition)) tolerance:PAL::kCMTimeZero];
-        return;
-    }
-
-    [m_mediaSourceObserver mediaSource].currentPlaybackPosition = convert(WTF::move(currentPlaybackPosition));
+    // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
+    [[m_playbackControlObserver playbackControl] seekToPosition:convert(WTF::move(playbackPosition)) tolerance:PAL::kCMTimeZero];
 }
 
 MediaDeviceRoute::~MediaDeviceRoute()
@@ -347,22 +253,16 @@ MediaDeviceRoute::~MediaDeviceRoute()
 #endif
 }
 
-FOR_EACH_COMMON_KEY_PATH(DEFINE_GETTER)
-FOR_EACH_COMMON_READWRITE_KEY_PATH(DEFINE_SETTER)
+FOR_EACH_KEY_PATH(DEFINE_GETTER)
+FOR_EACH_READWRITE_KEY_PATH(DEFINE_SETTER)
 
 } // namespace WebCore
 
-#undef FOR_EACH_COMMON_READONLY_KEY_PATH
-#undef FOR_EACH_COMMON_READWRITE_KEY_PATH
-#undef FOR_EACH_COMMON_KEY_PATH
-#undef FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH
-#undef FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH
-#undef FOR_EACH_MEDIA_SOURCE_KEY_PATH
-#undef FOR_EACH_PLAYBACK_CONTROL_KEY_PATH
-#undef ADD_MEDIA_SOURCE_OBSERVER
-#undef REMOVE_MEDIA_SOURCE_OBSERVER
-#undef ADD_PLAYBACK_CONTROL_OBSERVER
-#undef REMOVE_PLAYBACK_CONTROL_OBSERVER
+#undef FOR_EACH_READONLY_KEY_PATH
+#undef FOR_EACH_READWRITE_KEY_PATH
+#undef FOR_EACH_KEY_PATH
+#undef ADD_OBSERVER
+#undef REMOVE_OBSERVER
 #undef OBSERVE_VALUE
 #undef DEFINE_GETTER
 #undef DEFINE_SETTER

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -280,7 +280,7 @@ void MediaPlayerPrivateWirelessPlayback::seekToTarget(const SeekTarget& seekTarg
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, seekTarget);
-    route->setCurrentPlaybackPosition(seekTarget.time);
+    route->setPlaybackPosition(seekTarget.time);
 }
 
 bool MediaPlayerPrivateWirelessPlayback::paused() const
@@ -430,12 +430,12 @@ void MediaPlayerPrivateWirelessPlayback::readyDidChange(MediaDeviceRoute& route)
         setReadyState(MediaPlayerReadyState::HaveEnoughData);
 }
 
-void MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange(MediaDeviceRoute& route)
+void MediaPlayerPrivateWirelessPlayback::errorDidChange(MediaDeviceRoute& route)
 {
     ASSERT(&route == this->route());
-    ALWAYS_LOG(LOGIDENTIFIER, !!route.playbackError());
+    ALWAYS_LOG(LOGIDENTIFIER, !!route.error());
 
-    if (route.playbackError())
+    if (route.error())
         setNetworkState(route.ready() ? MediaPlayer::NetworkState::DecodeError : MediaPlayer::NetworkState::FormatError);
 }
 
@@ -448,14 +448,14 @@ void MediaPlayerPrivateWirelessPlayback::audioOptionsDidChange(MediaDeviceRoute&
         player->characteristicChanged();
 }
 
-void MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange(MediaDeviceRoute& route)
+void MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange(MediaDeviceRoute& route)
 {
     ASSERT(&route == this->route());
 
-    auto currentPlaybackPosition = route.currentPlaybackPosition();
-    ALWAYS_LOG(LOGIDENTIFIER, currentPlaybackPosition);
+    auto playbackPosition = route.playbackPosition();
+    ALWAYS_LOG(LOGIDENTIFIER, playbackPosition);
 
-    updateTimebaseTimeAndRate(currentPlaybackPosition, route.playing() ? route.playbackSpeed() : 0);
+    updateTimebaseTimeAndRate(playbackPosition, route.playing() ? route.playbackSpeed() : 0);
 
     auto currentTime = this->currentTime();
 
@@ -492,7 +492,7 @@ CMTimebaseRef MediaPlayerPrivateWirelessPlayback::ensureTimebase()
     dispatch_activate(m_timerSource.get());
 
     if (RefPtr route = this->route())
-        updateTimebaseTimeAndRate(route->currentPlaybackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
+        updateTimebaseTimeAndRate(route->playbackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
 
     return m_timebase.get();
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -129,9 +129,9 @@ private:
     // MediaDeviceRouteClient
     void timeRangeDidChange(MediaDeviceRoute&) final;
     void readyDidChange(MediaDeviceRoute&) final;
-    void playbackErrorDidChange(MediaDeviceRoute&) final;
+    void errorDidChange(MediaDeviceRoute&) final;
     void audioOptionsDidChange(MediaDeviceRoute&) final;
-    void currentPlaybackPositionDidChange(MediaDeviceRoute&) final;
+    void playbackPositionDidChange(MediaDeviceRoute&) final;
 
     CMTimebaseRef ensureTimebase();
     void destroyTimebase();


### PR DESCRIPTION
#### 20202846a16f7e7b51ed01f4fad523d23ac72ae4
<pre>
[iOS] Remove support for AVMediaSource from MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=318166">https://bugs.webkit.org/show_bug.cgi?id=318166</a>
<a href="https://rdar.apple.com/178555755">rdar://178555755</a>

Reviewed by Jer Noble.

Removed support for AVMediaSource from MediaDeviceRoute and simplified the code now that an
AVPlaybackControl-conforming object is the only observee.

No new tests. Covered by existing tests.

* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRouteClient::errorDidChange):
(WebCore::MediaDeviceRouteClient::playbackPositionDidChange):
(WebCore::MediaDeviceRouteClient::playbackErrorDidChange): Deleted.
(WebCore::MediaDeviceRouteClient::currentPlaybackPositionDidChange): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebPlaybackControlObserver setPlaybackControl:]):
(-[WebPlaybackControlObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WebPlaybackControlObserver dealloc]):
(WebCore::convert):
(WebCore::MediaDeviceRoute::setPlaybackPosition):
(-[WebMediaSourceObserver initWithRoute:]): Deleted.
(-[WebMediaSourceObserver mediaSource]): Deleted.
(-[WebMediaSourceObserver setMediaSource:]): Deleted.
(-[WebMediaSourceObserver playbackControl]): Deleted.
(-[WebMediaSourceObserver setPlaybackControl:]): Deleted.
(-[WebMediaSourceObserver observeValueForKeyPath:ofObject:change:context:]): Deleted.
(-[WebMediaSourceObserver dealloc]): Deleted.
(WebCore::MediaDeviceRoute::playbackError const): Deleted.
(WebCore::MediaDeviceRoute::currentPlaybackPosition const): Deleted.
(WebCore::MediaDeviceRoute::setCurrentPlaybackPosition): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::seekToTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::errorDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::ensureTimebase):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange): Deleted.
(WebCore::MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:

Canonical link: <a href="https://commits.webkit.org/316168@main">https://commits.webkit.org/316168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd636c37daa7ea72d28280011c9f172ebf0a4e7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38240 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180275 "Build is in progress. Recent messages:Running apply-patch; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128611 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44e58e6c-6b73-4312-acd9-0e52738194ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61298792-0e20-4368-b783-4ffef72d2c16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113779 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed6b8fc9-ea6e-4d5f-9c9e-3a18409d47c7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35142 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33455 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF/PrintWithJSExecutionOptionTests.PDFWithNonPrintingOpenActionDoesNotPrint/allowsContentJavascript_is_true (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28955 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182860 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141756 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44477 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141566 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109871 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36828 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117057 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43677 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8228 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43081 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->