### PR TITLE
[Cocoa] GPU fast path for uploading a 2D canvas into a WebGL texture

### DIFF
--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-expected.txt
@@ -1,0 +1,56 @@
+Verify that texImage2D / texSubImage2D with HTMLCanvasElement (2D context) sources produce the expected pixels, regardless of whether the GPU-GPU IOSurface fast path or the CPU readback path is taken. Covers flipY Ã— premultiplyAlpha permutations and full-image / sub-image uploads.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+flipY=false, premultiplyAlpha=false, useSubImage=false
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=false, premultiplyAlpha=true, useSubImage=false
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=false, useSubImage=false
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=true, useSubImage=false
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+
+flipY=false, premultiplyAlpha=false, useSubImage=true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=false, premultiplyAlpha=true, useSubImage=true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=false, useSubImage=true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=true, useSubImage=true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>texImage2D with HTMLCanvasElement (2D) — pixel correctness in cases where the GPU-GPU fast path is intentionally bypassed.</title>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("The canvas-2D → WebGL fast path must skip and fall back to the CPU readback path for: WebGL2 with a bound PIXEL_UNPACK_BUFFER, level > 0 uploads, type != UNSIGNED_BYTE, format outside {RGB, RGBA}, and texImage3D. In every such case the pixels in the destination texture must still be correct.");
+
+const W = 8;
+const H = 8;
+
+function makeSource()
+{
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const ctx = c.getContext("2d");
+    ctx.fillStyle = "#ff8040";
+    ctx.fillRect(0, 0, W, H);
+    return c;
+}
+
+function makeWebGL2Context()
+{
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    return c.getContext("webgl2");
+}
+
+function readBack(gl, w, h)
+{
+    const buf = new Uint8Array(w * h * 4);
+    gl.readPixels(0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    return buf;
+}
+
+function checkOpaqueOrange(gl, w, h, label)
+{
+    const fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    const tex = gl.getParameter(gl.TEXTURE_BINDING_2D);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+    const buf = readBack(gl, w, h);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.deleteFramebuffer(fb);
+    const r = buf[0], g = buf[1], b = buf[2], a = buf[3];
+    debug(label + ` first pixel = [${r}, ${g}, ${b}, ${a}]`);
+    shouldBeTrue(`Math.abs(${r} - 255) <= 2 && Math.abs(${g} - 128) <= 2 && Math.abs(${b} - 64) <= 2 && Math.abs(${a} - 255) <= 2`);
+}
+
+// Case 1: WebGL2 with a bound PIXEL_UNPACK_BUFFER must take the CPU path.
+{
+    debug("\n--- WebGL2 with bound PIXEL_UNPACK_BUFFER ---");
+    const gl = makeWebGL2Context();
+    if (!gl) {
+        testFailed("WebGL2 not available");
+    } else {
+        const tex = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        const pbo = gl.createBuffer();
+        gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo);
+        // With a PBO bound and an HTMLCanvasElement source, the fast path must be skipped.
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, makeSource());
+        gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+        checkOpaqueOrange(gl, W, H, "PBO bound:");
+    }
+}
+
+// Case 2: level > 0 must take the CPU path.
+{
+    debug("\n--- level > 0 ---");
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const gl = c.getContext("webgl");
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, W, H, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texImage2D(gl.TEXTURE_2D, 1, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, makeSource()); // level 1
+    // Sample level 1 via an FBO + a 1x1 quad would require a separate test; here we
+    // just verify the upload didn't throw and the texture object is still usable.
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+}
+
+// Case 3: type != UNSIGNED_BYTE must take the CPU path.
+{
+    debug("\n--- type=UNSIGNED_SHORT_4_4_4_4 ---");
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const gl = c.getContext("webgl");
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, makeSource());
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+}
+
+// Case 4: format=LUMINANCE_ALPHA must take the CPU path.
+{
+    debug("\n--- format=LUMINANCE_ALPHA ---");
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const gl = c.getContext("webgl");
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.LUMINANCE_ALPHA, gl.LUMINANCE_ALPHA, gl.UNSIGNED_BYTE, makeSource());
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path.html
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>texImage2D / texSubImage2D from 2D canvas (GPU fast path) produce the same pixels as the CPU path.</title>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("Verify that texImage2D / texSubImage2D with HTMLCanvasElement (2D context) sources produce the expected pixels, regardless of whether the GPU-GPU IOSurface fast path or the CPU readback path is taken. Covers flipY × premultiplyAlpha permutations and full-image / sub-image uploads.");
+
+// Build a 16x16 source 2D canvas with four solid-colored quadrants. The 2D canvas
+// backing is premultiplied; we render colors at full alpha so values are stable
+// across both the fast path and the CPU fallback.
+const W = 16;
+const H = 16;
+
+function makeSourceCanvas()
+{
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const ctx = c.getContext("2d");
+    ctx.fillStyle = "rgba(255, 0, 0, 1)"; ctx.fillRect(0,    0,    W/2, H/2); // top-left red
+    ctx.fillStyle = "rgba(0, 255, 0, 1)"; ctx.fillRect(W/2,  0,    W/2, H/2); // top-right green
+    ctx.fillStyle = "rgba(0, 0, 255, 1)"; ctx.fillRect(0,    H/2,  W/2, H/2); // bottom-left blue
+    ctx.fillStyle = "rgba(255, 255, 0, 1)"; ctx.fillRect(W/2, H/2, W/2, H/2); // bottom-right yellow
+    return c;
+}
+
+const target = document.createElement("canvas");
+target.width = W;
+target.height = H;
+const gl = target.getContext("webgl", { preserveDrawingBuffer: true });
+const program = (function() {
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, "attribute vec2 p; varying vec2 uv; void main() { uv = (p + 1.0) * 0.5; gl_Position = vec4(p, 0.0, 1.0); }");
+    gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, "precision mediump float; uniform sampler2D t; varying vec2 uv; void main() { gl_FragColor = texture2D(t, uv); }");
+    gl.compileShader(fs);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    gl.useProgram(p);
+    const buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+    const loc = gl.getAttribLocation(p, "p");
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+    return p;
+})();
+
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+function readPixel(x, y)
+{
+    const buf = new Uint8Array(4);
+    gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    return [buf[0], buf[1], buf[2], buf[3]];
+}
+
+function approxEqual(rgba, expected)
+{
+    for (let i = 0; i < 4; ++i)
+        if (Math.abs(rgba[i] - expected[i]) > 2)
+            return false;
+    return true;
+}
+
+function runOne(flipY, premultiply, useSubImage)
+{
+    debug("");
+    debug(`flipY=${flipY}, premultiplyAlpha=${premultiply}, useSubImage=${useSubImage}`);
+
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiply);
+
+    const src = makeSourceCanvas();
+    if (useSubImage) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, W, H, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    } else
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, src);
+
+    gl.viewport(0, 0, W, H);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+    // WebGL framebuffer has its origin at the bottom-left. When flipY=true, the canvas
+    // is uploaded upright, so the top-left source quadrant (red) is sampled at the
+    // top of the rendered output (top → high y in framebuffer coords).
+    const topQuadRed   = flipY ? [255, 0,   0, 255] : [0,   0,   255, 255]; // canvas TL vs canvas BL
+    const topQuadGreen = flipY ? [0,   255, 0, 255] : [255, 255, 0,   255];
+    const botQuadBlue  = flipY ? [0,   0, 255, 255] : [255, 0,   0,   255];
+    const botQuadYel   = flipY ? [255, 255, 0, 255] : [0,   255, 0,   255];
+
+    const tl = readPixel(2, H - 2);   // top-left of framebuffer
+    const tr = readPixel(W - 2, H - 2);
+    const bl = readPixel(2, 2);       // bottom-left of framebuffer
+    const br = readPixel(W - 2, 2);
+
+    shouldBeTrue(`approxEqual([${tl}], [${topQuadRed}])`);
+    shouldBeTrue(`approxEqual([${tr}], [${topQuadGreen}])`);
+    shouldBeTrue(`approxEqual([${bl}], [${botQuadBlue}])`);
+    shouldBeTrue(`approxEqual([${br}], [${botQuadYel}])`);
+}
+
+// We render the source at full alpha = 1, so the premultiplied/unpremultiplied
+// representations are bit-identical. Both premultiply settings should yield the
+// same color values, exercising both branches of the alpha logic.
+for (const useSubImage of [false, true])
+    for (const flipY of [false, true])
+        for (const premultiply of [false, true])
+            runOne(flipY, premultiply, useSubImage);
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/texImage2DCanvas2D.html
+++ b/PerformanceTests/Canvas/texImage2DCanvas2D.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2048;
+source.height = 2048;
+const ctx = source.getContext("2d");
+ctx.fillStyle = "#a08040";
+ctx.fillRect(0, 0, source.width, source.height);
+
+target.width = source.width;
+target.height = source.height;
+const gl = target.getContext("webgl");
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+
+let isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: () => { isDone = true; }, unit: 'ms' });
+
+function runTest() {
+    const start = PerfTestRunner.now();
+    for (let i = 0; i < 30; ++i) {
+        // Force the canvas backing to be dirtied so any caching is invalidated.
+        ctx.fillStyle = `rgb(${i * 8 & 0xff}, 128, 64)`;
+        ctx.fillRect(0, 0, source.width, source.height);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
+    }
+    gl.finish();
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - start);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/texSubImage2DCanvas2D.html
+++ b/PerformanceTests/Canvas/texSubImage2DCanvas2D.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2048;
+source.height = 2048;
+const ctx = source.getContext("2d");
+ctx.fillStyle = "#a08040";
+ctx.fillRect(0, 0, source.width, source.height);
+
+target.width = source.width;
+target.height = source.height;
+const gl = target.getContext("webgl");
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, source.width, source.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+
+let isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: () => { isDone = true; }, unit: 'ms' });
+
+function runTest() {
+    const start = PerfTestRunner.now();
+    for (let i = 0; i < 30; ++i) {
+        ctx.fillStyle = `rgb(${i * 8 & 0xff}, 128, 64)`;
+        ctx.fillRect(0, 0, source.width, source.height);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, source);
+    }
+    gl.finish();
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - start);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -276,6 +276,7 @@ private:
     RefPtr<WebGLBuffer> validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage) final;
     RefPtr<WebGLBuffer> validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target) final;
     bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*) final;
+    bool hasBoundPixelUnpackBuffer() const final { return !!m_boundPixelUnpackBuffer.get(); }
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;
     bool validateCapability(ASCIILiteral functionName, GCGLenum cap) final;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3363,7 +3363,26 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
 
     if (RefPtr imageData = source.getImageData()) {
         texImageSourceHelper(functionID, target, level, internalformat, border, format, type, xoffset, yoffset, zoffset, sourceImageRect, depth, unpackImageHeight, TexImageSource(imageData.releaseNonNull()));
-    } else if (RefPtr image = source.copiedImage()) {
+        return { };
+    }
+
+    // GPU-GPU fast path for an IOSurface-backed 2D canvas; anything unsupported falls through
+    // to the CPU readback path below.
+    bool sourceImageRectIsDefault = sourceImageRect == texImageSourceSize(source);
+    bool isFastPathFunction = functionID == TexImageFunctionID::TexImage2D || functionID == TexImageFunctionID::TexSubImage2D;
+    if (isFastPathFunction && sourceImageRectIsDefault && texture
+        && (format == GraphicsContextGL::RGB || format == GraphicsContextGL::RGBA)
+        && type == GraphicsContextGL::UNSIGNED_BYTE
+        && !level && depth == 1
+        && !hasBoundPixelUnpackBuffer()) {
+        if (RefPtr buffer = source.makeRenderingResultsAvailable()) {
+            bool isSubImage = functionID == TexImageFunctionID::TexSubImage2D;
+            if (graphicsContextGL()->copyTextureFromCanvas2D(*buffer, texture->object(), target, level, internalformat, format, type, xoffset, yoffset, isSubImage, m_unpackPremultiplyAlpha, m_unpackFlipY))
+                return { };
+        }
+    }
+
+    if (RefPtr image = source.copiedImage()) {
         texImageImpl(functionID, target, level, internalformat, xoffset, yoffset, zoffset, format, type, *image, GraphicsContextGL::DOMSource::Canvas, m_unpackFlipY, m_unpackPremultiplyAlpha, false, sourceImageRect, depth, unpackImageHeight);
     }
     return { };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1012,6 +1012,11 @@ protected:
 
     virtual bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*);
 
+    // True when WebGL2's PIXEL_UNPACK_BUFFER target is bound to a non-null buffer.
+    // Used to disable the canvas-2D GPU-GPU fast path, which writes through the
+    // regular pixel-store state.
+    virtual bool hasBoundPixelUnpackBuffer() const { return false; }
+
     // Wrapper for GraphicsContextGLOpenGL::synthesizeGLError that sends a message to the JavaScript console.
     void synthesizeGLError(GCGLenum, ASCIILiteral functionName, ASCIILiteral description);
     void synthesizeLostContextGLError(GCGLenum, ASCIILiteral functionName, ASCIILiteral description);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1693,6 +1693,12 @@ public:
     WEBCORE_EXPORT virtual RefPtr<Image> videoFrameToImage(VideoFrame&);
 #endif
 
+    // GPU-GPU copy from a 2D canvas's ImageBuffer (must be IOSurface-backed) to a WebGL texture.
+    // Returns false if the fast path is not available (caller should fall back to CPU readback).
+    // For TexImage2D, the destination texture is reallocated; for TexSubImage2D, only the
+    // sub-rectangle at (xoffset, yoffset) is updated.
+    virtual bool copyTextureFromCanvas2D(ImageBuffer&, PlatformGLObject /*texture*/, GCGLenum /*target*/, GCGLint /*level*/, GCGLenum /*internalFormat*/, GCGLenum /*format*/, GCGLenum /*type*/, GCGLint /*xoffset*/, GCGLint /*yoffset*/, bool /*isSubImage*/, bool /*premultiplyAlpha*/, bool /*flipY*/) { return false; }
+
     IntSize getInternalFramebufferSize() const { return IntSize(m_currentWidth, m_currentHeight); }
 
     struct PixelStoreParameters final {

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -55,6 +55,10 @@ class GraphicsLayerContentsDisplayDelegate;
 class GraphicsContextGLCVCocoa;
 #endif
 
+#if PLATFORM(COCOA)
+class GraphicsContextGLCocoaCanvas2DCopier;
+#endif
+
 #if ENABLE(MEDIA_STREAM)
 class ImageRotationSessionVT;
 #endif
@@ -114,6 +118,14 @@ public:
 #if ENABLE(VIDEO)
     bool copyTextureFromVideoFrame(VideoFrame&, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) final;
 #endif
+    // The canvas-2D → WebGL fast path is invoked through IPC by the
+    // Remote* layer (which is the only code that has the IOSurface send-right).
+    // We do not override the generic ImageBuffer-taking entry point here; in
+    // direct-mode (non-GPU-process) builds the base class' default no-op
+    // implementation returns false and the caller falls back to the existing
+    // CPU readback path. The shared implementation below is the one piece used
+    // by the IPC handler.
+    bool copyTextureFromCanvas2DIOSurface(IOSurfaceRef, PlatformGLObject destTexture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) final;
 #endif
@@ -165,6 +177,13 @@ protected:
 #endif
     RetainPtr<MTLSharedEventListener> m_finishedMetalSharedEventListener;
     RetainPtr<id> m_finishedMetalSharedEvent; // FIXME: Remove all C++ includees and use id<MTLSharedEvent>.
+
+    // Dedicated, lazily-created share-group context for the canvas-2D → WebGL fast path,
+    // isolating its GL state from the WebGL application's (like GraphicsContextGLCVCocoa).
+#if PLATFORM(COCOA)
+    std::unique_ptr<GraphicsContextGLCocoaCanvas2DCopier> m_canvas2DCopier;
+    bool m_triedCreatingCanvas2DCopier { false };
+#endif
 #if ENABLE(WEBXR)
     using RasterizationRateMapArray =  EnumeratedArray<PlatformXR::Layout, RetainPtr<MTLRasterizationRateMap>, PlatformXR::Layout::Layered>;
     RasterizationRateMapArray m_rasterizationRateMap;
@@ -174,6 +193,9 @@ protected:
     size_t m_currentDrawingBufferIndex { 0 };
     std::array<IOSurfacePbuffer, maxReusedDrawingBuffers> m_drawingBuffers;
     friend class GraphicsContextGLCVCocoa;
+#if PLATFORM(COCOA)
+    friend class GraphicsContextGLCocoaCanvas2DCopier;
+#endif
 };
 
 inline IOSurfacePbuffer::IOSurfacePbuffer(std::unique_ptr<IOSurface>&& surface, void* pbuffer)

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -33,16 +33,21 @@
 #import "ANGLEUtilitiesCocoa.h"
 #import "CVUtilities.h"
 #import "GraphicsLayerContentsDisplayDelegate.h"
+#import "IOSurface.h"
 #import "IOSurfacePool.h"
 #import "Logging.h"
 #import "PixelBuffer.h"
 #import "ProcessIdentity.h"
 #import <CoreGraphics/CGBitmapContext.h>
+#import <CoreVideo/CVPixelBuffer.h>
 #import <Metal/Metal.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/MetalSPI.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/HashMap.h>
+#import <wtf/HashTraits.h>
 #import <wtf/RuntimeApplicationChecks.h>
+#import <wtf/Scope.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/darwin/WeakLinking.h>
 #import <wtf/text/CString.h>
@@ -69,6 +74,51 @@ namespace WebCore {
 using GL = GraphicsContextGL;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsContextGLCocoa);
+
+// Canvas-2D -> WebGL fast path. Runs entirely in its own share-group GL context, so the
+// WebGL application's GL state never needs to be saved or restored (same model as the
+// HTMLVideoElement path in GraphicsContextGLCVCocoa).
+class GraphicsContextGLCocoaCanvas2DCopier {
+    WTF_MAKE_TZONE_ALLOCATED(GraphicsContextGLCocoaCanvas2DCopier);
+public:
+    static std::unique_ptr<GraphicsContextGLCocoaCanvas2DCopier> create(GraphicsContextGLCocoa&);
+    ~GraphicsContextGLCocoaCanvas2DCopier();
+
+    bool copy(IOSurfaceRef, PlatformGLObject destTexture, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY);
+
+    // Drop the cached allocation record when the destination texture is deleted or re-specified,
+    // so a recycled GL name can't get a stale hit. Mirrors GraphicsContextGLCVCocoa's m_knownContent.
+    void invalidateTexture(GCGLuint texture) { m_destAllocations.remove(texture); }
+
+private:
+    explicit GraphicsContextGLCocoaCanvas2DCopier(GraphicsContextGLCocoa&);
+    bool makeCurrent() { return m_context && GraphicsContextGLCocoa::makeCurrent(m_display, m_context); }
+
+    GCGLDisplay m_display { nullptr };
+    GCGLContext m_context { nullptr };
+    GCGLConfig m_config { nullptr };
+    GCGLenum m_sourceTextureTarget { 0 };
+    PlatformGLObject m_program { 0 };
+    PlatformGLObject m_vertexBuffer { 0 };
+    PlatformGLObject m_framebuffer { 0 };
+    PlatformGLObject m_sourceTexture { 0 };
+    void* m_cachedPbuffer { nullptr };
+    uint32_t m_cachedSurfaceID { 0 };
+    GCGLint m_textureUniformLocation { -1 };
+    GCGLint m_flipYUniformLocation { -1 };
+    GCGLint m_unmultiplyUniformLocation { -1 };
+    GCGLint m_texSizeUniformLocation { -1 };
+
+    struct DestAllocation {
+        IntSize size;
+        uint32_t internalFormat { 0 };
+        uint32_t format { 0 };
+        uint32_t type { 0 };
+        friend bool operator==(const DestAllocation&, const DestAllocation&) = default;
+    };
+    HashMap<GCGLuint, DestAllocation, IntHash<GCGLuint>, WTF::UnsignedWithZeroKeyHashTraits<GCGLuint>> m_destAllocations;
+};
+
 
 // This variable is accessed in single-threaded manner.
 // For WK1, this variable is accessed from multiple threads but always sequentially.
@@ -187,6 +237,7 @@ GraphicsContextGLCocoa::GraphicsContextGLCocoa(GraphicsContextGLAttributes&& cre
 
 GraphicsContextGLCocoa::~GraphicsContextGLCocoa()
 {
+    // m_canvas2DCopier owns its own GL context and tears it down in its destructor.
     if (makeContextCurrent())
         freeDrawingBuffers();
 }
@@ -827,6 +878,8 @@ void GraphicsContextGLCocoa::invalidateKnownTextureContent(GCGLuint texture)
 {
     if (m_cv)
         m_cv->invalidateKnownTextureContent(texture);
+    if (m_canvas2DCopier)
+        m_canvas2DCopier->invalidateTexture(texture);
 }
 
 RefPtr<NativeImage> GraphicsContextGLCocoa::copyNativeImageYFlipped(SurfaceBuffer buffer)
@@ -907,6 +960,310 @@ bool GraphicsContextGLCocoa::copyTextureFromVideoFrame(VideoFrame& videoFrame, P
     return contextCV->copyVideoSampleToTexture(*videoFrameCV, texture, level, internalFormat, format, type, WebCore::GraphicsContextGL::FlipY(flipY));
 }
 #endif
+
+static constexpr const char* s_canvas2DCopyVertexShaderTexture2D =
+    "attribute vec2 a_position;\n"
+    "uniform bool u_flipY;\n"
+    "varying vec2 v_texCoord;\n"
+    "void main() {\n"
+    "    vec2 uv = a_position * 0.5 + 0.5;\n"
+    "    if (u_flipY) uv.y = 1.0 - uv.y;\n"
+    "    v_texCoord = uv;\n"
+    "    gl_Position = vec4(a_position, 0.0, 1.0);\n"
+    "}\n";
+
+static constexpr const char* s_canvas2DCopyVertexShaderTextureRectangle =
+    "attribute vec2 a_position;\n"
+    "uniform bool u_flipY;\n"
+    "uniform vec2 u_texSize;\n"
+    "varying vec2 v_texCoord;\n"
+    "void main() {\n"
+    "    vec2 uv = a_position * 0.5 + 0.5;\n"
+    "    if (u_flipY) uv.y = 1.0 - uv.y;\n"
+    "    v_texCoord = uv * u_texSize;\n"
+    "    gl_Position = vec4(a_position, 0.0, 1.0);\n"
+    "}\n";
+
+static constexpr const char* s_canvas2DCopyFragmentShaderTexture2D =
+    "precision mediump float;\n"
+    "uniform sampler2D u_tex;\n"
+    "uniform bool u_unmultiply;\n"
+    "varying vec2 v_texCoord;\n"
+    "void main() {\n"
+    "    vec4 c = texture2D(u_tex, v_texCoord);\n"
+    "    if (u_unmultiply && c.a > 0.0) c.rgb /= c.a;\n"
+    "    gl_FragColor = c;\n"
+    "}\n";
+
+static constexpr const char* s_canvas2DCopyFragmentShaderTextureRectangle =
+    "precision mediump float;\n"
+    "uniform sampler2DRect u_tex;\n"
+    "uniform bool u_unmultiply;\n"
+    "varying vec2 v_texCoord;\n"
+    "void main() {\n"
+    "    vec4 c = texture2DRect(u_tex, v_texCoord);\n"
+    "    if (u_unmultiply && c.a > 0.0) c.rgb /= c.a;\n"
+    "    gl_FragColor = c;\n"
+    "}\n";
+
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(GraphicsContextGLCocoaCanvas2DCopier);
+
+std::unique_ptr<GraphicsContextGLCocoaCanvas2DCopier> GraphicsContextGLCocoaCanvas2DCopier::create(GraphicsContextGLCocoa& owner)
+{
+    std::unique_ptr<GraphicsContextGLCocoaCanvas2DCopier> copier { new GraphicsContextGLCocoaCanvas2DCopier(owner) };
+    if (!copier->m_context)
+        return nullptr;
+    return copier;
+}
+
+GraphicsContextGLCocoaCanvas2DCopier::~GraphicsContextGLCocoaCanvas2DCopier()
+{
+    if (!m_context || !GraphicsContextGLCocoa::makeCurrent(m_display, m_context))
+        return;
+    if (m_cachedPbuffer)
+        WebCore::destroyPbufferAndDetachIOSurface(m_display, m_cachedPbuffer);
+    if (m_sourceTexture)
+        GL_DeleteTextures(1, &m_sourceTexture);
+    GL_DeleteFramebuffers(1, &m_framebuffer);
+    GL_DeleteBuffers(1, &m_vertexBuffer);
+    GL_DeleteProgram(m_program);
+    EGL_DestroyContext(m_display, m_context);
+}
+
+GraphicsContextGLCocoaCanvas2DCopier::GraphicsContextGLCocoaCanvas2DCopier(GraphicsContextGLCocoa& owner)
+{
+    const EGLint contextAttributes[] = {
+        EGL_CONTEXT_CLIENT_VERSION, owner.m_isForWebGL2 ? 3 : 2,
+        EGL_CONTEXT_OPENGL_BACKWARDS_COMPATIBLE_ANGLE, EGL_FALSE,
+        EGL_CONTEXT_CLIENT_ARRAYS_ENABLED_ANGLE, EGL_FALSE,
+        EGL_CONTEXT_BIND_GENERATES_RESOURCE_CHROMIUM, EGL_FALSE,
+        EGL_NONE
+    };
+    EGLDisplay display = owner.platformDisplay();
+    EGLConfig config = owner.platformConfig();
+    EGLContext context = EGL_CreateContext(display, config, owner.m_contextObj, contextAttributes);
+    if (context == EGL_NO_CONTEXT)
+        return;
+    GraphicsContextGLCocoa::makeCurrent(display, context);
+    auto contextCleanup = makeScopeExit([display, context] {
+        GraphicsContextGLCocoa::makeCurrent(display, EGL_NO_CONTEXT);
+        EGL_DestroyContext(display, context);
+    });
+
+    GCGLenum sourceTextureTarget = owner.drawingBufferTextureTarget();
+    bool useTexture2D = sourceTextureTarget == GL_TEXTURE_2D;
+
+#if PLATFORM(MAC)
+    if (!useTexture2D) {
+        GL_RequestExtensionANGLE("GL_ANGLE_texture_rectangle");
+        GL_RequestExtensionANGLE("GL_EXT_texture_format_BGRA8888");
+        if (GL_GetError() != GL_NO_ERROR)
+            return;
+    }
+#endif
+
+    GLuint vertexShader = GL_CreateShader(GL_VERTEX_SHADER);
+    GLuint fragmentShader = GL_CreateShader(GL_FRAGMENT_SHADER);
+    GLuint program = GL_CreateProgram();
+    auto shaderCleanup = makeScopeExit([vertexShader, fragmentShader] {
+        GL_DeleteShader(vertexShader);
+        GL_DeleteShader(fragmentShader);
+    });
+    auto programCleanup = makeScopeExit([program] {
+        GL_DeleteProgram(program);
+    });
+    if (!vertexShader || !fragmentShader || !program) {
+        LOG(WebGL, "GraphicsContextGLCocoaCanvas2DCopier - failed to create shader or program.");
+        return;
+    }
+
+    const char* vertexShaderSource = useTexture2D ? s_canvas2DCopyVertexShaderTexture2D : s_canvas2DCopyVertexShaderTextureRectangle;
+    const char* fragmentShaderSource = useTexture2D ? s_canvas2DCopyFragmentShaderTexture2D : s_canvas2DCopyFragmentShaderTextureRectangle;
+    GL_ShaderSource(vertexShader, 1, &vertexShaderSource, nullptr);
+    GL_ShaderSource(fragmentShader, 1, &fragmentShaderSource, nullptr);
+    GL_CompileShader(vertexShader);
+    GL_CompileShader(fragmentShader);
+    GLint vertexCompileStatus = 0;
+    GLint fragmentCompileStatus = 0;
+    GL_GetShaderivRobustANGLE(vertexShader, GL_COMPILE_STATUS, 1, nullptr, &vertexCompileStatus);
+    GL_GetShaderivRobustANGLE(fragmentShader, GL_COMPILE_STATUS, 1, nullptr, &fragmentCompileStatus);
+    if (!vertexCompileStatus || !fragmentCompileStatus) {
+        LOG(WebGL, "GraphicsContextGLCocoaCanvas2DCopier - shader failed to compile.");
+        return;
+    }
+    GL_AttachShader(program, vertexShader);
+    GL_AttachShader(program, fragmentShader);
+    GL_LinkProgram(program);
+
+    GLuint vertexBuffer = 0;
+    GL_GenBuffers(1, &vertexBuffer);
+    auto vertexBufferCleanup = makeScopeExit([vertexBuffer] {
+        GL_DeleteBuffers(1, &vertexBuffer);
+    });
+    static constexpr float vertices[] = { -1, -1, 1, -1, -1, 1, 1, 1 };
+    GL_BindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    GL_BufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+    GLuint framebuffer = 0;
+    GL_GenFramebuffers(1, &framebuffer);
+    auto framebufferCleanup = makeScopeExit([framebuffer] {
+        GL_DeleteFramebuffers(1, &framebuffer);
+    });
+
+    GLint status = 0;
+    GL_GetProgramivRobustANGLE(program, GL_LINK_STATUS, 1, nullptr, &status);
+    if (!status) {
+        LOG(WebGL, "GraphicsContextGLCocoaCanvas2DCopier - program failed to link.");
+        return;
+    }
+
+    GLint positionAttributeLocation = GL_GetAttribLocation(program, "a_position");
+    if (positionAttributeLocation < 0) {
+        LOG(WebGL, "GraphicsContextGLCocoaCanvas2DCopier - missing a_position attribute.");
+        return;
+    }
+    GL_UseProgram(program);
+    GL_EnableVertexAttribArray(positionAttributeLocation);
+    GL_VertexAttribPointer(positionAttributeLocation, 2, GL_FLOAT, false, 0, 0);
+    GL_BindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+
+    contextCleanup.release();
+    programCleanup.release();
+    vertexBufferCleanup.release();
+    framebufferCleanup.release();
+    m_display = display;
+    m_context = context;
+    m_config = config;
+    m_sourceTextureTarget = sourceTextureTarget;
+    m_program = program;
+    m_vertexBuffer = vertexBuffer;
+    m_framebuffer = framebuffer;
+    m_textureUniformLocation = GL_GetUniformLocation(program, "u_tex");
+    m_flipYUniformLocation = GL_GetUniformLocation(program, "u_flipY");
+    m_unmultiplyUniformLocation = GL_GetUniformLocation(program, "u_unmultiply");
+    m_texSizeUniformLocation = GL_GetUniformLocation(program, "u_texSize");
+}
+
+bool GraphicsContextGLCocoaCanvas2DCopier::copy(IOSurfaceRef ioSurface, PlatformGLObject destTexture, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY)
+{
+    if (!makeCurrent())
+        return false;
+
+    // Derive the dimensions from the IOSurface itself rather than trusting a size sent over IPC.
+    int width = IOSurfaceGetWidth(ioSurface);
+    int height = IOSurfaceGetHeight(ioSurface);
+    if (width <= 0 || height <= 0)
+        return false;
+
+    if (isSubImage) {
+        // The FBO blit silently clips a sub-rectangle that runs off the destination, whereas
+        // glTexSubImage2D raises GL_INVALID_VALUE and uploads nothing. When the driver reports the
+        // destination level's dimensions, reject the out-of-bounds case so the caller falls back to
+        // the CPU path and preserves that error behavior. The common in-bounds upload stays on GPU.
+        GLint destWidth = 0;
+        GLint destHeight = 0;
+        GL_BindTexture(GL_TEXTURE_2D, destTexture);
+        GL_GetTexLevelParameterivRobustANGLE(GL_TEXTURE_2D, level, GL_TEXTURE_WIDTH, 1, nullptr, &destWidth);
+        GL_GetTexLevelParameterivRobustANGLE(GL_TEXTURE_2D, level, GL_TEXTURE_HEIGHT, 1, nullptr, &destHeight);
+        if (destWidth > 0 && destHeight > 0
+            && (xoffset < 0 || yoffset < 0 || xoffset + width > destWidth || yoffset + height > destHeight))
+            return false;
+    }
+
+    if (!m_sourceTexture) {
+        GL_GenTextures(1, &m_sourceTexture);
+        if (!m_sourceTexture)
+            return false;
+        GL_BindTexture(m_sourceTextureTarget, m_sourceTexture);
+        GL_TexParameteri(m_sourceTextureTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        GL_TexParameteri(m_sourceTextureTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        GL_TexParameteri(m_sourceTextureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        GL_TexParameteri(m_sourceTextureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+
+    uint32_t surfaceID = IOSurfaceGetID(ioSurface);
+    if (m_cachedPbuffer && m_cachedSurfaceID != surfaceID) {
+        WebCore::destroyPbufferAndDetachIOSurface(m_display, m_cachedPbuffer);
+        m_cachedPbuffer = nullptr;
+        m_cachedSurfaceID = 0;
+    }
+    if (!m_cachedPbuffer) {
+        GL_BindTexture(m_sourceTextureTarget, m_sourceTexture);
+        m_cachedPbuffer = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, m_sourceTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_BGRA_EXT, width, height, GL_UNSIGNED_BYTE, ioSurface, 0);
+        if (!m_cachedPbuffer)
+            return false;
+        m_cachedSurfaceID = surfaceID;
+    }
+
+    IntSize size { width, height };
+    DestAllocation desired { size, internalFormat, format, type };
+    bool needsAllocation = !isSubImage;
+    if (!isSubImage) {
+        auto it = m_destAllocations.find(destTexture);
+        if (it != m_destAllocations.end() && it->value == desired)
+            needsAllocation = false;
+    }
+    if (needsAllocation) {
+        GL_BindTexture(GL_TEXTURE_2D, destTexture);
+        GL_TexImage2D(GL_TEXTURE_2D, level, internalFormat, width, height, 0, format, type, nullptr);
+        m_destAllocations.set(destTexture, desired);
+    }
+
+    GL_BindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+    GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, destTexture, level);
+    if (GL_CheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE && !isSubImage && !needsAllocation) {
+        GL_BindTexture(GL_TEXTURE_2D, destTexture);
+        GL_TexImage2D(GL_TEXTURE_2D, level, internalFormat, width, height, 0, format, type, nullptr);
+        m_destAllocations.set(destTexture, desired);
+        GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, destTexture, level);
+    }
+
+    bool ok = GL_CheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+    if (ok) {
+        GL_ActiveTexture(GL_TEXTURE0);
+        GL_BindTexture(m_sourceTextureTarget, m_sourceTexture);
+        GL_Uniform1i(m_textureUniformLocation, 0);
+        GL_Uniform1i(m_flipYUniformLocation, flipY ? 1 : 0);
+        GL_Uniform1i(m_unmultiplyUniformLocation, premultiplyAlpha ? 0 : 1);
+        if (m_texSizeUniformLocation != -1)
+            GL_Uniform2f(m_texSizeUniformLocation, width, height);
+        if (isSubImage)
+            GL_Viewport(xoffset, yoffset, width, height);
+        else
+            GL_Viewport(0, 0, width, height);
+        GL_DrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    }
+
+    GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+    return ok;
+}
+
+bool GraphicsContextGLCocoa::copyTextureFromCanvas2DIOSurface(IOSurfaceRef ioSurface, PlatformGLObject destTexture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY)
+{
+    if (!ioSurface || !destTexture)
+        return false;
+    if (target != GL::TEXTURE_2D || level || type != GL::UNSIGNED_BYTE)
+        return false;
+    if (format != GL::RGB && format != GL::RGBA)
+        return false;
+
+    // Only sample surfaces we know are 32-bit BGRA, the way the video path inspects its pixel
+    // format before binding. A wide-gamut/float16 canvas (e.g. colorType: "float16") is backed by
+    // a non-BGRA8 surface that would otherwise be reinterpreted as BGRA8 and produce garbage; let
+    // those fall back to the CPU readback path.
+    auto pixelFormat = IOSurfaceGetPixelFormat(ioSurface);
+    if (pixelFormat != kCVPixelFormatType_32BGRA && pixelFormat != kCVPixelFormatType_Lossless_32BGRA)
+        return false;
+
+    if (!m_canvas2DCopier && !m_triedCreatingCanvas2DCopier) {
+        m_triedCreatingCanvas2DCopier = true;
+        m_canvas2DCopier = GraphicsContextGLCocoaCanvas2DCopier::create(*this);
+    }
+    if (!m_canvas2DCopier)
+        return false;
+    return m_canvas2DCopier->copy(ioSurface, destTexture, level, internalFormat, format, type, xoffset, yoffset, isSubImage, premultiplyAlpha, flipY);
+}
 
 void GraphicsContextGLCocoa::prepareForDrawingBufferWrite()
 {

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -137,6 +137,9 @@ protected:
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&&);
 #endif
+#if PLATFORM(COCOA)
+    void copyTextureFromCanvas2D(WTF::MachSendRight&& ioSurfaceSendRight, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&&);
+#endif
     void simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting);
     void getBufferSubDataInline(uint32_t target, uint64_t offset, uint64_t dataSize, CompletionHandler<void(std::span<const uint8_t>)>&&);
     void getBufferSubDataSharedMemory(uint32_t target, uint64_t offset, uint64_t dataSize, WebCore::SharedMemory::Handle, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -54,6 +54,9 @@ messages -> RemoteGraphicsContextGL Stream {
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
+#if PLATFORM(COCOA)
+    void CopyTextureFromCanvas2D(MachSendRight ioSurfaceSendRight, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
+#endif
     void SimulateEventForTesting(enum:uint8_t WebCore::GraphicsContextGLSimulatedEventForTesting event)
     void GetBufferSubDataInline(uint32_t target, uint64_t offset, uint64_t dataSize) -> (std::span<const uint8_t> data) Synchronous
     void GetBufferSubDataSharedMemory(uint32_t target, uint64_t offset, uint64_t dataSize, WebCore::SharedMemory::Handle handle) -> (bool valid) Synchronous NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -31,6 +31,8 @@
 #include "GPUConnectionToWebProcess.h"
 #include "IPCUtilities.h"
 #include "RemoteSharedResourceCache.h"
+#include <WebCore/GraphicsContextGLCocoa.h>
+#include <WebCore/IOSurface.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/MachSendRight.h>
@@ -75,6 +77,39 @@ void RemoteGraphicsContextGL::setSharedVideoFrameMemory(WebCore::SharedMemory::H
     m_sharedVideoFrameReader.setSharedMemory(WTF::move(handle));
 }
 #endif
+
+// The send-right can only reference an IOSurface the Web Process already owns, matching the
+// security posture of CopyTextureFromVideoFrame. GPU read/write ordering relies on IOSurface
+// use-counts and Metal's automatic barriers, as the video fast path does.
+void RemoteGraphicsContextGL::copyTextureFromCanvas2D(WTF::MachSendRight&& ioSurfaceSendRight, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, int32_t xoffset, int32_t yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
+
+    if (!m_objectNames.isValidKey(texture)) {
+        ASSERT_IS_TESTING_IPC();
+        completionHandler(false);
+        return;
+    }
+    PlatformGLObject destTextureName = m_objectNames.get(texture);
+
+    if (!ioSurfaceSendRight) {
+        completionHandler(false);
+        return;
+    }
+
+    auto importedSurface = WebCore::IOSurface::createFromSendRight(WTF::move(ioSurfaceSendRight));
+    if (!importedSurface) {
+        completionHandler(false);
+        return;
+    }
+
+    RefPtr context = m_context;
+    if (!context) {
+        completionHandler(false);
+        return;
+    }
+    completionHandler(context->copyTextureFromCanvas2DIOSurface(importedSurface->surface(), destTextureName, target, level, internalFormat, format, type, xoffset, yoffset, isSubImage, premultiplyAlpha, flipY));
+}
 
 namespace {
 

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -334,6 +334,10 @@
 
     [NotSentFromWebContent] MessageParam WebPage.SetObscuredContentInsetsFenced machSendRight
     [NotSentFromWebContent] MessageParamReply RemoteGraphicsContextGL.PrepareForDisplay displayBuffer
+
+    # Web process passes the canvas 2D IOSurface mach send-right to the GPU process so the
+    # WebGL fast path can bind it directly without a CPU readback.
+    [Legacy] MessageParam RemoteGraphicsContextGL.CopyTextureFromCanvas2D ioSurfaceSendRight
 }
 
 [UnsafeWrapper] Vector<MachSendRight> {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcessConnection.h"
+#include "ImageBufferBackendHandleSharing.h"
 #include "RemoteGraphicsContextGLInitializationState.h"
 #include "RemoteGraphicsContextGLMessages.h"
 #include "RemoteGraphicsContextGLProxyMessages.h"
@@ -262,7 +263,48 @@ bool RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame(WebCore::VideoFrame
     return false;
 #endif
 }
+#endif // ENABLE(VIDEO)
 
+bool RemoteGraphicsContextGLProxy::copyTextureFromCanvas2D(WebCore::ImageBuffer& source, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY)
+{
+#if PLATFORM(COCOA)
+    if (isContextLost())
+        return false;
+
+    // Flush the canvas's pending 2D drawing so the GPU process applies it to the backing surface
+    // before reading it; otherwise queued paint commands are not yet committed and we would sample
+    // a stale frame. The CPU readback path gets this for free via copyNativeImage().
+    source.flushDrawingContext();
+
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(source.toBackendSharing());
+    if (!sharing)
+        return false;
+    auto handle = sharing->createBackendHandle(WebCore::SharedMemory::Protection::ReadOnly);
+    if (!handle || !std::holds_alternative<MachSendRight>(*handle))
+        return false;
+    auto sendRight = std::get<MachSendRight>(WTF::move(*handle));
+    if (!sendRight)
+        return false;
+    if (source.backendSize().isEmpty())
+        return false;
+
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CopyTextureFromCanvas2D(WTF::move(sendRight), texture, target, level, internalFormat, format, type, xoffset, yoffset, isSubImage, premultiplyAlpha, flipY));
+    if (!sendResult.succeeded()) {
+        markContextLost();
+        return false;
+    }
+    auto [result] = sendResult.takeReply();
+    return result;
+#else
+    UNUSED_PARAM(source); UNUSED_PARAM(texture); UNUSED_PARAM(target); UNUSED_PARAM(level);
+    UNUSED_PARAM(internalFormat); UNUSED_PARAM(format); UNUSED_PARAM(type);
+    UNUSED_PARAM(xoffset); UNUSED_PARAM(yoffset); UNUSED_PARAM(isSubImage);
+    UNUSED_PARAM(premultiplyAlpha); UNUSED_PARAM(flipY);
+    return false;
+#endif
+}
+
+#if ENABLE(VIDEO)
 RefPtr<Image> RemoteGraphicsContextGLProxy::videoFrameToImage(WebCore::VideoFrame& frame)
 {
     if (isContextLost())

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -101,6 +101,7 @@ public:
     bool copyTextureFromVideoFrame(WebCore::VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type , bool premultiplyAlpha, bool flipY) final;
     RefPtr<WebCore::Image> videoFrameToImage(WebCore::VideoFrame&) final;
 #endif
+    bool copyTextureFromCanvas2D(WebCore::ImageBuffer&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, bool isSubImage, bool premultiplyAlpha, bool flipY) final;
 
     void simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting) final;
     void getBufferSubData(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data) final;


### PR DESCRIPTION
#### 462cc675bd9af1f80a87e37fc54ec0d697b3f979
<pre>
[Cocoa] GPU fast path for uploading a 2D canvas into a WebGL texture
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

texImage2D() and texSubImage2D() with an HTMLCanvasElement that uses a 2D
context currently copy the canvas back into system memory and re-upload it.
That readback dominates the cost of the call.

At Lumen5 we do compositing work in a 2D canvas context and upload the result
into a WebGL scene -- for example we render Lottie animations on a 2D canvas
and display the output on a WebGL scene. The readback is slow enough to drop
frames even on the latest Apple devices; today we work around it by uploading
smaller textures, which costs visible quality.

When the source 2D canvas is backed by an IOSurface, this change copies it
straight into the destination texture on the GPU: a share-group context samples
the IOSurface and blits it into the texture through an FBO, with no read back to
system memory. This mirrors the existing HTMLVideoElement fast path. In our
workload it makes these uploads roughly 40x faster.

The fast path falls back to the existing CPU readback path whenever it cannot
apply -- a non-BGRA8 surface (e.g. a wide-gamut/float16 canvas), an unsupported
format/type/target, an out-of-bounds texSubImage2D sub-rectangle, or a copier
that fails to initialize -- so observable behavior is unchanged. The destination
allocation cache is invalidated through invalidateKnownTextureContent(), and the
canvas&apos;s pending 2D drawing is flushed before the GPU process reads the surface.

* LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html: Added.
* LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path.html: Added.
* PerformanceTests/Canvas/texImage2DCanvas2D.html: Added.
* PerformanceTests/Canvas/texSubImage2DCanvas2D.html: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource): Take the GPU fast path for
an IOSurface-backed 2D canvas; fall through to the readback path otherwise.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:

</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/462cc675bd9af1f80a87e37fc54ec0d697b3f979

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170896 "3 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/44822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172762 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/46094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/46094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170217 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/46094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/44457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/28956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/46094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/44457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/182861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/44478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/182861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/109872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/43678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/38241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->