### PR TITLE
Fix Find in Page crash on iOS

### DIFF
--- a/LayoutTests/editing/find/ios/find-interaction-ignorable-character-expected.txt
+++ b/LayoutTests/editing/find/ios/find-interaction-ignorable-character-expected.txt
@@ -1,0 +1,10 @@
+Searching with the find interaction for a string that folds to an all-ignorable collation key (a lone soft hyphen, U+00AD) must not crash the Web Content process. rdar://170649898
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS matchCount is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello world

--- a/LayoutTests/editing/find/ios/find-interaction-ignorable-character.html
+++ b/LayoutTests/editing/find/ios/find-interaction-ignorable-character.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ findInteractionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p>hello world</p>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Searching with the find interaction for a string that folds to an all-ignorable collation key (a lone soft hyphen, U+00AD) must not crash the Web Content process. rdar://170649898");
+
+    // A soft hyphen folds to an empty collation key, so the searcher reports a
+    // zero-length match at the start of the document. The found text range that
+    // produces equals the empty value of the range map kept in the Web Content
+    // process; reporting it must not trip that map's key-validation assertion.
+    matchCount = await UIHelper.findStringMatchesUsingFindInteraction("\u00AD");
+    shouldBeZero("matchCount");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1629,6 +1629,18 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.runUIScript(`uiController.dismissFindNavigator()`, resolve));
     }
 
+    static findStringMatchesUsingFindInteraction(searchString) {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve(0);
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+                uiController.findStringMatchesUsingFindInteraction(${JSON.stringify(searchString)}, function(matchCount) {
+                    uiController.uiScriptComplete(matchCount);
+                });`, result => resolve(parseInt(result)));
+        });
+    }
+
     static resignFirstResponder()
     {
         if (!this.isWebKit2()) {

--- a/Source/WebCore/editing/CachedMatchFinder.cpp
+++ b/Source/WebCore/editing/CachedMatchFinder.cpp
@@ -95,6 +95,8 @@ void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, c
             if (!matchStartCandidate)
                 break;
             size_t matchLength = static_cast<size_t>(icuSearcher.matchedLength());
+            if (!matchLength)
+                break;
             if (!isMatch(*matchStartCandidate, matchLength))
                 continue;
             if (callback(*matchStartCandidate, *matchStartCandidate + matchLength) == SearchShouldContinue::No)
@@ -108,6 +110,8 @@ void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, c
             if (!matchStartCandidate || *matchStartCandidate >= startOffset)
                 break;
             size_t matchLength = static_cast<size_t>(icuSearcher.matchedLength());
+            if (!matchLength)
+                break;
             if (!isMatch(*matchStartCandidate, matchLength))
                 continue;
             matches.append({ *matchStartCandidate, *matchStartCandidate + matchLength });
@@ -124,6 +128,8 @@ void CachedMatchFinder::performSearch(StringView buffer, unsigned startOffset, c
             if (!matchStartCandidate)
                 break;
             size_t matchLength = icuSearcher.matchedLength();
+            if (!matchLength)
+                break;
             if (!isMatch(*matchStartCandidate, matchLength))
                 continue;
             if (callback(*matchStartCandidate, *matchStartCandidate + matchLength) == SearchShouldContinue::No)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -409,6 +409,8 @@ interface UIScriptController {
 
     undefined findString(DOMString string, unsigned long options, unsigned long maxCount);
 
+    undefined findStringMatchesUsingFindInteraction(DOMString string, object callback);
+
     undefined presentFindNavigator();
     undefined dismissFindNavigator();
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -345,6 +345,7 @@ public:
     // Find in Page
 
     virtual void findString(JSStringRef, unsigned long, unsigned long) { notImplemented(); }
+    virtual void findStringMatchesUsingFindInteraction(JSStringRef, JSValueRef) { notImplemented(); }
 
     virtual void presentFindNavigator() { notImplemented(); }
     virtual void dismissFindNavigator() { notImplemented(); }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -193,6 +193,7 @@ private:
 
     void presentFindNavigator() override;
     void dismissFindNavigator() override;
+    void findStringMatchesUsingFindInteraction(JSStringRef, JSValueRef) override;
 
     JSRetainPtr<JSStringRef> frontmostViewAtPoint(int, int) final;
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -105,6 +105,57 @@ SOFT_LINK_CLASS(UIKit, UIPhysicalKeyboardEvent)
 
 @end
 
+#if HAVE(UIFINDINTERACTION)
+@interface WTRTextSearchAggregator : NSObject <UITextSearchAggregator>
+- (instancetype)initWithCompletionHandler:(void (^)(NSUInteger matchCount))completionHandler;
+@end
+
+@implementation WTRTextSearchAggregator {
+    RetainPtr<NSMutableOrderedSet<UITextRange *>> _foundRanges;
+    BlockPtr<void(NSUInteger)> _completionHandler;
+}
+
+- (instancetype)initWithCompletionHandler:(void (^)(NSUInteger))completionHandler
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _foundRanges = adoptNS([[NSMutableOrderedSet alloc] init]);
+    _completionHandler = makeBlockPtr(completionHandler);
+
+    return self;
+}
+
+- (NSOrderedSet<UITextRange *> *)allFoundRanges
+{
+    return _foundRanges.get();
+}
+
+- (void)foundRange:(UITextRange *)range forSearchString:(NSString *)string inDocument:(UITextSearchDocumentIdentifier)document
+{
+    if (range)
+        [_foundRanges addObject:range];
+}
+
+- (void)finishedSearching
+{
+    if (_completionHandler)
+        _completionHandler([_foundRanges count]);
+}
+
+- (void)invalidateFoundRange:(UITextRange *)range inDocument:(UITextSearchDocumentIdentifier)document
+{
+    [_foundRanges removeObject:range];
+}
+
+- (void)invalidate
+{
+    [_foundRanges removeAllObjects];
+}
+
+@end
+#endif // HAVE(UIFINDINTERACTION)
+
 namespace WTR {
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
@@ -1686,6 +1737,26 @@ void UIScriptControllerIOS::presentFindNavigator()
 {
 #if HAVE(UIFINDINTERACTION)
     [webView().findInteraction presentFindNavigatorShowingReplace:NO];
+#endif
+}
+
+void UIScriptControllerIOS::findStringMatchesUsingFindInteraction(JSStringRef string, JSValueRef callback)
+{
+#if HAVE(UIFINDINTERACTION)
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+
+    RetainPtr aggregator = adoptNS([[WTRTextSearchAggregator alloc] initWithCompletionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID](NSUInteger matchCount) {
+        if (!m_context)
+            return;
+        JSValueRef matchCountValue = JSValueMakeNumber(m_context->jsContext(), matchCount);
+        m_context->asyncTaskComplete(callbackID, { matchCountValue });
+    }).get()]);
+
+    RetainPtr searchOptions = adoptNS([[UITextSearchOptions alloc] init]);
+    [(id<UITextSearching>)webView() performTextSearchWithQueryString:toWTFString(string).createNSString().get() usingOptions:searchOptions.get() resultAggregator:aggregator.get()];
+#else
+    UNUSED_PARAM(string);
+    UNUSED_PARAM(callback);
 #endif
 }
 


### PR DESCRIPTION
#### ce481c4cfedb670a0d26b50a5e0fe4b0051368e0
<pre>
Fix Find in Page crash on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=318169">https://bugs.webkit.org/show_bug.cgi?id=318169</a>
<a href="https://rdar.apple.com/170649898">rdar://170649898</a>

Reviewed by David Kilzer.

A search string that folds to an all-ignorable collation key
produces a zero-length match at every offset.

In WebFoundTextRangeController::findTextRangesForStringMatches() a
zero-length match at the start of the main frame becomes a WebFoundTextRange
equal to the HashMap empty value. Inserting it into m_cachedFoundRanges trips
the HashMap key-validation RELEASE_ASSERT, crashing the Web Content process.

To fix this, we stop the search when the match length is zero. An all-ignorable
target matches nothing meaningful, so reporting no matches is correct.

Tests: editing/find/ios/find-interaction-ignorable-character.html
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm

* LayoutTests/editing/find/ios/find-interaction-ignorable-character-expected.txt: Added.
* LayoutTests/editing/find/ios/find-interaction-ignorable-character.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.findStringMatchesUsingFindInteraction.return.new.Promise):
(window.UIHelper.findStringMatchesUsingFindInteraction):
* Source/WebCore/editing/CachedMatchFinder.cpp:
(WebCore::CachedMatchFinder::performSearch):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::findStringMatchesUsingFindInteraction):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/FindInPage.mm:
(TEST(WebKit, FindInPageIgnorableCharacterDoesNotCrash)):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(-[WTRTextSearchAggregator initWithCompletionHandler:]):
(-[WTRTextSearchAggregator allFoundRanges]):
(-[WTRTextSearchAggregator foundRange:forSearchString:inDocument:]):
(-[WTRTextSearchAggregator finishedSearching]):
(-[WTRTextSearchAggregator invalidateFoundRange:inDocument:]):
(-[WTRTextSearchAggregator invalidate]):
(WTR::UIScriptControllerIOS::findStringMatchesUsingFindInteraction):

Canonical link: <a href="https://commits.webkit.org/316114@main">https://commits.webkit.org/316114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36fe329c3334dddc12023bc228bd500a4ac21404

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128622 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eeec7b57-26d0-41fb-a6e5-257a62f53c90) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133302 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5ad6df8-c3f2-459b-81d3-5927283f94ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113782 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/457f9c75-32ad-41ff-830b-e236656a4e2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35141 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33463 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28966 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141762 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38192 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45177 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109882 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36832 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117068 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43688 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43092 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43223 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->