### PR TITLE
[WebCore] Data race on VideoFrameLibWebRTC::m_conversionCallback between clone and pixelBuffer causes use-after-free

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert-expected.txt
@@ -1,0 +1,3 @@
+
+PASS frame-clone-and-convert
+

--- a/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html
+++ b/LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const WIDTH = 320, HEIGHT = 240;
+const MAX_ITERATIONS = 3000;
+
+async function getVP8Keyframe(w, h) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        const enc = new VideoEncoder({
+            output: (chunk) => chunks.push(chunk),
+            error: reject
+        });
+        enc.configure({
+            codec: 'vp8',
+            width: w,
+            height: h,
+            bitrate: 500000,
+            framerate: 30
+        });
+
+        const canvas = new OffscreenCanvas(w, h);
+        const ctx = canvas.getContext('2d');
+        // Draw some content so it's a real frame
+        ctx.fillStyle = '#336699';
+        ctx.fillRect(0, 0, w, h);
+        ctx.fillStyle = '#FF0000';
+        ctx.fillRect(10, 10, 50, 50);
+        const bitmap = canvas.transferToImageBitmap();
+        const vf = new VideoFrame(bitmap, { timestamp: 0 });
+        enc.encode(vf, { keyFrame: true });
+        vf.close();
+        bitmap.close();
+
+        enc.flush().then(() => {
+            enc.close();
+            if (!chunks.length) { reject(new Error('No encoded chunks')); return; }
+            const buf = new ArrayBuffer(chunks[0].byteLength);
+            chunks[0].copyTo(buf);
+            resolve(buf);
+        }).catch(reject);
+    });
+}
+
+async function getVideoFrame(test)
+{
+    const vp8Data = await getVP8Keyframe(WIDTH, HEIGHT);
+    let resolveCallback;
+    const promise = new Promise((resolve, reject)  => {
+        resolveCallback = resolve;
+        test.step_timeout(() => reject("decoding timed out"), 5000);
+    });
+    const raceDecoder = new VideoDecoder({
+        output: frame => resolveCallback(frame),
+        error: (e) => {}
+    });
+    raceDecoder.configure({ codec: 'vp8' });
+    raceDecoder.decode(new EncodedVideoChunk({
+        type: 'key',
+        timestamp: 0,
+        data: vp8Data
+    }));
+
+    return promise;
+}
+
+promise_test(async t => {
+    let shouldDelay = false;
+    for (let i = 0; i < 10; ++i) {
+        const frame = await getVideoFrame(t);
+        t.add_cleanup(() => frame.close());
+
+        const raceEncoder = new VideoEncoder({
+            output: () => {},
+            error: (e) => {}
+        });
+        raceEncoder.configure({
+            codec: 'vp8',
+            width: WIDTH,
+            height: HEIGHT,
+            bitrate: 500000,
+            framerate: 30
+        });
+
+        const encodeCloneEncoder = new VideoEncoder({
+            output: () => {},
+            error: (e) => {}
+        });
+        encodeCloneEncoder.configure({
+            codec: 'vp8',
+            width: WIDTH,
+            height: HEIGHT,
+            bitrate: 500000,
+            framerate: 30
+        });
+
+        raceEncoder.encode(frame, { keyFrame: true });
+        if (shouldDelay)
+            await new Promise(resolve => t.step_timeout(resolve, 1));
+        shouldDelay = !shouldDelay;
+
+        const frameClone = new VideoFrame(frame, { timestamp: 1000 });
+        t.add_cleanup(() => frameClone.close());
+
+        encodeCloneEncoder.encode(frameClone, { keyFrame: true });
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -84,7 +84,13 @@ CVPixelBufferRef VideoFrameLibWebRTC::pixelBuffer() const
 
 Ref<VideoFrame> VideoFrameLibWebRTC::clone()
 {
-    return adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, m_buffer.get(), ConversionCallback { m_conversionCallback }));
+    Locker locker { m_pixelBufferLock };
+    Ref clone = adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, m_buffer.get(), ConversionCallback { m_conversionCallback }));
+
+    Locker cloneLocker { clone->m_pixelBufferLock };
+    clone->m_pixelBuffer = m_pixelBuffer;
+
+    return clone;
 }
 
 }

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -66,7 +66,7 @@ private:
     IntSize m_size;
     uint32_t m_videoPixelFormat { 0 };
 
-    mutable ConversionCallback m_conversionCallback;
+    mutable ConversionCallback m_conversionCallback WTF_GUARDED_BY_LOCK(m_pixelBufferLock);
     mutable RetainPtr<CVPixelBufferRef> m_pixelBuffer WTF_GUARDED_BY_LOCK(m_pixelBufferLock);
     mutable Lock m_pixelBufferLock;
 };


### PR DESCRIPTION
#### e7f7480061c3edc6ddbadaad7fe202f28fcd6154
<pre>
[WebCore] Data race on VideoFrameLibWebRTC::m_conversionCallback between clone and pixelBuffer causes use-after-free
<a href="https://rdar.apple.com/175482151">rdar://175482151</a>

Reviewed by Jean-Yves Avenard.

We add a thread annotation to make sure the conversion callback cannot be modified without the pixel buffer lock.
We update VideoFrameLibWebRTC::clone so that it holds the pixel buffer lock to ensure it gets a correct conversion callback.
We also copy the pixel buffer with a lock, as it could be null on the cloned video frame if the conversion callback has already been called.

Covered by LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html, which does the following:
1. Create a LibWebRTC VideoFrame.
2. Encode it using VP8 so that the VideoFrame pixelBuffer method is executed in a background queue.
3. In parallel, clone the VideoFrame to exercice the racy code path and encode the cloned frame.

* LayoutTests/http/wpt/webcodecs/frame-clone-and-convert-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/frame-clone-and-convert.html: Added.
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
(WebCore::VideoFrameLibWebRTC::clone):
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:

Originally-landed-as: 305413.760@safari-7624-branch (f4c62c374952). <a href="https://rdar.apple.com/180436627">rdar://180436627</a>
Canonical link: <a href="https://commits.webkit.org/316112@main">https://commits.webkit.org/316112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd72c3cc832e52bd08042cc7ceb5029c8eaf8e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180285 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133303 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35140 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33461 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182870 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141761 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141571 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38190 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45176 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109881 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36831 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117067 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43687 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43091 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->