### PR TITLE
GPU fast path for uploading a 2D canvas into a WebGL texture

### DIFF
--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-expected.txt
@@ -1,0 +1,56 @@
+Verify that texImage2D / texSubImage2D with HTMLCanvasElement (2D context) sources produce the expected pixels, regardless of whether the GPU-GPU IOSurface fast path or the CPU readback path is taken. Covers flipY Ã— premultiplyAlpha permutations and full-image / sub-image uploads.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+flipY=false, premultiplyAlpha=false, useSubImage=false
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=false, premultiplyAlpha=true, useSubImage=false
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=false, useSubImage=false
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=true, useSubImage=false
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+
+flipY=false, premultiplyAlpha=false, useSubImage=true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=false, premultiplyAlpha=true, useSubImage=true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=false, useSubImage=true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+
+flipY=true, premultiplyAlpha=true, useSubImage=true
+PASS approxEqual([255,0,0,255], [255,0,0,255]) is true
+PASS approxEqual([0,255,0,255], [0,255,0,255]) is true
+PASS approxEqual([0,0,255,255], [0,0,255,255]) is true
+PASS approxEqual([255,255,0,255], [255,255,0,255]) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks-expected.txt
@@ -1,0 +1,25 @@
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage2D: a buffer is bound to PIXEL_UNPACK_BUFFER
+The canvas-2D â†’ WebGL fast path must skip and fall back to the generic upload path for: WebGL2 with a bound PIXEL_UNPACK_BUFFER (which must raise INVALID_OPERATION), level > 0 uploads, type != UNSIGNED_BYTE, and format outside {RGB, RGBA}. In every such case the observable behavior must match the generic path.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+--- WebGL2 with bound PIXEL_UNPACK_BUFFER ---
+PASS pboUploadError is GL_INVALID_OPERATION
+after unbinding: first pixel = [255, 128, 64, 255]
+PASS pboUnboundPixelIsOrange is true
+
+--- level > 0 ---
+PASS levelUploadError is 0
+
+--- type=UNSIGNED_SHORT_4_4_4_4 ---
+PASS shortTypeUploadError is 0
+first pixel = [255, 136, 68, 255]
+PASS shortTypePixelIsOrange is true
+
+--- format=LUMINANCE_ALPHA ---
+PASS luminanceAlphaUploadError is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>texImage2D with HTMLCanvasElement (2D) — pixel correctness in cases where the GPU-GPU fast path is intentionally bypassed.</title>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("The canvas-2D → WebGL fast path must skip and fall back to the generic upload path for: WebGL2 with a bound PIXEL_UNPACK_BUFFER (which must raise INVALID_OPERATION), level > 0 uploads, type != UNSIGNED_BYTE, and format outside {RGB, RGBA}. In every such case the observable behavior must match the generic path.");
+
+const W = 8;
+const H = 8;
+
+function makeSource()
+{
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const ctx = c.getContext("2d");
+    ctx.fillStyle = "#ff8040";
+    ctx.fillRect(0, 0, W, H);
+    return c;
+}
+
+function makeWebGLContext(version)
+{
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    return c.getContext(version);
+}
+
+function firstPixel(gl)
+{
+    const fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    const tex = gl.getParameter(gl.TEXTURE_BINDING_2D);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+    const buf = new Uint8Array(4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.deleteFramebuffer(fb);
+    return buf;
+}
+
+function isOpaqueOrange(pixel)
+{
+    return Math.abs(pixel[0] - 255) <= 2 && Math.abs(pixel[1] - 128) <= 2 && Math.abs(pixel[2] - 64) <= 2 && Math.abs(pixel[3] - 255) <= 2;
+}
+
+// Case 1: WebGL2 with a bound PIXEL_UNPACK_BUFFER must raise INVALID_OPERATION and upload nothing.
+debug("\n--- WebGL2 with bound PIXEL_UNPACK_BUFFER ---");
+(function() {
+    const gl = makeWebGLContext("webgl2");
+    if (!gl) {
+        testFailed("WebGL2 not available");
+        return;
+    }
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    const pbo = gl.createBuffer();
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, makeSource());
+    window.pboUploadError = gl.getError();
+    window.GL_INVALID_OPERATION = gl.INVALID_OPERATION;
+    shouldBe("pboUploadError", "GL_INVALID_OPERATION");
+    // After unbinding the buffer the same upload must succeed with correct pixels.
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, makeSource());
+    const pixel = firstPixel(gl);
+    debug(`after unbinding: first pixel = [${pixel[0]}, ${pixel[1]}, ${pixel[2]}, ${pixel[3]}]`);
+    window.pboUnboundPixelIsOrange = isOpaqueOrange(pixel);
+    shouldBeTrue("pboUnboundPixelIsOrange");
+})();
+
+// Case 2: level > 0 must take the generic path.
+debug("\n--- level > 0 ---");
+(function() {
+    const gl = makeWebGLContext("webgl");
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, W, H, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texImage2D(gl.TEXTURE_2D, 1, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, makeSource());
+    window.levelUploadError = gl.getError();
+    shouldBe("levelUploadError", "0");
+})();
+
+// Case 3: type != UNSIGNED_BYTE must take the generic path.
+debug("\n--- type=UNSIGNED_SHORT_4_4_4_4 ---");
+(function() {
+    const gl = makeWebGLContext("webgl");
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, makeSource());
+    window.shortTypeUploadError = gl.getError();
+    shouldBe("shortTypeUploadError", "0");
+    const pixel = firstPixel(gl);
+    debug(`first pixel = [${pixel[0]}, ${pixel[1]}, ${pixel[2]}, ${pixel[3]}]`);
+    window.shortTypePixelIsOrange = Math.abs(pixel[0] - 255) <= 20 && Math.abs(pixel[1] - 128) <= 20 && Math.abs(pixel[2] - 64) <= 20 && Math.abs(pixel[3] - 255) <= 20;
+    shouldBeTrue("shortTypePixelIsOrange");
+})();
+
+// Case 4: format=LUMINANCE_ALPHA must take the generic path.
+debug("\n--- format=LUMINANCE_ALPHA ---");
+(function() {
+    const gl = makeWebGLContext("webgl");
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.LUMINANCE_ALPHA, gl.LUMINANCE_ALPHA, gl.UNSIGNED_BYTE, makeSource());
+    window.luminanceAlphaUploadError = gl.getError();
+    shouldBe("luminanceAlphaUploadError", "0");
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path.html
+++ b/LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>texImage2D / texSubImage2D from 2D canvas (GPU fast path) produce the same pixels as the CPU path.</title>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+description("Verify that texImage2D / texSubImage2D with HTMLCanvasElement (2D context) sources produce the expected pixels, regardless of whether the GPU-GPU IOSurface fast path or the CPU readback path is taken. Covers flipY × premultiplyAlpha permutations and full-image / sub-image uploads.");
+
+// Build a 16x16 source 2D canvas with four solid-colored quadrants. The 2D canvas
+// backing is premultiplied; we render colors at full alpha so values are stable
+// across both the fast path and the CPU fallback.
+const W = 16;
+const H = 16;
+
+function makeSourceCanvas()
+{
+    const c = document.createElement("canvas");
+    c.width = W;
+    c.height = H;
+    const ctx = c.getContext("2d");
+    ctx.fillStyle = "rgba(255, 0, 0, 1)"; ctx.fillRect(0,    0,    W/2, H/2); // top-left red
+    ctx.fillStyle = "rgba(0, 255, 0, 1)"; ctx.fillRect(W/2,  0,    W/2, H/2); // top-right green
+    ctx.fillStyle = "rgba(0, 0, 255, 1)"; ctx.fillRect(0,    H/2,  W/2, H/2); // bottom-left blue
+    ctx.fillStyle = "rgba(255, 255, 0, 1)"; ctx.fillRect(W/2, H/2, W/2, H/2); // bottom-right yellow
+    return c;
+}
+
+const target = document.createElement("canvas");
+target.width = W;
+target.height = H;
+const gl = target.getContext("webgl", { preserveDrawingBuffer: true });
+const program = (function() {
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, "attribute vec2 p; varying vec2 uv; void main() { uv = (p + 1.0) * 0.5; gl_Position = vec4(p, 0.0, 1.0); }");
+    gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, "precision mediump float; uniform sampler2D t; varying vec2 uv; void main() { gl_FragColor = texture2D(t, uv); }");
+    gl.compileShader(fs);
+    const p = gl.createProgram();
+    gl.attachShader(p, vs);
+    gl.attachShader(p, fs);
+    gl.linkProgram(p);
+    gl.useProgram(p);
+    const buf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+    const loc = gl.getAttribLocation(p, "p");
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+    return p;
+})();
+
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+function readPixel(x, y)
+{
+    const buf = new Uint8Array(4);
+    gl.readPixels(x, y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    return [buf[0], buf[1], buf[2], buf[3]];
+}
+
+function approxEqual(rgba, expected)
+{
+    for (let i = 0; i < 4; ++i)
+        if (Math.abs(rgba[i] - expected[i]) > 2)
+            return false;
+    return true;
+}
+
+function runOne(flipY, premultiply, useSubImage)
+{
+    debug("");
+    debug(`flipY=${flipY}, premultiplyAlpha=${premultiply}, useSubImage=${useSubImage}`);
+
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiply);
+
+    const src = makeSourceCanvas();
+    if (useSubImage) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, W, H, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    } else
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, src);
+
+    gl.viewport(0, 0, W, H);
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+    // WebGL framebuffer has its origin at the bottom-left. When flipY=true, the canvas
+    // is uploaded upright, so the top-left source quadrant (red) is sampled at the
+    // top of the rendered output (top → high y in framebuffer coords).
+    const topQuadRed   = flipY ? [255, 0,   0, 255] : [0,   0,   255, 255]; // canvas TL vs canvas BL
+    const topQuadGreen = flipY ? [0,   255, 0, 255] : [255, 255, 0,   255];
+    const botQuadBlue  = flipY ? [0,   0, 255, 255] : [255, 0,   0,   255];
+    const botQuadYel   = flipY ? [255, 255, 0, 255] : [0,   255, 0,   255];
+
+    const tl = readPixel(2, H - 2);   // top-left of framebuffer
+    const tr = readPixel(W - 2, H - 2);
+    const bl = readPixel(2, 2);       // bottom-left of framebuffer
+    const br = readPixel(W - 2, 2);
+
+    shouldBeTrue(`approxEqual([${tl}], [${topQuadRed}])`);
+    shouldBeTrue(`approxEqual([${tr}], [${topQuadGreen}])`);
+    shouldBeTrue(`approxEqual([${bl}], [${botQuadBlue}])`);
+    shouldBeTrue(`approxEqual([${br}], [${botQuadYel}])`);
+}
+
+// We render the source at full alpha = 1, so the premultiplied/unpremultiplied
+// representations are bit-identical. Both premultiply settings should yield the
+// same color values, exercising both branches of the alpha logic.
+for (const useSubImage of [false, true])
+    for (const flipY of [false, true])
+        for (const premultiply of [false, true])
+            runOne(flipY, premultiply, useSubImage);
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/texImage2DCanvas2D.html
+++ b/PerformanceTests/Canvas/texImage2DCanvas2D.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2048;
+source.height = 2048;
+const ctx = source.getContext("2d");
+ctx.fillStyle = "#a08040";
+ctx.fillRect(0, 0, source.width, source.height);
+
+target.width = source.width;
+target.height = source.height;
+const gl = target.getContext("webgl");
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+
+let isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: () => { isDone = true; }, unit: 'ms' });
+
+function runTest() {
+    const start = PerfTestRunner.now();
+    for (let i = 0; i < 30; ++i) {
+        // Force the canvas backing to be dirtied so any caching is invalidated.
+        ctx.fillStyle = `rgb(${i * 8 & 0xff}, 128, 64)`;
+        ctx.fillRect(0, 0, source.width, source.height);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
+    }
+    gl.finish();
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - start);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/PerformanceTests/Canvas/texSubImage2DCanvas2D.html
+++ b/PerformanceTests/Canvas/texSubImage2DCanvas2D.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="source"></canvas>
+<canvas id="target"></canvas>
+<script src="../resources/runner.js"></script>
+<script>
+source.width = 2048;
+source.height = 2048;
+const ctx = source.getContext("2d");
+ctx.fillStyle = "#a08040";
+ctx.fillRect(0, 0, source.width, source.height);
+
+target.width = source.width;
+target.height = source.height;
+const gl = target.getContext("webgl");
+const tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, source.width, source.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+
+let isDone = false;
+PerfTestRunner.prepareToMeasureValuesAsync({ done: () => { isDone = true; }, unit: 'ms' });
+
+function runTest() {
+    const start = PerfTestRunner.now();
+    for (let i = 0; i < 30; ++i) {
+        ctx.fillStyle = `rgb(${i * 8 & 0xff}, 128, 64)`;
+        ctx.fillRect(0, 0, source.width, source.height);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, source);
+    }
+    gl.finish();
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - start);
+    if (!isDone)
+        setTimeout(runTest, 0);
+}
+runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -276,6 +276,7 @@ private:
     RefPtr<WebGLBuffer> validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage) final;
     RefPtr<WebGLBuffer> validateBufferDataTarget(ASCIILiteral functionName, GCGLenum target) final;
     bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*) final;
+    bool hasBoundPixelUnpackBuffer() const final { return !!m_boundPixelUnpackBuffer.get(); }
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;
     bool validateCapability(ASCIILiteral functionName, GCGLenum cap) final;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3366,7 +3366,38 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
 
     if (RefPtr imageData = source.getImageData()) {
         texImageSourceHelper(functionID, target, level, internalformat, border, format, type, xoffset, yoffset, zoffset, sourceImageRect, depth, unpackImageHeight, TexImageSource(imageData.releaseNonNull()));
-    } else if (RefPtr image = source.copiedImage()) {
+        return { };
+    }
+
+#if PLATFORM(COCOA)
+    bool sourceImageRectIsDefault = sourceImageRect == texImageSourceSize(source);
+    bool isFastPathFunction = functionID == TexImageFunctionID::TexImage2D || functionID == TexImageFunctionID::TexSubImage2D;
+    RefPtr sourceContext = source.renderingContext();
+    if (isFastPathFunction && sourceImageRectIsDefault && texture
+        && sourceContext && sourceContext->is2d()
+        && target == GraphicsContextGL::TEXTURE_2D
+        && (format == GraphicsContextGL::RGB || format == GraphicsContextGL::RGBA)
+        && (functionID == TexImageFunctionID::TexSubImage2D || internalformat == GraphicsContextGL::RGB || internalformat == GraphicsContextGL::RGBA || internalformat == GraphicsContextGL::RGB8 || internalformat == GraphicsContextGL::RGBA8)
+        && type == GraphicsContextGL::UNSIGNED_BYTE
+        && !level && depth == 1
+        && !hasBoundPixelUnpackBuffer()) {
+        RefPtr buffer = source.makeRenderingResultsAvailable();
+        if (buffer && buffer->renderingMode() == RenderingMode::Accelerated && buffer->pixelFormat() == PixelFormat::BGRA8 && buffer->colorSpace() == DestinationColorSpace::SRGB()) {
+            if (RefPtr image = buffer->copyNativeImage(NativeImageCopyMode::CopyBackingStore)) {
+                bool copied = false;
+                RefPtr context = graphicsContextGL();
+                if (functionID == TexImageFunctionID::TexSubImage2D)
+                    copied = context->copySubTextureFromNativeImage(*image, target, texture->object(), level, format, xoffset, yoffset, m_unpackFlipY, false, !m_unpackPremultiplyAlpha);
+                else
+                    copied = context->copyTextureFromNativeImage(*image, target, texture->object(), level, internalformat, type, m_unpackFlipY, false, !m_unpackPremultiplyAlpha);
+                if (copied)
+                    return { };
+            }
+        }
+    }
+#endif
+
+    if (RefPtr image = source.copiedImage()) {
         texImageImpl(functionID, target, level, internalformat, xoffset, yoffset, zoffset, format, type, *image, GraphicsContextGL::DOMSource::Canvas, m_unpackFlipY, m_unpackPremultiplyAlpha, false, sourceImageRect, depth, unpackImageHeight);
     }
     return { };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1012,6 +1012,8 @@ protected:
 
     virtual bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*);
 
+    virtual bool hasBoundPixelUnpackBuffer() const { return false; }
+
     // Wrapper for GraphicsContextGLOpenGL::synthesizeGLError that sends a message to the JavaScript console.
     void synthesizeGLError(GCGLenum, ASCIILiteral functionName, ASCIILiteral description);
     void synthesizeLostContextGLError(GCGLenum, ASCIILiteral functionName, ASCIILiteral description);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -70,6 +70,7 @@ struct GCGLSpanTuple;
 
 namespace WebCore {
 class ImageBuffer;
+class NativeImage;
 class PixelBuffer;
 
 #if ENABLE(VIDEO) && USE(AVFOUNDATION)
@@ -1686,6 +1687,9 @@ public:
     virtual bool copyTextureFromVideoFrame(VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum  format, GCGLenum type, bool premultiplyAlpha, bool flipY) = 0;
     WEBCORE_EXPORT virtual RefPtr<Image> videoFrameToImage(VideoFrame&);
 #endif
+
+    virtual bool copyTextureFromNativeImage(NativeImage&, GCGLenum /*destTarget*/, PlatformGLObject /*destId*/, GCGLint /*destLevel*/, GCGLint /*internalFormat*/, GCGLenum /*destType*/, bool /*unpackFlipY*/, bool /*unpackPremultiplyAlpha*/, bool /*unpackUnmultiplyAlpha*/) { return false; }
+    virtual bool copySubTextureFromNativeImage(NativeImage&, GCGLenum /*destTarget*/, PlatformGLObject /*destId*/, GCGLint /*destLevel*/, GCGLenum /*format*/, GCGLint /*xoffset*/, GCGLint /*yoffset*/, bool /*unpackFlipY*/, bool /*unpackPremultiplyAlpha*/, bool /*unpackUnmultiplyAlpha*/) { return false; }
 
     IntSize getInternalFramebufferSize() const { return IntSize(m_currentWidth, m_currentHeight); }
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -343,6 +343,13 @@ RefPtr<NativeImage> ImageBuffer::copyNativeImage() const
     return nullptr;
 }
 
+RefPtr<NativeImage> ImageBuffer::copyNativeImage(NativeImageCopyMode mode) const
+{
+    if (auto* backend = ensureBackend())
+        return backend->copyNativeImage(mode);
+    return nullptr;
+}
+
 RefPtr<NativeImage> ImageBuffer::createNativeImageReference() const
 {
     if (auto* backend = ensureBackend())

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -186,6 +186,8 @@ public:
     // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage() const;
 
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage(NativeImageCopyMode) const;
+
     // Returns NativeImage referencing the back buffer. Changes to ImageBuffer might be reflected to the NativeImage.
     // Useful when caller can guarantee the use of the NativeImage ends "immediately", before the next draw to this ImageBuffer.
     WEBCORE_EXPORT virtual RefPtr<NativeImage> createNativeImageReference() const;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -73,6 +73,11 @@ RefPtr<NativeImage> ImageBufferBackend::sinkIntoNativeImage()
     return createNativeImageReference();
 }
 
+RefPtr<NativeImage> ImageBufferBackend::copyNativeImage(NativeImageCopyMode)
+{
+    return copyNativeImage();
+}
+
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
 void ImageBufferBackend::convertToLuminanceMaskFloat16()
 {

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -103,6 +103,11 @@ public:
     virtual bool isImageBufferBackendHandleSharing() const { return false; }
 };
 
+enum class NativeImageCopyMode : bool {
+    CopyOnWrite,
+    CopyBackingStore
+};
+
 class ImageBufferBackend {
 public:
     using Parameters = ImageBufferBackendParameters;
@@ -124,6 +129,7 @@ public:
     virtual void submitDrawingCommands() { }
 
     virtual RefPtr<NativeImage> copyNativeImage() = 0;
+    WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage(NativeImageCopyMode);
     virtual RefPtr<NativeImage> createNativeImageReference() = 0;
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
 

--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -70,6 +70,10 @@ NativeImage::~NativeImage()
 {
     for (CheckedRef observer : m_observers)
         observer->willDestroyNativeImage(*this);
+#if HAVE(IOSURFACE)
+    if (m_backingIOSurfaceReleaseHandler)
+        m_backingIOSurfaceReleaseHandler();
+#endif
 }
 
 const PlatformImagePtr& NativeImage::platformImage() const

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -33,10 +33,15 @@
 #include <WebCore/PlatformImage.h>
 #include <WebCore/RenderingResource.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 
 #if USE(SKIA)
 class GrDirectContext;
+#endif
+
+#if HAVE(IOSURFACE)
+typedef struct __IOSurface* IOSurfaceRef;
 #endif
 
 namespace WebCore {
@@ -83,6 +88,15 @@ public:
 
     WEBCORE_EXPORT void replacePlatformImage(PlatformImagePtr&&) const;
 
+#if HAVE(IOSURFACE)
+    IOSurfaceRef backingIOSurface() const { return m_backingIOSurface.get(); }
+    void setBackingIOSurface(RetainPtr<IOSurfaceRef>&& surface, Function<void()>&& releaseHandler = { })
+    {
+        m_backingIOSurface = WTF::move(surface);
+        m_backingIOSurfaceReleaseHandler = WTF::move(releaseHandler);
+    }
+#endif
+
 #if USE(SKIA) || USE(COORDINATED_GRAPHICS)
     uint64_t uniqueID() const;
 #endif
@@ -117,6 +131,10 @@ protected:
     mutable Headroom m_headroom { Headroom::None };
     mutable WeakHashSet<RenderingResourceObserver> m_observers;
     RenderingResourceIdentifier m_renderingResourceIdentifier { RenderingResourceIdentifier::generate() };
+#if HAVE(IOSURFACE)
+    RetainPtr<IOSurfaceRef> m_backingIOSurface;
+    Function<void()> m_backingIOSurfaceReleaseHandler;
+#endif
 #if USE(SKIA)
     GrDirectContext* m_grContext { nullptr };
 #endif

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -184,6 +184,48 @@ RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage()
     return NativeImage::create(createImage());
 }
 
+RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImage(NativeImageCopyMode mode)
+{
+    if (mode == NativeImageCopyMode::CopyBackingStore) {
+        if (auto image = copyNativeImageWithCopiedBackingStore())
+            return image;
+    }
+    return copyNativeImage();
+}
+
+RefPtr<NativeImage> ImageBufferIOSurfaceBackend::copyNativeImageWithCopiedBackingStore()
+{
+    if (m_parameters.bufferFormat.pixelFormat != PixelFormat::BGRA8)
+        return nullptr;
+    auto copySurface = IOSurface::create(m_ioSurfacePool.get(), m_surface->size(), m_parameters.colorSpace, IOSurface::Name::ImageBuffer);
+    if (!copySurface)
+        return nullptr;
+    RetainPtr copyContext = copySurface->createPlatformContext(m_displayID);
+    if (!copyContext)
+        return nullptr;
+    RetainPtr sourceImage = createImageReference();
+    if (!sourceImage)
+        return nullptr;
+    CGContextSetBlendMode(copyContext.get(), kCGBlendModeCopy);
+    auto size = m_surface->size();
+    CGContextDrawImage(copyContext.get(), CGRectMake(0, 0, size.width(), size.height()), sourceImage.get());
+    CGContextFlush(copyContext.get());
+    RetainPtr<IOSurfaceRef> surface = copySurface->surface();
+    RetainPtr snapshotImage = adoptCF(CGIOSurfaceContextCreateImageReference(copyContext.get()));
+    copyContext = nullptr;
+    auto image = NativeImage::create(WTF::move(snapshotImage));
+    if (!image)
+        return nullptr;
+    Function<void()> releaseHandler;
+    if (RefPtr pool = m_ioSurfacePool) {
+        releaseHandler = [pool = WTF::move(pool), snapshotSurface = WTF::move(copySurface)]() mutable {
+            IOSurface::moveToPool(WTF::move(snapshotSurface), pool.get());
+        };
+    }
+    image->setBackingIOSurface(WTF::move(surface), WTF::move(releaseHandler));
+    return image;
+}
+
 RefPtr<NativeImage> ImageBufferIOSurfaceBackend::createNativeImageReference()
 {
     // The destination backend needs to read the actual pixels. Returning non-refence will

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -62,8 +62,10 @@ protected:
     bool flushContextDraws();
     
     RefPtr<NativeImage> copyNativeImage() override;
+    RefPtr<NativeImage> copyNativeImage(NativeImageCopyMode) override;
     RefPtr<NativeImage> createNativeImageReference() override;
     RefPtr<NativeImage> sinkIntoNativeImage() override;
+    RefPtr<NativeImage> copyNativeImageWithCopiedBackingStore();
 
     void getPixelBuffer(const IntRect&, PixelBuffer&) override;
     void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) override;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -112,6 +112,8 @@ public:
 #if ENABLE(VIDEO)
     bool copyTextureFromVideoFrame(VideoFrame&, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) final;
 #endif
+    bool copyTextureFromNativeImage(NativeImage&, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLint internalFormat, GCGLenum destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha) final;
+    bool copySubTextureFromNativeImage(NativeImage&, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLenum format, GCGLint xoffset, GCGLint yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha) final;
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer) final;
 #endif
@@ -134,6 +136,9 @@ protected:
     void invalidateKnownTextureContent(GCGLuint) final;
     bool reshapeDrawingBuffer() final;
     void prepareForDrawingBufferWrite() final;
+
+    bool copyTextureFromNativeImageInternal(NativeImage&, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLint internalFormat, GCGLenum destType, std::optional<IntPoint> destOffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha);
+    void releaseNativeImageCopySources();
 
     IOSurfacePbuffer& NODELETE drawingBuffer();
     IOSurfacePbuffer& NODELETE displayBuffer();
@@ -163,6 +168,14 @@ protected:
 #endif
     RetainPtr<MTLSharedEventListener> m_finishedMetalSharedEventListener;
     RetainPtr<id> m_finishedMetalSharedEvent; // FIXME: Remove all C++ includees and use id<MTLSharedEvent>.
+
+    struct NativeImageCopySource {
+        uint32_t surfaceID { 0 };
+        void* pbuffer { nullptr };
+        PlatformGLObject texture { 0 };
+        RetainPtr<IOSurfaceRef> surface;
+    };
+    Vector<NativeImageCopySource> m_nativeImageCopySources;
 #if ENABLE(WEBXR)
     using RasterizationRateMapArray =  EnumeratedArray<PlatformXR::Layout, RetainPtr<MTLRasterizationRateMap>, PlatformXR::Layout::Layered>;
     RasterizationRateMapArray m_rasterizationRateMap;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -33,11 +33,13 @@
 #import "ANGLEUtilitiesCocoa.h"
 #import "CVUtilities.h"
 #import "GraphicsLayerContentsDisplayDelegate.h"
+#import "IOSurface.h"
 #import "IOSurfacePool.h"
 #import "Logging.h"
 #import "PixelBuffer.h"
 #import "ProcessIdentity.h"
 #import <CoreGraphics/CGBitmapContext.h>
+#import <CoreVideo/CVPixelBuffer.h>
 #import <Metal/Metal.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <pal/spi/cocoa/MetalSPI.h>
@@ -187,8 +189,10 @@ GraphicsContextGLCocoa::GraphicsContextGLCocoa(GraphicsContextGLAttributes&& cre
 
 GraphicsContextGLCocoa::~GraphicsContextGLCocoa()
 {
-    if (makeContextCurrent())
+    if (makeContextCurrent()) {
+        releaseNativeImageCopySources();
         freeDrawingBuffers();
+    }
 }
 
 IOSurface* GraphicsContextGLCocoa::displayBufferSurface()
@@ -889,6 +893,141 @@ bool GraphicsContextGLCocoa::copyTextureFromVideoFrame(VideoFrame& videoFrame, P
     return contextCV->copyVideoSampleToTexture(*videoFrameCV, texture, level, internalFormat, format, type, WebCore::GraphicsContextGL::FlipY(flipY));
 }
 #endif
+
+bool GraphicsContextGLCocoa::copyTextureFromNativeImage(NativeImage& image, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLint internalFormat, GCGLenum destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+    if (destType != GL::UNSIGNED_BYTE)
+        return false;
+    switch (internalFormat) {
+    case GL::RGB:
+    case GL::RGBA:
+    case GL::RGB8:
+    case GL::RGBA8:
+        break;
+    default:
+        return false;
+    }
+    return copyTextureFromNativeImageInternal(image, destTarget, destId, destLevel, internalFormat, destType, std::nullopt, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha);
+}
+
+bool GraphicsContextGLCocoa::copySubTextureFromNativeImage(NativeImage& image, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLenum format, GCGLint xoffset, GCGLint yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+    if (!destId || destTarget != GL::TEXTURE_2D)
+        return false;
+    if (!makeContextCurrent())
+        return false;
+
+    {
+        ScopedRestoreTextureBinding restoreBinding(GL::TEXTURE_BINDING_2D, GL::TEXTURE_2D);
+        GL_BindTexture(GL_TEXTURE_2D, destId);
+        updateErrors();
+        GL_TexSubImage2D(GL_TEXTURE_2D, destLevel, xoffset, yoffset, 0, 0, format, GL::UNSIGNED_BYTE, nullptr);
+        if (auto error = GL_GetError(); error != GL_NO_ERROR) {
+            addError(enumToErrorCode(error));
+            return true;
+        }
+    }
+    return copyTextureFromNativeImageInternal(image, destTarget, destId, destLevel, 0, 0, IntPoint { xoffset, yoffset }, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha);
+}
+
+bool GraphicsContextGLCocoa::copyTextureFromNativeImageInternal(NativeImage& image, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLint internalFormat, GCGLenum destType, std::optional<IntPoint> destOffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+    if (!destId || destTarget != GL::TEXTURE_2D)
+        return false;
+    if (!makeContextCurrent())
+        return false;
+
+    if (!enableExtensionsImpl({ "GL_CHROMIUM_copy_texture"_s }))
+        return false;
+
+    RetainPtr<IOSurfaceRef> surface = image.backingIOSurface();
+    if (surface) {
+        auto pixelFormat = IOSurfaceGetPixelFormat(surface.get());
+        bool isBGRA8 = pixelFormat == kCVPixelFormatType_32BGRA || pixelFormat == kCVPixelFormatType_Lossless_32BGRA;
+        if (!isBGRA8 || !image.hasAlpha() || image.colorSpace() != DestinationColorSpace::SRGB())
+            surface = nullptr;
+    }
+
+    std::unique_ptr<IOSurface> normalizedSurface;
+    if (!surface) {
+        RetainPtr platformImage = image.platformImage();
+        if (!platformImage)
+            return false;
+        auto size = image.size();
+        if (size.isEmpty())
+            return false;
+        normalizedSurface = IOSurface::create(nullptr, size, DestinationColorSpace::SRGB(), IOSurface::Name::GraphicsContextGL);
+        if (!normalizedSurface)
+            return false;
+        RetainPtr normalizedContext = normalizedSurface->createPlatformContext();
+        if (!normalizedContext)
+            return false;
+        CGContextSetBlendMode(normalizedContext.get(), kCGBlendModeCopy);
+        CGContextDrawImage(normalizedContext.get(), CGRectMake(0, 0, size.width(), size.height()), platformImage.get());
+        CGContextFlush(normalizedContext.get());
+        surface = normalizedSurface->surface();
+    }
+
+    int width = IOSurfaceGetWidth(surface.get());
+    int height = IOSurfaceGetHeight(surface.get());
+    if (width <= 0 || height <= 0)
+        return false;
+
+    static constexpr size_t maxCachedNativeImageCopySources = 16;
+    uint32_t surfaceID = IOSurfaceGetID(surface.get());
+    PlatformGLObject sourceTexture = 0;
+    for (size_t i = 0; i < m_nativeImageCopySources.size(); ++i) {
+        if (m_nativeImageCopySources[i].surfaceID == surfaceID) {
+            sourceTexture = m_nativeImageCopySources[i].texture;
+            if (i) {
+                auto entry = WTF::move(m_nativeImageCopySources[i]);
+                m_nativeImageCopySources.removeAt(i);
+                m_nativeImageCopySources.insert(0, WTF::move(entry));
+            }
+            break;
+        }
+    }
+    if (!sourceTexture) {
+        ScopedRestoreTextureBinding restoreBinding(GL::TEXTURE_BINDING_2D, GL::TEXTURE_2D);
+        GL_GenTextures(1, &sourceTexture);
+        if (!sourceTexture)
+            return false;
+        GL_BindTexture(GL_TEXTURE_2D, sourceTexture);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        GL_TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        void* pbuffer = createPbufferAndAttachIOSurface(GL_TEXTURE_2D, PbufferAttachmentUsage::Read, GL_BGRA_EXT, width, height, GL_UNSIGNED_BYTE, surface.get(), 0);
+        if (!pbuffer) {
+            GL_DeleteTextures(1, &sourceTexture);
+            return false;
+        }
+        m_nativeImageCopySources.insert(0, { surfaceID, pbuffer, sourceTexture, surface });
+        if (m_nativeImageCopySources.size() > maxCachedNativeImageCopySources) {
+            auto& evicted = m_nativeImageCopySources.last();
+            destroyPbufferAndDetachIOSurface(evicted.pbuffer);
+            GL_DeleteTextures(1, &evicted.texture);
+            m_nativeImageCopySources.removeLast();
+        }
+    }
+    if (destOffset)
+        GL_CopySubTextureCHROMIUM(sourceTexture, 0, destTarget, destId, destLevel, destOffset->x(), destOffset->y(), 0, 0, width, height, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha);
+    else
+        GL_CopyTextureCHROMIUM(sourceTexture, 0, destTarget, destId, destLevel, internalFormat, destType, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha);
+    // Destroying the image recycles its backing IOSurface to the pool, where it may be purged or
+    // overwritten by the next snapshot. Hold the image until the GPU has executed the copy.
+    insertFinishedSignalOrInvoke([image = Ref { image }] { });
+    return true;
+}
+
+void GraphicsContextGLCocoa::releaseNativeImageCopySources()
+{
+    for (auto& entry : m_nativeImageCopySources) {
+        destroyPbufferAndDetachIOSurface(entry.pbuffer);
+        GL_DeleteTextures(1, &entry.texture);
+    }
+    m_nativeImageCopySources.clear();
+}
 
 void GraphicsContextGLCocoa::prepareForDrawingBufferWrite()
 {

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp
@@ -96,6 +96,11 @@ RefPtr<NativeImage> RemoteSharedResourceCache::takeNativeImage(RenderingResource
     return m_nativeImages.take({ { identifier, 0 }, 0 }, defaultRemoteSharedResourceCacheTimeout);
 }
 
+RefPtr<NativeImage> RemoteSharedResourceCache::takeNativeImage(RenderingResourceIdentifier identifier, Seconds timeout)
+{
+    return m_nativeImages.take({ { identifier, 0 }, 0 }, timeout);
+}
+
 void RemoteSharedResourceCache::releaseSerializedImageBuffer(RemoteSerializedImageBufferIdentifier identifier)
 {
     // Must wait due to using current accounting mechanism.

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -62,6 +62,7 @@ public:
 
     bool addNativeImage(WebCore::RenderingResourceIdentifier, Ref<WebCore::NativeImage>);
     RefPtr<WebCore::NativeImage> takeNativeImage(WebCore::RenderingResourceIdentifier);
+    RefPtr<WebCore::NativeImage> takeNativeImage(WebCore::RenderingResourceIdentifier, Seconds timeout);
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -137,6 +137,11 @@ protected:
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&&);
 #endif
+#if PLATFORM(COCOA)
+    void copyTextureFromNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier, uint32_t destTarget, PlatformGLObject destId, int32_t destLevel, int32_t internalFormat, uint32_t destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha);
+    void copySubTextureFromNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier, uint32_t destTarget, PlatformGLObject destId, int32_t destLevel, uint32_t format, int32_t xoffset, int32_t yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha);
+    RefPtr<WebCore::NativeImage> takeSharedNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier);
+#endif
     void simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting);
     void getBufferSubDataInline(uint32_t target, uint64_t offset, uint64_t dataSize, CompletionHandler<void(std::span<const uint8_t>)>&&);
     void getBufferSubDataSharedMemory(uint32_t target, uint64_t offset, uint64_t dataSize, WebCore::SharedMemory::Handle, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -54,6 +54,10 @@ messages -> RemoteGraphicsContextGL Stream {
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
+#if PLATFORM(COCOA)
+    void CopyTextureFromNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier, uint32_t destTarget, PlatformGLObject destId, int32_t destLevel, int32_t internalFormat, uint32_t destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+    void CopySubTextureFromNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier, uint32_t destTarget, PlatformGLObject destId, int32_t destLevel, uint32_t format, int32_t xoffset, int32_t yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+#endif
     void SimulateEventForTesting(enum:uint8_t WebCore::GraphicsContextGLSimulatedEventForTesting event)
     void GetBufferSubDataInline(uint32_t target, uint64_t offset, uint64_t dataSize) -> (std::span<const uint8_t> data) Synchronous
     void GetBufferSubDataSharedMemory(uint32_t target, uint64_t offset, uint64_t dataSize, WebCore::SharedMemory::Handle handle) -> (bool valid) Synchronous NotStreamEncodable

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -31,6 +31,8 @@
 #include "GPUConnectionToWebProcess.h"
 #include "IPCUtilities.h"
 #include "RemoteSharedResourceCache.h"
+#include <WebCore/GraphicsContextGLCocoa.h>
+#include <WebCore/NativeImage.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/MachSendRight.h>
@@ -75,6 +77,56 @@ void RemoteGraphicsContextGL::setSharedVideoFrameMemory(WebCore::SharedMemory::H
     m_sharedVideoFrameReader.setSharedMemory(WTF::move(handle));
 }
 #endif
+
+RefPtr<WebCore::NativeImage> RemoteGraphicsContextGL::takeSharedNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier)
+{
+    assertIsCurrent(workQueue());
+    return m_sharedResourceCache->takeNativeImage(sharedImageIdentifier, 8_s);
+}
+
+void RemoteGraphicsContextGL::copyTextureFromNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier, uint32_t destTarget, PlatformGLObject destId, int32_t destLevel, int32_t internalFormat, uint32_t destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+    assertIsCurrent(workQueue());
+
+    RefPtr image = takeSharedNativeImage(sharedImageIdentifier);
+    if (!image)
+        return;
+
+    if (!m_objectNames.isValidKey(destId)) {
+        ASSERT_IS_TESTING_IPC();
+        return;
+    }
+    PlatformGLObject destTextureName = m_objectNames.get(destId);
+    if (!destTextureName)
+        return;
+
+    RefPtr context = m_context;
+    if (!context)
+        return;
+    context->copyTextureFromNativeImage(*image, destTarget, destTextureName, destLevel, internalFormat, destType, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha);
+}
+
+void RemoteGraphicsContextGL::copySubTextureFromNativeImage(WebCore::RenderingResourceIdentifier sharedImageIdentifier, uint32_t destTarget, PlatformGLObject destId, int32_t destLevel, uint32_t format, int32_t xoffset, int32_t yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+    assertIsCurrent(workQueue());
+
+    RefPtr image = takeSharedNativeImage(sharedImageIdentifier);
+    if (!image)
+        return;
+
+    if (!m_objectNames.isValidKey(destId)) {
+        ASSERT_IS_TESTING_IPC();
+        return;
+    }
+    PlatformGLObject destTextureName = m_objectNames.get(destId);
+    if (!destTextureName)
+        return;
+
+    RefPtr context = m_context;
+    if (!context)
+        return;
+    context->copySubTextureFromNativeImage(*image, destTarget, destTextureName, destLevel, format, xoffset, yoffset, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha);
+}
 
 namespace {
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -140,10 +140,10 @@ void RemoteImageBuffer::putPixelBuffer(const WebCore::PixelBufferSourceView& pix
     m_imageBuffer->putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
 }
 
-void RemoteImageBuffer::copyNativeImage(RenderingResourceIdentifier imageIdentifier)
+void RemoteImageBuffer::copyNativeImage(RenderingResourceIdentifier imageIdentifier, WebCore::NativeImageCopyMode mode)
 {
     assertIsCurrent(workQueue());
-    RefPtr image = m_imageBuffer->copyNativeImage();
+    RefPtr image = m_imageBuffer->copyNativeImage(mode);
     // FIXME: Handle OOM.
     MESSAGE_CHECK(image, "OOM");
     bool success = m_renderingBackend->remoteResourceCache().cacheNativeImage(imageIdentifier, image.releaseNonNull());

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -69,7 +69,7 @@ private:
     void getPixelBuffer(WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
     void getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
     void putPixelBuffer(const WebCore::PixelBufferSourceView&, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
-    void copyNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier);
+    void copyNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::NativeImageCopyMode);
     void filteredNativeImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();
     void transformToColorSpace(const WebCore::DestinationColorSpace&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -32,7 +32,7 @@ messages -> RemoteImageBuffer Stream {
     GetPixelBuffer(struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous
     GetPixelBufferWithNewMemory(WebCore::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous NotStreamEncodable
     PutPixelBuffer(WebCore::PixelBufferSourceView pixelBuffer, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat) StreamBatched
-    CopyNativeImage(WebCore::RenderingResourceIdentifier image)
+    CopyNativeImage(WebCore::RenderingResourceIdentifier image, enum:bool WebCore::NativeImageCopyMode mode)
     FilteredNativeImage(Ref<WebCore::Filter> filter) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     ConvertToLuminanceMask()
     TransformToColorSpace(WebCore::DestinationColorSpace colorSpace)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -409,6 +409,15 @@ void RemoteRenderingBackend::cacheNativeImageFromSharedNativeImage(WebCore::Rend
     MESSAGE_CHECK(success, "NativeImage already cached.");
 }
 
+void RemoteRenderingBackend::shareNativeImage(RenderingResourceIdentifier imageIdentifier, RenderingResourceIdentifier sharedImageIdentifier)
+{
+    assertIsCurrent(workQueue());
+    RefPtr image = m_remoteResourceCache.cachedNativeImage(imageIdentifier);
+    MESSAGE_CHECK(image, "NativeImage not found.");
+    bool success = m_sharedResourceCache->addNativeImage(sharedImageIdentifier, image.releaseNonNull());
+    MESSAGE_CHECK(success, "Shared NativeImage already exists.");
+}
+
 void RemoteRenderingBackend::releaseNativeImage(RenderingResourceIdentifier identifier)
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -162,6 +162,7 @@ private:
     void nativeImageBitmap(WebCore::RenderingResourceIdentifier imageIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>)>&&);
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheNativeImageFromSharedNativeImage(WebCore::RenderingResourceIdentifier);
+    void shareNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::RenderingResourceIdentifier sharedImageIdentifier);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
     void cachePathImpl(Ref<WebCore::PathImpl>&&, RemotePathImplIdentifier);
     void releasePathImpl(RemotePathImplIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -38,6 +38,7 @@ messages -> RemoteRenderingBackend Stream {
     NativeImageBitmap(WebCore::RenderingResourceIdentifier identifier) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     CacheNativeImageFromSharedNativeImage(WebCore::RenderingResourceIdentifier sharedNativeImageIdentifier)
+    ShareNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::RenderingResourceIdentifier sharedImageIdentifier)
     ReleaseNativeImage(WebCore::RenderingResourceIdentifier identifier)
     CachePathImpl(Ref<WebCore::PathImpl> path, WebKit::RemotePathImplIdentifier identifier)
     ReleasePathImpl(WebKit::RemotePathImplIdentifier identifier)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1349,6 +1349,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::ModalContainerControlType': ['<WebCore/ModalContainerTypes.h>'],
         'WebCore::ModalContainerDecision': ['<WebCore/ModalContainerTypes.h>'],
         'WebCore::MouseEventPolicy': ['<WebCore/DocumentLoader.h>'],
+        'WebCore::NativeImageCopyMode': ['<WebCore/ImageBufferBackend.h>'],
         'WebCore::NetworkTransactionInformation': ['<WebCore/NetworkLoadInformation.h>'],
         'WebCore::NavigationUpgradeToHTTPSBehavior': ['<WebCore/FrameLoaderTypes.h>'],
         'WebCore::NowPlayingMetadata': ['<WebCore/NowPlayingInfo.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -877,6 +877,9 @@ enum class WebCore::RenderingMode : uint8_t {
     DisplayList,
 };
 
+header: <WebCore/ImageBufferBackend.h>
+enum class WebCore::NativeImageCopyMode : bool;
+
 enum class WebCore::RenderingPurpose : uint8_t {
     Unspecified,
     Canvas,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -252,7 +252,78 @@ bool RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame(WebCore::VideoFrame
     return false;
 #endif
 }
+#endif // ENABLE(VIDEO)
 
+#if PLATFORM(COCOA)
+std::optional<WebCore::RenderingResourceIdentifier> RemoteGraphicsContextGLProxy::shareNativeImageForCopy(WebCore::NativeImage& image)
+{
+    if (isContextLost())
+        return std::nullopt;
+    RefPtr renderingBackend = m_renderingBackend.get();
+    if (!renderingBackend) [[unlikely]]
+        return std::nullopt;
+    if (!renderingBackend->remoteResourceCacheProxy().recordNativeImageUse(image, image.colorSpace()))
+        return std::nullopt;
+    auto sharedImageIdentifier = WebCore::RenderingResourceIdentifier::generate();
+    renderingBackend->shareNativeImage(image.renderingResourceIdentifier(), sharedImageIdentifier);
+    return sharedImageIdentifier;
+}
+#endif
+
+bool RemoteGraphicsContextGLProxy::copyTextureFromNativeImage(WebCore::NativeImage& image, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLint internalFormat, GCGLenum destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+#if PLATFORM(COCOA)
+    auto sharedImageIdentifier = shareNativeImageForCopy(image);
+    if (!sharedImageIdentifier)
+        return false;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTextureFromNativeImage(*sharedImageIdentifier, destTarget, destId, destLevel, internalFormat, destType, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha));
+    if (sendResult != IPC::Error::NoError) [[unlikely]] {
+        markContextLost();
+        return false;
+    }
+    return true;
+#else
+    UNUSED_PARAM(image);
+    UNUSED_PARAM(destTarget);
+    UNUSED_PARAM(destId);
+    UNUSED_PARAM(destLevel);
+    UNUSED_PARAM(internalFormat);
+    UNUSED_PARAM(destType);
+    UNUSED_PARAM(unpackFlipY);
+    UNUSED_PARAM(unpackPremultiplyAlpha);
+    UNUSED_PARAM(unpackUnmultiplyAlpha);
+    return false;
+#endif
+}
+
+bool RemoteGraphicsContextGLProxy::copySubTextureFromNativeImage(WebCore::NativeImage& image, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLenum format, GCGLint xoffset, GCGLint yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha)
+{
+#if PLATFORM(COCOA)
+    auto sharedImageIdentifier = shareNativeImageForCopy(image);
+    if (!sharedImageIdentifier)
+        return false;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopySubTextureFromNativeImage(*sharedImageIdentifier, destTarget, destId, destLevel, format, xoffset, yoffset, unpackFlipY, unpackPremultiplyAlpha, unpackUnmultiplyAlpha));
+    if (sendResult != IPC::Error::NoError) [[unlikely]] {
+        markContextLost();
+        return false;
+    }
+    return true;
+#else
+    UNUSED_PARAM(image);
+    UNUSED_PARAM(destTarget);
+    UNUSED_PARAM(destId);
+    UNUSED_PARAM(destLevel);
+    UNUSED_PARAM(format);
+    UNUSED_PARAM(xoffset);
+    UNUSED_PARAM(yoffset);
+    UNUSED_PARAM(unpackFlipY);
+    UNUSED_PARAM(unpackPremultiplyAlpha);
+    UNUSED_PARAM(unpackUnmultiplyAlpha);
+    return false;
+#endif
+}
+
+#if ENABLE(VIDEO)
 RefPtr<Image> RemoteGraphicsContextGLProxy::videoFrameToImage(WebCore::VideoFrame& frame)
 {
     if (isContextLost())

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -39,6 +39,7 @@
 #include <WebCore/GCGLSpan.h>
 #include <WebCore/GraphicsContextGL.h>
 #include <WebCore/NotImplemented.h>
+#include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/WeakPtr.h>
 
@@ -99,6 +100,11 @@ public:
 #if ENABLE(VIDEO)
     bool copyTextureFromVideoFrame(WebCore::VideoFrame&, PlatformGLObject texture, GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLenum format, GCGLenum type , bool premultiplyAlpha, bool flipY) final;
     RefPtr<WebCore::Image> videoFrameToImage(WebCore::VideoFrame&) final;
+#endif
+    bool copyTextureFromNativeImage(WebCore::NativeImage&, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLint internalFormat, GCGLenum destType, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha) final;
+    bool copySubTextureFromNativeImage(WebCore::NativeImage&, GCGLenum destTarget, PlatformGLObject destId, GCGLint destLevel, GCGLenum format, GCGLint xoffset, GCGLint yoffset, bool unpackFlipY, bool unpackPremultiplyAlpha, bool unpackUnmultiplyAlpha) final;
+#if PLATFORM(COCOA)
+    std::optional<WebCore::RenderingResourceIdentifier> shareNativeImageForCopy(WebCore::NativeImage&);
 #endif
 
     void simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -274,12 +274,17 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackend() const
 
 RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage() const
 {
+    return copyNativeImage(NativeImageCopyMode::CopyOnWrite);
+}
+
+RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage(NativeImageCopyMode mode) const
+{
     auto* backend = ensureBackend();
     if (!backend)
         return nullptr;
-    if (backend->canMapBackingStore()) {
+    if (mode == NativeImageCopyMode::CopyOnWrite && backend->canMapBackingStore()) {
         const_cast<RemoteImageBufferProxy*>(this)->flushDrawingContext();
-        return ImageBuffer::copyNativeImage();
+        return ImageBuffer::copyNativeImage(mode);
     }
     RefPtr renderingBackend = m_renderingBackend.get();
     if (!renderingBackend) [[unlikely]]
@@ -289,7 +294,7 @@ RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage() const
     // This read-back bypasses flushDrawingContext(), so send any buffered line
     // strokes into the stream before the (in-order) CopyNativeImage message.
     sendPendingDrawsIfNecessary();
-    const_cast<RemoteImageBufferProxy*>(this)->send(Messages::RemoteImageBuffer::CopyNativeImage(nativeImage->renderingResourceIdentifier()));
+    const_cast<RemoteImageBufferProxy*>(this)->send(Messages::RemoteImageBuffer::CopyNativeImage(nativeImage->renderingResourceIdentifier(), mode));
     return nativeImage;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -92,6 +92,7 @@ private:
     RemoteImageBufferProxy(Parameters, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&);
 
     RefPtr<WebCore::NativeImage> copyNativeImage() const final;
+    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::NativeImageCopyMode) const final;
     RefPtr<WebCore::NativeImage> createNativeImageReference() const final;
     bool isRemoteImageBufferProxy() const final { return true; }
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -421,6 +421,11 @@ void RemoteRenderingBackendProxy::cacheNativeImageFromSharedNativeImage(const Re
     send(Messages::RemoteRenderingBackend::CacheNativeImageFromSharedNativeImage(image.renderingResourceIdentifier()));
 }
 
+void RemoteRenderingBackendProxy::shareNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::RenderingResourceIdentifier sharedImageIdentifier)
+{
+    send(Messages::RemoteRenderingBackend::ShareNativeImage(imageIdentifier, sharedImageIdentifier));
+}
+
 void RemoteRenderingBackendProxy::releaseNativeImage(RenderingResourceIdentifier identifier)
 {
     if (!m_connection)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -119,6 +119,7 @@ public:
     RefPtr<WebCore::ShareableBitmap> nativeImageBitmap(const RemoteNativeImageProxy&);
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheNativeImageFromSharedNativeImage(const RemoteNativeImageProxy&);
+    void shareNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::RenderingResourceIdentifier sharedImageIdentifier);
     void releaseNativeImage(WebCore::RenderingResourceIdentifier);
     void cachePathImpl(Ref<WebCore::PathImpl>&&, RemotePathImplIdentifier);
     void releasePathImpl(RemotePathImplIdentifier);


### PR DESCRIPTION
GPU fast path for uploading a 2D canvas into a WebGL texture
https://bugs.webkit.org/show_bug.cgi?id=315417

Reviewed by NOBODY (OOPS!).

texImage2D() and texSubImage2D() with a 2D-context HTMLCanvasElement currently
copy the canvas back into system memory and re-upload it, and that readback
dominates the cost of the call.

At Lumen5 we composite in a 2D canvas and upload the result into a WebGL scene -
for example we render Lottie animations on a 2D canvas and show the output on a
WebGL scene. The readback is slow enough to drop frames even on the latest Apple
devices; we currently work around it by uploading smaller textures, at a visible
cost to quality.

When the source canvas is backed by an IOSurface, this copies it directly into
the destination texture on the GPU with no system-memory readback, which makes
these uploads roughly 40x faster in our workload (measured on an M1 Pro). It
falls back to the existing readback path whenever it cannot apply, so observable
behavior is unchanged.

A live demo and benchmark is available at:
https://stepancar.github.io/articles/articles/canvas2d-to-webgl-upload-performance/demo/index.html

* LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html: Added.
* LayoutTests/fast/canvas/webgl/texImage2D-canvas2d-fast-path.html: Added.
* PerformanceTests/Canvas/texImage2DCanvas2D.html: Added.
* PerformanceTests/Canvas/texSubImage2DCanvas2D.html: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource): Take the GPU fast path for
an IOSurface-backed 2D canvas; fall through to the readback path otherwise.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5dbf44827afbd8180d048ef79836b71f98ac5ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136677 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96206 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117155 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/174857 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38738 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37125 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36929 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33594 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187544 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49812 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33553 "Found 5 new test failures: fast/canvas/webgl/canvas-2d-webgl-texture.html fast/canvas/webgl/tex-image-and-sub-image-2d-with-canvas.html fast/canvas/webgl/texImage2D-canvas2d-fast-path-fallbacks.html fast/canvas/webgl/texImage2D-canvas2d-fast-path.html fast/canvas/webgl/texture-active-bind.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145483 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40303 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122005 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/115774 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48319 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11905 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/47951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->