### PR TITLE
Cross-Origin Iframe Can Read Clipboard via Top-Level User Interaction in Safari

### DIFF
--- a/LayoutTests/editing/async-clipboard/clipboard-change-data-while-getting-type.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-change-data-while-getting-type.html
@@ -14,7 +14,7 @@
             description("This test verifies that if platform pasteboard contents are changed before reading from a ClipboardItem, the new contents of the pasteboard should not be exposed to the page and the result of getType() should be rejected. This test requires WebKitTestRunner.");
 
             await UIHelper.copyText("Foo");
-            items = await navigator.clipboard.read();
+            items = await readClipboardWithUserActivation();
             shouldBe("items.length", "1");
             await UIHelper.copyText("Bar");
             try {

--- a/LayoutTests/editing/async-clipboard/clipboard-get-type-with-old-items.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-get-type-with-old-items.html
@@ -14,7 +14,7 @@
             description("This test verifies that it's still possible to read from the clipboard, after attempting to read data from stale items. Requires DumpRenderTree or WebKitTestRunner.");
 
             await UIHelper.copyText("Hello");
-            itemsBeforeChange = await navigator.clipboard.read();
+            itemsBeforeChange = await readClipboardWithUserActivation();
             shouldBe("itemsBeforeChange.length", "1");
 
             try {
@@ -26,7 +26,7 @@
             }
 
             await UIHelper.copyText("World");
-            itemsAfterChange = await navigator.clipboard.read();
+            itemsAfterChange = await readClipboardWithUserActivation();
             shouldBe("itemsAfterChange.length", "1");
 
             try {

--- a/LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js
+++ b/LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js
@@ -99,3 +99,29 @@ async function checkClipboardItemString(item, type, expectedString)
     else
         testFailed(`getType("${type}") resolved to "${observedString}; expected "${expectedString}"`);
 }
+
+// Calls navigator.clipboard.read() with a fresh user activation, as required by the W3C
+// Clipboard API spec. Adds a transient button to the document, activates it, and reads the
+// clipboard while the relevant global object has transient activation.
+async function readClipboardWithUserActivation()
+{
+    const button = document.createElement("button");
+    button.textContent = "Read clipboard";
+    document.body.appendChild(button);
+
+    // Wait for the freshly-added button to be committed to the UI process's layer tree
+    // before tapping it. Otherwise, on iOS the tap gesture may hit-test before the render
+    // tree update is committed, miss the button, and cause the test to time out waiting for
+    // the click that never arrives.
+    await UIHelper.ensurePresentationUpdate();
+
+    const clicked = new Promise(resolve => button.addEventListener("click", resolve, { once: true }));
+    UIHelper.activateElement(button);
+    await clicked;
+
+    try {
+        return await navigator.clipboard.read();
+    } finally {
+        button.remove();
+    }
+}

--- a/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied-expected.txt
+++ b/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied-expected.txt
@@ -1,0 +1,21 @@
+Verifies that a cross-origin iframe cannot read or write the clipboard by consuming transient user activation from the top-level page via postMessage. navigator.clipboard.readText(), navigator.clipboard.read(), navigator.clipboard.writeText(), and navigator.clipboard.write() in the iframe should all be rejected with NotAllowedError because transient activation does not propagate to cross-origin iframes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Result for navigator.clipboard.readText():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+Result for navigator.clipboard.read():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+Result for navigator.clipboard.writeText():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+Result for navigator.clipboard.write():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html
+++ b/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncClipboardAPIEnabled=true JavaScriptCanAccessClipboard=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="/resources/js-test-pre.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<style>
+button, iframe {
+    display: block;
+    width: 400px;
+    height: 100px;
+}
+</style>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<button id="run">Click to postMessage clipboard request to cross-origin iframe</button>
+<iframe id="frame" src="http://localhost:8080/security/clipboard/resources/clipboard-access-from-iframe.html"></iframe>
+<script>
+description("Verifies that a cross-origin iframe cannot read or write the clipboard by consuming transient user activation from the top-level page via postMessage. navigator.clipboard.readText(), navigator.clipboard.read(), navigator.clipboard.writeText(), and navigator.clipboard.write() in the iframe should all be rejected with NotAllowedError because transient activation does not propagate to cross-origin iframes.");
+jsTestIsAsync = true;
+
+const frame = document.getElementById("frame");
+const runButton = document.getElementById("run");
+
+let pendingMethod = null;
+let pendingResolve = null;
+
+runButton.addEventListener("click", () => {
+    frame.contentWindow.postMessage({ method: pendingMethod }, "*");
+});
+
+async function testMethod(method) {
+    pendingMethod = method;
+    const result = await new Promise(resolve => {
+        pendingResolve = resolve;
+        UIHelper.activateElement(runButton);
+    });
+    window.iframeStatus = result.status;
+    window.iframeErrorName = result.errorName;
+    debug(`Result for navigator.clipboard.${method}():`);
+    shouldBeEqualToString("iframeStatus", "rejected");
+    shouldBeEqualToString("iframeErrorName", "NotAllowedError");
+}
+
+window.addEventListener("message", async event => {
+    if (!event.data)
+        return;
+
+    if (event.data.type === "iframe-loaded") {
+        if (!window.testRunner)
+            return;
+        await testMethod("readText");
+        await testMethod("read");
+        await testMethod("writeText");
+        await testMethod("write");
+        runButton.remove();
+        frame.remove();
+        finishJSTest();
+        return;
+    }
+
+    if (event.data.type === "iframe-result" && pendingResolve) {
+        const resolve = pendingResolve;
+        pendingResolve = null;
+        resolve(event.data);
+    }
+});
+</script>
+<script src="/resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/clipboard/resources/clipboard-access-from-iframe.html
+++ b/LayoutTests/http/tests/security/clipboard/resources/clipboard-access-from-iframe.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+async function invoke(method) {
+    switch (method) {
+    case "readText":
+        return navigator.clipboard.readText();
+    case "read":
+        return navigator.clipboard.read();
+    case "writeText":
+        return navigator.clipboard.writeText("iframe-written text");
+    case "write": {
+        const blob = new Blob(["iframe-written text"], { type: "text/plain" });
+        return navigator.clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+    }
+    }
+    throw new Error(`unknown method: ${method}`);
+}
+
+window.addEventListener("message", async event => {
+    if (!event.data)
+        return;
+
+    const method = event.data.method;
+    let result;
+    try {
+        await invoke(method);
+        result = { type: "iframe-result", method, status: "resolved" };
+    } catch (err) {
+        result = { type: "iframe-result", method, status: "rejected", errorName: err.name };
+    }
+    parent.postMessage(result, "*");
+});
+
+parent.postMessage({ type: "iframe-loaded" }, "*");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https-expected.txt
@@ -1,6 +1,8 @@
+Body needed for test_driver.click()
 
 PASS navigator.clipboard exists
 PASS navigator.clipboard.write([text/plain ClipboardItem]) succeeds
+FAIL navigator.clipboard.write([>1 ClipboardItems]) fails (not implemented) assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS navigator.clipboard.write() fails (expect [ClipboardItem])
 PASS navigator.clipboard.write(null) fails (expect [ClipboardItem])
 PASS navigator.clipboard.write(DOMString) fails (expect [ClipboardItem])
@@ -15,6 +17,6 @@ FAIL navigator.clipboard.write(image/png DOMString) fails promise_rejects_js: fu
 }" ("TypeError")
 PASS navigator.clipboard.read() succeeds
 PASS navigator.clipboard.readText() succeeds
-FAIL navigator.clipboard.write(Promise<Blob>) succeeds promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: getPermissions"
-FAIL navigator.clipboard.write(Promise<Blob>s) succeeds promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: getPermissions"
+PASS navigator.clipboard.write(Promise<Blob>) succeeds
+PASS navigator.clipboard.write(Promise<Blob>s) succeeds
 

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html
@@ -2,9 +2,21 @@
 <meta charset="utf-8">
 <title>Async Clipboard input type validation tests</title>
 <link rel="help" href="https://w3c.github.io/clipboard-apis/#async-clipboard-api">
+<body>Body needed for test_driver.click()</body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/user-activation.js"></script>
 <script>
+
+// Permissions are required in order to invoke navigator.clipboard functions in
+// an automated test.
+async function getPermissions() {
+  await tryGrantReadPermission();
+  await tryGrantWritePermission();
+  await waitForUserActivation();
+}
 
 test(() => {
   assert_not_equals(navigator.clipboard, undefined);
@@ -13,6 +25,7 @@ test(() => {
 }, 'navigator.clipboard exists');
 
 promise_test(async () => {
+  await getPermissions();
   const blob = new Blob(['hello'], {type: 'text/plain'});
   const item = new ClipboardItem({'text/plain': blob});
 
@@ -20,38 +33,58 @@ promise_test(async () => {
 }, 'navigator.clipboard.write([text/plain ClipboardItem]) succeeds');
 
 promise_test(async t => {
+  await getPermissions();
+  const blob1 = new Blob(['hello'], {type: 'text/plain'});
+  const blob2 = new Blob(['world'], {type: 'text/plain'});
+
+  const item1 = new ClipboardItem({'text/plain': blob1});
+  const item2 = new ClipboardItem({'text/plain': blob2});
+
+  await promise_rejects_dom(t, "NotAllowedError",
+      navigator.clipboard.write([item1, item2]));
+}, 'navigator.clipboard.write([>1 ClipboardItems]) fails (not implemented)');
+
+promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError, navigator.clipboard.write());
 }, 'navigator.clipboard.write() fails (expect [ClipboardItem])');
 
 promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError, navigator.clipboard.write(null));
 }, 'navigator.clipboard.write(null) fails (expect [ClipboardItem])');
 
 promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError,
-                         navigator.clipboard.write('Bad string'));
+                           navigator.clipboard.write('Bad string'));
 }, 'navigator.clipboard.write(DOMString) fails (expect [ClipboardItem])');
 
 promise_test(async t => {
+  await getPermissions();
   const blob = new Blob(['hello'], {type: 'text/plain'});
   await promise_rejects_js(t, TypeError, navigator.clipboard.write(blob));
 }, 'navigator.clipboard.write(Blob) fails (expect [ClipboardItem])');
 
 promise_test(async () => {
+  await getPermissions();
   await navigator.clipboard.writeText('New clipboard text');
 }, 'navigator.clipboard.writeText(DOMString) succeeds');
 
 promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError,
-                         navigator.clipboard.writeText());
+                           navigator.clipboard.writeText());
 }, 'navigator.clipboard.writeText() fails (expect DOMString)');
 
 promise_test(async () => {
+  await getPermissions();
   const item = new ClipboardItem({'text/plain': 'test'});
   await navigator.clipboard.write([item]);
 }, 'navigator.clipboard.write({string : DOMString}) succeeds');
 
 promise_test(async () => {
+  await getPermissions();
   const fetched = await fetch('/clipboard-apis/resources/greenbox.png');
   const image = await fetched.blob();
   const item = new ClipboardItem({'image/png': image});
@@ -60,6 +93,7 @@ promise_test(async () => {
 }, 'navigator.clipboard.write({string : image/png Blob}) succeeds');
 
 promise_test(async() => {
+  await getPermissions();
   const fetched = await fetch('/clipboard-apis/resources/greenbox.png');
   const image = await fetched.blob();
   const item = new ClipboardItem({
@@ -70,17 +104,20 @@ promise_test(async() => {
 }, 'navigator.clipboard.write([text + png] succeeds');
 
 promise_test(async t => {
+  await getPermissions();
   const item = new ClipboardItem({'image/png': 'not an image'});
   await promise_rejects_js(t, TypeError, navigator.clipboard.write([item]));
 }, 'navigator.clipboard.write(image/png DOMString) fails');
 
 promise_test(async () => {
+  await getPermissions();
   const result = await navigator.clipboard.read();
   assert_true(result instanceof Object);
   assert_true(result[0] instanceof ClipboardItem);
 }, 'navigator.clipboard.read() succeeds');
 
 promise_test(async () => {
+  await getPermissions();
   const result = await navigator.clipboard.readText();
   assert_equals(typeof result, 'string');
 }, 'navigator.clipboard.readText() succeeds');

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/resources/user-activation.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/resources/user-activation.js
@@ -23,3 +23,33 @@ async function waitForUserActivation() {
   test_driver.click(document.body);
   await clickedPromise;
 }
+
+async function trySetPermission(perm, state) {
+  try {
+    await test_driver.set_permission({ name: perm }, state)
+  } catch {
+    // This is expected, as clipboard permissions are not supported by every engine
+    // and also the set_permission. The permission is not required by such engines as
+    // they require user activation instead.
+  }
+}
+
+async function tryGrantReadPermission() {
+  await trySetPermission("clipboard-read", "granted");
+}
+
+async function tryGrantWritePermission() {
+  await trySetPermission("clipboard-write", "granted");
+}
+
+async function sendPasteShortcutKey() {
+  const modifier = navigator.platform.includes("Mac") ? "\uE03d" // META
+                                                      : "\uE009"; // CONTROL
+  await new test_driver.Actions()
+    .keyDown(modifier)
+    .keyDown("v")
+    .keyUp("v")
+    .keyUp(modifier)
+    .send();
+}
+

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -42,6 +42,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMPromiseDeferred.h"
+#include "LocalDOMWindow.h"
 #include "LocalFrameInlines.h"
 #include "Navigator.h"
 #include "PagePasteboardContext.h"
@@ -49,7 +50,6 @@
 #include "Settings.h"
 #include "SharedBuffer.h"
 #include "TaskSource.h"
-#include "UserGestureIndicator.h"
 #include "WebContentReader.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -57,6 +57,22 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Clipboard);
+
+// https://w3c.github.io/clipboard-apis/ requires the relevant global object to have transient
+// activation. Transient activation is not propagated to cross-origin iframes, so a user
+// interaction on a top-level page cannot be used by a cross-origin iframe to access the
+// clipboard via postMessage.
+static bool frameHasTransientActivation(const LocalFrame& frame)
+{
+    RefPtr window = frame.window();
+    return window && window->hasTransientActivation();
+}
+
+static bool documentHasTransientActivation(const Document& document)
+{
+    RefPtr window = document.window();
+    return window && window->hasTransientActivation();
+}
 
 static bool shouldProceedWithClipboardWrite(const LocalFrame& frame)
 {
@@ -68,7 +84,7 @@ static bool shouldProceedWithClipboardWrite(const LocalFrame& frame)
     case ClipboardAccessPolicy::Allow:
         return true;
     case ClipboardAccessPolicy::RequiresUserGesture:
-        return UserGestureIndicator::processingUserGesture();
+        return frameHasTransientActivation(frame);
     case ClipboardAccessPolicy::Deny:
         return false;
     }
@@ -112,7 +128,7 @@ void Clipboard::readText(Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();
     RefPtr document = frame ? frame->document() : nullptr;
-    if (!document) {
+    if (!document || !documentHasTransientActivation(*document)) {
         promise->reject(ExceptionCode::NotAllowedError);
         return;
     }
@@ -178,7 +194,7 @@ void Clipboard::read(Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();
     RefPtr document = frame ? frame->document() : nullptr;
-    if (!document) {
+    if (!document || !documentHasTransientActivation(*document)) {
         m_activeSession = std::nullopt;
         promise->reject(ExceptionCode::NotAllowedError);
         return;


### PR DESCRIPTION
#### 73645abad282e4903019e36d01c753145fd79a14
<pre>
Cross-Origin Iframe Can Read Clipboard via Top-Level User Interaction in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=314806">https://bugs.webkit.org/show_bug.cgi?id=314806</a>
<a href="https://rdar.apple.com/176023893">rdar://176023893</a>

Reviewed by Ryosuke Niwa.

navigator.clipboard.readText(), read(), writeText(), and write() relied on WebKit&apos;s
legacy UserGestureIndicator for activation checks (directly for writes, via
LocalFrame::requestDOMPasteAccess() for reads). LocalDOMWindow::processPostMessage
explicitly forwards the active UserGestureToken into the receiving iframe&apos;s event
handler, so a user click on a top-level page let a cross-origin iframe see &quot;processing
a user gesture&quot; and access the clipboard. This violates the W3C Clipboard API spec,
which requires transient activation on the relevant global object.

Fix this by checking LocalDOMWindow::hasTransientActivation() at the entry point of
each clipboard method. Transient activation is a property of the window and only
propagates to ancestor frames and same-origin descendant frames -- it is never
propagated to cross-origin descendants via postMessage. This matches the behavior of
Blink and Firefox.

Test: http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html

* LayoutTests/editing/async-clipboard/clipboard-change-data-while-getting-type.html:
* LayoutTests/editing/async-clipboard/clipboard-get-type-with-old-items.html:
* LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js:
Fix existing tests so they keep passing.

* LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied-expected.txt: Added.
* LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html: Added.
* LayoutTests/http/tests/security/clipboard/resources/clipboard-access-from-iframe.html: Added.
New test coverage.

* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html:
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/resources/user-activation.js:
Resync existing WPT test so it keeps passing.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::frameHasTransientActivation):
(WebCore::shouldProceedWithClipboardWrite):
(WebCore::Clipboard::readText):
(WebCore::Clipboard::read):

Originally-landed-as: 305413.908@safari-7624-branch (526ac3579021). <a href="https://rdar.apple.com/180436853">rdar://180436853</a>
Canonical link: <a href="https://commits.webkit.org/316338@main">https://commits.webkit.org/316338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a14a2580a191ceece03ebebc83e9d16316f7aa02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35691 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33953 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29876 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183794 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142378 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38440 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46087 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110861 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37365 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117775 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44605 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->