### PR TITLE
[WebXR] Use-after-free when ending an XRSession whose owning WebXRSystem has been garbage collected

### DIFF
--- a/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt
+++ b/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html
+++ b/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.internals)
+    internals.settings.setWebXREnabled(true);
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function forceGC()
+{
+    if (window.GCController)
+        GCController.collect();
+}
+
+async function run()
+{
+    let iframe = document.createElement('iframe');
+    iframe.srcdoc = '<!DOCTYPE html><body>child</body>';
+    document.body.appendChild(iframe);
+    await new Promise(resolve => { iframe.onload = resolve; });
+
+    let childXR = iframe.contentWindow.navigator.xr;
+
+    // Call the parent realm's requestSession on the child's XRSystem so that
+    // the resulting XRSession's wrapper lives in the parent realm while the
+    // owning WebXRSystem belongs to the child realm.
+    let session;
+    try {
+        session = await XRSystem.prototype.requestSession.call(childXR, 'inline');
+    } catch (e) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    childXR = null;
+    iframe.remove();
+    iframe = null;
+
+    // Allow the child realm's JSDOMWindow / Navigator / WebXRSystem to be
+    // collected, leaving the session with a stale back-reference.
+    for (let i = 0; i < 3; ++i) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        forceGC();
+    }
+
+    try {
+        await session.end();
+    } catch (e) {
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+run();
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 1d46772984f6a2857ade7cd1e2e93d04ab37780f
<pre>
[WebXR] Use-after-free when ending an XRSession whose owning WebXRSystem has been garbage collected
<a href="https://rdar.apple.com/175674872">rdar://175674872</a>

Reviewed by REVIEWER.

WebXRSession held a raw reference (WebXRSystem&amp;) to its owning WebXRSystem.
When a session&apos;s wrapper lives in one realm but the XRSystem belongs to a
cross-realm iframe (e.g. via XRSystem.prototype.requestSession.call(childXR, ...)),
destroying the iframe can collect the child realm&apos;s JSDOMWindow / Navigator /
WebXRSystem while the parent-realm XRSession is still alive. Calling
session.end() then dereferences the stale pointer in shutdown() when it calls
m_xrSystem.sessionEnded(*this).

Fix by changing m_xrSystem from a raw reference to a
WeakPtr&lt;WebXRSystem, WeakPtrImplWithEventTargetData&gt; and guarding the
sessionEnded() call with a null check.

Test: webxr/xr-session-end-after-cross-realm-system-gc.html

* LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt: Added.

Originally-landed-as: 305413.844@safari-7624-branch (99867d817a6d). <a href="https://rdar.apple.com/180436711">rdar://180436711</a>
* LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html: Added.

Canonical link: <a href="https://commits.webkit.org/316209@main">https://commits.webkit.org/316209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5946bcc6c3c43c4b0e7a141b3af3c484df3d5c66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128804 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133411 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113879 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35241 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33566 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29148 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183053 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141869 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141678 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38326 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45359 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110064 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36932 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43870 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->