### PR TITLE
[CoreIPC] [GPUP] off-main-thread ~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit mutates unlocked AudioSession interruption-observer WeakHashSet

### DIFF
--- a/LayoutTests/fast/mediastream/delete-audio-unit-expected.txt
+++ b/LayoutTests/fast/mediastream/delete-audio-unit-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Delete a running audio unit without stopping it
+

--- a/LayoutTests/fast/mediastream/delete-audio-unit.html
+++ b/LayoutTests/fast/mediastream/delete-audio-unit.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" controls autoplay=""></video>
+        <script>
+promise_test(async () => {
+    internals?.setPageMediaVolume(0.01);
+
+    const context = new AudioContext();
+    const oscillator = context.createOscillator();
+    const streamDestination = context.createMediaStreamDestination();
+    oscillator.connect(streamDestination);
+    oscillator.start();
+
+    video.srcObject = streamDestination.stream;
+    await video.play();
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    internals?.deleteAudioUnit();
+    internals?.setPageMediaVolume(0);
+    await new Promise(resolve => setTimeout(resolve, 100));
+}, "Delete a running audio unit without stopping it");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -59,6 +59,7 @@ public:
     virtual void close() { };
     virtual void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&) = 0;
     virtual void setLastDeviceUsed(const String&) { }
+    virtual void deleteUnitForTesting() { }
 };
 
 }

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -142,6 +142,14 @@ void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHand
     unit->retrieveFormatDescription(WTF::move(callback));
 }
 
+void AudioMediaStreamTrackRendererUnit::deleteUnitForTesting()
+{
+    assertIsMainThread();
+
+    Ref unit = ensureDeviceUnit(AudioMediaStreamTrackRenderer::defaultDeviceID());
+    unit->deleteUnitForTesting();
+}
+
 AudioMediaStreamTrackRendererUnit::Unit::Unit(const String& deviceID)
     : m_internalUnit(AudioMediaStreamTrackRendererInternalUnit::create(deviceID, *this))
     , m_isDefaultUnit(deviceID == AudioMediaStreamTrackRenderer::defaultDeviceID())
@@ -212,6 +220,12 @@ void AudioMediaStreamTrackRendererUnit::Unit::setLastDeviceUsed(const String& de
 {
     assertIsMainThread();
     m_internalUnit->setLastDeviceUsed(deviceID);
+}
+
+void AudioMediaStreamTrackRendererUnit::Unit::deleteUnitForTesting()
+{
+    assertIsMainThread();
+    m_internalUnit->deleteUnitForTesting();
 }
 
 void AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -63,6 +63,8 @@ public:
     void removeSource(const String&, AudioSampleDataSource&) final;
     void addResetObserver(const String&, ResetObserver&) final;
 
+    WEBCORE_EXPORT void deleteUnitForTesting();
+
 private:
     AudioMediaStreamTrackRendererUnit();
 
@@ -87,6 +89,7 @@ private:
         void close();
         void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&);
         void setLastDeviceUsed(const String&);
+        void deleteUnitForTesting();
 
     private:
         explicit Unit(const String&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -346,6 +346,9 @@
 #endif
 
 #if ENABLE(MEDIA_STREAM)
+#if PLATFORM(COCOA)
+#include "AudioMediaStreamTrackRendererUnit.h"
+#endif
 #include "MediaStream.h"
 #include "MockRealtimeMediaSourceCenter.h"
 #include "VideoFrame.h"
@@ -6906,6 +6909,13 @@ bool Internals::supportsMultiMicrophoneCaptureWithoutEchoCancellation() const
     return true;
 #else
     return false;
+#endif
+}
+
+void Internals::deleteAudioUnit()
+{
+#if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
+    AudioMediaStreamTrackRendererUnit::singleton().deleteUnitForTesting();
 #endif
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1109,6 +1109,7 @@ public:
     bool NODELETE isMediaStreamSourceEnded(MediaStreamTrack&) const;
     bool NODELETE isMockRealtimeMediaSourceCenterEnabled();
     bool NODELETE shouldAudioTrackPlay(const AudioTrack&);
+    void deleteAudioUnit();
 #endif // ENABLE(MEDIA_STREAM)
 #if ENABLE(WEB_RTC)
     String rtcNetworkInterfaceName() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1268,6 +1268,7 @@ enum ContentsFormat {
     [Conditional=MEDIA_STREAM] DOMString mediaStreamTrackPersistentId(MediaStreamTrack track);
     [Conditional=MEDIA_STREAM] unsigned long audioCaptureSourceCount();
     [Conditional=MEDIA_STREAM] boolean supportsMultiMicrophoneCaptureWithoutEchoCancellation();
+    [Conditional=MEDIA_STREAM] undefined deleteAudioUnit();
 
     [Conditional=WEB_RTC] readonly attribute DOMString rtcNetworkInterfaceName;
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -136,8 +136,11 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::createUnit(AudioMed
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 {
-    if (!m_units.remove(identifier))
+    RefPtr unit = m_units.take(identifier);
+    if (!unit)
         return;
+
+    unit->stop();
 
     if (m_units.isEmpty()) {
         if (auto connection = m_gpuConnectionToWebProcess.get())
@@ -200,6 +203,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
     , m_localUnit(WebCore::AudioMediaStreamTrackRendererInternalUnit::create(deviceID, *this))
     , m_canUseCaptureUnit(deviceID == WebCore::AudioMediaStreamTrackRenderer::defaultDeviceID())
 {
+    ASSERT(isMainRunLoop());
     protect(m_localUnit)->retrieveFormatDescription([weakThis = ThreadSafeWeakPtr { *this }, this, callback = WTF::move(callback)](auto&& description) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !description) {
@@ -216,6 +220,8 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStre
 
 RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit()
 {
+    ASSERT(isMainRunLoop());
+    ASSERT(!m_isPlaying);
     stop();
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -76,6 +76,7 @@ private:
 
     void retrieveFormatDescription(CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>)>&&) final;
     void setLastDeviceUsed(const String&) final;
+    void deleteUnitForTesting() final;
 
     void initialize(const WebCore::CAAudioStreamDescription&, size_t frameChunkSize);
     void storageChanged(WebCore::SharedMemory*, const WebCore::CAAudioStreamDescription&, size_t);
@@ -229,6 +230,11 @@ void AudioMediaStreamTrackRendererInternalUnitManagerProxy::retrieveFormatDescri
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::setLastDeviceUsed(const String& deviceID)
 {
     WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::SetLastDeviceUsed { deviceID }, 0);
+}
+
+void AudioMediaStreamTrackRendererInternalUnitManagerProxy::deleteUnitForTesting()
+{
+    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::DeleteUnit { identifier() }, 0);
 }
 
 void AudioMediaStreamTrackRendererInternalUnitManagerProxy::stopThread()


### PR DESCRIPTION
#### a9c37a133ad499b796b891cdfed52783586bc28c
<pre>
[CoreIPC] [GPUP] off-main-thread ~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit mutates unlocked AudioSession interruption-observer WeakHashSet
<a href="https://rdar.apple.com/175520451">rdar://175520451</a>

Reviewed by Jean-Yves Avenard.

If WebProcess sends an IPC message to delete unit while it is running, the unit may be destroyed in the rendering thread.
This will cause it to unregister itself from the AudioSession observer map, which is not thread safe and supposed to only happen in main thread.
To prevent this, we make sure that deleting the unit will stop the unit. This will prevent the rendering thread to have the last ref of the unit.

We add an internals API to trigger deleting a unit that is playing.

* LayoutTests/fast/mediastream/delete-audio-unit-expected.txt: Added.
* LayoutTests/fast/mediastream/delete-audio-unit.html: Added.
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
(WebCore::AudioMediaStreamTrackRendererInternalUnit::deleteUnitForTesting):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::deleteUnitForTesting):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::deleteUnitForTesting):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::deleteAudioUnit):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::~RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManagerProxy::deleteUnitForTesting):

Originally-landed-as: 305413.814@safari-7624-branch (5503234cd8cd). <a href="https://rdar.apple.com/180436518">rdar://180436518</a>
Canonical link: <a href="https://commits.webkit.org/316360@main">https://commits.webkit.org/316360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c91f266689a523e2e1ed7d72f961d85efd0145f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133767 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114238 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35796 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34053 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183916 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38251 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142474 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38463 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46208 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30623 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110868 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37466 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117896 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44726 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->