### PR TITLE
DOM XSS in committers-autocomplete.js

### DIFF
--- a/Websites/bugs.webkit.org/committers-autocomplete.js
+++ b/Websites/bugs.webkit.org/committers-autocomplete.js
@@ -157,18 +157,31 @@ WebKitCommitters = (function() {
             return;
         }
 
-        var html = [];
+        function appendSpan(parent, className, text) {
+            var span = document.createElement('span');
+            span.className = className;
+            span.textContent = text;
+            parent.append(span, ' ');
+        }
+
+        var menu = getMenu();
+        menu.textContent = '';
         for (var i = 0; i < contacts.length; i++) {
             var contact = contacts[i];
-            html.push('<div class="committer-suggestion" ' + 'email=' +
-                contact.emails[0] + '><span class="committer-name">' + contact.name + '</span> <span class="committer-email">&lt;' + contact.emails[0] + '&gt;</span> ');
+
+            var suggestion = document.createElement('div');
+            suggestion.className = 'committer-suggestion';
+            suggestion.setAttribute('email', contact.emails[0]);
+
+            appendSpan(suggestion, 'committer-name', contact.name);
+            appendSpan(suggestion, 'committer-email', '<' + contact.emails[0] + '>');
             if (contact.nicks)
-                html.push(' <span class="committer-nick">@' + contact.nicks.join(', @') + '</span>');
+                appendSpan(suggestion, 'committer-nick', '@' + contact.nicks.join(', @'));
             if (contact.type)
-                html.push(' <span class="committer-type">' + contact.type + '</span>');
-            html.push('</div>');
+                appendSpan(suggestion, 'committer-type', contact.type);
+
+            menu.appendChild(suggestion);
         }
-        getMenu().innerHTML = html.join('');
         selectItem(0);
         showMenu(true);
     }


### PR DESCRIPTION
#### 3ab3db0b0feca78b2895ab53af90b90e46e44f21
<pre>
DOM XSS in committers-autocomplete.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=318161">https://bugs.webkit.org/show_bug.cgi?id=318161</a>
<a href="https://rdar.apple.com/180319278">rdar://180319278</a>

Reviewed by Alexey Proskuryakov.

Construct the autocomplete suggestion menu with createElement and
behavior.

* Websites/bugs.webkit.org/committers-autocomplete.js:
(updateMenu.appendSpan):
(updateMenu):

Canonical link: <a href="https://commits.webkit.org/316158@main">https://commits.webkit.org/316158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcd36385770d48ff7ebd1b4c9c0f24b129f691f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171476 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38821 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/196eed9b-5f2b-4a19-9f02-e44cb9af5d40) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45038 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd2debd6-2396-447f-9472-786c4f5b8589) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174435 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0819b9b-124f-432b-b4ba-e44c0725767e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183445 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/141994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45748 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37227 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44258 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->