### PR TITLE
REGRESSION(305413.516@safari-7624-branch): The height of the FEMorphology filter might be off by 1

### DIFF
--- a/Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h
@@ -90,11 +90,12 @@ inline bool applyPlatformParallel(typename ParallelJobs<ApplyParameters>::Worker
 
     // Copy together the parts of the image.
     currentY = 0;
+    int scratchHeight = calculateAdjustedBlockHeight(0);
     for (int job = 1; job < jobs; ++job) {
         ApplyParameters& params = parallelJobs.parameter(job);
-        int scratchHeight = calculateAdjustedBlockHeight(job);
 
         currentY += scratchHeight;
+        scratchHeight = calculateAdjustedBlockHeight(job);
 
         unsigned destinationOffset = currentY * scanline;
         unsigned scratchSize = scratchHeight * scanline;


### PR DESCRIPTION
#### d97d1afd0b8bd640d288c83dc501ee4e2e6c1421
<pre>
REGRESSION(305413.516@safari-7624-branch): The height of the FEMorphology filter might be off by 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=314268">https://bugs.webkit.org/show_bug.cgi?id=314268</a>
<a href="https://rdar.apple.com/175674532">rdar://175674532</a>

Reviewed by Simon Fraser.

In <a href="https://commits.webkit.org/305413.516@safari-7624-branch">https://commits.webkit.org/305413.516@safari-7624-branch</a>, ParallelJobs are
used to apply the FEMorphology filter. Applying the filter in parallel happens
in two steps:

1. Split the destination pixel buffer into `jobs` horizontal strips and then
   dispatches them in parallel
2. When all the parallel jobs finish, the scratch outputs are stitched back via
   a gather loop.

The first job is done directly into the destination PixelBuffer. So no stitching
is needed for job_0. Stitching the rest of the jobs (job_1 .. job_{n-1}) requires
moving the y-position in destination PixelBuffer by the height of the previous
job. And it requires also calculating the height of the current job. The problem
is the height of the current job is used to move y-position. This may prevent
stitching the last line in the last job to the destination PixelBuffer.

* Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h:
(WebCore::applyPlatformParallel):

Originally-landed-as: 305413.865@safari-7624-branch (5d5fdc06de11). <a href="https://rdar.apple.com/180437652">rdar://180437652</a>
Canonical link: <a href="https://commits.webkit.org/316267@main">https://commits.webkit.org/316267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fec77e062356329a3396a117ced5eef2ded0ae66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133315 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94076 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113793 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35162 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33471 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28982 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145620 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.MultipleAccounts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182887 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141771 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44504 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141581 "Found 1 new API test failure: WebKitGTK/TestResources:/webkit/WebKitWebResource/get-data-empty (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38380 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30143 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109898 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36847 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117084 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43704 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8259 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->