### PR TITLE
Missing allowsFirstPartyForCookies check in loadPing() IPC may lead to cross-origin cookie access

### DIFF
--- a/LayoutTests/ipc/coreipc.js
+++ b/LayoutTests/ipc/coreipc.js
@@ -759,6 +759,10 @@ export class ArgumentSerializer {
                 if (argument === null) {
                     return [];
                 } else throw new SerializationError(`std::nullptr_t is not null`);
+            case 'std::monostate':
+                if (argument === null) {
+                    return [];
+                } else throw new SerializationError(`std::monostate is not null`);
             case 'WebCore::SharedMemory::Handle':
             case 'WebCore::SharedMemoryHandle':
             case 'MachSendRight':
@@ -1199,7 +1203,9 @@ export class ArgumentParser {
                 return [position, {parsedValue: result, parsedType: 'String'}];
             }
             case 'std::nullptr_t':
-                return [position, {parsedValue: 'null', parsedType: 'std::nullptr_t'}];
+                return [position, {parsedValue: null, parsedType: 'std::nullptr_t'}];
+            case 'std::monostate':
+                return [position, {parsedValue: null, parsedType: 'std::monostate'}];
         }
         return undefined;
     }

--- a/LayoutTests/ipc/loadping-firstpartyforcookies-message-check-expected.txt
+++ b/LayoutTests/ipc/loadping-firstpartyforcookies-message-check-expected.txt
@@ -1,0 +1,3 @@
+
+PASS LoadPing rejects forged firstPartyForCookies via MESSAGE_CHECK
+

--- a/LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html
+++ b/LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that LoadPing validates firstPartyForCookies via MESSAGE_CHECK</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+
+    const forgedFirstParty = 'http://localhost:8080/';
+
+    const resourceLoadParameters = {
+        webPageProxyID: BigInt(IPC.webPageProxyID),
+        webPageID: BigInt(IPC.pageID),
+        webFrameID: BigInt(IPC.frameID),
+        request: {
+            getRequestDataToSerialize: {
+                variantType: 'WebCore::ResourceRequest::RequestData',
+                variant: {
+                    m_url: { string: forgedFirstParty },
+                    m_firstPartyForCookies: { string: forgedFirstParty },
+                    m_timeoutInterval: 60.0,
+                    m_httpMethod: 'GET',
+                    m_httpHeaderFields: { commonHeaders: [], uncommonHeaders: [] },
+                    m_responseContentDispositionEncodingFallbackArray: [],
+                    m_cachePolicy: 0,
+                    m_sameSiteDisposition: 1,
+                    m_priority: 2,
+                    m_requester: 0,
+                    m_allowCookies: true,
+                    m_isTopSite: true,
+                    m_isAppInitiated: true,
+                    m_privacyProxyFailClosedForUnreachableNonMainHosts: false,
+                    m_useAdvancedPrivacyProtections: false,
+                    m_didFilterLinkDecoration: false,
+                    m_isPrivateTokenUsageByThirdPartyAllowed: false,
+                    m_wasSchemeOptimisticallyUpgraded: false,
+                    m_targetAddressSpace: 0,
+                },
+            },
+            cachePartition: '',
+            hiddenFromInspector: false,
+        },
+        requestBody: { data: {}, sandboxExtensionHandles: [] },
+        topOrigin: {},
+        sourceOrigin: {},
+        parentPID: { alias: 0 },
+        contentSniffingPolicy: 0,
+        contentEncodingSniffingPolicy: 0,
+        storedCredentialsPolicy: 1,
+        clientCredentialPolicy: 0,
+        shouldClearReferrerOnHTTPSToHTTPRedirect: true,
+        needsCertificateInfo: false,
+        isMainFrameNavigation: false,
+        mainResourceNavigationDataForAnyFrame: {},
+        shouldPreconnectOnly: 0,
+        isNavigatingToAppBoundDomain: {},
+        hadMainFrameMainResourcePrivateRelayed: false,
+        allowPrivacyProxy: true,
+        advancedPrivacyProtections: 0,
+        requiredCookiesVersion: 0n,
+        identifier: { optionalValue: 99001n },
+        requestBodySandboxExtensions: [],
+        resourceSandboxExtension: {},
+        maximumBufferingTime: { value: 0 },
+        options: {
+            destination: 0,
+            mode: 0,
+            credentials: 0,
+            cache: 0,
+            redirect: 0,
+            referrerPolicy: 0,
+            keepAlive: true,
+            integrity: '',
+            clientIdentifier: {},
+            resultingClientIdentifier: {},
+        },
+        cspResponseHeaders: {},
+        parentFrameURL: { string: '' },
+        frameURL: { string: '' },
+        parentCrossOriginEmbedderPolicy: {
+            value: 0,
+            reportOnlyValue: 0,
+            reportingEndpoint: '',
+            reportOnlyReportingEndpoint: '',
+        },
+        crossOriginEmbedderPolicy: {
+            value: 0,
+            reportOnlyValue: 0,
+            reportingEndpoint: '',
+            reportOnlyReportingEndpoint: '',
+        },
+        originalRequestHeaders: { commonHeaders: [], uncommonHeaders: [] },
+        preflightPolicy: 0,
+        shouldEnableCrossOriginResourcePolicy: false,
+        frameAncestorOrigins: [],
+        pageHasResourceLoadClient: false,
+        parentFrameID: {},
+        crossOriginAccessControlCheckEnabled: false,
+        documentURL: { string: '' },
+        isCrossOriginOpenerPolicyEnabled: false,
+        isClearSiteDataHeaderEnabled: false,
+        isClearSiteDataExecutionContextEnabled: false,
+        isDisplayingInitialEmptyDocument: false,
+        effectiveSandboxFlags: { alias: 0 },
+        openerURL: { string: '' },
+        sourceCrossOriginOpenerPolicy: {
+            value: 0,
+            reportOnlyValue: 0,
+            reportingEndpoint: '',
+            reportOnlyReportingEndpoint: '',
+        },
+        navigationID: {},
+        navigationRequester: {},
+        serviceWorkersMode: 1,
+        serviceWorkerRegistrationIdentifier: {},
+        httpHeadersToKeep: 0,
+        navigationPreloadIdentifier: {},
+        workerIdentifier: { alias: { variantType: 'std::monostate', variant: null } },
+        mainDocumentURL: { string: '' },
+        userContentControllerIdentifier: {},
+        pageHasLoadedWebExtensions: false,
+        linkPreconnectEarlyHintsEnabled: false,
+        shouldRecordFrameLoadForStorageAccess: false,
+        isInitiatorPrefetch: false,
+        isInitiatedByDedicatedWorker: false,
+    };
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.LoadPing(0, { resourceLoadParameters: resourceLoadParameters });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'LoadPing with forged firstPartyForCookies should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+
+}, 'LoadPing rejects forged firstPartyForCookies via MESSAGE_CHECK');
+
+done();
+</script>
+</body>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -669,6 +669,7 @@ void NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingFo
 
 void NetworkConnectionToWebProcess::loadPing(NetworkResourceLoadParameters&& loadParameters)
 {
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
     CONNECTION_RELEASE_LOG(Loading, "loadPing: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto completionHandler = [connection = m_connection, identifier = *loadParameters.identifier] (const ResourceError& error, const ResourceResponse& response) {


### PR DESCRIPTION
#### 6aa96bce5d11350a8e088781eede139a860d8bb6
<pre>
Missing allowsFirstPartyForCookies check in loadPing() IPC may lead to cross-origin cookie access
<a href="https://bugs.webkit.org/show_bug.cgi?id=313496">https://bugs.webkit.org/show_bug.cgi?id=313496</a>
<a href="https://rdar.apple.com/174708224">rdar://174708224</a>

Reviewed by Charlie Wolfe and Sihui Liu.

A web process could send an IPC message containing a cross-site origin and
loadPing() would then send the request to the cross-site origin which would
respond with its cookies.

To prevent this, add a MESSAGE_CHECK in loadPing() which will check if the
web process has first party cookie access to the origin in the request and
terminate the web process if not.

New layout test confirms that we hit the message check:
loadping-firstpartyforcookies-message-check.html

* LayoutTests/ipc/coreipc.js:
(export.ArgumentSerializer):
* LayoutTests/ipc/loadping-firstpartyforcookies-message-check-expected.txt: Added.
* LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::loadPing):

Originally-landed-as: 305413.799@safari-7624-branch (fd5906672902). <a href="https://rdar.apple.com/180435156">rdar://180435156</a>
Canonical link: <a href="https://commits.webkit.org/316167@main">https://commits.webkit.org/316167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c22b9e562b4336cf42ce47a239432dcdd57ae4b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171504 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38857 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45066 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174463 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29569 "Failed to checkout and rebase branch from PR 68151") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183473 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/37246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44287 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->