### PR TITLE
[GPUP] WebGPU BindGroup Validation-Cache Key Collision Leads to GPU OOB Write

### DIFF
--- a/LayoutTests/fast/webgpu/pipeline-id-collision-bindgroup-validation-bypass-expected.txt
+++ b/LayoutTests/fast/webgpu/pipeline-id-collision-bindgroup-validation-bypass-expected.txt
@@ -1,0 +1,1 @@
+PASS: validation error raised for undersized buffer in render pass after compute cache priming CONTROL: PASS: validation error raised for fresh BindGroup with undersized buffer

--- a/LayoutTests/fast/webgpu/pipeline-id-collision-bindgroup-validation-bypass.html
+++ b/LayoutTests/fast/webgpu/pipeline-id-collision-bindgroup-validation-bypass.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+<script>
+function log(s) { document.body.appendChild(document.createTextNode(s + '\n')); }
+
+async function main() {
+    if (!navigator.gpu) {
+        log('SKIP: WebGPU not available');
+        return;
+    }
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) { log('SKIP: no adapter'); return; }
+    const device = await adapter.requestDevice();
+    if (!device) { log('SKIP: no device'); return; }
+
+    // Single explicit BindGroupLayout shared by both pipelines.
+    // minBindingSize:0 defers the size check to draw/dispatch time.
+    const bgl = device.createBindGroupLayout({
+        entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+            buffer: { type: 'storage', minBindingSize: 0 }
+        }]
+    });
+    const pl = device.createPipelineLayout({ bindGroupLayouts: [bgl] });
+
+    // Compute shader: needs only 4 bytes.
+    const cmod = device.createShaderModule({
+        code: `
+            @group(0) @binding(0) var<storage, read_write> small : u32;
+            @compute @workgroup_size(1) fn cmain() { small = 1u; }
+        `
+    });
+
+    // Render shader: fragment needs 65536 bytes (array<u32, 16384>).
+    const rmod = device.createShaderModule({
+        code: `
+            @vertex fn vmain(@builtin(vertex_index) i:u32) -> @builtin(position) vec4f {
+                var p = array<vec2f,3>(vec2f(-1,-1), vec2f(3,-1), vec2f(-1,3));
+                return vec4f(p[i], 0, 1);
+            }
+            @group(0) @binding(0) var<storage, read_write> big : array<u32, 16384>;
+            @fragment fn fmain(@builtin(position) pos: vec4f) -> @location(0) vec4f {
+                big[16383u] = 0u;
+                return vec4f(1,0,0,1);
+            }
+        `
+    });
+
+    // First ComputePipeline on this device -> uniqueId == 1 (m_computePipelineId).
+    const cp = device.createComputePipeline({ layout: pl, compute: { module: cmod, entryPoint: 'cmain' } });
+    // First RenderPipeline on this device -> uniqueId == 1 (m_renderPipelineId). ID collision.
+    const rp = device.createRenderPipeline({
+        layout: pl,
+        vertex:   { module: rmod, entryPoint: 'vmain' },
+        fragment: { module: rmod, entryPoint: 'fmain', targets: [{ format: 'rgba8unorm' }] }
+    });
+
+    // 4-byte buffer — valid for compute (u32), invalid for fragment (array<u32,16384>).
+    const tiny = device.createBuffer({ size: 4, usage: GPUBufferUsage.STORAGE });
+    const bg = device.createBindGroup({ layout: bgl, entries: [{ binding: 0, resource: { buffer: tiny } }] });
+
+    const rt = device.createTexture({ size: [4,4], format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT });
+
+    // Encode a compute pass (primes the pipeline cache) then a render pass (which
+    // should still validate the binding size against the render pipeline's requirements).
+    device.pushErrorScope('validation');
+
+    const enc = device.createCommandEncoder();
+
+    const cpass = enc.beginComputePass();
+    cpass.setPipeline(cp);
+    cpass.setBindGroup(0, bg);
+    cpass.dispatchWorkgroups(1);
+    cpass.end();
+
+    const rpass = enc.beginRenderPass({
+        colorAttachments: [{ view: rt.createView(), loadOp: 'clear', storeOp: 'store', clearValue: [0,0,0,0] }]
+    });
+    rpass.setPipeline(rp);
+    rpass.setBindGroup(0, bg);
+    rpass.draw(3);
+    rpass.end();
+
+    device.queue.submit([enc.finish()]);
+    await device.queue.onSubmittedWorkDone();
+
+    const err = await device.popErrorScope();
+    if (err)
+        log('PASS: validation error raised for undersized buffer in render pass after compute cache priming');
+    else
+        log('FAIL: no validation error — pipeline ID collision bypassed binding size check');
+
+    // Control: a fresh BindGroup (no cache) used with the render pipeline alone must
+    // also produce a validation error on both correct and vulnerable implementations.
+    device.pushErrorScope('validation');
+    const bg2 = device.createBindGroup({ layout: bgl, entries: [{ binding: 0, resource: { buffer: tiny } }] });
+    const enc2 = device.createCommandEncoder();
+    const rpass2 = enc2.beginRenderPass({
+        colorAttachments: [{ view: rt.createView(), loadOp: 'clear', storeOp: 'store', clearValue: [0,0,0,0] }]
+    });
+    rpass2.setPipeline(rp);
+    rpass2.setBindGroup(0, bg2);
+    rpass2.draw(3);
+    rpass2.end();
+    device.queue.submit([enc2.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    const err2 = await device.popErrorScope();
+    log('CONTROL: ' + (err2 ? 'PASS: validation error raised for fresh BindGroup with undersized buffer' : 'FAIL: no validation error for fresh BindGroup'));
+}
+
+main()
+    .catch(e => log('FAIL: ' + e + '\n' + (e && e.stack)))
+    .finally(() => { if (window.testRunner) testRunner.notifyDone(); });
+</script>

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -128,7 +128,7 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
     if (!size.width || size.width > deviceLimits.maxComputeWorkgroupSizeX || !size.height || size.height > deviceLimits.maxComputeWorkgroupSizeY || !size.depth || size.depth > deviceLimits.maxComputeWorkgroupSizeZ || size.width * size.height * size.depth > deviceLimits.maxComputeInvocationsPerWorkgroup)
         return returnInvalidComputePipeline(*this, isAsync);
 
-    if (m_computePipelineId == Device::maxPipelines) {
+    if (m_pipelineId == Device::maxPipelines) {
         loseTheDevice(WGPUDeviceLostReason_Undefined);
         return returnInvalidComputePipeline(*this, isAsync, @"too many compute pipelines");
     }
@@ -149,14 +149,14 @@ std::pair<Ref<ComputePipeline>, NSString*> Device::createComputePipeline(const W
         if (!computePipelineState)
             return returnFailedPSOCreation();
 
-        return std::make_pair(ComputePipeline::create(computePipelineState, WTF::move(generatedPipelineLayout), size, WTF::move(minimumBufferSizes), ++m_computePipelineId, *this), nil);
+        return std::make_pair(ComputePipeline::create(computePipelineState, WTF::move(generatedPipelineLayout), size, WTF::move(minimumBufferSizes), ++m_pipelineId, *this), nil);
     }
 
     auto computePipelineState = createComputePipelineState(m_device, function, pipelineLayout, size, label.get(), shaderValidationState(), WTF::move(shaderSource));
     if (!computePipelineState)
         return returnFailedPSOCreation();
 
-    return std::make_pair(ComputePipeline::create(computePipelineState, WTF::move(pipelineLayout), size, WTF::move(minimumBufferSizes), ++m_computePipelineId, *this), nil);
+    return std::make_pair(ComputePipeline::create(computePipelineState, WTF::move(pipelineLayout), size, WTF::move(minimumBufferSizes), ++m_pipelineId, *this), nil);
 }
 
 void Device::createComputePipelineAsync(const WGPUComputePipelineDescriptor& descriptor, CompletionHandler<void(WGPUCreatePipelineAsyncStatus, Ref<ComputePipeline>&&, String&& message)>&& callback)

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -335,8 +335,7 @@ private:
     mutable HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_bindGroupCompatibilityCache;
     uint64_t m_commandEncoderId { 0 };
     uint64_t m_pipelineLayoutId { 0 };
-    uint64_t m_renderPipelineId { 0 };
-    uint64_t m_computePipelineId { 0 };
+    uint64_t m_pipelineId { 0 };
     uint32_t m_bindGroupLayoutId { 0 };
     uint32_t m_bindGroupId { 0 };
     uint32_t m_appleGPUFamily { 0 };

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1753,7 +1753,7 @@ std::pair<Ref<RenderPipeline>, NSString*> Device::createRenderPipeline(const WGP
     if (error)
         return returnInvalidRenderPipeline(*this, isAsync, error.localizedDescription);
 
-    if (m_renderPipelineId == Device::maxPipelines) {
+    if (m_pipelineId == Device::maxPipelines) {
         loseTheDevice(WGPUDeviceLostReason_Undefined);
         return returnInvalidRenderPipeline(*this, isAsync, @"too many render pipelines");
     }
@@ -1762,10 +1762,10 @@ std::pair<Ref<RenderPipeline>, NSString*> Device::createRenderPipeline(const WGP
         if (!generatedPipelineLayout->isValid())
             return returnInvalidRenderPipeline(*this, isAsync, "Generated pipeline layout is not valid"_s);
 
-        return std::make_pair(RenderPipeline::create(mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, mtlDepthClipMode, depthStencilDescriptor, WTF::move(generatedPipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, sampleMask, mtlRenderPipelineDescriptor, colorAttachmentCount, descriptor, WTF::move(requiredBufferIndices), WTF::move(minimumBufferSizes), ++m_renderPipelineId, vertexShaderBindingCount, *this), nil);
+        return std::make_pair(RenderPipeline::create(mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, mtlDepthClipMode, depthStencilDescriptor, WTF::move(generatedPipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, sampleMask, mtlRenderPipelineDescriptor, colorAttachmentCount, descriptor, WTF::move(requiredBufferIndices), WTF::move(minimumBufferSizes), ++m_pipelineId, vertexShaderBindingCount, *this), nil);
     }
 
-    return std::make_pair(RenderPipeline::create(mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, mtlDepthClipMode, depthStencilDescriptor, const_cast<PipelineLayout&>(*pipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, sampleMask, mtlRenderPipelineDescriptor, colorAttachmentCount, descriptor, WTF::move(requiredBufferIndices), WTF::move(minimumBufferSizes), ++m_renderPipelineId, vertexShaderBindingCount, *this), nil);
+    return std::make_pair(RenderPipeline::create(mtlPrimitiveType, mtlIndexType, mtlFrontFace, mtlCullMode, mtlDepthClipMode, depthStencilDescriptor, const_cast<PipelineLayout&>(*pipelineLayout), depthBias, depthBiasSlopeScale, depthBiasClamp, sampleMask, mtlRenderPipelineDescriptor, colorAttachmentCount, descriptor, WTF::move(requiredBufferIndices), WTF::move(minimumBufferSizes), ++m_pipelineId, vertexShaderBindingCount, *this), nil);
 }
 
 void Device::createRenderPipelineAsync(const WGPURenderPipelineDescriptor& descriptor, CompletionHandler<void(WGPUCreatePipelineAsyncStatus, Ref<RenderPipeline>&&, String&& message)>&& callback)


### PR DESCRIPTION
#### 144aa0db1a51ac0b8a993f17bd35a136fb4a6b4a
<pre>
[GPUP] WebGPU BindGroup Validation-Cache Key Collision Leads to GPU OOB Write
<a href="https://bugs.webkit.org/show_bug.cgi?id=313360">https://bugs.webkit.org/show_bug.cgi?id=313360</a>
<a href="https://rdar.apple.com/174662781">rdar://174662781</a>

Reviewed by Dan Glastonbury.

Share identifiers for render and compute pipelines to avoid
validation succeeding for a given bind group + render pipeline
which was validated for the hash key identical to the same
bind group but with a compute pipeline which has the same key.

* Source/WebGPU/WebGPU/ComputePipeline.mm:
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:

Originally-landed-as: 305413.739@safari-7624-branch (427fc7a6307d). <a href="https://rdar.apple.com/180429272">rdar://180429272</a>
Canonical link: <a href="https://commits.webkit.org/316116@main">https://commits.webkit.org/316116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dfc64934d6986646ce50361799b202c648b596a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128644 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35152 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33475 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182893 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141776 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141586 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45199 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109904 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36845 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117090 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43710 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43114 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->