### PR TITLE
FilterImage may return uninitialized PixelBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
@@ -187,6 +187,9 @@ bool FEBlendNeonApplier::apply(const Filter&, std::span<const Ref<FilterImage>> 
     auto effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     auto sourcePixelArrayB = input2.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectBDrawingRect);
 
+    if (!sourcePixelArrayA || !sourcePixelArrayB)
+        return false;
+
     unsigned sourcePixelArrayLength = sourcePixelArrayA->bytes().size();
     ASSERT(sourcePixelArrayLength == sourcePixelArrayB->bytes().size());
 

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -149,25 +149,26 @@ ImageBuffer* FilterImage::imageBufferFromPixelBuffer()
     return m_imageBuffer.get();
 }
 
-static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer)
+static bool copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer)
 {
     ASSERT(sourcePixelBuffer.size() == destinationPixelBuffer.size());
 
     auto destinationSize = destinationPixelBuffer.size();
     auto rowBytes = CheckedUint32(destinationSize.width()) * 4;
     if (rowBytes.hasOverflowed()) [[unlikely]]
-        return;
+        return false;
 
     ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes() };
     PixelBufferConversionView destination { destinationPixelBuffer.format(), rowBytes, destinationPixelBuffer.bytes() };
 
     convertImagePixels(source, destination, destinationSize);
+    return true;
 }
 
-static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
+static bool copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
 {
-    auto sourcePixelBufferRect = IntRect { { }, sourcePixelBuffer.size() };
-    auto destinationPixelBufferRect = IntRect { { }, destinationPixelBuffer.size() };
+    const auto sourcePixelBufferRect = IntRect { { }, sourcePixelBuffer.size() };
+    const auto destinationPixelBufferRect = IntRect { { }, destinationPixelBuffer.size() };
 
     auto sourceRectClipped = intersection(sourcePixelBufferRect, sourceRect);
     auto destinationRect = IntRect { { }, sourceRectClipped.size() };
@@ -181,13 +182,9 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     destinationRect.intersect(destinationPixelBufferRect);
     sourceRectClipped.setSize(destinationRect.size());
 
-    // Initialize the destination to transparent black, if not entirely covered by the source.
-    if (destinationRect.size() != destinationPixelBufferRect.size())
-        destinationPixelBuffer.zeroFill();
-
     // Early return if the rect does not intersect with the source.
     if (destinationRect.isEmpty())
-        return;
+        return false;
 
     auto size = CheckedUint32(sourceRectClipped.width()) * 4;
     auto destinationBytesPerRow = CheckedUint32(destinationPixelBufferRect.width()) * 4;
@@ -196,7 +193,11 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     auto sourceOffset = sourceRectClipped.y() * sourceBytesPerRow + CheckedUint32(sourceRectClipped.x()) * 4;
 
     if (size.hasOverflowed() || destinationBytesPerRow.hasOverflowed() || sourceBytesPerRow.hasOverflowed() || destinationOffset.hasOverflowed() || sourceOffset.hasOverflowed()) [[unlikely]]
-        return;
+        return false;
+
+    // Initialize the destination to transparent black, if not entirely covered by the source.
+    if (destinationRect.size() != destinationPixelBufferRect.size())
+        destinationPixelBuffer.zeroFill();
 
     auto destinationPixel = destinationPixelBuffer.bytes().subspan(destinationOffset.value());
     auto sourcePixel = sourcePixelBuffer.bytes().subspan(sourceOffset.value());
@@ -208,6 +209,8 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
         }
         memcpySpan(destinationPixel, sourcePixel.first(size));
     }
+
+    return true;
 }
 
 static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImageBuffer& imageBuffer, AlphaPremultiplication alphaFormat, const IntRect& sourceRect, DestinationColorSpace colorSpace, ImageBufferAllocator& allocator)
@@ -280,11 +283,15 @@ PixelBuffer* FilterImage::pixelBuffer(AlphaPremultiplication alphaFormat)
         return nullptr;
 
     if (alphaFormat == AlphaPremultiplication::Unpremultiplied) {
-        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Premultiplied))
-            copyImageBytes(*sourcePixelBuffer, *pixelBuffer);
+        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Premultiplied)) {
+            if (!copyImageBytes(*sourcePixelBuffer, *pixelBuffer))
+                return nullptr;
+        }
     } else {
-        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Unpremultiplied))
-            copyImageBytes(*sourcePixelBuffer, *pixelBuffer);
+        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Unpremultiplied)) {
+            if (!copyImageBytes(*sourcePixelBuffer, *pixelBuffer))
+                return nullptr;
+        }
     }
 
     return pixelBuffer.get();
@@ -300,11 +307,13 @@ RefPtr<PixelBuffer> FilterImage::getPixelBuffer(AlphaPremultiplication alphaForm
     if (!pixelBuffer)
         return nullptr;
 
-    copyPixelBuffer(*pixelBuffer, sourceRect);
+    if (!copyPixelBuffer(*pixelBuffer, sourceRect))
+        return nullptr;
+
     return pixelBuffer;
 }
 
-void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
+bool FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
 {
     auto alphaFormat = destinationPixelBuffer.format().alphaFormat;
     auto& colorSpace = destinationPixelBuffer.format().colorSpace;
@@ -317,8 +326,8 @@ void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const Int
             if (m_imageBuffer) {
                 IntRect rect { { }, m_absoluteImageRect.size() };
                 if (auto convertedPixelBuffer = getConvertedPixelBuffer(Ref { *m_imageBuffer }, alphaFormat, rect, colorSpace, m_allocator))
-                    copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
-                return;
+                    return copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
+                return false;
             }
         }
 
@@ -326,15 +335,15 @@ void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const Int
     }
 
     if (!sourcePixelBuffer)
-        return;
+        return false;
 
     if (requiresPixelBufferColorSpaceConversion(colorSpace)) {
         if (auto convertedPixelBuffer = getConvertedPixelBuffer(*sourcePixelBuffer, alphaFormat, colorSpace, m_allocator))
-            copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
-        return;
+            return copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
+        return false;
     }
 
-    copyImageBytes(*sourcePixelBuffer, destinationPixelBuffer, sourceRect);
+    return copyImageBytes(*sourcePixelBuffer, destinationPixelBuffer, sourceRect);
 }
 
 void FilterImage::correctPremultipliedPixelBuffer()

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -75,7 +75,7 @@ public:
     PixelBuffer* pixelBuffer(AlphaPremultiplication);
 
     RefPtr<PixelBuffer> getPixelBuffer(AlphaPremultiplication, const IntRect& sourceRect, std::optional<DestinationColorSpace> = std::nullopt);
-    void copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect);
+    bool copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect);
 
     void NODELETE correctPremultipliedPixelBuffer();
     void NODELETE transformToColorSpace(const DestinationColorSpace&);


### PR DESCRIPTION
#### bb98ffd5c7336141c471e359b03b57d0f6de7142
<pre>
FilterImage may return uninitialized PixelBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=314906">https://bugs.webkit.org/show_bug.cgi?id=314906</a>
<a href="https://rdar.apple.com/176813834">rdar://176813834</a>

Reviewed by Darin Adler.

FilterImage provides three different representations of the image: ImageBuffer,
Unpremultiplied PixelBuffer and Premultiplied PixelBuffer. These three buffers
are lazily created. Each of them is created only when it is needed. But keep in
mind they are copies of each other. In other words, when one is created it has
to copy the pixels from the existing buffers. Otherwise it has to be zero-filled.

A problem may happen when copying the pixels from one buffer to a newly created
buffer fails. In this case we send uninitialized PixelBuffer which may expose user
private data. Not able to copy existing pixels to the PixelBuffer should be treated
as an error. So a null PixelBuffer should be returned in this case.

* Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp:
(WebCore::FEBlendNeonApplier::apply const):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::copyImageBytes):
(WebCore::FilterImage::pixelBuffer):
(WebCore::FilterImage::getPixelBuffer):
(WebCore::FilterImage::copyPixelBuffer):
* Source/WebCore/platform/graphics/filters/FilterImage.h:

Originally-landed-as: 305413.919@safari-7624-branch (dbf10417aa9e). <a href="https://rdar.apple.com/180436188">rdar://180436188</a>
Canonical link: <a href="https://commits.webkit.org/316126@main">https://commits.webkit.org/316126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84104e853f294061be45a9403db9623225343936

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44855 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38274 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113799 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33480 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28989 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2161 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182894 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141783 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44511 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141593 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38216 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45200 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109905 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36855 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117091 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43711 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43115 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Running checkout-pull-request; Compiled WebKit (warnings)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43357 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->