### PR TITLE
[WebGPU] Per-buffer m_mustTakeSlowIndexValidationPath cleared between command buffers leads to GPU OOB vertex fetch

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/index-buffer-invalidation-multi-command-buffer-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/index-buffer-invalidation-multi-command-buffer-expected.txt
@@ -1,0 +1,5 @@
+Pass
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/webgpu/nocrash/index-buffer-invalidation-multi-command-buffer.html
+++ b/LayoutTests/fast/webgpu/nocrash/index-buffer-invalidation-multi-command-buffer.html
@@ -1,0 +1,71 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<script src="../../../resources/js-test.js"></script>
+<script>
+window.jsTestIsAsync = true;
+
+async function run() {
+    const adapter = await navigator.gpu.requestAdapter();
+    const device = await adapter.requestDevice();
+    const queue = device.queue;
+
+    const indexBuffer = device.createBuffer({ size: 24, usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST });
+    const vbufSmall = device.createBuffer({ size: 3 * 16, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    const vbufBig = device.createBuffer({ size: 200 * 16, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST });
+    const tex = device.createTexture({ size: [4, 4], format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT });
+
+    const module = device.createShaderModule({
+        code: `
+            @vertex fn vs(@location(0) p : vec4f) -> @builtin(position) vec4f { return p; }
+            @fragment fn fs() -> @location(0) vec4f { return vec4f(1.0); }
+        `
+    });
+    const pipe = device.createRenderPipeline({
+        layout: 'auto',
+        vertex: { module, entryPoint: 'vs', buffers: [{ arrayStride: 16, stepMode: 'vertex', attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x4' }] }] },
+        fragment: { module, entryPoint: 'fs', targets: [{ format: 'bgra8unorm' }] },
+        primitive: { topology: 'triangle-list' }
+    });
+
+    const rpDesc = () => ({ colorAttachments: [{ view: tex.createView(), loadOp: 'clear', storeOp: 'store', clearValue: [0, 0, 0, 0] }] });
+
+    queue.writeBuffer(indexBuffer, 0, new Uint32Array([0, 1, 2, 100, 101, 102]));
+    const encZ = device.createCommandEncoder();
+    const pZ = encZ.beginRenderPass(rpDesc());
+    pZ.setPipeline(pipe);
+    pZ.setIndexBuffer(indexBuffer, 'uint32');
+    pZ.setVertexBuffer(0, vbufSmall);
+    pZ.drawIndexed(3, 1, 0, 0, 0);
+    pZ.setVertexBuffer(0, vbufBig);
+    pZ.drawIndexed(3, 1, 3, 0, 0);
+    pZ.end();
+    queue.submit([encZ.finish()]);
+    await queue.onSubmittedWorkDone();
+
+    const encA = device.createCommandEncoder();
+    const pA = encA.beginRenderPass(rpDesc());
+    pA.setPipeline(pipe);
+    pA.setIndexBuffer(indexBuffer, 'uint32');
+    pA.setVertexBuffer(0, vbufSmall);
+    pA.drawIndexed(3, 1, 0, 0, 0);
+    pA.end();
+    const cbA = encA.finish();
+
+    const encB = device.createCommandEncoder();
+    const pB = encB.beginRenderPass(rpDesc());
+    pB.setPipeline(pipe);
+    pB.setIndexBuffer(indexBuffer, 'uint32');
+    pB.setVertexBuffer(0, vbufBig);
+    pB.drawIndexed(3, 1, 3, 0, 0);
+    pB.end();
+    const cbB = encB.finish();
+
+    const BIG = 0x00100000;
+    queue.writeBuffer(indexBuffer, 0, new Uint32Array([0, 1, 2, BIG, BIG + 1, BIG + 2]));
+
+    queue.submit([cbA, cbB]);
+    await queue.onSubmittedWorkDone();
+    debug('Pass');
+}
+
+run().catch(e => debug('Error: ' + e)).finally(finishJSTest);
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -129,7 +129,7 @@ public:
     void indirectBufferInvalidated(CommandEncoder&);
     void removeSkippedValidationCommandEncoder(uint64_t);
     bool mustTakeSlowIndexValidationPath() const { return m_mustTakeSlowIndexValidationPath; }
-    void clearMustTakeSlowIndexValidationPath() { m_mustTakeSlowIndexValidationPath = false; }
+    void clearMustTakeSlowIndexValidationPath();
     void takeSlowIndexValidationPath(CommandBuffer&, uint32_t firstIndex, uint32_t indexCount, MTLIndexType, uint32_t primitiveOffset, uint32_t vertexCount);
     bool needsIndexValidation(uint32_t, uint16_t);
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -663,7 +663,7 @@ void Buffer::skippedDrawIndirectIndexedValidation(CommandEncoder& commandEncoder
         if (protectedThis->m_mustTakeSlowIndexValidationPath) {
             protectedThis->takeSlowIndirectIndexValidationPath(commandBuffer, *apiIndexBuffer.get(), indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, primitiveType);
             commandBuffer.addPostCommitHandler([protectedThis = WTF::move(protectedThis)](id<MTLCommandBuffer>) {
-                protectedThis->m_mustTakeSlowIndexValidationPath = false;
+                protectedThis->clearMustTakeSlowIndexValidationPath();
             });
         }
         return true;
@@ -682,7 +682,7 @@ void Buffer::skippedDrawIndirectValidation(CommandEncoder& commandEncoder, uint6
         if (protectedThis->m_mustTakeSlowIndexValidationPath) {
             protectedThis->takeSlowIndirectValidationPath(commandBuffer, indirectOffset, minVertexCount, minInstanceCount);
             commandBuffer.addPostCommitHandler([protectedThis = WTF::move(protectedThis)](id<MTLCommandBuffer>) {
-                protectedThis->m_mustTakeSlowIndexValidationPath = false;
+                protectedThis->clearMustTakeSlowIndexValidationPath();
             });
         }
         return true;
@@ -787,6 +787,13 @@ void Buffer::indirectBufferInvalidated(CommandEncoder* commandEncoder)
 void Buffer::removeSkippedValidationCommandEncoder(uint64_t uniqueId)
 {
     m_skippedValidationCommandEncoders.remove(uniqueId);
+}
+
+void Buffer::clearMustTakeSlowIndexValidationPath()
+{
+    if (computeSize(m_skippedValidationCommandEncoders, m_device.get()))
+        return;
+    m_mustTakeSlowIndexValidationPath = false;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -153,7 +153,7 @@ CommandEncoder::CommandEncoder(id<MTLCommandBuffer> commandBuffer, Device& devic
                     auto& value = keyValuePair.second;
                     apiBuffer->takeSlowIndexValidationPath(commandBuffer, key.firstIndex, key.indexCount, key.indexType(), key.primitiveOffset(), value);
                     commandBuffer.addPostCommitHandler([bufferIdentifier, device = protect(commandBuffer.device())](id<MTLCommandBuffer>) {
-                        if (auto* apiBuffer = device->lookupBuffer(bufferIdentifier))
+                        if (RefPtr apiBuffer = device->lookupBuffer(bufferIdentifier))
                             apiBuffer->clearMustTakeSlowIndexValidationPath();
                     });
                 }


### PR DESCRIPTION
#### cf0a14a0f239bd54510623530f01b1ddee0214b4
<pre>
[WebGPU] Per-buffer m_mustTakeSlowIndexValidationPath cleared between command buffers leads to GPU OOB vertex fetch
<a href="https://bugs.webkit.org/show_bug.cgi?id=314835">https://bugs.webkit.org/show_bug.cgi?id=314835</a>
<a href="https://rdar.apple.com/176482961">rdar://176482961</a>

Reviewed by Mike Wyrzykowski.

Buffer::m_mustTakeSlowIndexValidationPath is a single per-Buffer bool that
guards re-validation of cache-hit drawIndexed/drawIndirect calls after the
buffer is invalidated via writeBuffer/copyBufferToBuffer/unmap. Queue::submit
processes submitted command buffers sequentially with preCommitHandler -&gt;
commit -&gt; postCommitHandler per buffer. The first command buffer&apos;s
postCommitHandler clears the per-buffer flag before the second command
buffer&apos;s preCommitHandler reads it, so the second command buffer skips
takeSlowIndexValidationPath and its pre-recorded direct
drawIndexedPrimitives executes against rewritten OOB indices, causing a
GPU-side out-of-bounds vertex fetch at an attacker-controlled offset.
Reachable via the public navigator.gpu API only.

The fix gates clearMustTakeSlowIndexValidationPath() on
m_skippedValidationCommandEncoders being empty, using the existing
computeSize() helper that prunes destroyed-encoder IDs. The flag now stays
set until every encoder that was pending at invalidation time has run its
preCommit. This is conservative: while a finished-unsubmitted command buffer
that cache-hit this buffer remains alive, subsequent cache-hit draws also
take the slow path; this fails safe (over-validates) and is bounded by
command buffer lifetime.

The two raw m_mustTakeSlowIndexValidationPath = false writes in the
drawIndexedIndirect and drawIndirect on-commit lambdas are routed through
the gated accessor for the same reason.

* LayoutTests/fast/webgpu/nocrash/index-buffer-invalidation-multi-command-buffer-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/index-buffer-invalidation-multi-command-buffer.html: Added.
* Source/WebGPU/WebGPU/Buffer.h:
(WebGPU::Buffer::clearMustTakeSlowIndexValidationPath): Deleted.
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::skippedDrawIndirectIndexedValidation):
(WebGPU::Buffer::skippedDrawIndirectValidation):
(WebGPU::Buffer::clearMustTakeSlowIndexValidationPath):

Originally-landed-as: 305413.907@safari-7624-branch (69246dd9556c). <a href="https://rdar.apple.com/180437229">rdar://180437229</a>
Canonical link: <a href="https://commits.webkit.org/316379@main">https://commits.webkit.org/316379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c37828c932374b3f136962dafde055f167f7114

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181482 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129596 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133827 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35873 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34137 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30095 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184014 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142558 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142449 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38479 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46306 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30702 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110969 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37539 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117994 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44824 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8796 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44224 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->