### PR TITLE
[cleanup] Rename RenderBox::setWidth()/setHeight() to setBorderBoxWidth()/setBorderBoxHeight()

### DIFF
--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp
@@ -153,8 +153,8 @@ void FlexLayout::layout()
             auto isOrthogonal = flexContainerIsHorizontal != renderer->writingMode().isHorizontal();
             auto borderBox = Layout::BoxGeometry::borderBoxRect(layoutState().geometryForBox(layoutBox));
 
-            renderer->setWidth(LayoutUnit { });
-            renderer->setHeight(LayoutUnit { });
+            renderer->setBorderBoxWidth(LayoutUnit { });
+            renderer->setBorderBoxHeight(LayoutUnit { });
             // logical here means width and height constraints for the _content_ of the flex items not the flex items' own dimension inside the flex container.
             renderer->setOverridingBorderBoxLogicalWidth(isOrthogonal ? borderBox.height() : borderBox.width());
             renderer->setOverridingBorderBoxLogicalHeight(isOrthogonal ? borderBox.width() : borderBox.height());
@@ -163,8 +163,8 @@ void FlexLayout::layout()
             renderer->layoutIfNeeded();
             renderer->clearOverridingSize();
 
-            renderer->setWidth(flexContainerIsHorizontal ? borderBox.width() : borderBox.height());
-            renderer->setHeight(flexContainerIsHorizontal ? borderBox.height() : borderBox.width());
+            renderer->setBorderBoxWidth(flexContainerIsHorizontal ? borderBox.width() : borderBox.height());
+            renderer->setBorderBoxHeight(flexContainerIsHorizontal ? borderBox.height() : borderBox.width());
         }
     };
     relayoutFlexItems();
@@ -178,8 +178,8 @@ void FlexLayout::updateRenderers()
         auto& flexItemGeometry = layoutState().geometryForBox(layoutBox);
         auto borderBox = Layout::BoxGeometry::borderBoxRect(flexItemGeometry);
         renderer->setLocation(flexContainerIsHorizontal ? borderBox.topLeft() : borderBox.topLeft().transposedPoint());
-        renderer->setWidth(flexContainerIsHorizontal ? borderBox.width() : borderBox.height());
-        renderer->setHeight(flexContainerIsHorizontal ? borderBox.height() : borderBox.width());
+        renderer->setBorderBoxWidth(flexContainerIsHorizontal ? borderBox.width() : borderBox.height());
+        renderer->setBorderBoxHeight(flexContainerIsHorizontal ? borderBox.height() : borderBox.width());
 
         renderer->setMarginStart(flexItemGeometry.marginStart());
         renderer->setMarginEnd(flexItemGeometry.marginEnd());

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -161,8 +161,8 @@ void GridLayout::updateGridItemRenderers()
         auto borderBoxRect = Layout::BoxGeometry::borderBoxRect(gridItemGeometry);
 
         renderer->setLocation(contentBoxOffset + borderBoxRect.topLeft());
-        renderer->setWidth(borderBoxRect.width());
-        renderer->setHeight(borderBoxRect.height());
+        renderer->setBorderBoxWidth(borderBoxRect.width());
+        renderer->setBorderBoxHeight(borderBoxRect.height());
 
         renderer->setMarginBefore(gridItemGeometry.marginBefore());
         renderer->setMarginAfter(gridItemGeometry.marginAfter());
@@ -182,9 +182,9 @@ void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutCon
         auto& rowSizes = usedTrackSizes.rowSizes;
         auto usedRowGutter = Layout::GridFormattingContext::usedGapValue(renderGrid->style().rowGap());
         auto blockContentSize = std::reduce(rowSizes.begin(), rowSizes.end()) + Layout::GridLayoutUtils::totalGuttersSize(rowSizes.size(), usedRowGutter);
-        renderGrid->setHeight(blockContentSize + renderGrid->borderAndPaddingLogicalHeight());
+        renderGrid->setBorderBoxHeight(blockContentSize + renderGrid->borderAndPaddingLogicalHeight());
     } else
-        renderGrid->setHeight(layoutConstraints.blockAxis.availableSpace() + renderGrid->borderAndPaddingLogicalHeight());
+        renderGrid->setBorderBoxHeight(layoutConstraints.blockAxis.availableSpace() + renderGrid->borderAndPaddingLogicalHeight());
 
     for (CheckedRef layoutBox : formattingContextBoxes(gridBox()))
         orderIteratorPopulator.collectChild(CheckedRef { downcast<RenderBox>(*layoutBox->rendererForIntegration()) });

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -74,8 +74,8 @@ public:
 
     template<typename T> void setX(T x) { m_frameRect.setX(x); }
     template<typename T> void setY(T y) { m_frameRect.setY(y); }
-    template<typename T> void setWidth(T width) { m_frameRect.setWidth(width); }
-    template<typename T> void setHeight(T height) { m_frameRect.setHeight(height); }
+    template<typename T> void setBorderBoxWidth(T width) { m_frameRect.setWidth(width); }
+    template<typename T> void setBorderBoxHeight(T height) { m_frameRect.setHeight(height); }
 
     inline LayoutUnit logicalLeft() const;
     inline LayoutUnit logicalRight() const;

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -210,9 +210,9 @@ inline const LayoutRect RenderBox::scrollablePaddingAreaOverflowRect() const
 inline void RenderBox::setLogicalHeight(LayoutUnit size)
 {
     if (writingMode().isHorizontal())
-        setHeight(size);
+        setBorderBoxHeight(size);
     else
-        setWidth(size);
+        setBorderBoxWidth(size);
 }
 
 inline void RenderBox::setLogicalLeft(LayoutUnit left)
@@ -234,9 +234,9 @@ inline void RenderBox::setLogicalTop(LayoutUnit top)
 inline void RenderBox::setLogicalWidth(LayoutUnit size)
 {
     if (writingMode().isHorizontal())
-        setWidth(size);
+        setBorderBoxWidth(size);
     else
-        setHeight(size);
+        setBorderBoxHeight(size);
 }
 
 inline bool RenderBox::hasStretchedLogicalHeight(StretchingMode mode) const

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -370,7 +370,7 @@ void RenderDeprecatedFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren,
                 && parent()->style().boxAlign() == BoxAlignment::Stretch))
             relayoutChildren = RelayoutChildren::Yes;
 
-        setHeight(0);
+        setBorderBoxHeight(0);
 
         m_stretchingChildren = false;
 
@@ -487,7 +487,7 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
     // The first pass skips flexible objects completely.
     do {
         // Reset our height.
-        setHeight(yPos);
+        setBorderBoxHeight(yPos);
 
         xPos = borderLeft() + paddingLeft();
 
@@ -527,17 +527,17 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
                 maxDescent = std::max(maxDescent, descent);
 
                 // Now update our height.
-                setHeight(std::max(yPos + maxAscent + maxDescent, borderBoxHeight()));
+                setBorderBoxHeight(std::max(yPos + maxAscent + maxDescent, borderBoxHeight()));
             }
             else
-                setHeight(std::max(borderBoxHeight(), yPos + child->borderBoxHeight() + child->verticalMarginExtent()));
+                setBorderBoxHeight(std::max(borderBoxHeight(), yPos + child->borderBoxHeight() + child->verticalMarginExtent()));
         }
         ASSERT(childIndex == childLayoutDeltas.size());
 
         if (!iterator.first() && hasLineIfEmpty())
-            setHeight(borderBoxHeight() + lineHeight());
+            setBorderBoxHeight(borderBoxHeight() + lineHeight());
 
-        setHeight(borderBoxHeight() + toAdd);
+        setBorderBoxHeight(borderBoxHeight() + toAdd);
 
         oldHeight = borderBoxHeight();
         updateLogicalHeight();
@@ -746,7 +746,7 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
     // So that the computeLogicalHeight in layoutBlock() knows to relayout positioned objects because of
     // a height change, we revert our height back to the intrinsic height before returning.
     if (heightSpecified)
-        setHeight(oldHeight);
+        setBorderBoxHeight(oldHeight);
 }
 
 void RenderDeprecatedFlexibleBox::layoutSingleClampedFlexItem()
@@ -774,7 +774,7 @@ void RenderDeprecatedFlexibleBox::layoutSingleClampedFlexItem()
     } else
         childBoxBottom += clampedRendererCandidate.contentBoxRect().height() + clampedRendererCandidate.marginBottom();
 
-    setHeight(childBoxBottom + paddingBottom() + borderBottom());
+    setBorderBoxHeight(childBoxBottom + paddingBottom() + borderBottom());
     updateLogicalHeight();
 
     computeInFlowOverflow(flippedContentBoxRect());
@@ -815,7 +815,7 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
     // Our first pass is done without flexing.  We simply lay the children
     // out within the box.
     do {
-        setHeight(borderTop() + paddingTop());
+        setBorderBoxHeight(borderTop() + paddingTop());
         LayoutUnit minHeight = borderBoxHeight() + toAdd;
 
         for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
@@ -839,7 +839,7 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
             child->computeAndSetBlockDirectionMargins(*this);
 
             // Add in the child's marginTop to our height.
-            setHeight(borderBoxHeight() + child->marginTop());
+            setBorderBoxHeight(borderBoxHeight() + child->marginTop());
 
             if (!haveLineClamp)
                 child->markForPaginationRelayoutIfNeeded();
@@ -872,20 +872,20 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
 
             // Place the child.
             placeChild(child, LayoutPoint(childX, borderBoxHeight()));
-            setHeight(borderBoxHeight() + child->borderBoxHeight() + child->marginBottom());
+            setBorderBoxHeight(borderBoxHeight() + child->borderBoxHeight() + child->marginBottom());
         }
 
         yPos = borderBoxHeight();
 
         if (!iterator.first() && hasLineIfEmpty())
-            setHeight(borderBoxHeight() + lineHeight());
+            setBorderBoxHeight(borderBoxHeight() + lineHeight());
 
-        setHeight(borderBoxHeight() + toAdd);
+        setBorderBoxHeight(borderBoxHeight() + toAdd);
 
         // Negative margins can cause our height to shrink below our minimal height (border/padding).
         // If this happens, ensure that the computed height is increased to the minimal height.
         if (borderBoxHeight() < minHeight)
-            setHeight(minHeight);
+            setBorderBoxHeight(minHeight);
 
         // Now we have to calc our height, so we know how much space we have remaining.
         oldHeight = borderBoxHeight();
@@ -1041,12 +1041,12 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
         };
         auto usedHeight = borderBoxHeight();
         auto clampedHeight = contentOffset() + clampedContent.contentHeight + borderBottom() + paddingBottom();
-        setHeight(clampedHeight);
+        setBorderBoxHeight(clampedHeight);
         updateLogicalHeight();
         if (clampedHeight != borderBoxHeight())
-            setHeight(heightSpecified ? oldHeight : usedHeight);
+            setBorderBoxHeight(heightSpecified ? oldHeight : usedHeight);
     } else if (heightSpecified)
-        setHeight(oldHeight);
+        setBorderBoxHeight(oldHeight);
 }
 
 static size_t lineCountFor(const RenderBlockFlow& blockFlow)

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -440,8 +440,8 @@ void RenderFrameSet::layout()
     }
 
     if (!parent()->isRenderFrameSet() && !protect(document())->printing()) {
-        setWidth(view().viewWidth());
-        setHeight(view().viewHeight());
+        setBorderBoxWidth(view().viewWidth());
+        setBorderBoxHeight(view().viewHeight());
     }
 
     unsigned cols = frameSetElement().totalCols();
@@ -480,8 +480,8 @@ static void resetFrameRendererAndDescendants(RenderBox* frameSetChild, RenderFra
         return;
 
     for (auto* descendant = frameSetChild; descendant; descendant = downcast<RenderBox>(RenderObjectTraversal::next(*descendant, &parentFrameSet))) {
-        descendant->setWidth(0);
-        descendant->setHeight(0);
+        descendant->setBorderBoxWidth(0);
+        descendant->setBorderBoxHeight(0);
         descendant->clearNeedsLayout();
     }
 }
@@ -505,8 +505,8 @@ void RenderFrameSet::positionFrames()
             int width = m_cols.m_sizes[c];
 
             // has to be resized and itself resize its contents
-            child->setWidth(width);
-            child->setHeight(height);
+            child->setBorderBoxWidth(width);
+            child->setBorderBoxHeight(height);
 #if PLATFORM(IOS_FAMILY)
             // FIXME: Is this iOS-specific?
             child->setNeedsLayout(MarkingBehavior::MarkOnlyThis);

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -339,8 +339,8 @@ void RenderListMarker::layout()
     if (isImage()) {
         updateInlineMarginsAndContent();
         RefPtr image = m_image;
-        setWidth(image->imageSize(this, style().usedZoom()).width());
-        setHeight(image->imageSize(this, style().usedZoom()).height());
+        setBorderBoxWidth(image->imageSize(this, style().usedZoom()).width());
+        setBorderBoxHeight(image->imageSize(this, style().usedZoom()).height());
         m_layoutBounds = { borderBoxHeight(), 0 };
     } else {
         setLogicalWidth(minContentLogicalWidthContribution());

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -158,7 +158,7 @@ void RenderReplaced::layout()
 
     LayoutRect oldContentRect = replacedContentRect();
     
-    setHeight(minimumReplacedHeight());
+    setBorderBoxHeight(minimumReplacedHeight());
 
     updateLogicalWidth();
     updateLogicalHeight();

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -67,11 +67,11 @@ void RenderScrollbarPart::layout()
 void RenderScrollbarPart::layoutHorizontalPart()
 {
     if (m_part == ScrollbarBGPart) {
-        setWidth(protect(m_scrollbar.get())->width());
+        setBorderBoxWidth(protect(m_scrollbar.get())->width());
         computeScrollbarHeight();
     } else {
         computeScrollbarWidth();
-        setHeight(protect(m_scrollbar.get())->height());
+        setBorderBoxHeight(protect(m_scrollbar.get())->height());
     }
 }
 
@@ -79,9 +79,9 @@ void RenderScrollbarPart::layoutVerticalPart()
 {
     if (m_part == ScrollbarBGPart) {
         computeScrollbarWidth();
-        setHeight(protect(m_scrollbar.get())->height());
+        setBorderBoxHeight(protect(m_scrollbar.get())->height());
     } else {
-        setWidth(protect(m_scrollbar.get())->width());
+        setBorderBoxWidth(protect(m_scrollbar.get())->width());
         computeScrollbarHeight();
     }
 }
@@ -115,7 +115,7 @@ void RenderScrollbarPart::computeScrollbarWidth()
     auto width = calcScrollbarThicknessUsing(style().width(), zoomFactor);
     auto minWidth = calcScrollbarThicknessUsing(style().minWidth(), zoomFactor);
     auto maxWidth = style().maxWidth().isNone() ? width : calcScrollbarThicknessUsing(style().maxWidth(), zoomFactor);
-    setWidth(std::max(minWidth, std::min(maxWidth, width)));
+    setBorderBoxWidth(std::max(minWidth, std::min(maxWidth, width)));
     
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
     m_marginBox.setLeft(Style::evaluateMinimum<LayoutUnit>(style().marginLeft(), 0_lu, style().usedZoomForLength()));
@@ -130,7 +130,7 @@ void RenderScrollbarPart::computeScrollbarHeight()
     auto height = calcScrollbarThicknessUsing(style().height(), zoomFactor);
     auto minHeight = calcScrollbarThicknessUsing(style().minHeight(), zoomFactor);
     auto maxHeight = style().maxHeight().isNone() ? height : calcScrollbarThicknessUsing(style().maxHeight(), zoomFactor);
-    setHeight(std::max(minHeight, std::min(maxHeight, height)));
+    setBorderBoxHeight(std::max(minHeight, std::min(maxHeight, height)));
 
     // Buttons and track pieces can all have margins along the axis of the scrollbar. 
     m_marginBox.setTop(Style::evaluateMinimum<LayoutUnit>(style().marginTop(), 0_lu, style().usedZoomForLength()));
@@ -167,8 +167,8 @@ void RenderScrollbarPart::paintIntoRect(GraphicsContext& graphicsContext, const 
 {
     // Make sure our dimensions match the rect.
     setLocation(rect.location() - toLayoutSize(paintOffset));
-    setWidth(rect.width());
-    setHeight(rect.height());
+    setBorderBoxWidth(rect.width());
+    setBorderBoxHeight(rect.height());
 
     if (graphicsContext.paintingDisabled() || style().opacity().isTransparent())
         return;

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -80,7 +80,7 @@ void RenderSVGForeignObject::paint(PaintInfo& paintInfo, const LayoutPoint& pain
 
 void RenderSVGForeignObject::updateLogicalWidth()
 {
-    setWidth(enclosingLayoutRect(m_viewport).width());
+    setBorderBoxWidth(enclosingLayoutRect(m_viewport).width());
 }
 
 RenderBox::LogicalExtentComputedValues RenderSVGForeignObject::computeLogicalHeight(LayoutUnit, LayoutUnit logicalTop) const


### PR DESCRIPTION
#### 3c46119f53450bbe2474543a21f78b7b24b28fec
<pre>
[cleanup] Rename RenderBox::setWidth()/setHeight() to setBorderBoxWidth()/setBorderBoxHeight()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318039">https://bugs.webkit.org/show_bug.cgi?id=318039</a>
&lt;<a href="https://rdar.apple.com/problem/180975454">rdar://problem/180975454</a>&gt;

Reviewed by Antti Koivisto.

Follow-up to the width()/height() -&gt; borderBoxWidth()/borderBoxHeight() rename.
setWidth()/setHeight() set the border box width/height, but the bare names
didn&apos;t say so -- the unqualified odd ones out next to setBorderBoxSize() and the
borderBox* getters. Name them for what they are.

Mechanical rename across WebCore; no behavior change.

* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.cpp:
(FlexLayout::layout):
(FlexLayout::updateRenderers):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(GridLayout::updateGridItemRenderers):
(GridLayout::updateFormattingContextRootRenderer):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxInlines.h:
(RenderBox::setLogicalHeight):
(RenderBox::setLogicalWidth):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(RenderDeprecatedFlexibleBox::layoutBlock):
(RenderDeprecatedFlexibleBox::layoutHorizontalBox):
(RenderDeprecatedFlexibleBox::layoutSingleClampedFlexItem):
(RenderDeprecatedFlexibleBox::layoutVerticalBox):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(RenderFrameSet::layout):
(resetFrameRendererAndDescendants):
(RenderFrameSet::positionFrames):
* Source/WebCore/rendering/RenderListMarker.cpp:
(RenderListMarker::layout):
* Source/WebCore/rendering/RenderReplaced.cpp:
(RenderReplaced::layout):
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
(RenderScrollbarPart::layoutHorizontalPart):
(RenderScrollbarPart::layoutVerticalPart):
(RenderScrollbarPart::computeScrollbarWidth):
(RenderScrollbarPart::computeScrollbarHeight):
(RenderScrollbarPart::paintIntoRect):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(RenderSVGForeignObject::updateLogicalWidth):

Canonical link: <a href="https://commits.webkit.org/316122@main">https://commits.webkit.org/316122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e22a56ed244e2d1d697578ca807f97b32c3e7438

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128649 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07045d7a-9103-4fb9-b91b-ae199e3826e3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133332 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2a51371-8555-419a-979d-501bb9149ffa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113808 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d391021-f24c-449f-8a0c-3a6a75c154d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33483 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141785 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44515 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141595 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38208 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45204 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109909 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36858 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117095 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43715 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->