### PR TITLE
[JSC] DFGArgumentsEliminationPhase removeViaKill should reset node scan index between InlineCallFrames

### DIFF
--- a/JSTests/stress/arguments-elimination-multiple-inline-call-frames.js
+++ b/JSTests/stress/arguments-elimination-multiple-inline-call-frames.js
@@ -1,0 +1,38 @@
+//@ skip if $buildType == "debug"
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=500")
+
+let g = 0;
+function restY(c, ...r) { g = c ? 1 : 2; return r; }
+function h(c, ...r) { return r; }
+function h2(...r) { return r; }
+function sink() {
+    let out = [];
+    for (let i = 0; i < arguments.length; i++) out.push(arguments[i]);
+    return out;
+}
+noInline(sink);
+
+function restX(c, ...rx) {
+    let arr = [...rx, ...restY(c, ...rx)];
+    let dummy = [0, 0, 0, 0, 0, 0, 0, h(50, 9.9, 8.8)];
+    return [sink.apply(null, arr), dummy];
+}
+for (let i = 0; i < 1000000; i++) restX(i & 1, 0.1, 0.2);
+
+function makeSrc(k) {
+return `
+(function() {
+function victim${k}(c1) {
+    let q = restX(c1, 0.1, 0.2);
+    let z = h2(7.7, 6.6);
+    return [q, z];
+}
+noInline(victim${k});
+for (let i = 0; i < 1000000; i++) {
+    victim${k}(i & 1);
+}
+})()
+`;
+}
+
+for (let k = 0; k < 30; k++) eval(makeSrc(k));

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -604,7 +604,7 @@ private:
             return interfere;
         };
 
-        auto removeViaKill = [&](BasicBlock* block, unsigned nodeIndex, Node* candidate) {
+        auto removeViaKill = [&](BasicBlock* block, const unsigned nodeIndex, Node* candidate) {
             if (!m_candidates.contains(candidate))
                 return;
 
@@ -660,21 +660,17 @@ private:
                 }
 
                 // This loop considers all nodes up to the nodeIndex, excluding the nodeIndex.
+                // scanIndex is a working copy so each inline call frame independently
+                // scans the full [0, nodeIndex) range.
                 //
-                // Note: nodeIndex here has a double meaning. Before entering this
-                // while loop, it refers to the remaining number of nodes that have
-                // yet to be processed. Inside the loop, it refers to the index
-                // of the current node to process (after we decrement it).
-                //
-                // If the remaining number of nodes is 0, we should not decrement nodeIndex.
-                // Hence, we must only decrement nodeIndex inside the while loop instead of
-                // in its condition statement. Note that this while loop is embedded in an
-                // outer for loop. If we decrement nodeIndex in the condition statement, a
-                // nodeIndex of 0 will become UINT_MAX, and the outer loop will wrongly
-                // treat this as there being UINT_MAX remaining nodes to process.
-                while (nodeIndex) {
-                    --nodeIndex;
-                    Node* node = block->at(nodeIndex);
+                // If the remaining number of nodes is 0, we should not decrement
+                // scanIndex. Hence, we must only decrement it inside the while loop
+                // instead of in its condition statement; otherwise a scanIndex of 0 would
+                // become UINT_MAX.
+                unsigned scanIndex = nodeIndex;
+                while (scanIndex) {
+                    --scanIndex;
+                    Node* node = block->at(scanIndex);
                     if (node == candidate)
                         break;
 
@@ -693,7 +689,7 @@ private:
                         NoOpClobberize());
 
                     if (found) {
-                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", block->at(nodeIndex));
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", block->at(scanIndex));
                         transitivelyRemoveCandidate(candidate);
                         return;
                     }


### PR DESCRIPTION
#### c3ca56b3af803be584aad6498beab4fec68b6a1e
<pre>
[JSC] DFGArgumentsEliminationPhase removeViaKill should reset node scan index between InlineCallFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=314850">https://bugs.webkit.org/show_bug.cgi?id=314850</a>
<a href="https://rdar.apple.com/176966728">rdar://176966728</a>

Reviewed by Yusuke Suzuki.

In DFGArgumentsEliminationPhase::eliminateCandidatesThatInterfere(), the removeViaKill
lambda contains two nested loops. The outer loop iterates over inline call frames. For
each frame, the inner loop is expected to iterate the nodes of the given basic block in
reverse order in the range [0, nodeIndex). However, because the inner loop mutates the
lambda parameter nodeIndex directly, this only works as intended for the first inline call
frame. Each subsequent call frame begins where the previous one left off.

The change introduces a separate iteration variable for the inner loop, which starts off
at nodeIndex for each inline call frame. nodeIndex parameter is marked as &apos;const&apos; to make
explicit the expectation that it should not change.

Test: JSTests/stress/arguments-elimination-multiple-inline-call-frames.js

Originally-landed-as: 305413.912@safari-7624-branch (3270ebdb7366). <a href="https://rdar.apple.com/180435783">rdar://180435783</a>
Canonical link: <a href="https://commits.webkit.org/316118@main">https://commits.webkit.org/316118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fadb33855dc7e9e0b56be78692e2102913b9bfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180314 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133323 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35164 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33478 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28994 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2167 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182899 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32191 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141778 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44516 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141588 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45205 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109910 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36853 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117096 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203613 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43716 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54500 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->