### PR TITLE
[WebCore][bindings] Empty JSValue returned to script from callPromisePairFunction when argument conversion throws

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-throwing-argument-conversion-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-throwing-argument-conversion-expected.txt
@@ -1,0 +1,16 @@
+Tests that navigation.navigate() returns a valid NavigationResult when argument conversion throws
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.message is "test error"
+PASS finishedError.message is "test error"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-throwing-argument-conversion.html
+++ b/LayoutTests/navigation-api/navigation-navigate-throwing-argument-conversion.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() returns a valid NavigationResult when argument conversion throws");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    result = navigation.navigate({ toString() { throw new Error("test error"); } });
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.message", "test error");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.message", "test error");
+
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
@@ -56,10 +56,10 @@ public:
     }
 
     using Operation2 = JSC::EncodedJSValue(JSC::JSGlobalObject*, JSC::CallFrame*, ClassParameter, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
-    template<Operation2 operation, CastedThisErrorBehavior shouldThrow = CastedThisErrorBehavior::RejectPromise>
+    template<Operation2 operation, typename DictionaryType, CastedThisErrorBehavior shouldThrow = CastedThisErrorBehavior::RejectPromise>
     static JSC::EncodedJSValue callReturningPromisePair(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, const char* operationName)
     {
-        return callPromisePairFunction(lexicalGlobalObject, callFrame, [&operationName] (JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, Ref<DeferredPromise>&& promise, Ref<DeferredPromise>&& promise2) {
+        return callPromisePairFunction<DictionaryType>(lexicalGlobalObject, callFrame, [&operationName] (JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, Ref<DeferredPromise>&& promise, Ref<DeferredPromise>&& promise2) {
             auto* thisObject = IDLOperation<JSClass>::cast(lexicalGlobalObject, callFrame);
             if constexpr (shouldThrow != CastedThisErrorBehavior::Assert) {
                 if (!thisObject) [[unlikely]]

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -250,18 +250,30 @@ void DeferredPromise::reject(ExceptionCode ec, const String& message, RejectAsHa
         handleUncaughtException(scope, lexicalGlobalObject);
 }
 
-void rejectPromiseWithExceptionIfAny(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, JSPromise& promise, JSC::TopExceptionScope& catchScope)
+static JSValue takeNonTerminationException(JSC::TopExceptionScope& catchScope)
 {
-    UNUSED_PARAM(lexicalGlobalObject);
     if (!catchScope.exception()) [[likely]]
-        return;
+        return { };
     if (catchScope.vm().hasPendingTerminationException())
-        return;
+        return { };
 
     JSValue error = catchScope.exception()->value();
     catchScope.clearException();
+    return error;
+}
 
-    DeferredPromise::create(globalObject, promise)->reject<IDLAny>(error);
+void rejectPromiseWithExceptionIfAny(JSC::JSGlobalObject&, JSDOMGlobalObject& globalObject, JSPromise& promise, JSC::TopExceptionScope& catchScope)
+{
+    if (auto error = takeNonTerminationException(catchScope)) [[unlikely]]
+        DeferredPromise::create(globalObject, promise)->reject<IDLAny>(error);
+}
+
+void rejectPromisesWithExceptionIfAny(JSC::JSGlobalObject&, JSDOMGlobalObject& globalObject, JSPromise& promise1, JSPromise& promise2, JSC::TopExceptionScope& catchScope)
+{
+    if (auto error = takeNonTerminationException(catchScope)) [[unlikely]] {
+        DeferredPromise::create(globalObject, promise1)->reject<IDLAny>(error);
+        DeferredPromise::create(globalObject, promise2)->reject<IDLAny>(error);
+    }
 }
 
 JSC::EncodedJSValue createRejectedPromiseWithTypeError(JSC::JSGlobalObject& lexicalGlobalObject, const String& errorMessage, RejectedPromiseWithTypeErrorCause cause)

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -32,6 +32,7 @@
 #include <WebCore/JSDOMConvertBase.h>
 #include <WebCore/JSDOMGlobalObject.h>
 #include <WebCore/JSDOMGuardedObject.h>
+#include <WebCore/JSDOMPromise.h>
 #include <WebCore/JSDOMPromiseDeferredForward.h>
 #include <WebCore/ScriptExecutionContext.h>
 
@@ -373,6 +374,7 @@ void fulfillPromiseWithArrayBufferFromSpan(Ref<DeferredPromise>&&, std::span<con
 void fulfillPromiseWithUint8Array(Ref<DeferredPromise>&&, Uint8Array*);
 void fulfillPromiseWithUint8ArrayFromSpan(Ref<DeferredPromise>&&, std::span<const uint8_t>);
 WEBCORE_EXPORT void rejectPromiseWithExceptionIfAny(JSC::JSGlobalObject&, JSDOMGlobalObject&, JSC::JSPromise&, JSC::TopExceptionScope&);
+WEBCORE_EXPORT void rejectPromisesWithExceptionIfAny(JSC::JSGlobalObject&, JSDOMGlobalObject&, JSC::JSPromise&, JSC::JSPromise&, JSC::TopExceptionScope&);
 
 enum class RejectedPromiseWithTypeErrorCause { NativeGetter, InvalidThis };
 JSC::EncodedJSValue createRejectedPromiseWithTypeError(JSC::JSGlobalObject&, const String&, RejectedPromiseWithTypeErrorCause);
@@ -422,25 +424,33 @@ inline JSC::JSValue callPromiseFunction(JSC::JSGlobalObject& lexicalGlobalObject
 
 using PromisePairFunction = JSC::EncodedJSValue(JSC::JSGlobalObject&, JSC::CallFrame&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-template<typename PromisePairFunctor>
+template<typename DictionaryType, typename PromisePairFunctor>
 inline JSC::EncodedJSValue callPromisePairFunction(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, PromisePairFunctor functor)
 {
     JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
     auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     auto& globalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
-    auto* promise = JSC::JSPromise::create(vm, globalObject.promiseStructure());
-    ASSERT(promise);
+    auto* promise1 = JSC::JSPromise::create(vm, globalObject.promiseStructure());
+    ASSERT(promise1);
     auto* promise2 = JSC::JSPromise::create(vm, globalObject.promiseStructure());
     ASSERT(promise2);
 
-    auto result = functor(globalObject, callFrame, DeferredPromise::create(globalObject, *promise, DeferredPromise::Mode::RetainPromiseOnResolve), DeferredPromise::create(globalObject, *promise2, DeferredPromise::Mode::RetainPromiseOnResolve));
+    auto result = functor(globalObject, callFrame, DeferredPromise::create(globalObject, *promise1, DeferredPromise::Mode::RetainPromiseOnResolve), DeferredPromise::create(globalObject, *promise2, DeferredPromise::Mode::RetainPromiseOnResolve));
 
-    rejectPromiseWithExceptionIfAny(lexicalGlobalObject, globalObject, *promise, catchScope);
-    rejectPromiseWithExceptionIfAny(lexicalGlobalObject, globalObject, *promise2, catchScope);
+    rejectPromisesWithExceptionIfAny(lexicalGlobalObject, globalObject, *promise1, *promise2, catchScope);
+
     // FIXME: We could have error since any JS call can throw stack-overflow errors.
     // https://bugs.webkit.org/show_bug.cgi?id=203402
     RETURN_IF_EXCEPTION(catchScope, JSC::encodedJSValue());
+
+    // When the functor threw (e.g. during IDL argument conversion), its return
+    // value is an empty JSValue sentinel. Rebuild a valid result dictionary from
+    // the (now rejected) promises via convertDictionaryToJS.
+    if (!JSC::JSValue::decode(result)) [[unlikely]] {
+        result = JSC::JSValue::encode(convertDictionaryToJS(lexicalGlobalObject, globalObject, DictionaryType { DOMPromise::create(globalObject, *promise1), DOMPromise::create(globalObject, *promise2) }));
+        RETURN_IF_EXCEPTION(catchScope, JSC::encodedJSValue());
+    }
 
     return result;
 }

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6369,6 +6369,11 @@ sub GenerateOperationTrampolineDefinition
 
     my @callFunctionTemplateArguments = ();
     push(@callFunctionTemplateArguments, $functionBodyName);
+    if ($operation->extendedAttributes->{ReturnsPromisePair}) {
+        my $dictClassName = GetDictionaryClassName($operation->type, $interface);
+        push(@callFunctionTemplateArguments, $dictClassName);
+        AddToImplIncludes("JSDOMPromise.h", $operation->extendedAttributes->{Conditional});
+    }
     push(@callFunctionTemplateArguments, "CastedThisErrorBehavior::Assert") if ($operation->extendedAttributes->{PrivateIdentifier} and not $operation->extendedAttributes->{PublicIdentifier});
 
     push(@$outputArray, "JSC_DEFINE_HOST_FUNCTION(${functionName}, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))\n");

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -65,6 +65,7 @@
 #include "JSDOMIterator.h"
 #include "JSDOMOperation.h"
 #include "JSDOMOperationReturningPromise.h"
+#include "JSDOMPromise.h"
 #include "JSDOMStringList.h"
 #include "JSDOMWindowBase.h"
 #include "JSDOMWrapperCache.h"
@@ -7824,7 +7825,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_returnsPromisePairB
 
 JSC_DEFINE_HOST_FUNCTION(jsTestObjPrototypeFunction_returnsPromisePair, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))
 {
-    return IDLOperationReturningPromise<JSTestObj>::callReturningPromisePair<jsTestObjPrototypeFunction_returnsPromisePairBody>(*lexicalGlobalObject, *callFrame, "returnsPromisePair");
+    return IDLOperationReturningPromise<JSTestObj>::callReturningPromisePair<jsTestObjPrototypeFunction_returnsPromisePairBody, TestObj::PromisePair>(*lexicalGlobalObject, *callFrame, "returnsPromisePair");
 }
 
 #if ENABLE(TEST_FEATURE)


### PR DESCRIPTION
#### fd534310ae5b062f39edf63d07f15ae47b24fc4f
<pre>
[WebCore][bindings] Empty JSValue returned to script from callPromisePairFunction when argument conversion throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=313618">https://bugs.webkit.org/show_bug.cgi?id=313618</a>
<a href="https://rdar.apple.com/175673155">rdar://175673155</a>

Reviewed by Ryosuke Niwa.

callPromisePairFunction stored the functor&apos;s EncodedJSValue and returned it
after passing the catch scope through rejectPromiseWithExceptionIfAny. When the
generated operation body threw during IDL argument conversion, it returned
encodedJSValue() (the empty JSValue sentinel) with a pending exception. The
first rejectPromiseWithExceptionIfAny call cleared that exception to reject the
first promise, so the second call was a no-op — leaving the second promise
unrejected — and RETURN_IF_EXCEPTION did not fire. The empty sentinel was then
returned to JavaScript as a script-visible value.

Fix by:
  - Introducing rejectPromisesWithExceptionIfAny, which saves the error value
    before clearing the exception and rejects both promises. Shared
    takeNonTerminationException helper factors out the check-save-clear logic
    from rejectPromiseWithExceptionIfAny.
  - Adding a DictionaryType template parameter to callPromisePairFunction. When
    the functor returns an empty JSValue (the error-path sentinel),
    callPromisePairFunction reconstructs a valid result dictionary from the
    rejected promises via convertDictionaryToJS.
  - Threading the concrete dictionary type (e.g. Navigation::Result) from the
    code generator through callReturningPromisePair to callPromisePairFunction.

Test: navigation-api/navigation-navigate-throwing-argument-conversion.html

* LayoutTests/navigation-api/navigation-navigate-throwing-argument-conversion-expected.txt: Added.
* LayoutTests/navigation-api/navigation-navigate-throwing-argument-conversion.html: Added.
* Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h:
(WebCore::IDLOperationReturningPromise::callReturningPromisePair):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::takeNonTerminationException):
(WebCore::rejectPromiseWithExceptionIfAny):
(WebCore::rejectPromisesWithExceptionIfAny):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::callPromisePairFunction):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateOperationTrampolineDefinition):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):

Originally-landed-as: 305413.776@safari-7624-branch (332eff8c4870). <a href="https://rdar.apple.com/180436895">rdar://180436895</a>
Canonical link: <a href="https://commits.webkit.org/316150@main">https://commits.webkit.org/316150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8fd73a60cf9f1fa496ddc506dfad0359f910088

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172859 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46191 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133364 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33516 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182958 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141818 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141627 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38256 "Failed to push commit to Webkit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45264 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109969 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36886 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117155 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43775 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->