### PR TITLE
YarrJIT negativeOffsetIndexedAddress discards adjusted base register

### DIFF
--- a/JSTests/stress/yarr-negative-offset.js
+++ b/JSTests/stress/yarr-negative-offset.js
@@ -1,0 +1,33 @@
+//@ skip if $memoryLimited
+
+// YarrJIT OOB crash — page-aligned variant
+//
+// sizeof(StringImpl) = 0x14, page_size = 0x4000 (Apple Silicon 16K pages)
+// Solve: 0x14 + (K + 0x40000000)*2 ≡ 0 (mod 0x4000)  →  K = 0x1FF6
+//
+// Pattern: \u0100{K} [\u0100] \u0100{0x3FFFFFFF}    flags: y
+// Subject: "\u0100".repeat(K + 0x40000000)
+//
+// The OOB ldrh lands at alloc_base + page_size*N exactly → unmapped → SIGSEGV
+
+"use strict";
+
+const K     = 0x1FF6;
+const LEN   = K + 0x40000000;   // 0x40001FF6
+const QUANT = 0x3FFFFFFF;
+
+// allocate
+let s;
+try {
+    s = "\u0100".repeat(LEN);
+} catch (e) {
+    print("[!] OOM: " + e);
+    quit();
+}
+if(s.length !== 0x40001ff6) throw new Error("unexpected s.length "+s.length);
+
+let pattern = "\\u0100{" + K + "}[\\u0100]\\u0100{" + QUANT + "}";
+let re = new RegExp(pattern, "y");
+re.lastIndex = 0;
+
+re.test(s); // should SIGSEGV if the bug is present

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1326,9 +1326,9 @@ class YarrGenerator final : public YarrJITInfo {
         Checked<int32_t> characterOffset(-static_cast<int32_t>(negativeCharacterOffset));
 
         if (m_charSize == CharSize::Char8)
-            return MacroAssembler::BaseIndex(m_regs.input, indexReg, MacroAssembler::TimesOne, characterOffset * static_cast<int32_t>(sizeof(char)));
+            return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesOne, characterOffset * static_cast<int32_t>(sizeof(char)));
 
-        return MacroAssembler::BaseIndex(m_regs.input, indexReg, MacroAssembler::TimesTwo, characterOffset * static_cast<int32_t>(sizeof(char16_t)));
+        return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesTwo, characterOffset * static_cast<int32_t>(sizeof(char16_t)));
     }
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)


### PR DESCRIPTION
#### bd5f1e5b17d9fbc4bfc6e5d78e1f7d6153f7416a
<pre>
YarrJIT negativeOffsetIndexedAddress discards adjusted base register
<a href="https://bugs.webkit.org/show_bug.cgi?id=312415">https://bugs.webkit.org/show_bug.cgi?id=312415</a>
<a href="https://rdar.apple.com/174714198">rdar://174714198</a>

Reviewed by Yijia Huang.

In YarrJIT negativeOffsetIndexedAddress computes a negative offset from
a base address but the function mistakenly uses the original value
instead of the adjusted value. This patch fixes it to use the adjusted
value.

Test: JSTests/stress/yarr-negative-offset.js

* JSTests/stress/yarr-negative-offset.js: Added.
(catch):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Originally-landed-as: 305413.685@safari-7624-branch (30c8460241f3). <a href="https://rdar.apple.com/180436598">rdar://180436598</a>
Canonical link: <a href="https://commits.webkit.org/316127@main">https://commits.webkit.org/316127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e23cbd8562c665269391d5428870934fe0c3efa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128653 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133325 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33481 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28997 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2183 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182902 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32194 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141784 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44519 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141594 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38220 "Failed to checkout and rebase branch from PR 68162") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45208 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109913 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36856 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117099 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203616 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43719 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54501 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->