### PR TITLE
[CoreIPC] [NP] Heap UAF in WebCore::IDBServer::MemoryIndexCursor reverse iterator when a Prev/Prevunique cursor's next-higher index entry is deleted

### DIFF
--- a/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private-expected.txt
@@ -1,0 +1,16 @@
+Tests that a reverse index cursor doesn't use-after-free when a record is deleted whose index key is the next-higher value from the cursor's current position.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+PASS cursorKeys.length is 3
+PASS cursorKeys[0] is 30
+PASS cursorKeys[1] is 20
+PASS cursorKeys[2] is 10
+Transaction completed successfully.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private.html
+++ b/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private.html
@@ -1,0 +1,86 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script>
+description("Tests that a reverse index cursor doesn't use-after-free when a record " +
+            "is deleted whose index key is the next-higher value from the " +
+            "cursor's current position.");
+
+removeVendorPrefixes();
+
+var dbname = "index-cursor-reverse-delete-next-higher-key-private";
+var db, tx, store, index;
+var cursorKeys = [];
+
+var request = indexedDB.open(dbname);
+request.onupgradeneeded = function(event) {
+    db = event.target.result;
+    store = db.createObjectStore("store", { keyPath: "pk" });
+    index = store.createIndex("idx", "v");
+};
+request.onsuccess = function(event) {
+    db = event.target.result;
+    runTest();
+};
+request.onerror = unexpectedErrorCallback;
+
+function runTest() {
+    tx = db.transaction("store", "readwrite");
+    store = tx.objectStore("store");
+    index = store.index("idx");
+
+    // Add 3 records with distinct index keys: 10, 20, 30.
+    store.put({ pk: 1, v: 10 });
+    store.put({ pk: 2, v: 20 });
+    store.put({ pk: 3, v: 30 });
+
+    // Open a reverse key cursor on the index.
+    var cursorReq = index.openKeyCursor(null, "prev");
+    var step = 0;
+
+    cursorReq.onsuccess = function(event) {
+        var cursor = event.target.result;
+        if (!cursor) {
+            shouldBe("cursorKeys.length", "3");
+            shouldBe("cursorKeys[0]", "30");
+            shouldBe("cursorKeys[1]", "20");
+            shouldBe("cursorKeys[2]", "10");
+            return;
+        }
+
+        cursorKeys.push(cursor.key);
+
+        if (step === 0) {
+            // Cursor at indexKey=30, pk=3. The reverse_iterator base() = end().
+            // Advance to next lower key.
+            step++;
+            cursor.continue();
+        } else if (step === 1) {
+            // Cursor at indexKey=20, pk=2.  base() now = iterator-to-node-30.
+            // Delete pk=3 (indexKey=30).  This frees the node that base() references
+            // while indexValueChanged() early-returns (m_currentKey 20 != 30).
+            // Then advance -- without the fix this dereferences the freed node.
+            step++;
+            store.delete(3);
+            cursor.continue();
+        } else {
+            // Cursor at indexKey=10, pk=1 (should reach here after fix).
+            step++;
+            cursor.continue();
+        }
+    };
+
+    cursorReq.onerror = unexpectedErrorCallback;
+    tx.onerror = unexpectedErrorCallback;
+    tx.oncomplete = function() {
+        debug("Transaction completed successfully.");
+        finishJSTest();
+    };
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
@@ -221,7 +221,12 @@ void MemoryIndexCursor::indexRecordsAllChanged()
 
 void MemoryIndexCursor::indexValueChanged(const IDBKeyData& key, const IDBKeyData& primaryKey)
 {
-    if (m_currentKey != key || m_currentPrimaryKey != primaryKey)
+    // For Prev/Prevunique cursors, m_currentIterator wraps std::set reverse_iterators
+    // whose stored base() points one element past the logical position. Erasing that
+    // adjacent element leaves base() dangling even though m_currentKey/m_currentPrimaryKey
+    // are unchanged, so for reverse cursors we must invalidate on any index mutation
+    // and let iterate() re-seek via reverseFind().
+    if (info().isDirectionForward() && (m_currentKey != key || m_currentPrimaryKey != primaryKey))
         return;
 
     m_currentIterator.invalidate();


### PR DESCRIPTION
#### 16b1bde3c1918236d0eefee504bcf4180566087f
<pre>
[CoreIPC] [NP] Heap UAF in WebCore::IDBServer::MemoryIndexCursor reverse iterator when a Prev/Prevunique cursor&apos;s next-higher index entry is deleted
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313818">https://bugs.webkit.org/show_bug.cgi?id=313818</a>&gt;
&lt;<a href="https://rdar.apple.com/174678764">rdar://174678764</a>&gt;

Reviewed by Sihui Liu.

MemoryIndexCursor caches an IndexValueStore::Iterator across IPC messages.
For Prev/Prevunique cursors this wraps std::set&lt;IDBKeyData&gt;::reverse_iterator
objects (one for the outer IndexValueStore::m_orderedKeys set, one nested in
IndexValueEntry::Iterator for the inner per-index-key set). A
std::reverse_iterator stores a forward base() iterator pointing one element
past the logical position; for libc++ std::set that is a raw __tree_node*.

MemoryIndexCursor::indexValueChanged() only invalidates m_currentIterator
when the changed (key, primaryKey) equals the cursor&apos;s current logical
position. Deleting the next-higher index key (Variant A, outer set) or the
next-higher primary key under a shared index key (Variant B, inner set)
therefore frees exactly the __tree_node base() references while the guard
early-returns. The next IterateCursor IPC executes ++m_reverseIterator =&gt;
--base() =&gt; __tree_prev_iter(freed_node), a heap-use-after-free in
com.apple.WebKit.Networking reachable from a compromised WebContent process
via NetworkStorageManager IPC with WCP-controlled
IDBDatabaseIdentifier.m_isTransient = true forcing MemoryIDBBackingStore.

Fix by gating the equality early-return on info().isDirectionForward(). For
reverse cursors we now invalidate m_currentIterator on any index mutation;
iterate() already re-seeks via reverseFind(m_currentKey, m_currentPrimaryKey)
when the iterator is invalid. Both removeEntriesWithValueKey() erase paths
(outer m_orderedKeys.erase() and inner IndexValueEntry::removeKey()) reach
indexValueChanged() through MemoryIndex::notifyCursorsOfValueChange(), so
both variants are closed.

* LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private.html: Added.
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp:
(WebCore::IDBServer::MemoryIndexCursor::indexValueChanged):

Originally-landed-as: 305413.842@safari-7624-branch (d14d12e915f3). <a href="https://rdar.apple.com/180436983">rdar://180436983</a>
Canonical link: <a href="https://commits.webkit.org/316129@main">https://commits.webkit.org/316129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e758723c6bbaf9160711199637d3abebd541157

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133326 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33482 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182903 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141782 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141592 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109914 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36852 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Running run-layout-tests-in-stress-mode; 1 flakes") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117100 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43720 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->