### PR TITLE
[WebCore] unchecked exception return in ReadableByteStreamController::closeAndRespondToPendingPullIntos and TeeDefaultReadRequest::runCloseSteps

### DIFF
--- a/LayoutTests/streams/byob-close-exception-expected.txt
+++ b/LayoutTests/streams/byob-close-exception-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Read too much in a blob
+

--- a/LayoutTests/streams/byob-close-exception.html
+++ b/LayoutTests/streams/byob-close-exception.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    window.onerror = () => {
+        assert_not_reached("error should not fire");
+    };
+    window.addEventListener("unhandledrejection", e => {
+        assert_not_reached("there should no unhandled rejected promise");
+    });
+
+    for (let i = 0; i < 3; ++i) {
+        const response = new Response(new Blob([new Uint8Array([1, 2, 3])]));
+        const reader = response.body.getReader({ mode: "byob" });
+        await reader.read(new Uint32Array(1)).then(() => assert_not_reached("should fail"), () => { });
+    }
+}, "Read too much in a blob");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -148,7 +148,7 @@ ExceptionOr<void> ReadableByteStreamController::closeForBindings(JSDOMGlobalObje
     if (protect(stream())->state() != ReadableStream::State::Readable)
         return Exception { ExceptionCode::TypeError, "controller's stream is not readable"_s };
 
-    close(globalObject);
+    close(globalObject, ShouldThrowOnError::Yes);
     return { };
 }
 
@@ -248,7 +248,12 @@ void ReadableByteStreamController::didStart(JSDOMGlobalObject& globalObject)
 // Part of https://streams.spec.whatwg.org/#readablestream-close
 void ReadableByteStreamController::closeAndRespondToPendingPullIntos(JSDOMGlobalObject& globalObject)
 {
-    close(globalObject);
+    auto& vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm);
+
+    if (!close(globalObject, ShouldThrowOnError::No))
+        return;
+
     while (!m_pendingPullIntos.isEmpty())
         respond(globalObject, 0);
 }

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -93,7 +93,7 @@ public:
     void error(JSDOMGlobalObject&, JSC::JSValue);
 
     enum class ShouldThrowOnError : bool { No, Yes };
-    bool close(JSDOMGlobalObject&, ShouldThrowOnError = ShouldThrowOnError::Yes);
+    bool close(JSDOMGlobalObject&, ShouldThrowOnError);
     void closeAndRespondToPendingPullIntos(JSDOMGlobalObject&);
     size_t pullFromBytes(JSDOMGlobalObject&, JSC::ArrayBuffer&, size_t offset);
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBufferView&);

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -445,10 +445,15 @@ private:
         RefPtr branch2 = m_state->branch2();
 
         m_state->setReading(false);
+
+        bool shouldStopSteps = false;
         if (!m_state->canceled1() && branch1)
-            branch1->controller()->close(*globalObject);
+            shouldStopSteps = !branch1->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
         if (!m_state->canceled2() && branch2)
-            branch2->controller()->close(*globalObject);
+            shouldStopSteps |= !branch2->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
+
+        if (shouldStopSteps)
+            return;
 
         if (branch1 && branch1->controller()->hasPendingPullIntos())
             branch1->controller()->respond(*globalObject, 0);


### PR DESCRIPTION
#### b7516bee73066d5798581e69c381fbe25aeab58c
<pre>
[WebCore] unchecked exception return in ReadableByteStreamController::closeAndRespondToPendingPullIntos and TeeDefaultReadRequest::runCloseSteps
<a href="https://rdar.apple.com/175673816">rdar://175673816</a>

Reviewed by Chris Dumez.

ReadableByteStreamController::closeAndRespondToPendingPullIntos() and
TeeDefaultReadRequest::runCloseSteps() both call close(globalObject) with
the default ShouldThrowOnError::Yes flag and discard the bool return value.
When the first pending pull-into has bytesFilled % elementSize != 0,
close() calls this-&gt;error(), then throwException(...), and returns false —
leaving a TypeError pending on the VM with no RETURN_IF_EXCEPTION guard in
any caller.

The sibling BYOB path (TeeBYOBReadRequest::runCloseSteps) was fixed in
<a href="https://rdar.apple.com/165613840">rdar://165613840</a> (303821@main) to use ShouldThrowOnError::No and check the
return; these two callers were not updated at the same time.

This patch mirrors the <a href="https://rdar.apple.com/165613840">rdar://165613840</a> pattern at both unfixed callers:
- Pass ShouldThrowOnError::No and check return value in both callers
- Stop processing pending pull-intos when close() fails

It also makes ShouldThrowOnError parameter non-optional to prevent future misuse.

Test: streams/byob-close-exception.html

* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
(WebCore::ReadableByteStreamController::closeForBindings):
(WebCore::ReadableByteStreamController::closeAndRespondToPendingPullIntos):
* Source/WebCore/Modules/streams/ReadableByteStreamController.h:
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
(WebCore::TeeDefaultReadRequest::runCloseSteps):

Originally-landed-as: 305413.819@safari-7624-branch (cbd729a317dc). <a href="https://rdar.apple.com/180429188">rdar://180429188</a>
Canonical link: <a href="https://commits.webkit.org/316363@main">https://commits.webkit.org/316363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/860cea2cefca434c35172e72051d7e465f3583ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133753 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35775 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34039 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183900 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142462 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142352 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38466 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46192 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110850 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37451 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117880 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44710 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->