### PR TITLE
ANGLE: Metal: Inconsistent implementation of various DrawElements variations

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		7B8EC8472DF2E5FC00105EB6 /* EnsureLoopForwardProgress.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8EC8442DF2E5FC00105EB6 /* EnsureLoopForwardProgress.h */; };
 		7B8EC8482DF2E5FC00105EB6 /* EnsureLoopForwardProgress.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8EC8442DF2E5FC00105EB6 /* EnsureLoopForwardProgress.h */; };
 		7B8EC8492DF2E5FC00105EB6 /* EnsureLoopForwardProgress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B8EC8452DF2E5FC00105EB6 /* EnsureLoopForwardProgress.cpp */; };
+		7B91C9A82F8CE63A00420427 /* VertexArrayMtl_unittest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B91C9A62F8CDB5400420427 /* VertexArrayMtl_unittest.mm */; };
 		7B9A99BA2DDC685100160B6E /* ReduceInterfaceBlocks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A99B92DDC685100160B6E /* ReduceInterfaceBlocks.cpp */; };
 		7B9A99BB2DDC685100160B6E /* ReduceInterfaceBlocks.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B9A99B82DDC685100160B6E /* ReduceInterfaceBlocks.h */; };
 		7B9A99BC2DDC685100160B6E /* ReduceInterfaceBlocks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A99B92DDC685100160B6E /* ReduceInterfaceBlocks.cpp */; };
@@ -2402,6 +2403,7 @@
 		7B8EC83F2DF1BC9100105EB6 /* ImageTestMetal.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ImageTestMetal.mm; sourceTree = "<group>"; };
 		7B8EC8442DF2E5FC00105EB6 /* EnsureLoopForwardProgress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnsureLoopForwardProgress.h; sourceTree = "<group>"; };
 		7B8EC8452DF2E5FC00105EB6 /* EnsureLoopForwardProgress.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnsureLoopForwardProgress.cpp; sourceTree = "<group>"; };
+		7B91C9A62F8CDB5400420427 /* VertexArrayMtl_unittest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VertexArrayMtl_unittest.mm; sourceTree = "<group>"; };
 		7B9829372E0EB05200F1E9FB /* ANGLETranslator.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ANGLETranslator.xcconfig; sourceTree = "<group>"; };
 		7B9A99B82DDC685100160B6E /* ReduceInterfaceBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReduceInterfaceBlocks.h; sourceTree = "<group>"; };
 		7B9A99B92DDC685100160B6E /* ReduceInterfaceBlocks.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReduceInterfaceBlocks.cpp; sourceTree = "<group>"; };
@@ -4711,6 +4713,7 @@
 				FF81FEA425818D6800894E24 /* TransformFeedbackMtl.mm */,
 				FF81FE9725818D6800894E24 /* VertexArrayMtl.h */,
 				FF81FE9A25818D6800894E24 /* VertexArrayMtl.mm */,
+				7B91C9A62F8CDB5400420427 /* VertexArrayMtl_unittest.mm */,
 			);
 			path = metal;
 			sourceTree = "<group>";
@@ -6547,6 +6550,7 @@
 				7BFAF5C12DE59E0900327F7F /* UniformTest.cpp in Sources */,
 				7BFAF6062DE59E0900327F7F /* UnpackAlignmentTest.cpp in Sources */,
 				7BFAF5F22DE59E0900327F7F /* UnpackRowLength.cpp in Sources */,
+				7B91C9A82F8CE63A00420427 /* VertexArrayMtl_unittest.mm in Sources */,
 				7BFAF5FE2DE59E0900327F7F /* VertexAttributeTest.cpp in Sources */,
 				7BFAF5FC2DE59E0900327F7F /* ViewportTest.cpp in Sources */,
 				7BFAF6152DE59E2300327F7F /* WebGLCompatibilityTest.cpp in Sources */,


### PR DESCRIPTION
#### 8d4c7092266659c6cf81d92ba23176feb8852178
<pre>
ANGLE: Metal: Inconsistent implementation of various DrawElements variations
<a href="https://bugs.webkit.org/show_bug.cgi?id=312470">https://bugs.webkit.org/show_bug.cgi?id=312470</a>
<a href="https://rdar.apple.com/174919762">rdar://174919762</a>

Reviewed by Dan Glastonbury.

The implementation of DrawElements would be inconsistent:

The implementation has multiple stages of possible intermediate buffers.
At various stages, offsets and counts were mixed between incorrect
stages.

Historically the confusions were partly due to the logic loading
the primitive ranges sometimes from generate intermediary buffers,
sometimes from the original client-provided buffer. This was partly
fixed to load only from client-provided buffers and client arrays
in &quot;WebGL: consecutive UNSIGNED_BYTE drawElements() draw in wrong
location&quot;, but this caused a regression by other part of the code
using counts from incorrect stages.

The implementation strategy would not working for non-strip topologies,
such as GL_TRIANGLES, in primitive restart cases when provoking vertex
rewrite was needed. The provoking vertex rewrite operates per primitive.
For strip topologies, this works as each vertex index also defines a
primitive. For non-strip topologies, this is not possible as the
provoking vertex generation shader cannot know where the primitive
starts. Example: GL_TRIANGLES of {0, ff, 1, 2, 3, 4} would be dispatched
as primitives starting at 0 and 2, but the proper dispatch list
would contain just primitive at 1.

Furthermore, the logic to determine drawn index ranges was based on
scanning for primitive restart ranges, and then converting those
to draw index ranges. This algorithm was brittle and contained
quite many confusions.

Fix by:
- Resolve the draw index ranges by resolving the draw index ranges
  instead of restart ranges. These index ranges are then intersected
  with the client provided offset and count, which define the first
  index, last index range pair.
- Consistently resolve the draw index ranges ƒrom the client buffers.
- Keep all intermediate buffers consistent with the first index, count:
  the intermediate buffers always have the similar unused prefix
  than the original client-provided index buffer.
- Keep all the intermediate buffers offsets separated from the
  client-provided offset (first index). The intermediate buffers are
  allocated from the buffer pool, so they&apos;re not separate buffers but
  buffer, offset pairs. Keep these buffer, offset pairs separate from
  the client first index
- For non-strip topology draws, provide the draw ranges already to the
  provoking vertex shader helper. The provoking vertex shader is
  only run for the real draw indices instead of the full draw.
  This allows the shader to function correctly.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.h:
(rx::DrawIndexRange::DrawIndexRange):
(rx::BufferMtl::DrawIndexRangeCache::DrawIndexRangeCache):
(rx::IndexRange::IndexRange): Deleted.
(rx::BufferMtl::RestartRangeCache::RestartRangeCache): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm:
(rx::BufferMtl::markConversionBuffersDirty):
(rx::BufferMtl::clearConversionBuffers):
(rx::CalculateDrawIndexRanges):
(rx::BufferMtl::getDrawIndexRanges):
(rx::BufferMtl::GetDrawIndexRangesFromClientData):
(rx::IndexConversionBufferMtl::getRangeForConvertedBuffer): Deleted.
(rx::CalculateRestartRanges): Deleted.
(rx::BufferMtl::getRestartIndices): Deleted.
(rx::BufferMtl::GetRestartIndicesFromClientData): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h:
(rx::ContextMtl::getProvokingVertexHelper):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::drawElementsImpl):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm:
(rx::ProvokingVertexHelper::preconditionIndexBuffer):
(rx::ProvokingVertexHelper::generateIndexBuffer):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::AppendDrawCommands):
(rx::AppendDrawCommandRanges):
(rx::VertexArrayMtl::resolveDrawElementsDraw):
(rx::VertexArrayMtl::getIndexBuffer): Deleted.
(rx::VertexArrayMtl::getDrawIndices): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl_unittest.mm: Added.
* Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawElementsTest.cpp:
(angle::convertIndexBufferContents):

Originally-landed-as: 305413.713@safari-7624-branch (23eba5e02916). <a href="https://rdar.apple.com/180437073">rdar://180437073</a>
Canonical link: <a href="https://commits.webkit.org/316130@main">https://commits.webkit.org/316130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7de3bedb92bf6b921279663d9f52743ce50be2a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180540 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133437 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174119 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113902 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29220 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183125 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141907 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44742 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141716 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45431 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110136 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36969 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43942 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->