### PR TITLE
[WebKit Networking] continueWillSendRequest m_redirectionForCurrentNavigation early-return reaches Cache::storeRedirect with unrestored cachePartition

### DIFF
--- a/LayoutTests/ipc/use-redirection-for-current-navigation-message-check-expected.txt
+++ b/LayoutTests/ipc/use-redirection-for-current-navigation-message-check-expected.txt
@@ -1,0 +1,2 @@
+PASS: UseRedirectionForCurrentNavigation with non-redirect response was rejected
+

--- a/LayoutTests/ipc/use-redirection-for-current-navigation-message-check.html
+++ b/LayoutTests/ipc/use-redirection-for-current-navigation-message-check.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>
+<pre id="log"></pre>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+const out = s => document.getElementById("log").textContent += s + "\n";
+
+function fixup(CoreIPC, ArgumentSerializer) {
+    function addEnum(n) {
+        if (!(n in CoreIPC.enumInfo)) CoreIPC.enumInfo[n] = { size: 1, isOptionSet: true, validValues: [] };
+        if (n in CoreIPC.typeInfo) delete CoreIPC.typeInfo[n];
+    }
+    for (const e of ['WebCore::ResourceResponseBase::Source', 'WebCore::ResourceResponseBase::Type',
+                     'WebCore::ResourceResponseBase::Tainting', 'WebCore::UsedLegacyTLS',
+                     'WebCore::WasPrivateRelayed', 'WebCore::IPAddressSpace'])
+        addEnum(e);
+    const so = ArgumentSerializer.serializeOptional.bind(ArgumentSerializer);
+    ArgumentSerializer.serializeOptional = (t, a) => so(t, a ?? {});
+    const sm = ArgumentSerializer.serializeMarkable.bind(ArgumentSerializer);
+    ArgumentSerializer.serializeMarkable = (t, a) => sm(t, a ?? {});
+}
+
+function makeResponse(statusCode) {
+    return {
+        getResponseData: {
+            optionalValue: {
+                url: { string: 'http://target.webkit.test/app.js' },
+                mimeType: '', expectedContentLength: -1, textEncodingName: '',
+                httpStatusCode: statusCode, httpStatusText: 'X', httpVersion: 'HTTP/1.1',
+                httpHeaderFields: {
+                    commonHeaders: [{ key: 54, value: 'http://target.webkit.test/inject.js' }],
+                    uncommonHeaders: []
+                },
+                networkLoadMetrics: {}, source: 1, type: 2, tainting: 0, isRedirected: false,
+                usedLegacyTLS: 0, wasPrivateRelayed: 0, proxyName: '', isRangeRequested: false,
+                certificateInfo: {}, ipAddressSpace: 0,
+            }
+        }
+    };
+}
+
+function takeError(CoreIPC) {
+    return new Promise(resolve => {
+        CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, reply => resolve(reply.error));
+    });
+}
+
+(async () => {
+    if (!window.IPC) { out("PASS: UseRedirectionForCurrentNavigation with non-redirect response was rejected"); return testRunner?.notifyDone(); }
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+    fixup(CoreIPC, ArgumentSerializer);
+
+    // NetworkConnectionToWebProcess::useRedirectionForCurrentNavigation must reject a response that
+    // is not a redirection. A compromised WebContent process could otherwise stash a forged 301 with
+    // source=Network and an attacker-chosen Location: header on a loader and reach
+    // NetworkCache::Cache::storeRedirect with WebContent-supplied {cachePartition, url}.
+    await takeError(CoreIPC);
+    CoreIPC.Networking.NetworkConnectionToWebProcess.UseRedirectionForCurrentNavigation(0, {
+        resourceLoadIdentifier: 1n,
+        response: makeResponse(200),
+    });
+    const err = await takeError(CoreIPC);
+    out(err.includes("isRedirection")
+        ? "PASS: UseRedirectionForCurrentNavigation with non-redirect response was rejected"
+        : "FAIL: UseRedirectionForCurrentNavigation with non-redirect response was accepted (error='" + err + "')");
+
+    testRunner?.notifyDone();
+})().catch(e => { out("FAIL: " + e + "\n" + e.stack); testRunner?.notifyDone(); });
+</script>
+</body>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1853,8 +1853,12 @@ void NetworkConnectionToWebProcess::installMockContentFilter(WebCore::MockConten
 
 void NetworkConnectionToWebProcess::useRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier identifier, WebCore::ResourceResponse&& response)
 {
-    if (RefPtr loader = m_networkResourceLoaders.get(identifier))
-        loader->useRedirectionForCurrentNavigation(WTF::move(response));
+    MESSAGE_CHECK(response.isRedirection());
+    RefPtr loader = m_networkResourceLoaders.get(identifier);
+    if (!loader)
+        return;
+    MESSAGE_CHECK(loader->isMainFrameLoad());
+    loader->useRedirectionForCurrentNavigation(WTF::move(response));
 }
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1539,6 +1539,12 @@ void NetworkResourceLoader::continueWillSendRequest(ResourceRequest&& newRequest
 {
     LOADER_RELEASE_LOG("continueWillSendRequest: (isAllowedToAskUserForCredentials=%d)", isAllowedToAskUserForCredentials);
 
+    // If there is a match in the network cache, we need to reuse the original cache policy and partition.
+    // This must happen before any branch below that may store a redirect in the disk cache, otherwise a
+    // compromised WebContent process could poison the cache for an arbitrary partition.
+    newRequest.setCachePolicy(originalRequest().cachePolicy());
+    newRequest.setShouldBlockThirdPartyStorage(originalRequest().shouldBlockThirdPartyStorage());
+
     if (m_redirectionForCurrentNavigation) {
         LOADER_RELEASE_LOG("continueWillSendRequest: using stored redirect response");
         auto redirection = std::exchange(m_redirectionForCurrentNavigation, { });
@@ -1599,10 +1605,6 @@ void NetworkResourceLoader::continueWillSendRequest(ResourceRequest&& newRequest
     }
 
     m_isAllowedToAskUserForCredentials = isAllowedToAskUserForCredentials;
-
-    // If there is a match in the network cache, we need to reuse the original cache policy and partition.
-    newRequest.setCachePolicy(originalRequest().cachePolicy());
-    newRequest.setShouldBlockThirdPartyStorage(originalRequest().shouldBlockThirdPartyStorage());
 
     if (m_isWaitingContinueWillSendRequestForCachedRedirect) {
         m_isWaitingContinueWillSendRequestForCachedRedirect = false;


### PR DESCRIPTION
#### c312747ab66d89c767c51172ca1eab0b9de5d288
<pre>
[WebKit Networking] continueWillSendRequest m_redirectionForCurrentNavigation early-return reaches Cache::storeRedirect with unrestored cachePartition
<a href="https://bugs.webkit.org/show_bug.cgi?id=314862">https://bugs.webkit.org/show_bug.cgi?id=314862</a>
<a href="https://rdar.apple.com/176914483">rdar://176914483</a>

Reviewed by Alex Christensen.

A compromised WebContent process can poison the Network Process persistent
disk cache for an arbitrary cross-origin partition.

NetworkConnectionToWebProcess::useRedirectionForCurrentNavigation accepts a
WebContent-supplied ResourceResponse with no validation and stashes it on the
loader as m_redirectionForCurrentNavigation. When the loader&apos;s WillSendRequest
async reply later delivers a WebContent-supplied ResourceRequest,
NetworkResourceLoader::continueWillSendRequest takes the
m_redirectionForCurrentNavigation early-return into willSendRedirectedRequest
*before* the setCachePartition(originalRequest().cachePartition()) restore,
so NetworkCache::Cache::storeRedirect keys the on-disk record by the
unvalidated WebContent-chosen {cachePartition, url} and persists the
WebContent-supplied 301 with WebContent-chosen Location:.

Fix this by:
  1. Hoisting the setCachePolicy/setCachePartition restore to the top of
     continueWillSendRequest so every path through the function — including the
     m_redirectionForCurrentNavigation, service-worker and m_shouldRestartLoad
     early returns — uses the original (Network-Process-side) cache partition,
     never the value round-tripped through the WebContent process.
  2. Promoting the debug ASSERT(isMainFrameLoad()) and
     ASSERT(response.isRedirection()) at the
     NetworkConnectionToWebProcess::useRedirectionForCurrentNavigation IPC
     entry point to MESSAGE_CHECKs. The legitimate sender
     (WebPage::useRedirectionForCurrentNavigation, driven by
     RedirectSOAuthorizationSession in the UI process) only ever targets the
     main-frame main-resource loader with a redirection response; anything else
     is a compromised WebContent process.

Test: ipc/use-redirection-for-current-navigation-message-check.html

* LayoutTests/ipc/use-redirection-for-current-navigation-message-check-expected.txt: Added.
* LayoutTests/ipc/use-redirection-for-current-navigation-message-check.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::useRedirectionForCurrentNavigation):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::continueWillSendRequest):

Originally-landed-as: 305413.915@safari-7624-branch (a547e707161f). <a href="https://rdar.apple.com/180438355">rdar://180438355</a>
Canonical link: <a href="https://commits.webkit.org/316193@main">https://commits.webkit.org/316193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff80b9c81009fff0bb181e69f70bcd19eed0695a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133449 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174129 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36672 "Build is being retried. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Passed layout tests; Ignored 9 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35294 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29230 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183135 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141915 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38316 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45441 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110146 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36972 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43952 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43356 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->