### PR TITLE
[CoreIPC] [GPUP] FEComponentTransfer CoreImage Metal kernel can read past bounds with empty tableValues

### DIFF
--- a/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated-expected.txt
+++ b/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated-expected.txt
@@ -1,0 +1,3 @@
+This test passes if an FEComponentTransfer with an empty Table/Discrete tableValues sent over IPC with FilterRenderingMode::Accelerated does not cause the CoreImage Metal kernel to read past the bounds of its table buffer.
+
+PASS

--- a/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html
+++ b/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if an FEComponentTransfer with an empty Table/Discrete tableValues sent over IPC with FilterRenderingMode::Accelerated does not cause the CoreImage Metal kernel to read past the bounds of its table buffer.</p>
+<pre id="log"></pre>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+
+let finished = false;
+function done(s) {
+    if (finished)
+        return;
+    finished = true;
+    document.getElementById('log').textContent = s;
+    testRunner?.notifyDone();
+}
+let nextID = 100000; function genID() { return nextID++; }
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return done('PASS');
+    try {
+        const { CoreIPC } = await import('./coreipc.js');
+
+        // std::optional<CoreIPCCGColorSpace> needs its bool discriminator exposed.
+        CoreIPC.typeInfo['WebCore::PlatformColorSpace'] = [
+            { type: 'std::optional<WebKit::CoreIPCCGColorSpace>', name: 'alias' }
+        ];
+        // Look the ColorSpace value up by name rather than hardcoding an ordinal.
+        const CS = {};
+        for (const e of IPC.serializedEnumInfo['WebCore::ColorSpace'].valueMap) CS[e.name] = e.value;
+        const sRGB = { serializableColorSpace: { alias: { optionalValue: {
+            m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: CS.SRGB } } } } } };
+
+        const sc = CoreIPC.newStreamConnection();
+        const RBID = genID();
+        CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+            renderingBackendIdentifier: RBID,
+            connectionHandle: sc
+        });
+        const rrb = sc.newInterface('RemoteRenderingBackend', RBID);
+        const init = sc.connection.waitForMessage(RBID, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name);
+        sc.connection.setSemaphores(init[0].value, init[1].value);
+
+        function createImageBuffer(id, ctx) {
+            rrb.CreateImageBuffer({
+                logicalSize: { width: 32, height: 32 }, renderingMode: 1, renderingPurpose: 0,
+                resolutionScale: 1.0, colorSpace: sRGB,
+                bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+                identifier: id, contextIdentifier: ctx,
+            });
+            // Drain the unsolicited DidCreateBackend in-turn; otherwise it reaches the stream
+            // connection's dummy receiver, which ASSERT_NOT_REACHED()s in debug builds.
+            sc.connection.waitForMessage(id, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name);
+        }
+
+        // Source buffer, filled opaque white.
+        const SRC = genID(), SRCCTX = genID();
+        createImageBuffer(SRC, SRCCTX);
+        sc.newInterface('RemoteGraphicsContext', SRCCTX).FillRectWithColor({
+            rect: { location: { x: 0, y: 0 }, size: { width: 32, height: 32 } },
+            color: { data: { optionalValue: { isSemantic: false, usesFunctionSerialization: false,
+                data: { variantType: 'WebCore::PackedColor::RGBA', variant: { value: 0xFFFFFFFF } } } } }
+        });
+        sc.newInterface('RemoteImageBuffer', SRC).FlushContext({});
+
+        function ctf(type, table) {
+            return { type: type, slope: 0, intercept: 0, amplitude: 0, exponent: 0, offset: 0, tableValues: table };
+        }
+        const sourceGraphic = { subclasses: { variantType: 'WebCore::SourceGraphic', variant: { operatingColorSpace: sRGB } } };
+        const identity = ctf(1, []);
+        const sentinel = 0.37;
+
+        // Destination buffer: draw SRC through an FEComponentTransfer whose red channel has a
+        // one-entry DISCRETE table (the sentinel) and whose green channel has an *empty* DISCRETE
+        // table. Before the fix the CoreImage kernel indexed tableStart[-1] for the empty channel,
+        // leaking the adjacent (red) table entry into green.
+        const DST = genID(), DSTCTX = genID();
+        createImageBuffer(DST, DSTCTX);
+        sc.newInterface('RemoteGraphicsContext', DSTCTX).DrawFilteredImageBuffer({
+            sourceImageIdentifier: { optionalValue: SRC },
+            sourceImageRect: { location: { x: 0, y: 0 }, size: { width: 32, height: 32 } },
+            filter: { subclasses: { variantType: 'WebCore::SVGFilterRenderer', variant: {
+                primitiveUnits: 1,
+                expression: { alias: [{ index: 0, level: 1, geometry: {} }, { index: 1, level: 0, geometry: {} }] },
+                effects: [sourceGraphic,
+                    { subclasses: { variantType: 'WebCore::FEComponentTransfer', variant: {
+                        redFunction: ctf(3, [sentinel]), greenFunction: ctf(3, []),
+                        blueFunction: identity, alphaFunction: identity,
+                        operatingColorSpace: sRGB } } }],
+                geometry: { referenceBox: { location: { x: 0, y: 0 }, size: { width: 32, height: 32 } },
+                    filterRegion: { location: { x: 0, y: 0 }, size: { width: 32, height: 32 } },
+                    scale: { width: 1, height: 1 } },
+                filterRenderingModes: 3, renderingOptions: 0,
+                renderingResourceIdentifierIfExists: {},
+            } } },
+        });
+        sc.newInterface('RemoteImageBuffer', DST).FlushContext({});
+
+        // Read the filtered result back synchronously into shared memory.
+        const N = 32 * 32 * 4;
+        const shm = IPC.createSharedMemory(N);
+        shm.writeBytes(new Uint8Array(N).fill(0xAA));
+        sc.newInterface('RemoteImageBuffer', DST).GetPixelBufferWithNewMemory({
+            handle: { protection: 'ReadWrite', handle: shm },
+            outputFormat: { alphaFormat: 0, pixelFormat: 0, colorSpace: sRGB },
+            srcPoint: { x: 0, y: 0 }, srcSize: { width: 32, height: 32 },
+        });
+        const px = new Uint8Array(shm.readBytes(0, N));
+        const green = px[(8 * 32 + 8) * 4 + 1];
+
+        const sentinelByte = Math.round(sentinel * 255);
+        sc.connection.invalidate();
+        if (Math.abs(green - sentinelByte) <= 4)
+            done('FAIL: empty-table DISCRETE channel returned the adjacent table entry (green=' + green + '); kernel indexed tableStart[-1]');
+        else
+            done('PASS');
+    } catch (e) {
+        done('PASS');
+    }
+}, 0);
+
+setTimeout(() => done('PASS'), 25000);
+</script>

--- a/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm
@@ -119,7 +119,7 @@ float applyTransferFunction(float component, constant TransferFunction& function
         int tableLength = function.tableLength;
         int n = tableLength - 1;
 
-        int k = min((int)(component * n), n);
+        int k = clamp((int)(component * n), 0, n);
         float v1 = tableStart[k];
         float v2 = tableStart[min(k + 1, n)];
         return v1 + ((component * n) - k) * (v2 - v1);
@@ -127,7 +127,7 @@ float applyTransferFunction(float component, constant TransferFunction& function
     case TransferType::Discrete: {
         constant float* tableStart = tables + function.tableStart;
         int n = function.tableLength;
-        int k = min((int)(component * n), n - 1);
+        int k = clamp((int)(component * n), 0, n - 1);
         return tableStart[k];
     }
     case TransferType::Linear:
@@ -253,6 +253,10 @@ RetainPtr<CIImage> FEComponentTransferCoreImageApplier::applyOther(RetainPtr<CII
 
         case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_TABLE:
         case ComponentTransferType::FECOMPONENTTRANSFER_TYPE_DISCRETE:
+            if (function.tableValues.isEmpty()) {
+                result.functionType = TransferType::Identity;
+                break;
+            }
             result.tableLength = function.tableValues.size();
             result.tableStart = tableData.size();
             tableData.appendVector(function.tableValues);


### PR DESCRIPTION
#### 88ab9e1efc4a43e8065a042bb666fdaf536feb51
<pre>
[CoreIPC] [GPUP] FEComponentTransfer CoreImage Metal kernel can read past bounds with empty tableValues
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=314461">https://bugs.webkit.org/show_bug.cgi?id=314461</a>&gt;
&lt;<a href="https://rdar.apple.com/174740239">rdar://174740239</a>&gt;

Reviewed by Simon Fraser.

A compromised WebContent process can send DrawFilteredImageBuffer with an
SVGFilterRenderer that selects FilterRenderingMode::Accelerated and carries an
FEComponentTransfer whose Table or Discrete transfer function has an empty
tableValues vector. The CoreImage applier propagated tableLength = 0 to the
Metal kernel, whose Table/Discrete branches computed the table index as
min((int)(component * n), n - 1) with no lower clamp, yielding k = -1 and
dereferencing tableStart[-1] inside CoreImage&apos;s stitched argument buffer. The
result was rendered to an IOSurface readable by the WebContent process.

The software path in FEComponentTransfer::computeLookupTable() guards this with
&quot;if (n &lt; 1) return;&quot; but the CoreImage path never adopted that guard.

Fix this in two places:
- In applyOther(), treat an empty tableValues for a Table/Discrete channel as
  Identity, matching the software path.
- In the Metal kernel, clamp the table index to [0, n - 1] / [0, n] so a
  negative input component (extended-range pixels) cannot drive a negative
  index either.

Test: ipc/feComponentTransfer-empty-tableValues-accelerated.html

* LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated-expected.txt: Added.
* LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html: Added.
* Source/WebCore/platform/graphics/coreimage/FEComponentTransferCoreImageApplier.mm:
(WebCore::compontentTransferKernel):

Originally-landed-as: 305413.914@safari-7624-branch (b63cccc1753d). <a href="https://rdar.apple.com/180429219">rdar://180429219</a>
Canonical link: <a href="https://commits.webkit.org/316461@main">https://commits.webkit.org/316461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b134589d4c120b1e1d5fc5d088c2bbb4b8029867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134050 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37475 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36109 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30412 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184342 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142821 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142702 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46623 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111350 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37756 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45140 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44540 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->