### PR TITLE
[YARR] Don't save sibling and ancestor sibling frame slots for ParenContext

### DIFF
--- a/JSTests/microbenchmarks/regexp-sequential-parencontext-groups.js
+++ b/JSTests/microbenchmarks/regexp-sequential-parencontext-groups.js
@@ -1,0 +1,35 @@
+(function() {
+    var result = 0;
+    var n = 3000;
+
+    function buildPattern(groupCount) {
+        var parts = [];
+        for (var i = 0; i < groupCount; ++i)
+            parts.push("(x" + i + "|y" + i + ")+");
+        return parts.join("") + "z";
+    }
+
+    function buildMatchingInput(groupCount) {
+        var s = "";
+        for (var i = 0; i < groupCount; ++i)
+            s += (i % 2 === 0 ? "x" : "y") + i;
+        return s + "z";
+    }
+
+    var groupCount = 250;
+    var re = new RegExp(buildPattern(groupCount));
+    var matchInput = buildMatchingInput(groupCount);
+    // Missing the trailing "z" forces a backtrack back out through every group's ParenContext
+    // (restoreParenContext) before the match finally fails.
+    var failInput = matchInput.slice(0, -1);
+
+    for (var i = 0; i < n; ++i) {
+        if (re.exec(matchInput) !== null)
+            ++result;
+        if (re.exec(failInput) === null)
+            ++result;
+    }
+
+    if (result != n * 2)
+        throw "Error: bad result: " + result;
+})();

--- a/JSTests/stress/regexp-parencontext-large-frame.js
+++ b/JSTests/stress/regexp-parencontext-large-frame.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null && expected !== null)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got null`);
+    if (actual === null && expected === null)
+        return;
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+// The YARR JIT copies a repeating group's interior frame slots to/from its ParenContext either by
+// direct unrolled copies (fewer than 5 slots) or by a runtime copy loop indexed relative to the
+// group's own frame base (5 or more slots, to bound generated code size). These tests force a
+// group with >=5 interior slots to exercise the loop path, and force several frame-slot-owning
+// terms *before* the group (a large frame base) to exercise the base-relative indexing into the
+// (now much smaller) ParenContext save area.
+
+// Large interior: six variable-quantified character classes inside one repeating group.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/([ab]?[cd]?[ef]?[gh]?[ij]?[kl]?)+z/.exec("acegikacegikz"), ["acegikacegikz", "acegik"], "large interior, multiple iterations");
+    shouldBeArray(/([ab]?[cd]?[ef]?[gh]?[ij]?[kl]?)+z/.exec("z"), ["z", ""], "large interior, single empty iteration");
+}
+
+// Large base: six preceding capturing groups (each owning its own frame slot) before the
+// repeating group, so the group's own interior sits far from the start of the frame.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/(z*)(y*)(x*)(w*)(v*)(u*)(a|ab)+c/.exec("zyxwvuababac"), ["zyxwvuababac", "z", "y", "x", "w", "v", "u", "a"], "large base, all preceding groups match");
+    shouldBeArray(/(z*)(y*)(x*)(w*)(v*)(u*)(a|ab)+c/.exec("ac"), ["ac", "", "", "", "", "", "", "a"], "large base, all preceding groups empty");
+}

--- a/JSTests/stress/regexp-parencontext-multi-alt-backreference.js
+++ b/JSTests/stress/regexp-parencontext-multi-alt-backreference.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null && expected !== null)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got null`);
+    if (actual === null && expected === null)
+        return;
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+// Multi-alternative repeating groups additionally save/restore a returnAddress slot (used to
+// resume the forward pass in the right alternative on the next iteration), on top of the
+// per-iteration captures and any trailing sibling frame slots. These tests combine that with a
+// following capturing group and with backreferences into the repeating group's own captures, so
+// a bug in the interior-only save/restore would show up as either the wrong alternative being
+// resumed or a stale/incorrect backreference value.
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/((a)|(bb)|(ccc))+z([0-9])*q/.exec("abbcccz123q"), ["abbcccz123q", "ccc", undefined, undefined, "ccc", "3"], "multi-alt group with trailing sibling group");
+
+    let re = /((a)|(bb)|(ccc))+z([0-9])*q/g;
+    shouldBeArray(re.exec("az1q bbz2q"), ["az1q", "a", "a", undefined, undefined, "1"], "multi-alt group, global match 1");
+    shouldBeArray(re.exec("az1q bbz2q"), ["bbz2q", "bb", undefined, "bb", undefined, "2"], "multi-alt group, global match 2");
+
+    shouldBeArray(/(a|b)+(x|y)\1/.exec("ababxb"), ["ababxb", "b", "x"], "repeating group capture read back by backreference");
+    shouldBe(/(a|b)+(x|y)\1/.exec("ababya"), null, "backreference forces failure when last iteration's capture doesn't match");
+
+    shouldBeArray(/((a)|(b))+\2\3?/.exec("aabbbb"), ["aabbbb", "b", undefined, "b"], "backreferences to duplicate-alternative captures across iterations");
+}

--- a/JSTests/stress/regexp-parencontext-sibling-frame-slots.js
+++ b/JSTests/stress/regexp-parencontext-sibling-frame-slots.js
@@ -1,0 +1,47 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null && expected !== null)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got null`);
+    if (actual === null && expected === null)
+        return;
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+// The YARR JIT's ParenContext save area for a repeating group only holds that group's own
+// interior frame slots, not the frame slots of sibling or ancestor-sibling terms. These tests
+// have several repeating groups back-to-back (siblings) or nested inside each other
+// (ancestor-siblings) so that each group's frame slots land immediately next to another group's,
+// exercising backtracking across the boundary between them.
+
+// Sequential top-level repeating groups: (c|d)+ and (e|f)+'s frame slots are (a|b)+'s siblings.
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/(a|b)+(c|d)+(e|f)+g/.exec("ababccddeeefg"), ["ababccddeeefg", "b", "d", "f"], "sequential groups full match");
+    shouldBeArray(/(a|b)+(c|d)+(e|f)+g/.exec("accfg"), ["accfg", "a", "c", "f"], "sequential groups minimal match");
+    shouldBe(/(a|b)+(c|d)+(e|f)+g/.exec("aczzfg"), null, "sequential groups forced backtrack failure");
+
+    let re = /(a|b)+(c|d)+(e|f)+g/g;
+    let m1 = re.exec("accfg abaccddeg");
+    shouldBeArray(m1, ["accfg", "a", "c", "f"], "sequential groups global match 1");
+    let m2 = re.exec("accfg abaccddeg");
+    shouldBeArray(m2, ["abaccddeg", "a", "d", "e"], "sequential groups global match 2");
+}
+
+// Nested repeating groups: the inner (a|b)+ group's frame slots are interior to the outer
+// group, while the outer group's own frame slots are ancestor-siblings to any top-level term
+// that follows it (here, the "d+e" tail).
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/((a|b)+c)+d+e/.exec("abcabcddde"), ["abcabcddde", "abc", "b"], "nested groups full match");
+    shouldBeArray(/((a|b)+c)+d+e/.exec("acdde"), ["acdde", "ac", "a"], "nested groups minimal match");
+
+    shouldBe(/(p(a|aa)*q)+r(c|cc)*s/.exec("paaqraccs"), null, "nested groups with siblings, no match");
+    shouldBeArray(/(p(a|aa)*q)+r(c|cc)*s/.exec("paqpaaqrccs"), ["paqpaaqrccs", "paaq", "a", "c"], "nested groups with siblings, match after backtrack");
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -800,7 +800,11 @@ class YarrGenerator final : public YarrJITInfo {
 
     enum class FrameSlotTransfer : bool { Save, Restore };
 
-    // Copy frame slots [firstSlot, lastSlot) between the frame and the ParenContext save area.
+    // Copy frame slots [firstSlot, lastSlot) between the frame and the ParenContext save area. The
+    // save area is indexed relative to firstSlot (i.e. frame slot firstSlot maps to save-area slot
+    // 0), so the area only needs to hold m_maxParenContextFrameSize slots. A group's
+    // sibling/ancestor slots do not need to be saved.
+    //
     // contextGPR is preserved. framePointerGPR and scratchGPR are clobbered in the walking path.
     void emitFrameSlotsTransfer(FrameSlotTransfer direction, MacroAssembler::RegisterID contextGPR, MacroAssembler::RegisterID framePointerGPR, MacroAssembler::RegisterID scratchGPR, unsigned firstSlot, unsigned lastSlot)
     {
@@ -815,9 +819,9 @@ class YarrGenerator final : public YarrJITInfo {
 
         // Copy each slot directly if count is less than the threshold.
         if (count < directCopySlotThreshold) {
-            for (unsigned slot = firstSlot; slot < lastSlot; ++slot) {
-                MacroAssembler::Address frameSlot = frameAddress().withOffset(slot * sizeof(uintptr_t));
-                MacroAssembler::Address contextSlot(contextGPR, contextSaveAreaOffset + slot * sizeof(uintptr_t));
+            for (unsigned index = 0; index < count; ++index) {
+                MacroAssembler::Address frameSlot = frameAddress().withOffset((firstSlot + index) * sizeof(uintptr_t));
+                MacroAssembler::Address contextSlot(contextGPR, contextSaveAreaOffset + index * sizeof(uintptr_t));
                 if (isSave)
                     m_jit.transferPtr(frameSlot, contextSlot);
                 else
@@ -827,7 +831,9 @@ class YarrGenerator final : public YarrJITInfo {
         }
 
         const intptr_t framePointerBias = frameAddress().offset + static_cast<intptr_t>(firstSlot) * static_cast<intptr_t>(sizeof(uintptr_t));
-        const intptr_t contextPointerBias = contextSaveAreaOffset + static_cast<intptr_t>(firstSlot) * static_cast<intptr_t>(sizeof(uintptr_t));
+        // The save area is base-relative (frame slot firstSlot -> save-area slot 0), so the context
+        // pointer starts at the save-area base regardless of firstSlot.
+        const intptr_t contextPointerBias = contextSaveAreaOffset;
 
         m_jit.addPtr(MacroAssembler::TrustedImmPtr(framePointerBias), GPRInfo::callFrameRegister, framePointerGPR);
         m_jit.addPtr(MacroAssembler::TrustedImmPtr(contextPointerBias), contextGPR);
@@ -882,14 +888,17 @@ class YarrGenerator final : public YarrJITInfo {
     }
 
     // On return matchAmountGPR holds the pre-iteration matchAmount for the caller to increment.
-    void saveParenContext(MacroAssembler::RegisterID parenContextReg, MacroAssembler::RegisterID matchAmountGPR, MacroAssembler::RegisterID scratchGPR, unsigned firstSubpattern, unsigned lastSubpattern, unsigned subpatternBaseFrameLocation, bool savesReturnAddress)
+    void saveParenContext(MacroAssembler::RegisterID parenContextReg, MacroAssembler::RegisterID matchAmountGPR, MacroAssembler::RegisterID scratchGPR, unsigned firstSubpattern, unsigned lastSubpattern, unsigned subpatternBaseFrameLocation, bool savesReturnAddress, unsigned lastSlot)
     {
         ASSERT(noOverlap(parenContextReg, matchAmountGPR, scratchGPR, m_regs.index, GPRInfo::callFrameRegister));
 
         BitVector duplicateNamedCaptureGroups;
         bool hasNamedCaptures = m_pattern.hasDuplicateNamedCaptureGroups();
 
-        emitFrameSlotsTransfer(FrameSlotTransfer::Save, parenContextReg, matchAmountGPR, scratchGPR, subpatternBaseFrameLocation + YarrStackSpaceForBackTrackInfoParentheses, m_parenContextSizes.frameSlots());
+        // Save only this group's own interior slots [base+4, lastSlot); a group's
+        // sibling/ancestor slots are never touched by its iterations, so they do not need to be
+        // snapshotted.
+        emitFrameSlotsTransfer(FrameSlotTransfer::Save, parenContextReg, matchAmountGPR, scratchGPR, subpatternBaseFrameLocation + YarrStackSpaceForBackTrackInfoParentheses, lastSlot);
 
         // Save-at-BEGIN: snapshot the pre-iteration index and matchAmount.
         loadFromFrame(subpatternBaseFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), matchAmountGPR);
@@ -922,16 +931,16 @@ class YarrGenerator final : public YarrJITInfo {
     }
 
     // On return matchAmountGPR holds the restored matchAmount, so the caller can use it without reloading from the frame.
-    void restoreParenContext(MacroAssembler::RegisterID parenContextReg, MacroAssembler::RegisterID matchAmountGPR, MacroAssembler::RegisterID scratchGPR, unsigned firstSubpattern, unsigned lastSubpattern, unsigned subpatternBaseFrameLocation, bool savesReturnAddress)
+    void restoreParenContext(MacroAssembler::RegisterID parenContextReg, MacroAssembler::RegisterID matchAmountGPR, MacroAssembler::RegisterID scratchGPR, unsigned firstSubpattern, unsigned lastSubpattern, unsigned subpatternBaseFrameLocation, bool savesReturnAddress, unsigned lastSlot)
     {
         ASSERT(noOverlap(parenContextReg, matchAmountGPR, scratchGPR, m_regs.index, GPRInfo::callFrameRegister));
 
         BitVector duplicateNamedCaptureGroups;
         bool hasNamedCaptures = m_pattern.hasDuplicateNamedCaptureGroups();
 
-        // Copy the saved frame slots back first (this clobbers matchAmountGPR), then load
+        // Copy this group's own interior slots back first (this clobbers matchAmountGPR), then load
         // matchAmount into matchAmountGPR so it stays live for the caller.
-        emitFrameSlotsTransfer(FrameSlotTransfer::Restore, parenContextReg, matchAmountGPR, scratchGPR, subpatternBaseFrameLocation + YarrStackSpaceForBackTrackInfoParentheses, m_parenContextSizes.frameSlots());
+        emitFrameSlotsTransfer(FrameSlotTransfer::Restore, parenContextReg, matchAmountGPR, scratchGPR, subpatternBaseFrameLocation + YarrStackSpaceForBackTrackInfoParentheses, lastSlot);
 
         loadBeginAndMatchAmountFromParenContext(parenContextReg, m_regs.index, matchAmountGPR);
         storeToFrame(m_regs.index, subpatternBaseFrameLocation + BackTrackInfoParentheses::beginIndex());
@@ -4482,7 +4491,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // Save-at-BEGIN. saveParenContext leaves the pre-iteration matchAmount
                 // in regT2 (countTemporary) for the increment below.
                 bool savesReturnAddress = term->parentheses.disjunction->m_alternatives.size() > 1;
-                saveParenContext(newParenContextReg, /* matchAmountGPR */ countTemporary, /* scratchGPR */ m_regs.regT3, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation, savesReturnAddress);
+                saveParenContext(newParenContextReg, /* matchAmountGPR */ countTemporary, /* scratchGPR */ m_regs.regT3, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation, savesReturnAddress, term->parentheses.disjunction->m_callFrameSize);
 
                 // Bump matchAmount: the just-pushed context captured the pre-increment value.
                 m_jit.add32(MacroAssembler::TrustedImm32(1), countTemporary);
@@ -5208,7 +5217,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // matchAmount in regT2, which survives freeParenContext below, so we skip
                 // reloading it from the frame.
                 bool savesReturnAddress = term->parentheses.disjunction->m_alternatives.size() > 1;
-                restoreParenContext(currParenContextReg, /* matchAmountGPR */ countTemporary, /* scratchGPR */ m_regs.regT3, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation, savesReturnAddress);
+                restoreParenContext(currParenContextReg, /* matchAmountGPR */ countTemporary, /* scratchGPR */ m_regs.regT3, term->parentheses.subpatternId, term->parentheses.lastSubpatternId, parenthesesFrameLocation, savesReturnAddress, term->parentheses.disjunction->m_callFrameSize);
 
                 m_jit.loadPtr(MacroAssembler::Address(currParenContextReg, ParenContext::nextOffset()), newParenContextReg);
                 freeParenContext(currParenContextReg);
@@ -6822,7 +6831,7 @@ public:
         , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
+        , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_maxParenContextFrameSize)
 #endif
         , m_sampleString(sampleString)
         , m_sampler(charSize)
@@ -6846,7 +6855,7 @@ public:
         , m_callFrameSizeInBytes(alignCallFrameSizeInBytes(m_pattern.m_body->m_callFrameSize))
         , m_canonicalMode(m_pattern.eitherUnicode() ? CanonicalMode::Unicode : CanonicalMode::UCS2)
 #if ENABLE(YARR_JIT_ALL_PARENS_EXPRESSIONS)
-        , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_body->m_callFrameSize)
+        , m_parenContextSizes(needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numSubpatterns : 0, needsSubpatternRecording(executionMode, m_pattern) ? m_pattern.m_numDuplicateNamedCaptureGroups : 0, m_pattern.m_maxParenContextFrameSize)
 #endif
         , m_sampler(charSize)
     {

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1981,6 +1981,12 @@ public:
                     error = setupDisjunctionOffsets(term.parentheses.disjunction, currentCallFrameSize, currentInputPosition, currentCallFrameSize);
                     if (hasError(error))
                         return error;
+                    // The JIT saves this group's interior frame slots [base+4, m_callFrameSize) into a
+                    // ParenContext using indices relative to base+4, so the saved-frame area only needs to
+                    // hold the max size across all repeating groups.
+                    unsigned innerFrameBase = term.frameLocation + YarrStackSpaceForBackTrackInfoParentheses;
+                    ASSERT(term.parentheses.disjunction->m_callFrameSize >= innerFrameBase);
+                    m_pattern.m_maxParenContextFrameSize = std::max(m_pattern.m_maxParenContextFrameSize, term.parentheses.disjunction->m_callFrameSize - innerFrameBase);
                 }
                 // Fixed count of 1 could be accepted, if they have a fixed size *AND* if all alternatives are of the same length.
                 alternative->m_hasFixedSize = false;

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -609,6 +609,7 @@ struct YarrPattern {
         m_numSubpatterns = 0;
         m_initialStartValueFrameLocation = 0;
         m_numDuplicateNamedCaptureGroups = 0;
+        m_maxParenContextFrameSize = 0;
 
         m_containsBackreferences = false;
         m_containsBOL = false;
@@ -795,6 +796,9 @@ struct YarrPattern {
     unsigned m_numSubpatterns { 0 };
     unsigned m_initialStartValueFrameLocation { 0 };
     unsigned m_numDuplicateNamedCaptureGroups { 0 };
+    // Maximum interior frame size (m_callFrameSize - (base+4)) of any repeating
+    // ParenthesesSubpattern term.
+    unsigned m_maxParenContextFrameSize { 0 };
     PatternDisjunction* m_body;
     Vector<std::unique_ptr<PatternDisjunction>, 4> m_disjunctions;
     Vector<std::unique_ptr<CharacterClass>> m_userCharacterClasses;


### PR DESCRIPTION
#### e1def8f4e5fdd2c8cbce4fa68c8e228f02041e83
<pre>
[YARR] Don&apos;t save sibling and ancestor sibling frame slots for ParenContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=318174">https://bugs.webkit.org/show_bug.cgi?id=318174</a>
<a href="https://rdar.apple.com/180908109">rdar://180908109</a>

Reviewed by Yusuke Suzuki.

The YARR JIT&apos;s ParenContext save area, used to snapshot inter-iteration state
for capturing/backtrackable repeating parenthesized groups, was sized to the
entire pattern&apos;s call frame.  This meant every repeating group&apos;s ParenContext
reserved space for, and coped on each iteration copied, its own interior frame
slots in addition to every sibling and ancestor-sibling term&apos;s frame slots.

For patterns with several repeating groups in sequence (e.g.
/(a|b)+(c|d)+(e|f)+.../), each group&apos;s frame slots are laid out after the
previous ones&apos;, so the whole-frame save area grows with the pattern and the
amount of work redundantly copied per group grows with it, resulting in the
copying being quadratic in the number of groups.

This PR optimizes copying the be linear.

A repeating group&apos;s PatternDisjunction is laid out at frame offsets
[frameLocation + YarrStackSpaceForBackTrackInfoParentheses, m_callFrameSize),
and nothing outside that range is ever touched while looping over that
group&apos;s iterations: a forward continuation into a following term
reinitializes that term&apos;s own backtrack slots before reading them, and a
backtrack into the group&apos;s own content only re-touches its own interior
range. So the save area only needs to be as large as the largest such
interior range across the whole pattern, and slots can be saved/restored
using indices relative to the group&apos;s own base rather than absolute
frame-slot indices.

ParenContext objects are fixed sizes for all parenthesized groups in a pattern.
Currently this is the whole pattern body&apos;s frame size. This PR changes it so
that it&apos;s the maximum interior frame size across all repeating groups.

This PR also adds a microbenchmark with a chain of 250 sequential quantified
alternation groups, matched and force-backtracked 3000 times. This change makes
this ~53x faster.

* JSTests/microbenchmarks/regexp-sequential-parencontext-groups.js: Added.
(buildPattern):
(buildMatchingInput):
* JSTests/stress/regexp-parencontext-large-frame.js: Added.
(shouldBe):
* JSTests/stress/regexp-parencontext-multi-alt-backreference.js: Added.
(shouldBe):
* JSTests/stress/regexp-parencontext-sibling-frame-slots.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::YarrPattern::resetForReparsing):

Canonical link: <a href="https://commits.webkit.org/318318@main">https://commits.webkit.org/318318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a1e681ced65a6b456abb5480a7d438407f07209

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187484 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138646 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff95b335-de5d-4db6-ac71-0dcd1b293fa8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119109 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab68a586-452e-4ad8-9382-eeff689ac542) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39198 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/1078 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7886 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38886 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35945 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/39145 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189913 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51479 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147784 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52161 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147555 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42259 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124413 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50669 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13865 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->