### PR TITLE
Data race on MIMETypeCache::m_cachedResults / m_supportedTypes in MIMETypeCache::canDecodeType

### DIFF
--- a/Source/WebCore/platform/graphics/MIMETypeCache.cpp
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.cpp
@@ -33,13 +33,20 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MIMETypeCache);
 
-HashSet<String>& MIMETypeCache::supportedTypes()
+void MIMETypeCache::ensureSupportedTypes()
 {
+    Locker locker { m_supportedTypesLock };
     if (!m_supportedTypes) {
         m_supportedTypes = HashSet<String> { };
         initializeCache(*m_supportedTypes);
     }
+}
 
+HashSet<String> MIMETypeCache::supportedTypes()
+{
+    ensureSupportedTypes();
+
+    Locker locker { m_supportedTypesLock };
     return *m_supportedTypes;
 }
 
@@ -51,7 +58,13 @@ bool MIMETypeCache::supportsContainerType(const String& containerType)
     if (isUnsupportedContainerType(containerType))
         return false;
 
-    return isStaticContainerType(containerType) || supportedTypes().contains(containerType);
+    if (isStaticContainerType(containerType))
+        return true;
+
+    ensureSupportedTypes();
+
+    Locker locker { m_supportedTypesLock };
+    return m_supportedTypes->contains(containerType);
 }
 
 MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeType)
@@ -59,11 +72,8 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
     if (mimeType.isEmpty())
         return MediaPlayerEnums::SupportsType::IsNotSupported;
 
-    if (m_cachedResults) {
-        auto it = m_cachedResults->find(mimeType);
-        if (it != m_cachedResults->end())
-            return it->value;
-    }
+    if (auto supports = getCachedResult(mimeType))
+        return *supports;
 
     auto result = MediaPlayerEnums::SupportsType::IsNotSupported;
     do {
@@ -90,20 +100,34 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
 
     } while (0);
 
-    if (!m_cachedResults)
-        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType>();
-    m_cachedResults->add(mimeType, result);
+    addCachedResult(mimeType, result);
 
     return result;
 }
 
 void MIMETypeCache::addSupportedTypes(const Vector<String>& newTypes)
 {
-    if (!m_supportedTypes)
-        m_supportedTypes = HashSet<String> { };
+    ensureSupportedTypes();
 
+    Locker locker { m_supportedTypesLock };
     for (auto& type : newTypes)
         m_supportedTypes->add(type);
+}
+
+std::optional<MediaPlayerEnums::SupportsType> MIMETypeCache::getCachedResult(const String& mimeType) const
+{
+    Locker locker { m_cachedResultsLock };
+    if (m_cachedResults)
+        return m_cachedResults->getOptional(mimeType);
+    return std::nullopt;
+}
+
+void MIMETypeCache::addCachedResult(const String& mimeType, MediaPlayerEnums::SupportsType result)
+{
+    Locker locker { m_cachedResultsLock };
+    if (!m_cachedResults)
+        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType>();
+    m_cachedResults->add(mimeType, result);
 }
 
 bool MIMETypeCache::isStaticContainerType(StringView)
@@ -123,6 +147,7 @@ bool MIMETypeCache::isAvailable() const
 
 bool MIMETypeCache::isEmpty() const
 {
+    Locker locker { m_supportedTypesLock };
     return m_supportedTypes && m_supportedTypes->isEmpty();
 }
 

--- a/Source/WebCore/platform/graphics/MIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.h
@@ -44,15 +44,19 @@ public:
 
     virtual bool isAvailable() const;
     virtual MediaPlayerEnums::SupportsType canDecodeType(const String&);
-    virtual HashSet<String>& supportedTypes();
+    virtual HashSet<String> supportedTypes();
 
-    bool NODELETE isEmpty() const;
+    bool isEmpty() const;
     bool supportsContainerType(const String&);
 
 protected:
     void addSupportedTypes(const Vector<String>&);
 
 private:
+    void ensureSupportedTypes();
+    std::optional<MediaPlayerEnums::SupportsType> getCachedResult(const String&) const;
+    void addCachedResult(const String&, MediaPlayerEnums::SupportsType);
+
     virtual bool isStaticContainerType(StringView);
     virtual bool isUnsupportedContainerType(const String&);
     virtual void initializeCache(HashSet<String>&);
@@ -60,8 +64,11 @@ private:
 
     bool shouldOverrideExtendedType(const ContentType&);
 
-    std::optional<HashSet<String>> m_supportedTypes;
-    std::optional<HashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults;
+    mutable Lock m_supportedTypesLock;
+    std::optional<HashSet<String>> m_supportedTypes WTF_GUARDED_BY_LOCK(m_supportedTypesLock);
+
+    mutable Lock m_cachedResultsLock;
+    std::optional<HashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults WTF_GUARDED_BY_LOCK(m_cachedResultsLock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h
@@ -42,7 +42,7 @@ public:
 
     bool isAvailable() const final;
     MediaPlayerEnums::SupportsType canDecodeType(const String&) final;
-    HashSet<String>& supportedTypes() final;
+    HashSet<String> supportedTypes() final;
 
 private:
     friend NeverDestroyed<AVStreamDataParserMIMETypeCache>;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
@@ -76,7 +76,7 @@ MediaPlayerEnums::SupportsType AVStreamDataParserMIMETypeCache::canDecodeType(co
     return MediaPlayerEnums::SupportsType::IsNotSupported;
 }
 
-HashSet<String>& AVStreamDataParserMIMETypeCache::supportedTypes()
+HashSet<String> AVStreamDataParserMIMETypeCache::supportedTypes()
 {
     if (isAvailable())
         return MIMETypeCache::supportedTypes();
@@ -103,10 +103,14 @@ bool AVStreamDataParserMIMETypeCache::canDecodeExtendedType(const ContentType& t
     //  so just replace the container type with a valid one from AVAssetMIMETypeCache and ask that cache if it
     //  can decode this type.
     auto& assetCache = AVAssetMIMETypeCache::singleton();
-    if (!assetCache.isAvailable() || assetCache.supportedTypes().isEmpty())
+    if (!assetCache.isAvailable())
         return false;
 
-    String replacementType = makeStringByReplacingAll(type.raw(), type.containerType(), *assetCache.supportedTypes().begin());
+    auto supportedTypes = assetCache.supportedTypes();
+    if (supportedTypes.isEmpty())
+        return false;
+
+    String replacementType = makeStringByReplacingAll(type.raw(), type.containerType(), *supportedTypes.begin());
     return assetCache.canDecodeType(replacementType) == MediaPlayerEnums::SupportsType::IsSupported;
 #endif
 


### PR DESCRIPTION
#### 576ee4a20b0e79ffd48d34c6f3b3b03bd999db94
<pre>
Data race on MIMETypeCache::m_cachedResults / m_supportedTypes in MIMETypeCache::canDecodeType
<a href="https://rdar.apple.com/175674693">rdar://175674693</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313842">https://bugs.webkit.org/show_bug.cgi?id=313842</a>

Reviewed by Eric Carlson.

It&apos;s unsafe to return a raw reference to an inner data member (without BorrowChecker)
as the underlying object can be mutated or freed leaving a dangling reference. Make two
changes to MIMETypeCache as a result:
- Require a lock be held to access the inner data member variable
- Return a copy of the inner member rather than a reference

* Source/WebCore/platform/graphics/MIMETypeCache.cpp:
(WebCore::MIMETypeCache::ensureSupportedTypes):
(WebCore::MIMETypeCache::supportedTypes):
(WebCore::MIMETypeCache::supportsContainerType):
(WebCore::MIMETypeCache::canDecodeType):
(WebCore::MIMETypeCache::addSupportedTypes):
(WebCore::MIMETypeCache::getCachedResult const):
(WebCore::MIMETypeCache::addCachedResult):
(WebCore::MIMETypeCache::isEmpty const):
* Source/WebCore/platform/graphics/MIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::supportedTypes):
(WebCore::AVStreamDataParserMIMETypeCache::canDecodeExtendedType):

Originally-landed-as: 305413.822@safari-7624-branch (720a8f0b10ab). <a href="https://rdar.apple.com/180428110">rdar://180428110</a>
Canonical link: <a href="https://commits.webkit.org/316458@main">https://commits.webkit.org/316458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e61877349ad6fdd271a3117ec3987ca269141c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181654 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133940 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37376 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154491 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.Back (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114413 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36007 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34280 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146448 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33996 "Found 1 new test failure: platform/mac/media/audio-session-deactivated-when-suspended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184192 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142699 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45792 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142581 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46472 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111366 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37666 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118227 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44990 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->