### PR TITLE
Remove redundant m_renderRange.start() null checks in RenderHighlight::highlightStateForRenderer

### DIFF
--- a/Source/WebCore/rendering/RenderHighlight.cpp
+++ b/Source/WebCore/rendering/RenderHighlight.cpp
@@ -126,10 +126,9 @@ RenderObject::HighlightState RenderHighlight::highlightStateForRenderer(const Re
         return renderer.selectionState();
 
     if (&renderer == m_renderRange.start()) {
-        if (m_renderRange.start() && m_renderRange.end() && m_renderRange.start() == m_renderRange.end())
+        if (m_renderRange.end() && m_renderRange.start() == m_renderRange.end())
             return RenderObject::HighlightState::Both;
-        if (m_renderRange.start())
-            return RenderObject::HighlightState::Start;
+        return RenderObject::HighlightState::Start;
     }
     if (&renderer == m_renderRange.end())
         return RenderObject::HighlightState::End;


### PR DESCRIPTION
#### ad3c1ab54438f924e55d6727caad0c24d70f5d3d
<pre>
Remove redundant m_renderRange.start() null checks in RenderHighlight::highlightStateForRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=318175">https://bugs.webkit.org/show_bug.cgi?id=318175</a>
<a href="https://rdar.apple.com/180977788">rdar://180977788</a>

Reviewed by Alan Baradlay.

The branch is entered only when `&amp;renderer == m_renderRange.start()`. Since
renderer is a reference, &amp;renderer is never null, so m_renderRange.start() is
guaranteed non-null inside the block. The two further m_renderRange.start()
checks were therefore always true: the leading term of the Both test and the
guard on the Start return.

Drop both dead checks. The Start return becomes the unconditional fall-through
after the Both case, and the end() null check is retained since end() can
legitimately be null. No change in behavior.

* Source/WebCore/rendering/RenderHighlight.cpp:
(WebCore::RenderHighlight::highlightStateForRenderer):

Canonical link: <a href="https://commits.webkit.org/316115@main">https://commits.webkit.org/316115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e622cea6a98812a75ae669079bef2e16b73e3d9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180331 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128667 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca9b1d05-9573-4856-829a-2574d88d0384) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133335 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbd544a0-b453-474e-b66a-5b72a1b55baa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173910 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113811 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/296c1524-75e3-45b8-9c4b-71bc17483257) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35197 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29011 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182916 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141792 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44533 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141601 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45222 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36861 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43733 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43379 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43268 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->