### PR TITLE
UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate()

### DIFF
--- a/LayoutTests/workers/permissions-query-crash-expected.txt
+++ b/LayoutTests/workers/permissions-query-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/workers/permissions-query-crash.html
+++ b/LayoutTests/workers/permissions-query-crash.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+const workerCode = `
+onmessage = () => {
+    for (let i = 0; i < 20; i++) {
+        navigator.permissions.query({name: i % 3 === 0 ? 'camera' : (i % 3 === 1 ? 'geolocation' : 'notifications')}).catch(()=>{});
+    }
+    postMessage('go');
+};
+`;
+
+const blob = new Blob([workerCode], {type: 'application/javascript'});
+const blobURL = URL.createObjectURL(blob);
+
+let iterations = 0;
+const maxIterations = 20;
+
+function next() {
+    iterations++;
+    if (iterations > maxIterations) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+    
+    let w = new Worker(blobURL);
+    w.onmessage = () => {
+        w.terminate();
+        setTimeout(next, 0);
+    };
+    w.postMessage(0);
+}
+
+window.onload = () => {
+    next();
+};
+</script>
+</head>
+<body>
+This test passes if it does not crash.
+</body>
+</html>

--- a/Source/WebCore/Modules/permissions/NavigatorPermissions.h
+++ b/Source/WebCore/Modules/permissions/NavigatorPermissions.h
@@ -40,7 +40,7 @@ public:
     explicit NavigatorPermissions(Navigator&);
 
     static Permissions& permissions(Navigator&);
-    Permissions& NODELETE permissions();
+    Permissions& permissions();
 
 private:
     static NavigatorPermissions& from(Navigator&);

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -55,6 +55,7 @@
 #include "WorkerThread.h"
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <optional>
+#include <wtf/Expected.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
@@ -62,6 +63,34 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Permissions);
+
+#if ENABLE(GEOLOCATION)
+
+static std::optional<PermissionState> determineGeolocationPermissionState(PermissionState permissionState, const Document& document)
+{
+    RefPtr window = document.window();
+    if (!window)
+        return std::nullopt;
+
+    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(protect(window->navigator()));
+
+    switch (permissionState) {
+    case PermissionState::Granted:
+        return PermissionState::Granted;
+    case PermissionState::Denied:
+        if (!geolocation || !geolocation->hasBeenRequested())
+            return PermissionState::Prompt;
+        return PermissionState::Denied;
+    case PermissionState::Prompt:
+        if (!geolocation || !geolocation->hasBeenRequested())
+            return PermissionState::Prompt;
+        return geolocation->isAllowed() ? PermissionState::Granted : PermissionState::Denied;
+    };
+
+    return std::nullopt;
+}
+
+#endif // ENABLE(GEOLOCATION)
 
 Ref<Permissions> Permissions::create(NavigatorBase& navigator)
 {
@@ -78,7 +107,12 @@ NavigatorBase* Permissions::navigator()
     return m_navigator.get();
 }
 
-Permissions::~Permissions() = default;
+Permissions::~Permissions()
+{
+    auto queryPromises = std::exchange(m_queryPromises, { });
+    for (auto& promise : queryPromises.values())
+        promise->reject(ExceptionCode::AbortError, "Promise was rejected because the browsing context is going away"_s);
+}
 
 static bool isAllowedByPermissionsPolicy(const Document& document, PermissionName name)
 {
@@ -127,24 +161,51 @@ std::optional<PermissionName> Permissions::toPermissionName(const String& name)
     return std::nullopt;
 }
 
-void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DOMPromiseDeferred<IDLInterface<PermissionStatus>>&& promise)
+static Expected<PermissionState, Exception> processPermissionQueryResult(std::optional<PermissionState> permissionState, const PermissionDescriptor& permissionDescriptor, const Document& document)
+{
+    if (!permissionState)
+        return makeUnexpected(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
+
+#if !ENABLE(GEOLOCATION) && !ENABLE(MEDIA_STREAM)
+    UNUSED_PARAM(permissionDescriptor);
+    UNUSED_PARAM(document);
+#endif
+
+#if ENABLE(GEOLOCATION)
+    if (permissionDescriptor.name == PermissionName::Geolocation) {
+        if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))
+            permissionState = geolocationPermissionState;
+        else
+            return makeUnexpected(Exception { ExceptionCode::InvalidStateError, "The Document does not have a Geolocation object"_s });
+    }
+#endif
+
+#if ENABLE(MEDIA_STREAM)
+    if (document.quirks().shouldEnableCameraAndMicrophonePermissionStateQuirk() && (permissionDescriptor.name == PermissionName::Camera || permissionDescriptor.name == PermissionName::Microphone) && *permissionState == PermissionState::Prompt)
+        permissionState = PermissionState::Granted;
+#endif
+
+    return *permissionState;
+}
+
+void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, Ref<DeferredPromise>&& promise)
 {
     RefPtr context = m_navigator ? m_navigator->scriptExecutionContext() : nullptr;
     if (!context || !context->globalObject()) {
-        promise.reject(Exception { ExceptionCode::InvalidStateError, "The context is invalid"_s });
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The context is invalid"_s });
         return;
     }
 
     auto source = sourceFromContext(*context);
     if (!source) {
-        promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query is not supported in this context"_s  });
+        promise->reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query is not supported in this context"_s  });
         return;
     }
 
     RefPtr document = dynamicDowncast<Document>(*context);
     if (document && !document->isFullyActive()) {
-        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active"_s });
-        return; 
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active"_s });
+        return;
     }
 
     auto& vm = context->globalObject()->vm();
@@ -152,7 +213,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
 
     auto permissionDescriptorConversionResult = convert<IDLDictionary<PermissionDescriptor>>(*context->globalObject(), permissionDescriptorValue.get());
     if (permissionDescriptorConversionResult.hasException(scope)) [[unlikely]] {
-        promise.reject(Exception { ExceptionCode::ExistingExceptionError });
+        promise->reject(Exception { ExceptionCode::ExistingExceptionError });
         return;
     }
 
@@ -161,119 +222,71 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
     RefPtr origin = context->securityOrigin();
     auto originData = origin ? origin->data() : SecurityOriginData { };
 
-    if (document) {
-        WeakPtr page = document->page();
-        if (!page) {
-            promise.reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
-            return;
-        }
+    auto contextIdentifier = context->identifier();
 
-        if (!isAllowedByPermissionsPolicy(*document, permissionDescriptor.name)) {
-            promise.resolve(PermissionStatus::create(*context, PermissionState::Denied, permissionDescriptor, PermissionQuerySource::Window, *page));
-            return;
-        }
+    auto promiseIdentifier = PromiseIdentifier::generate();
+    m_queryPromises.add(promiseIdentifier, WTF::move(promise));
 
-        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTF::move(originData) }, permissionDescriptor, *page, *source, [document = protect(*document), page, permissionDescriptor, promise = WTF::move(promise)](auto permissionState) mutable {
-            if (!permissionState) {
-                promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
-                return;
-            }
-
-#if ENABLE(GEOLOCATION)
-            if (permissionDescriptor.name == PermissionName::Geolocation) {
-                if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))
-                    permissionState = geolocationPermissionState;
-                else {
-                    promise.reject(Exception { ExceptionCode::InvalidStateError, "The Document does not have a Geolocation object"_s });
-                    return;
-                }
-            }
-#endif
-
-#if ENABLE(MEDIA_STREAM)
-            if (document->quirks().shouldEnableCameraAndMicrophonePermissionStateQuirk() && (permissionDescriptor.name == PermissionName::Camera || permissionDescriptor.name == PermissionName::Microphone) && *permissionState == PermissionState::Prompt)
-                permissionState = PermissionState::Granted;
-#endif
-            promise.resolve(PermissionStatus::create(document, *permissionState, permissionDescriptor, PermissionQuerySource::Window, WTF::move(page)));
-        });
-        return;
-    }
-
-    Ref workerGlobalScope = downcast<WorkerGlobalScope>(*context);
-    auto completionHandler = [originData = WTF::move(originData).isolatedCopy(), permissionDescriptor, contextIdentifier = workerGlobalScope->identifier(), source = *source, promise = WTF::move(promise)] (auto& context) mutable {
+    auto queryPermissionOnMainThread = [originData = WTF::move(originData).isolatedCopy(), permissionDescriptor, contextIdentifier, source = *source, promiseIdentifier, weakThis = WeakPtr { *this }] (ScriptExecutionContext& mainThreadContext) mutable {
         ASSERT(isMainThread());
 
-        Ref document = downcast<Document>(context);
-        if (!document->page()) {
-            ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise)](auto&) mutable {
-                promise.reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
+        auto& document = downcast<Document>(mainThreadContext);
+        if (!document.page()) {
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier](auto&) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis)
+                    return;
+                if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                    promise->reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
             });
             return;
         }
 
-        auto page = source == PermissionQuerySource::DedicatedWorker ? WeakPtr { *document->page() } : nullptr;
+        if (source == PermissionQuerySource::Window && !isAllowedByPermissionsPolicy(document, permissionDescriptor.name)) {
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, permissionDescriptor, page = WeakPtr { *document.page() }](auto& context) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis)
+                    return;
+                if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                    promise->resolve<IDLInterface<PermissionStatus>>(PermissionStatus::create(context, PermissionState::Denied, permissionDescriptor, PermissionQuerySource::Window, WTF::move(page)));
+            });
+            return;
+        }
 
-        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTF::move(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, promise = WTF::move(promise), source, page, document](auto permissionState) mutable {
+        auto page = source == PermissionQuerySource::DedicatedWorker || source == PermissionQuerySource::Window ? WeakPtr { *document.page() } : nullptr;
+
+        PermissionController::singleton().query(ClientOrigin { document.topOrigin().data(), WTF::move(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, weakThis = WTF::move(weakThis), promiseIdentifier, source, page, document = Ref { document }](auto permissionState) mutable {
             ASSERT(isMainThread());
 
-            if (!permissionState) {
-                ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise)](auto&) mutable {
-                    promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
+            auto result = processPermissionQueryResult(permissionState, permissionDescriptor, document);
+            if (!result) {
+                ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, exception = result.error()](auto&) mutable {
+                    RefPtr protectedThis = weakThis;
+                    if (!protectedThis)
+                        return;
+                    if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                        promise->reject(WTF::move(exception));
                 });
-
                 return;
             }
 
-#if ENABLE(GEOLOCATION)
-            if (permissionDescriptor.name == PermissionName::Geolocation) {
-                if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))
-                    permissionState = geolocationPermissionState;
-                else {
-                    ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise)](auto&) mutable {
-                        promise.reject(Exception { ExceptionCode::InvalidStateError, "The Document does not have a Geolocation object"_s });
-                    });
-
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, permissionState = *result, permissionDescriptor, source, page = WTF::move(page)](auto& context) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis)
                     return;
-                }
-            }
-#endif
-
-            ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise), permissionState, permissionDescriptor, source, page = WTF::move(page)](auto& context) mutable {
-                promise.resolve(PermissionStatus::create(context, *permissionState, permissionDescriptor, source, WTF::move(page)));
+                if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                    promise->resolve<IDLInterface<PermissionStatus>>(PermissionStatus::create(context, permissionState, permissionDescriptor, source, WTF::move(page)));
             });
         });
     };
 
-    if (CheckedPtr workerLoaderProxy = workerGlobalScope->thread()->workerLoaderProxy())
-        workerLoaderProxy->postTaskToLoader(WTF::move(completionHandler));
+    if (document)
+        queryPermissionOnMainThread(*document);
+    else {
+        Ref workerGlobalScope = downcast<WorkerGlobalScope>(*context);
+        if (CheckedPtr workerLoaderProxy = workerGlobalScope->thread()->workerLoaderProxy())
+            workerLoaderProxy->postTaskToLoader(WTF::move(queryPermissionOnMainThread));
+    }
 }
-
-#if ENABLE(GEOLOCATION)
-
-static std::optional<PermissionState> determineGeolocationPermissionState(PermissionState permissionState, const Document& document)
-{
-    RefPtr window = document.window();
-    if (!window)
-        return std::nullopt;
-
-    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(protect(window->navigator()));
-
-    switch (permissionState) {
-    case PermissionState::Granted:
-        return PermissionState::Granted;
-    case PermissionState::Denied:
-        if (!geolocation || !geolocation->hasBeenRequested())
-            return PermissionState::Prompt;
-        return PermissionState::Denied;
-    case PermissionState::Prompt:
-        if (!geolocation || !geolocation->hasBeenRequested())
-            return PermissionState::Prompt;
-        return geolocation->isAllowed() ? PermissionState::Granted : PermissionState::Denied;
-    };
-
-    return std::nullopt;
-}
-
-#endif // ENABLE(GEOLOCATION)
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/Permissions.h
+++ b/Source/WebCore/Modules/permissions/Permissions.h
@@ -27,6 +27,8 @@
 
 #include <JavaScriptCore/Strong.h>
 #include <WebCore/IDLTypes.h>
+#include <wtf/ObjectIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -50,14 +52,14 @@ enum class PermissionState : uint8_t;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
-class Permissions : public RefCounted<Permissions> {
+class Permissions : public RefCountedAndCanMakeWeakPtr<Permissions> {
     WTF_MAKE_TZONE_ALLOCATED(Permissions);
 public:
-    static Ref<Permissions> NODELETE create(NavigatorBase&);
+    static Ref<Permissions> create(NavigatorBase&);
     ~Permissions();
 
     NavigatorBase* NODELETE navigator();
-    void query(JSC::Strong<JSC::JSObject>, DOMPromiseDeferred<IDLInterface<PermissionStatus>>&&);
+    void query(JSC::Strong<JSC::JSObject>, Ref<DeferredPromise>&&);
     WEBCORE_EXPORT static std::optional<PermissionQuerySource> sourceFromContext(const ScriptExecutionContext&);
     WEBCORE_EXPORT static std::optional<PermissionName> toPermissionName(const String&);
 
@@ -65,6 +67,10 @@ private:
     explicit Permissions(NavigatorBase&);
 
     WeakPtr<NavigatorBase> m_navigator;
+
+    enum class PromiseIdentifierType { };
+    using PromiseIdentifier = AtomicObjectIdentifier<PromiseIdentifierType>;
+    HashMap<PromiseIdentifier, Ref<DeferredPromise>> m_queryPromises;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.h
+++ b/Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.h
@@ -40,7 +40,7 @@ public:
     explicit WorkerNavigatorPermissions(WorkerNavigator&);
 
     static Permissions& permissions(WorkerNavigator&);
-    Permissions& NODELETE permissions();
+    Permissions& permissions();
 
 private:
     static WorkerNavigatorPermissions& from(WorkerNavigator&);


### PR DESCRIPTION
#### 4aaa3c1477e296e67b03e1461479b8caf57c37dd
<pre>
UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312459">https://bugs.webkit.org/show_bug.cgi?id=312459</a>
<a href="https://rdar.apple.com/174651133">rdar://174651133</a>

Reviewed by Ryosuke Niwa.

When Permissions::query() is called in a worker, we would dispatch a lambda
to the main thread, get the information and then try to go back to the
worker thread using ScriptExecutionContext::postTaskTo() in order to
call the promise with the result. However, in case of worker termination,
ScriptExecutionContext::postTaskTo() would fail and the lambda would get
destroyed on the main thread, without getting called. This would lead to
a security bug because the lambda was capturing the promise object which
is a worker object and thus should not get destroyed on the main thread.

To address the issue, we now store the promise in a HashMap on the
Permissions object. We then capture a promise identifier in the lambda
instead of the promise. In the ~Permissions() destructor, if there are
pending promises, we reject them.

I made the following changes also:
1. I used `Ref&lt;DeferredPromise&gt;` type for the promise instead of
   `DOMPromiseDeferred&lt;IDLInterface&lt;PermissionStatus&gt;&gt;` so that I could
   store the promise in a HashMap.
2. There was a LOT of code duplication in Permissions::query() for the
   main thread code path and the worker code path. I merged them so we
   now have a single code path for both. This simplifies things a lot.

Test: workers/permissions-query-crash.html

* LayoutTests/workers/permissions-query-crash-expected.txt: Added.
* LayoutTests/workers/permissions-query-crash.html: Added.
* Source/WebCore/Modules/permissions/NavigatorPermissions.h:
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::determineGeolocationPermissionState):
(WebCore::Permissions::~Permissions):
(WebCore::processPermissionQueryResult):
(WebCore::Permissions::query):
* Source/WebCore/Modules/permissions/Permissions.h:

Originally-landed-as: 305413.686@safari-7624-branch (f7d3c0785bb0). <a href="https://rdar.apple.com/180428980">rdar://180428980</a>
Canonical link: <a href="https://commits.webkit.org/316383@main">https://commits.webkit.org/316383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f8259d322a45a8e98f39cc2a2ce88933d8ee1a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133854 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114327 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35912 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184055 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142597 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142486 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38481 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46346 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111009 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37573 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44864 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8838 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->