### PR TITLE
Use-after-free in XRSessionInit dictionary conversion via sequence<any>

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -51,9 +51,6 @@
 #include "WebXRSession.h"
 #include "XRReferenceSpaceType.h"
 #include "XRSessionInit.h"
-#include <JavaScriptCore/JSCJSValuePropertyInlines.h>
-#include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/JSString.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -140,7 +137,7 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
     });
 }
 
-void WebXRSystem::obtainCurrentDevice(XRSessionMode mode, const JSFeatureList& requiredFeatures, const JSFeatureList& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&& callback)
+void WebXRSystem::obtainCurrentDevice(XRSessionMode mode, const Vector<String>& requiredFeatures, const Vector<String>& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&& callback)
 {
     if (isImmersive(mode)) {
         ensureImmersiveXRDeviceIsSelected([this, callback = WTF::move(callback)]() mutable {
@@ -225,12 +222,11 @@ bool WebXRSystem::immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow
 // https://immersive-web.github.io/webxr/#inline-session-request-is-allowed
 bool WebXRSystem::inlineSessionRequestIsAllowedForGlobalObject(LocalDOMWindow& globalObject, Document& document, const XRSessionInit& init) const
 {
-    auto isEmptyOrViewer = [&document](const JSFeatureList& features) {
+    auto isEmptyOrViewer = [](const Vector<String>& features) {
         if (features.isEmpty())
             return true;
-        if (features.size() == 1 && document.globalObject()) {
-            auto featureString = features.first().toWTFString(document.globalObject());
-            auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(featureString);
+        if (features.size() == 1) {
+            auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(features.first());
             if (sessionFeature && *sessionFeature == PlatformXR::SessionFeature::ReferenceSpaceTypeViewer)
                 return true;
         }
@@ -335,7 +331,7 @@ bool WebXRSystem::isFeatureSupported(PlatformXR::SessionFeature feature, XRSessi
 }
 
 // https://immersive-web.github.io/webxr/#resolve-the-requested-features
-std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveRequestedFeatures(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device, JSC::JSGlobalObject& globalObject) const
+std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveRequestedFeatures(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device) const
 {
     // 1. Let consentRequired be an empty list of DOMString.
     // 2. Let consentOptional be an empty list of DOMString.
@@ -355,19 +351,16 @@ std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveReques
     //    with mode to the indicated feature list if it is not already present.
     // https://immersive-web.github.io/webxr/#default-features
     auto requiredFeaturesWithDefaultFeatures = init.requiredFeatures;
-    {
-        JSC::JSLockHolder locker(&globalObject);
-        requiredFeaturesWithDefaultFeatures.append(JSC::jsStringWithCache(globalObject.vm(), PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeViewer)));
-        if (isImmersive(mode))
-            requiredFeaturesWithDefaultFeatures.append(JSC::jsStringWithCache(globalObject.vm(), PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeLocal)));
-    }
+    requiredFeaturesWithDefaultFeatures.append(PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeViewer));
+    if (isImmersive(mode))
+        requiredFeaturesWithDefaultFeatures.append(PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeLocal));
 
     // 8. For each feature in requiredFeatures|optionalFeatures perform the following steps:
     // 9. For each feature in optionalFeatures perform the following steps:
     // We're merging both loops in a single lambda. The only difference is that a failure on any required features
     // implies cancelling the whole process while failures in optional features are just skipped.
     enum class ParsingMode { Strict, Loose };
-    auto parseFeatures = [this, &device, &globalObject, mode, &resolvedFeatures, &previouslyEnabled] (const JSFeatureList& sessionFeatures, ParsingMode parsingMode) -> bool {
+    auto parseFeatures = [this, &device, mode, &resolvedFeatures, &previouslyEnabled](const Vector<String>& sessionFeatures, ParsingMode parsingMode) -> bool {
         bool returnOnFailure = parsingMode == ParsingMode::Strict;
         for (const auto& sessionFeature : sessionFeatures) {
             // 1. If the feature is null, continue to the next entry.
@@ -381,8 +374,7 @@ std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveReques
             //   2.1. Let s be the result of calling ? ToString(feature).
             //   2.2. If s is not a valid feature descriptor or is undefined, (return null|continue to next entry).
             //   2.3. Set feature to s.
-            auto featureString = sessionFeature.toWTFString(&globalObject);
-            auto feature = PlatformXR::parseSessionFeatureDescriptor(featureString);
+            auto feature = PlatformXR::parseSessionFeatureDescriptor(sessionFeature);
             if (!feature)
                 RETURN_FALSE_OR_CONTINUE(returnOnFailure);
 
@@ -434,7 +426,7 @@ std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveReques
 }
 
 // https://immersive-web.github.io/webxr/#request-the-xr-permission
-void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device, JSC::JSGlobalObject& globalObject, CompletionHandler<void(std::optional<FeatureList>&&)>&& completionHandler) const
+void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device, CompletionHandler<void(std::optional<FeatureList>&&)>&& completionHandler) const
 {
     // 1. Set status's granted to an empty FrozenArray.
     // 2. Let requiredFeatures be descriptor's requiredFeatures.
@@ -442,7 +434,7 @@ void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionI
     // 4. Let device be the result of obtaining the current device for mode, requiredFeatures, and optionalFeatures.
 
     // 5. Let result be the result of resolving the requested features given requiredFeatures,optionalFeatures, and mode.
-    auto resolvedFeatures = resolveRequestedFeatures(mode, init, device, globalObject);
+    auto resolvedFeatures = resolveRequestedFeatures(mode, init, device);
 
     // 6. If result is null, run the following steps:
     //  6.1. Set status's state to "denied".
@@ -558,10 +550,6 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         if (!device || !device->supports(mode))
             return;
 
-        auto* globalObject = protectedDocument->globalObject();
-        if (!globalObject)
-            return;
-
         rejectPromiseWithNotSupportedError.release();
 
         // WebKit does not currently support the Permissions API. https://w3c.github.io/permissions/
@@ -573,7 +561,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         // 5.4.5 Let status be an XRPermissionStatus, initially null
         // 5.4.6 Request the xr permission with descriptor and status.
         // 5.4.7 If status' state is "denied" run the following steps: (same as above in 5.4.1)
-        resolveFeaturePermissions(mode, init, device, *globalObject, [this, weakThis = WeakPtr { *this }, protectedDocument, device, immersive, mode, promise](std::optional<FeatureList>&& requestedFeatures) mutable {
+        resolveFeaturePermissions(mode, init, device, [this, weakThis = WeakPtr { *this }, protectedDocument, device, immersive, mode, promise](std::optional<FeatureList>&& requestedFeatures) mutable {
             if (!weakThis || !requestedFeatures) {
                 promise.reject(Exception { ExceptionCode::NotSupportedError });
                 m_pendingImmersiveSession = false;

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -46,10 +46,6 @@
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
-namespace JSC {
-class JSGlobalObject;
-}
-
 namespace WebCore {
 
 class LocalDOMWindow;
@@ -105,8 +101,7 @@ private:
     explicit WebXRSystem(Navigator&);
 
     using FeatureList = PlatformXR::Device::FeatureList;
-    using JSFeatureList = Vector<JSC::JSValue>;
-    void obtainCurrentDevice(XRSessionMode, const JSFeatureList& requiredFeatures, const JSFeatureList& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&&);
+    void obtainCurrentDevice(XRSessionMode, const Vector<String>& requiredFeatures, const Vector<String>& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&&);
 
     bool immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&) const;
     bool inlineSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&, const XRSessionInit&) const;
@@ -114,8 +109,8 @@ private:
     bool isFeaturePermitted(PlatformXR::SessionFeature) const;
     bool isFeatureSupported(PlatformXR::SessionFeature, XRSessionMode, const PlatformXR::Device&) const;
     struct ResolvedRequestedFeatures;
-    std::optional<ResolvedRequestedFeatures> resolveRequestedFeatures(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, JSC::JSGlobalObject&) const;
-    void resolveFeaturePermissions(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, JSC::JSGlobalObject&, CompletionHandler<void(std::optional<FeatureList>&&)>&&) const;
+    std::optional<ResolvedRequestedFeatures> resolveRequestedFeatures(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>) const;
+    void resolveFeaturePermissions(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, CompletionHandler<void(std::optional<FeatureList>&&)>&&) const;
 
     // https://immersive-web.github.io/webxr/#default-inline-xr-device
     class DummyInlineDevice final : public PlatformXR::Device, public ContextDestructionObserver {

--- a/Source/WebCore/Modules/webxr/XRSessionInit.h
+++ b/Source/WebCore/Modules/webxr/XRSessionInit.h
@@ -27,18 +27,13 @@
 
 #if ENABLE(WEBXR)
 
-#include <JavaScriptCore/Strong.h>
 #include <wtf/Forward.h>
-
-namespace JSC {
-class JSValue;
-}
 
 namespace WebCore {
 
 struct XRSessionInit {
-    Vector<JSC::JSValue> requiredFeatures;
-    Vector<JSC::JSValue> optionalFeatures;
+    Vector<String> requiredFeatures;
+    Vector<String> optionalFeatures;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRSessionInit.idl
+++ b/Source/WebCore/Modules/webxr/XRSessionInit.idl
@@ -28,6 +28,6 @@
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
 ] dictionary XRSessionInit {
-    [ImplementationDefaultValue=[]] sequence<any> requiredFeatures;
-    [ImplementationDefaultValue=[]] sequence<any> optionalFeatures;
+    [ImplementationDefaultValue=[]] sequence<DOMString> requiredFeatures;
+    [ImplementationDefaultValue=[]] sequence<DOMString> optionalFeatures;
 };

--- a/Source/WebCore/bindings/js/JSDOMConvertSequences.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertSequences.h
@@ -353,8 +353,12 @@ template<> struct Converter<IDLFrozenArray<IDLUnrestrictedFloat>> : Detail::Nume
 template<> struct Converter<IDLFrozenArray<IDLDouble>> : Detail::NumericSequenceConverter<IDLFrozenArray<IDLDouble>> { };
 template<> struct Converter<IDLFrozenArray<IDLUnrestrictedDouble>> : Detail::NumericSequenceConverter<IDLFrozenArray<IDLUnrestrictedDouble>> { };
 
-template<typename T, size_t N> struct Converter<IDLSequence<T, N>> : Detail::SequenceConverter<IDLSequence<T, N>> { };
-template<typename T, size_t N> struct Converter<IDLFrozenArray<T, N>> : Detail::SequenceConverter<IDLFrozenArray<T, N>> { };
+template<typename T, size_t N> struct Converter<IDLSequence<T, N>> : Detail::SequenceConverter<IDLSequence<T, N>> {
+    static_assert(!std::is_same_v<T, IDLAny>, "sequence<any> is insecure as input; use a concrete type");
+};
+template<typename T, size_t N> struct Converter<IDLFrozenArray<T, N>> : Detail::SequenceConverter<IDLFrozenArray<T, N>> {
+    static_assert(!std::is_same_v<T, IDLAny>, "FrozenArray<any> is insecure as input; use a concrete type");
+};
 
 template<typename T, size_t N> struct JSConverter<IDLSequence<T, N>> {
     static constexpr bool needsState = true;

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -37,7 +37,6 @@
 #include "UserGestureIndicator.h"
 #include "WebXRSystem.h"
 #include "XRSessionMode.h"
-#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 
@@ -48,15 +47,12 @@ WebXRTest::WebXRTest(WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData>&& syst
 
 WebXRTest::~WebXRTest() = default;
 
-static PlatformXR::Device::FeatureList parseFeatures(const Vector<JSC::JSValue>& featureList, ScriptExecutionContext& context)
+static PlatformXR::Device::FeatureList parseFeatures(const Vector<String>& featureList)
 {
     PlatformXR::Device::FeatureList features;
-    if (auto* globalObject = context.globalObject()) {
-        for (auto& feature : featureList) {
-            auto featureString = feature.toWTFString(globalObject);
-            if (auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(featureString))
-                features.append(*sessionFeature);
-        }
+    for (auto& feature : featureList) {
+        if (auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(feature))
+            features.append(*sessionFeature);
     }
     return features;
 }
@@ -64,14 +60,14 @@ static PlatformXR::Device::FeatureList parseFeatures(const Vector<JSC::JSValue>&
 void WebXRTest::simulateDeviceConnection(ScriptExecutionContext& context, const FakeXRDeviceInit& init, WebFakeXRDevicePromise&& promise)
 {
     // https://immersive-web.github.io/webxr-test-api/#dom-xrtest-simulatedeviceconnection
-    context.postTask([this, protectedThis = protect(*this), init, promise = WTF::move(promise)] (ScriptExecutionContext& context) mutable {
+    context.postTask([this, protectedThis = protect(*this), init, promise = WTF::move(promise)](auto&) mutable {
         auto device = WebFakeXRDevice::create();
         auto& simulatedDevice = device->simulatedXRDevice();
 
         device->setViews(init.views);
 
-        auto supportedFeatures = parseFeatures(init.supportedFeatures, context);
-        auto enabledFeatures = parseFeatures(init.enabledFeatures, context);
+        auto supportedFeatures = parseFeatures(init.supportedFeatures);
+        auto enabledFeatures = parseFeatures(init.enabledFeatures);
 
         if (init.boundsCoordinates) {
             if (init.boundsCoordinates->size() < 3) {

--- a/Source/WebCore/testing/WebXRTest.h
+++ b/Source/WebCore/testing/WebXRTest.h
@@ -33,7 +33,6 @@
 #include "WebFakeXRDevice.h"
 #include "XRSessionMode.h"
 #include "XRSimulateUserActivationFunction.h"
-#include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -48,8 +47,8 @@ public:
         std::optional<Vector<XRSessionMode>> supportedModes;
         Vector<FakeXRViewInit> views;
 
-        Vector<JSC::JSValue> supportedFeatures;
-        Vector<JSC::JSValue> enabledFeatures;
+        Vector<String> supportedFeatures;
+        Vector<String> enabledFeatures;
 
         std::optional<Vector<FakeXRBoundsPoint>> boundsCoordinates;
 

--- a/Source/WebCore/testing/WebXRTest.idl
+++ b/Source/WebCore/testing/WebXRTest.idl
@@ -60,11 +60,11 @@
     // If not specified/empty, the device supports no features.
     // NOTE: This is meant to emulate hardware support, not whether a feature is
     // currently available (e.g. bounds not being tracked per below)
-    sequence<any> supportedFeatures = [];
+    sequence<DOMString> supportedFeatures = [];
 
     // The list of features that are automatically enabled and do
     // not need further explicit consent.
-    sequence<any> enabledFeatures = [];
+    sequence<DOMString> enabledFeatures = [];
 
     // The bounds coordinates. If empty, no bounded reference space is currently tracked.
     // If not, must have at least three elements.


### PR DESCRIPTION
#### 3a88b7cf55602cbb76f98e54838363a2d8eee504
<pre>
Use-after-free in XRSessionInit dictionary conversion via sequence&lt;any&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=312348">https://bugs.webkit.org/show_bug.cgi?id=312348</a>
<a href="https://rdar.apple.com/174448452">rdar://174448452</a>

Reviewed by Ryosuke Niwa.

sequence&lt;any&gt; and FrozenArray&lt;any&gt; are fundamentally unsafe as
currently implemented. Fortunately the only place where we use
sequence&lt;any&gt; can use sequence&lt;DOMString&gt;.

So adopt sequence&lt;DOMString&gt; there and add static asserts to prevent
future adoption of the unsafe constructs.

Originally-landed-as: 305413.680@safari-7624-branch (65ba1780134a). <a href="https://rdar.apple.com/180437855">rdar://180437855</a>
Canonical link: <a href="https://commits.webkit.org/316227@main">https://commits.webkit.org/316227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df772b1ec96d62cee484528020d309d4702a92e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38577 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180612 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133476 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33608 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29292 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145768 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.MultipleAccounts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183200 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141963 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44814 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141772 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38343 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45504 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110208 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37012 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117345 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44014 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8352 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->