### PR TITLE
MockSampleBox should not have negative timeScales and duration

### DIFF
--- a/Source/WebCore/platform/mock/mediasource/MockBox.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockBox.cpp
@@ -92,7 +92,7 @@ MockInitializationBox::MockInitializationBox(ArrayBuffer* data)
 
     auto view = JSC::DataView::create(data, 0, data->byteLength());
     int32_t timeValue = view->get<int32_t>(8, true);
-    int32_t timeScale = view->get<int32_t>(12, true);
+    uint32_t timeScale = view->get<uint32_t>(12, true);
     m_duration = MediaTime(timeValue, timeScale);
     
     size_t offset = 16;
@@ -120,7 +120,7 @@ MockSampleBox::MockSampleBox(ArrayBuffer* data)
     ASSERT(m_length == 30);
 
     auto view = JSC::DataView::create(data, 0, data->byteLength());
-    int32_t timeScale = view->get<int32_t>(8, true);
+    uint32_t timeScale = view->get<uint32_t>(8, true);
 
     int32_t timeValue = view->get<int32_t>(12, true);
     m_presentationTimestamp = MediaTime(timeValue, timeScale);
@@ -128,8 +128,8 @@ MockSampleBox::MockSampleBox(ArrayBuffer* data)
     timeValue = view->get<int32_t>(16, true);
     m_decodeTimestamp = MediaTime(timeValue, timeScale);
 
-    timeValue = view->get<int32_t>(20, true);
-    m_duration = MediaTime(timeValue, timeScale);
+    uint32_t durationValue = view->get<uint32_t>(20, true);
+    m_duration = MediaTime(durationValue, timeScale);
 
     m_trackID = view->get<int32_t>(24, true);
     m_flags = view->get<uint8_t>(28, true);


### PR DESCRIPTION
#### 82a21e0b3ea89e71d4d34894e98f6c5ebe254a87
<pre>
MockSampleBox should not have negative timeScales and duration
<a href="https://rdar.apple.com/174740124">rdar://174740124</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313917">https://bugs.webkit.org/show_bug.cgi?id=313917</a>

Reviewed by Simon Fraser.

* Source/WebCore/platform/mock/mediasource/MockBox.cpp:
(WebCore::MockInitializationBox::MockInitializationBox):
(WebCore::MockSampleBox::MockSampleBox):

Originally-landed-as: 305413.813@safari-7624-branch (4f7a3cfefe44). <a href="https://rdar.apple.com/180437504">rdar://180437504</a>
Canonical link: <a href="https://commits.webkit.org/316121@main">https://commits.webkit.org/316121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/190b2ced38024ee3fec50db1879deb651763fdf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180340 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133342 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33495 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29020 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182925 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141797 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44542 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141606 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38210 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109936 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36868 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43742 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->