### PR TITLE
Use-after-free in FocusController::findAndFocusElementInDocumentOrder

### DIFF
--- a/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash-expected.txt
+++ b/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if PASS (no crash)

--- a/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash.html
+++ b/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input>
+<iframe tabindex="0" srcdoc="<input tabindex='0'><script>parent.innerInput = document.querySelector('input');</script>"></iframe>
+<script>
+let iframe = document.querySelector('iframe');
+let outerInput = document.querySelector('input');
+let innerInput = null;
+
+if (window.testRunner && window.GCController) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    iframe.onload = () => setTimeout(runTest, 0);
+} else
+    document.write('<p>FAIL - This test requires testRunner and GCController</p>');
+
+function runTest() {
+    let innerInput = window.innerInput;
+    window.innerInput = null;
+
+    outerInput.addEventListener('blur', () => {
+        document.adoptNode(innerInput);
+        innerInput = null;
+        iframe.remove();
+        iframe = null;
+        GCController.collect();
+    }, { once: true });
+
+    outerInput.focus();
+    outerInput.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, view: window, detail: 0,
+        key: 'Tab', code: 'Tab', keyIdentifier: 'U+0009', location: 222, ctrlKey: false, altKey: true, shiftKey: false, metaKey: false }));
+
+    document.body.innerHTML = '<p>This test passes if PASS (no crash)</p>';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 87fedd82a16530e11847ba929c480693992c8443
<pre>
Use-after-free in FocusController::findAndFocusElementInDocumentOrder
<a href="https://bugs.webkit.org/show_bug.cgi?id=313702">https://bugs.webkit.org/show_bug.cgi?id=313702</a>
<a href="https://rdar.apple.com/175673194">rdar://175673194</a>

Reviewed by Aditya Keerthi.

Fixed the bug by deploying a smart pointer.

Test: fast/events/new-focused-document-removal-during-blur-event-handler-crash.html

* LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash-expected.txt: Added.
* LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash.html: Added.
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findAndFocusElementInDocumentOrderStartingWithFrame):

Originally-landed-as: 305413.804@safari-7624-branch (f9763c9248db). <a href="https://rdar.apple.com/180428014">rdar://180428014</a>
Canonical link: <a href="https://commits.webkit.org/316373@main">https://commits.webkit.org/316373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f6fcf46c34d42eefbb67f972e38ff851617ecd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129561 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133804 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35846 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34106 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183979 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142533 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142424 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38473 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46271 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110934 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37516 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44789 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8775 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->