### PR TITLE
Reject IndexedDB transactions during version change operation

### DIFF
--- a/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change-expected.txt
+++ b/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change.html
+++ b/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change.html
@@ -1,0 +1,117 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>This test passes if it does not crash.</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { ArgumentSerializer, IPCWireTap } = await import('./coreipc.js');
+
+    function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+    const origin = {
+        topOrigin: {
+            data: { variantIndex: 0, variant: { protocol: 'http', host: '127.0.0.1', port: {} } },
+        },
+        clientOrigin: {
+            data: { variantIndex: 0, variant: { protocol: 'http', host: '127.0.0.1', port: {} } },
+        },
+    };
+
+    function resId(connId, resourceNum) {
+        return {
+            m_idbConnectionIdentifier: { optionalValue: { alias: connId } },
+            m_resourceNumber: { optionalValue: resourceNum },
+        };
+    }
+
+    function mkReq(connId, resNum, reqType) {
+        return {
+            m_serverConnectionIdentifier: { alias: connId },
+            m_requestIdentifier: resId(connId, resNum),
+            m_databaseIdentifier: {
+                m_databaseName: 'crashdb',
+                m_origin: origin,
+                m_isTransient: false,
+            },
+            m_requestedVersion: 1n,
+            m_requestType: reqType,
+        };
+    }
+
+    function sendMessage(messageDesc, destinationID, args) {
+        const connection = IPC.connectionForProcessTarget('Networking');
+        const serializedArguments = ArgumentSerializer.serializeArguments(messageDesc.arguments, args);
+        connection.sendMessage(destinationID, messageDesc.name, serializedArguments);
+    }
+
+    const CONN = 42n;
+
+    // Wiretap to capture databaseConnectionIdentifier
+    let dbConnIds = [];
+    const inTap = new IPCWireTap("Networking", "Incoming");
+    inTap.tapAll((process, connID, name, typed, result) => {
+        if (!result) return;
+        const r = result.result;
+        if (!r) return;
+        if (r.m_databaseConnectionIdentifier && r.m_databaseConnectionIdentifier.optionalValue) {
+            let id = BigInt(String(r.m_databaseConnectionIdentifier.optionalValue).replace('n',''));
+            dbConnIds.push(id);
+        }
+    });
+
+    // Step 1: Open DB with version change (0 -> 1)
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDatabase, 0n, {
+        requestData: mkReq(CONN, 1n, 0),
+    });
+    await sleep(300);
+
+    let vc1ConnId = dbConnIds[0];
+    if (!vc1ConnId) { console.log('FAIL: no dbConnId captured'); return; }
+
+    // Step 2: Queue Open #2 behind VC1
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDatabase, 0n, {
+        requestData: mkReq(CONN, 2n, 0),
+    });
+    await sleep(50);
+
+    // Step 3: Establish a regular transaction on VC1's connection.
+    sendMessage(IPC.messages.NetworkStorageManager_EstablishTransaction, 0n, {
+        databaseConnectionIdentifier: vc1ConnId,
+        info: {
+            identifier: resId(CONN, 100n),
+            mode: 1, // ReadWrite
+            durability: 0,
+            newVersion: 0n,
+            objectStores: ['store1'],
+            originalDatabaseInfo: {},
+        },
+    });
+    await sleep(50);
+
+    // Step 4: Close VC1's connection via DatabaseConnectionClosed.
+    sendMessage(IPC.messages.NetworkStorageManager_DatabaseConnectionClosed, 0n, {
+        databaseConnectionIdentifier: vc1ConnId,
+    });
+    await sleep(300);
+
+    // Step 5: Cancel Open #2
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDBRequestCancelled, 0n, {
+        requestData: mkReq(CONN, 2n, 0),
+    });
+    await sleep(300);
+
+    // Cancel Open #1 in case it's still pending
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDBRequestCancelled, 0n, {
+        requestData: mkReq(CONN, 1n, 0),
+    });
+    await sleep(1000);
+
+    window.testRunner?.notifyDone();
+}, 10);
+</script>

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1379,6 +1379,11 @@ void UniqueIDBDatabase::connectionClosedFromClient(UniqueIDBDatabaseConnection& 
     handleTransactions();
 }
 
+bool UniqueIDBDatabase::isVersionChangeTransactionActive(const UniqueIDBDatabaseConnection& connection) const
+{
+    return m_versionChangeDatabaseConnection == &connection && m_versionChangeTransaction;
+}
+
 void UniqueIDBDatabase::connectionClosedFromServer(UniqueIDBDatabaseConnection& connection)
 {
     ASSERT(!isMainThread());

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -110,6 +110,7 @@ public:
 
     void didFinishHandlingVersionChange(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& transactionIdentifier);
     void connectionClosedFromClient(UniqueIDBDatabaseConnection&);
+    WEBCORE_EXPORT bool isVersionChangeTransactionActive(const UniqueIDBDatabaseConnection&) const;
     void didFireVersionChangeEvent(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer);
     WEBCORE_EXPORT void openDBRequestCancelled(const IDBResourceIdentifier& requestIdentifier);
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2045,8 +2045,16 @@ void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const We
 
 void NetworkStorageManager::establishTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
 {
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
-        connection->establishTransaction(transactionInfo);
+    RefPtr databaseConnection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection);
+    if (!databaseConnection)
+        return;
+
+    // FIXME: consider converting this early return to MESSAGE_CHECK.
+    CheckedPtr database = databaseConnection->database();
+    if (database && database->isVersionChangeTransactionActive(*databaseConnection))
+        return;
+
+    databaseConnection->establishTransaction(transactionInfo);
 }
 
 void NetworkStorageManager::databaseConnectionPendingClose(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)


### PR DESCRIPTION
#### e2b88c2f80488fed156450007f317f5ff0e564f4
<pre>
Reject IndexedDB transactions during version change operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312391">https://bugs.webkit.org/show_bug.cgi?id=312391</a>
<a href="https://rdar.apple.com/173799670">rdar://173799670</a>

Reviewed by Sihui Liu.

When an IndexedDB connection is closed while a version
change transaction is active, UniqueIDBDatabase::connectionClosedFromClient
successfully closes the version change transaction however it does
not clear any other pending transactions due to an early return
when clearing version change transactions.

Instead of being defensive and clearing the pending transaciton
in the case of the early return, we should reject any incoming
transactions which come on a version change connection.

Only whenever a version change operation completes, can
a new transaction be established. So, this patch rejects any
incoming transactions which come while a version change operation
is active.

The IndexedDB spec describes the steps for starting a new transaction:

        The transaction(storeNames, mode, options) method steps are:
        1. If a live upgrade transaction is associated with the connection, throw an &quot;InvalidStateError&quot; DOMException.

<a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction">https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction</a>

This check already happens in the web process during
IDBDatabase::transaction where it returns an &quot;InvalidStateError&quot;
in this state.

However, this doesn&apos;t account for a compromised web process
who avoids this client side check and makes it across IPC
to invoke transaction creation in the NetworkProcess.

This patch adds a check for this scenario of a comprimised web
process who manages to start a new transaction during a
version change, if this is detected, we return early and
don&apos;t move forward with creating the transaction

This patch checks that the current connection isn&apos;t the
stored UniqueIDBDatabase::m_versionChangeDatabaseConnection.
That member variable will point to the active version change connection,
if any, and it is cleared when the version change completes.
It also checks if m_versionChangeTransaction is non-null
since it will only be null once the version change transaction
is completed.

* LayoutTests/ipc/networksindexeddb-close-connection-during-version-change-expected.txt: Added.
* LayoutTests/ipc/networksindexeddb-close-connection-during-version-change.html: Added.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::isVersionChangeTransactionActive const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::establishTransaction):
(WebKit::NetworkStorageManager::databaseConnectionPendingClose):

Originally-landed-as: 305413.734@safari-7624-branch (6b2393e40648). <a href="https://rdar.apple.com/180437837">rdar://180437837</a>
Canonical link: <a href="https://commits.webkit.org/316133@main">https://commits.webkit.org/316133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/428fccb10b0dda512bf711a58eebd68adad57252

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36576 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153785 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35198 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33499 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29023 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182928 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141802 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141611 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38228 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45234 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30158 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109939 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36871 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117125 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43745 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43149 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->