### PR TITLE
[WebCore] Take graphLock() in BiquadFilterNode::setType() to avoid race

### DIFF
--- a/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race-expected.txt
+++ b/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash when toggling BiquadFilterNode.type while the channel count changes on the audio thread.
+
+PASS: did not crash.

--- a/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race.html
+++ b/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function runTest()
+{
+    const context = new OfflineAudioContext(1, 48000 * 30, 48000);
+    const biquad = new BiquadFilterNode(context);
+    biquad.channelCountMode = 'explicit';
+    biquad.channelCount = 32;
+    biquad.connect(context.destination);
+
+    let last = biquad;
+    for (let i = 0; i < 50; ++i) {
+        const node = new BiquadFilterNode(context);
+        last.connect(node);
+        last = node;
+    }
+    last.connect(context.destination);
+
+    context.startRendering();
+
+    const types = ['lowpass', 'highpass'];
+    const counts = [31, 32];
+    let k = 0;
+    const deadline = performance.now() + 2000;
+
+    function spin()
+    {
+        for (let outer = 0; outer < 200; ++outer) {
+            biquad.channelCount = counts[k & 1];
+            ++k;
+            for (let i = 0; i < 4000; ++i)
+                biquad.type = types[i & 1];
+        }
+        if (performance.now() < deadline)
+            setTimeout(spin, 0);
+        else {
+            document.getElementById('result').textContent = 'PASS: did not crash.';
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    }
+    spin();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>This test passes if it does not crash when toggling BiquadFilterNode.type while the channel count changes on the audio thread.</p>
+<p id="result"></p>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -28,6 +28,8 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "BiquadFilterNode.h"
+
+#include "BaseAudioContext.h"
 #include "ExceptionOr.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -70,6 +72,11 @@ BiquadFilterType BiquadFilterNode::type() const
 
 void BiquadFilterNode::setType(BiquadFilterType type)
 {
+    ASSERT(isMainThread());
+
+    // Synchronize with any graph changes or changes to channel configuration since
+    // BiquadProcessor::setType() may iterate the processor's kernels via reset().
+    Locker contextLocker { context().graphLock() };
     protect(biquadProcessor())->setType(type);
 }
 


### PR DESCRIPTION
#### 2f91fd7d2ec69d1ca85edef694626ee9cebac8f1
<pre>
[WebCore] Take graphLock() in BiquadFilterNode::setType() to avoid race
 with audio-thread kernel reallocation
<a href="https://rdar.apple.com/174652790">rdar://174652790</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312796">https://bugs.webkit.org/show_bug.cgi?id=312796</a>

Reviewed by Chris Dumez.

BiquadFilterNode::setType() runs on the main thread from JS bindings and calls
BiquadProcessor::setType(), which in turn calls AudioDSPKernelProcessor::reset()
to iterate m_kernels and virtual-call reset() on each kernel. This was done
without holding the context&apos;s graphLock().

Concurrently, every render quantum the audio thread runs
AudioBasicProcessorNode::checkNumberOfChannelsForInput() under graphLock() and,
when the input channel count has changed, calls uninitialize() / initialize()
on the processor, which clear()s and move-assigns m_kernels.

With the lock held only on one side, the main thread could load a kernel pointer
from a Vector slot that is being/already freed, leading to a use-after-free virtual
dispatch into a destroyed BiquadDSPKernel and writes through stale Biquad
buffer spans, or a null deref if the slot was already zeroed.

Fix by taking context().graphLock() in BiquadFilterNode::setType(), matching the
existing convention in WaveShaperNode::setOversampleForBindings() and
AudioNode::setChannelCount().

Test: webaudio/biquadfilternode-set-type-channel-count-race.html
* LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race-expected.txt: Added.
* LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race.html: Added.
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
(WebCore::BiquadFilterNode::setType):

Originally-landed-as: 305413.717@safari-7624-branch (41efaeddddf2). <a href="https://rdar.apple.com/180436998">rdar://180436998</a>
Canonical link: <a href="https://commits.webkit.org/316175@main">https://commits.webkit.org/316175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea735eef4ae172a0c201673bc73c8d7864c4d87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171576 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38911 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45133 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174534 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183547 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153634 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38297 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44358 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->