### PR TITLE
Cross-Thread UAF Write in AsyncFileStream::read via NetworkDataTaskBlob

### DIFF
--- a/Source/WebCore/fileapi/AsyncFileStream.cpp
+++ b/Source/WebCore/fileapi/AsyncFileStream.cpp
@@ -164,12 +164,12 @@ void AsyncFileStream::close()
     });
 }
 
-void AsyncFileStream::read(std::span<uint8_t> buffer)
+void AsyncFileStream::read(const Box<Vector<uint8_t>>& buffer, Function<void(int bytesRead)>&& didRead)
 {
-    perform([buffer](FileStream& stream) -> Function<void(FileStreamClient&)> {
-        int bytesRead = stream.read(buffer);
-        return [bytesRead](FileStreamClient& client) {
-            client.didRead(bytesRead);
+    perform([buffer, didRead = WTF::move(didRead)](FileStream& stream) mutable -> Function<void(FileStreamClient&)> {
+        int bytesRead = stream.read(*buffer);
+        return [bytesRead, didRead = WTF::move(didRead)](FileStreamClient&) {
+            didRead(bytesRead);
         };
     });
 }

--- a/Source/WebCore/fileapi/AsyncFileStream.h
+++ b/Source/WebCore/fileapi/AsyncFileStream.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <wtf/Box.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
@@ -50,7 +51,7 @@ public:
     void getSize(const String& path, std::optional<WallTime> expectedModificationTime);
     void openForRead(const String& path, long long offset, long long length);
     void close();
-    void read(std::span<uint8_t> buffer);
+    void read(const Box<Vector<uint8_t>>& outputBuffer, Function<void(int bytesRead)>&&);
 
 private:
     void start();

--- a/Source/WebCore/platform/FileStreamClient.h
+++ b/Source/WebCore/platform/FileStreamClient.h
@@ -38,7 +38,6 @@ class FileStreamClient : public AbstractRefCountedAndCanMakeWeakPtr<FileStreamCl
 public:
     virtual void didOpen(bool) { } // false signals failure.
     virtual void didGetSize(long long) { } // -1 signals failure.
-    virtual void didRead(int) { } // -1 signals failure.
     virtual void didWrite(int) { } // -1 signals failure.
     virtual void didTruncate(bool) { } // false signals failure.
 

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -273,7 +273,7 @@ bool BlobResourceHandle::shouldAbortDispatchDidReceiveResponse()
 void BlobResourceHandle::didReceiveResponse(ResourceResponse&& response)
 {
     client()->didReceiveResponseAsync(this, WTF::move(response), [this, protectedThis = Ref { *this }] {
-        buffer().resize(bufferSize);
+        resizeBuffer(bufferSize);
         readAsync();
     });
 }

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -33,6 +33,7 @@
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include <wtf/MainThread.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -43,6 +44,7 @@ static constexpr auto httpPartialContentText = "Partial Content"_s;
 
 BlobResourceHandleBase::BlobResourceHandleBase(bool async, RefPtr<BlobData>&& blobData)
     : m_blobData(WTF::move(blobData))
+    , m_buffer(Box<Vector<uint8_t>>::create())
 {
     if (async)
         m_stream = makeUnique<AsyncFileStream>(*this);
@@ -294,12 +296,25 @@ bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item, DataSegment
     return consumeData(span);
 }
 
+void BlobResourceHandleBase::resizeBuffer(size_t newSize)
+{
+    RELEASE_ASSERT(!m_isWritingIntoBuffer);
+    m_buffer->resize(newSize);
+}
+
 void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item, BlobDataFileReference& file)
 {
     ASSERT(isMainThread());
 
     if (m_isFileOpen) {
-        asyncStream()->read(buffer().mutableSpan());
+        m_isWritingIntoBuffer = true;
+        asyncStream()->read(m_buffer, [weakThis = WeakPtr { *this }](int bytesRead) {
+            RefPtr protectedThis = weakThis;
+            if (!protectedThis)
+                return;
+            protectedThis->m_isWritingIntoBuffer = false;
+            protectedThis->didRead(bytesRead);
+        });
         return;
     }
 
@@ -341,7 +356,7 @@ void BlobResourceHandleBase::didRead(int bytesRead)
         return;
     }
 
-    if (consumeData(m_buffer.subspan(0, bytesRead)))
+    if (consumeData(m_buffer->subspan(0, bytesRead)))
         readAsync();
 }
 

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.h
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.h
@@ -29,6 +29,7 @@
 #include <WebCore/BlobData.h>
 #include <WebCore/FileStreamClient.h>
 #include <WebCore/HTTPParsers.h>
+#include <wtf/Box.h>
 #include <wtf/Forward.h>
 #include <wtf/Variant.h>
 #include <wtf/Vector.h>
@@ -73,8 +74,8 @@ protected:
     WEBCORE_EXPORT BlobData* NODELETE blobData() const;
     FileStream* syncStream() const;
     AsyncFileStream* asyncStream() const;
-    Vector<uint8_t>& buffer() LIFETIME_BOUND { return m_buffer; }
-    const Vector<uint8_t>& buffer() const LIFETIME_BOUND { return m_buffer; }
+    WEBCORE_EXPORT void resizeBuffer(size_t);
+    const Vector<uint8_t>& buffer() const LIFETIME_BOUND { return *m_buffer; }
 
 private:
     void getSizeForNext();
@@ -85,6 +86,7 @@ private:
     void readFileAsync(const BlobDataItem&, BlobDataFileReference&);
     void dispatchDidReceiveResponse();
     void doStart();
+    void didRead(int); // -1 in case of error.
 
     virtual void didReceiveResponse(ResourceResponse&&) = 0;
     virtual void didFail(Error) = 0;
@@ -98,13 +100,13 @@ private:
     // FileStreamClient methods.
     WEBCORE_EXPORT void didOpen(bool) final;
     WEBCORE_EXPORT void didGetSize(long long) final;
-    WEBCORE_EXPORT void didRead(int) final;
 
     RefPtr<BlobData> m_blobData;
     // For Async or Sync loading.
     Variant<std::unique_ptr<AsyncFileStream>, std::unique_ptr<FileStream>> m_stream;
     std::optional<HTTPRange> m_range;
-    Vector<uint8_t> m_buffer;
+    bool m_isWritingIntoBuffer { false };
+    const Box<Vector<uint8_t>> m_buffer;
     Vector<uint64_t> m_itemLengthList;
     uint64_t m_totalSize { 0 };
     uint64_t m_totalRemainingSize { 0 };

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -148,7 +148,7 @@ void NetworkDataTaskBlob::didReceiveResponse(ResourceResponse&& response)
 
         switch (policyAction) {
         case PolicyAction::Use:
-            buffer().resize(bufferSize);
+            resizeBuffer(bufferSize);
             readAsync();
             break;
         case PolicyAction::LoadWillContinueInAnotherProcess:
@@ -215,7 +215,7 @@ void NetworkDataTaskBlob::download()
 
     ASSERT(!m_client);
 
-    buffer().resize(bufferSize);
+    resizeBuffer(bufferSize);
     readAsync();
 }
 


### PR DESCRIPTION
#### 629adf4b07f2d5d71ff096c95de0ed67da38ded5
<pre>
Cross-Thread UAF Write in AsyncFileStream::read via NetworkDataTaskBlob
<a href="https://bugs.webkit.org/show_bug.cgi?id=312449">https://bugs.webkit.org/show_bug.cgi?id=312449</a>
<a href="https://rdar.apple.com/174655475">rdar://174655475</a>

Reviewed by Ryosuke Niwa.

BlobResourceHandleBase was passing a mutable span to its m_buffer Vector
to AsyncFileStream for it to write into asynchronously on a background
thread. However, nothing guaranteed that the BlobResourceHandleBase
(and thus its m_buffer) stayed alive until AsyncFileStream was done
writing.

Address the issue by using a `Box&lt;Vector&lt;uint8_t&gt;&gt;` instead of a simple
Vector so that the buffer is now ThreadSafeRefCounted. Then update the
AsyncFileStream API to take in a `Box&lt;Vector&lt;uint8_t&gt;&gt;` instead of a
span.

For further hardening, I removed the non-const buffer getter on
BlobResourceHandleBase. This was too dangerous because any operation on
this buffer on the main thread could cause the background thread to
crash if it is currently writing to it. The non-const buffer getter was
only used to resize the buffer once we know the size of the data we
need to read. I thus added a more specific `resizeBuffer()` API to
BlobResourceHandleBase which has a RELEASE_ASSERT() to guarantee that
the background thread is NOT currently writing into the buffer. This was
not an issue with the current code but the RELEASE_ASSERT() makes sure
we cannot introduce such a security bug in the future.

* Source/WebCore/fileapi/AsyncFileStream.cpp:
(WebCore::AsyncFileStream::read):
* Source/WebCore/fileapi/AsyncFileStream.h:
* Source/WebCore/platform/FileStreamClient.h:
(WebCore::FileStreamClient::didGetSize):
(WebCore::FileStreamClient::didRead): Deleted.
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::didReceiveResponse):
* Source/WebCore/platform/network/BlobResourceHandleBase.cpp:
(WebCore::BlobResourceHandleBase::BlobResourceHandleBase):
(WebCore::BlobResourceHandleBase::resizeBuffer):
(WebCore::BlobResourceHandleBase::readFileAsync):
(WebCore::BlobResourceHandleBase::didRead):
* Source/WebCore/platform/network/BlobResourceHandleBase.h:
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::didReceiveResponse):

Originally-landed-as: 305413.682@safari-7624-branch (70917758773a). <a href="https://rdar.apple.com/180428931">rdar://180428931</a>
Canonical link: <a href="https://commits.webkit.org/316253@main">https://commits.webkit.org/316253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c1bc7d571baf557cfb5d5f2e2d9061501508eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129061 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174415 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35450 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33711 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183425 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142105 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45038 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141983 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38366 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45728 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110405 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37219 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117458 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44238 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8458 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->