### PR TITLE
[WebCore] Capture WeakPtr to this (MediaMetadata) in ArtworkImageLoader callback

### DIFF
--- a/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash-expected.txt
+++ b/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash.html
+++ b/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useDollarVM=true ] -->
+<html>
+<head>
+    <script>
+        if (globalThis.testRunner) {
+            globalThis.testRunner.waitUntilDone();
+            globalThis.testRunner.dumpAsText();
+        }
+
+        let delays = [10, 50, 100];
+        let iteration = 0;
+        let innerBase64 = 'A'.repeat(64 * 1024);
+        let inner = 'data:image/png;base64,' + innerBase64;
+
+        function armNext() {
+            if (iteration >= delays.length) {
+                setTimeout(() => {
+                    if (globalThis.testRunner)
+                        globalThis.testRunner.notifyDone();
+                }, 500);
+                return;
+            }
+
+            let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">` +
+                      `<image href="${inner}" width="200" height="200"/>`.repeat(4) +
+                      `</svg>`;
+            let outer = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+
+            let m = new MediaMetadata({ artwork: [{ src: outer, sizes: 'any', type: 'image/svg+xml' }] });
+            navigator.mediaSession.metadata = m;
+
+            setTimeout(() => {
+                navigator.mediaSession.metadata = null;
+                m = null;
+                if (globalThis.$vm)
+                    $vm.gc();
+
+                setTimeout(armNext, 500);
+            }, delays[iteration++]);
+        }
+
+        window.onload = armNext;
+    </script>
+</head>
+<body>
+This test passes if it doesn't crash.
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -270,14 +270,17 @@ void MediaMetadata::tryNextArtworkImage(uint32_t index, Vector<Pair>&& artworks)
 
     String artworkImageSrc = artworks[index].src;
 
-    m_artworkLoader = ArtworkImageLoader::create(*document, artworkImageSrc, [this, index, artworkImageSrc, artworks = WTF::move(artworks)](Image* image) mutable {
+    m_artworkLoader = ArtworkImageLoader::create(*document, artworkImageSrc, [weakThis = WeakPtr { *this }, index, artworkImageSrc, artworks = WTF::move(artworks)](Image* image) mutable {
+        RefPtr strongThis = weakThis;
+        if (!strongThis)
+            return;
         if (image && image->data() && image->width() && image->height()) {
             IntSize size { int(image->width()), int(image->height()) };
             float imageScore = imageDimensionsScore(size.width(), size.height(), s_minimumSize, s_idealSize);
-            if (!index || (m_artworkImage && (imageDimensionsScore(protect(m_artworkImage)->width(), protect(m_artworkImage)->height(), s_minimumSize, s_idealSize) < imageScore))) {
-                m_artworkImageSrc = artworkImageSrc;
-                setArtworkImage(image);
-                metadataUpdated();
+            if (!index || (strongThis->m_artworkImage && (imageDimensionsScore(protect(strongThis->m_artworkImage)->width(), protect(strongThis->m_artworkImage)->height(), s_minimumSize, s_idealSize) < imageScore))) {
+                strongThis->m_artworkImageSrc = artworkImageSrc;
+                strongThis->setArtworkImage(image);
+                strongThis->metadataUpdated();
             }
             // If selection from `sizes` attribute yielded a valid image, or we have downloaded an image bigger than the ideal size we stop.
             if (artworks[index].score >= 0 || size.maxDimension() >= s_idealSize)
@@ -285,7 +288,7 @@ void MediaMetadata::tryNextArtworkImage(uint32_t index, Vector<Pair>&& artworks)
         }
 
         if (++index < artworks.size())
-            tryNextArtworkImage(index, WTF::move(artworks));
+            strongThis->tryNextArtworkImage(index, WTF::move(artworks));
     });
     protect(m_artworkLoader)->requestImageResource();
 }

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -75,7 +75,7 @@ private:
     CachedResourceHandle<CachedImage> m_cachedImage;
 };
 
-class MediaMetadata final : public RefCounted<MediaMetadata> {
+class MediaMetadata final : public RefCountedAndCanMakeWeakPtr<MediaMetadata> {
 public:
     static ExceptionOr<Ref<MediaMetadata>> create(ScriptExecutionContext&, std::optional<MediaMetadataInit>&&);
     static Ref<MediaMetadata> create(MediaSession&, Vector<URL>&&);


### PR DESCRIPTION
#### d6fb60c4fa7912ac11adc9b79f6de7aac952d967
<pre>
[WebCore] Capture WeakPtr to this (MediaMetadata) in ArtworkImageLoader callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=312480">https://bugs.webkit.org/show_bug.cgi?id=312480</a>
<a href="https://rdar.apple.com/174651594">rdar://174651594</a>

Reviewed by Geoffrey Garen.

In media artwork image loading, it is possible for a
callback lambda to outlive the lifetime of the
MediaMetadata which it captures with a raw &quot;this&quot;.

This callback is stored in ArtworkImageLoader::m_callback
and ArtworkImageLoader is owned by MediaMetadata.

The lambda captures a raw this to MediaMetadata during
MediaMetadata::tryNextArtworkImage.

However, it&apos;s possible for the lambda to outlive ArtworkImageLoader
and, in turn, MediaMetadata after beeing std::exchanged outside
of the artwork loader in ArtworkImageLoader::notifyFinished.
Then, it&apos;s possible for MediaMetadata to be destroyed while
the lambda has a dangling &quot;this&quot; pointer to the destroyed object.

This patch changes the lambda to capture a WeakPtr
to &quot;this&quot; (MediaMetadata) and returns early if it has
been destroyed. If weakThis is still alive, we keep it alive for the
duration of the lambda body with a RefPtr.

* LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash-expected.txt: Added.
* LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash.html: Added.
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::MediaMetadata::tryNextArtworkImage):
        Changed the artwork loader lambda to capture a WeakPtr
        to &quot;this&quot; and early return if weakThis is null.
        The rest of the lambda explicitly uses weakThis where needed.
* Source/WebCore/Modules/mediasession/MediaMetadata.h:
        Changed MediaMetadata to inherit from CanMakeWeakPtr.

Originally-landed-as: 305413.695@safari-7624-branch (9da5185f2406). <a href="https://rdar.apple.com/180437956">rdar://180437956</a>
Canonical link: <a href="https://commits.webkit.org/316179@main">https://commits.webkit.org/316179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/560a4b745f203c099d0fbe70144c0eb72cda4ea7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171583 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45140 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29635 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183554 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38299 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44365 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->