### PR TITLE
[WebKit] Use-after-free in ServiceWorkerDownloadTask via stale FunctionDispatcherQueue after second EstablishSWContextConnection

### DIFF
--- a/LayoutTests/http/tests/workers/service/resources/service-worker-download-task-uaf-worker.js
+++ b/LayoutTests/http/tests/workers/service/resources/service-worker-download-task-uaf-worker.js
@@ -1,0 +1,17 @@
+self.addEventListener("fetch", (event) => {
+    if (!event.request.url.includes("download-task-uaf"))
+        return;
+    const stream = new ReadableStream({
+        start: (controller) => {
+            controller.enqueue(new TextEncoder().encode("chunk"));
+            // Keep the stream open; the test will overwrite the SW context
+            // connection and burst DidFinish before this stream closes.
+        }
+    });
+    event.respondWith(new Response(stream, {
+        "headers": [
+            ["Content-Type", "application/binary"],
+            ["Content-Disposition", "attachment"]
+        ]
+    }));
+});

--- a/LayoutTests/http/tests/workers/service/service-worker-download-task-uaf.https-expected.txt
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-task-uaf.https-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+PASS

--- a/LayoutTests/http/tests/workers/service/service-worker-download-task-uaf.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-task-uaf.https.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<p>This test passes if WebKit does not crash.</p>
+<div id=logDiv></div>
+<script>
+
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+window.testRunner?.setShouldDownloadUndisplayableMIMETypes(true);
+window.testRunner?.setUseSeparateServiceWorkerProcess(false);
+
+function done(msg)
+{
+    logDiv.innerHTML = msg;
+    window.testRunner?.notifyDone();
+}
+
+function sleep(ms)
+{
+    return new Promise(r => setTimeout(r, ms));
+}
+
+async function run()
+{
+    if (!window.IPC)
+        return;
+
+    // We terminate network process to be sure that registering a service worker will get us a SW context connection.
+    window.testRunner.terminateNetworkProcess();
+    await fetch("").then(() => { }, () => { });
+
+    let captured = null;
+    const gotCapture = new Promise(resolve => {
+        IPC.addOutgoingMessageListener("Networking", m => {
+            if (m.description === "NetworkConnectionToWebProcess_EstablishSWContextConnection" && !captured) {
+                captured = m;
+                resolve();
+            }
+        });
+    });
+
+    const registration = await navigator.serviceWorker.register(
+        "resources/service-worker-download-task-uaf-worker.js",
+        { scope: "/workers/service/resources/" });
+    await registration.installing.ready;
+
+    const frame = document.createElement("iframe");
+    frame.src = "/workers/service/resources/download-task-uaf";
+    document.body.appendChild(frame);
+
+    await Promise.race([gotCapture, sleep(5000)]);
+    if (!captured)
+        throw "no NetworkConnectionToWebProcess_EstablishSWContextConnection captured";
+
+    const { CoreIPC } = await import("/ipc/coreipc.js"); 
+
+    const a = captured.arguments;
+    const args = {
+        webPageProxyID: a[0].value,
+        site: {
+            protocol: a[1].value?.protocol?.value ?? "http",
+            domain: { string: a[1].value?.domain?.value?.string?.value ?? "127.0.0.1" }
+        },
+        serviceWorkerPageIdentifier: {},
+        crossOriginEmbedderPolicy: 0
+    };
+
+    // Try overwriting m_swContextConnection in the Network Process.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.EstablishSWContextConnection(0, args, () => {});
+
+    await sleep(100);
+
+    for (let pass = 0; pass < 5; pass++) {
+        for (let F = 1; F <= 5; F++)
+            IPC.sendMessage("Networking", F, IPC.messages.ServiceWorkerDownloadTask_DidFinish.name, []);
+    }
+
+    await sleep(100);
+    frame.remove();
+}
+
+run().then(() => done("PASS"), e => done("FAIL:" + e));
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -316,6 +316,8 @@ public:
     WEBCORE_EXPORT void addRoutes(ServiceWorkerRegistrationIdentifier, Vector<ServiceWorkerRoute>&&, CompletionHandler<void(Expected<void, ExceptionData>&&)>&&);
     WEBCORE_EXPORT bool addHandlerIfHasControlledClients(CompletionHandler<void()>&&);
 
+    bool hasPendingConnectionDomain(const ContextConnectionKey& key) const { return m_pendingConnectionDomains.contains(key); }
+
 private:
     SWServer(SWServerDelegate&, UniqueRef<SWOriginStore>&&, bool processTerminationDelayEnabled, String&& registrationDatabaseDirectory, PAL::SessionID, bool shouldRunServiceWorkersOnMainThreadForTesting, bool hasServiceWorkerEntitlement, std::optional<unsigned> overrideServiceWorkerRegistrationCountTestingValue, ServiceWorkerIsInspectable);
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1707,6 +1707,16 @@ void NetworkConnectionToWebProcess::establishSWContextConnection(WebPageProxyIde
         Ref swServer = session->ensureSWServer();
         auto allowCookieAccess = session->networkProcess().allowsFirstPartyForCookies(webProcessIdentifier(), site.domain());
         MESSAGE_CHECK_COMPLETION(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate, completionHandler());
+
+        MESSAGE_CHECK_COMPLETION(swServer->hasPendingConnectionDomain({ site.domain(), crossOriginEmbedderPolicy }), completionHandler());
+
+        // FIXME: We should MESSAGE_CHECK m_swContextConnection.
+        ASSERT(!m_swContextConnection);
+        if (m_swContextConnection) {
+            CONNECTION_RELEASE_LOG_ERROR(ServiceWorker, "NetworkConnectionToWebProcess::establishSWContextConnection is called with an existing context connection");
+            closeSWContextConnection();
+        }
+
         m_swContextConnection = WebSWServerToContextConnection::create(*this, webPageProxyID, WTF::move(site), serviceWorkerPageIdentifier, swServer, crossOriginEmbedderPolicy);
     }
     completionHandler();
@@ -1728,9 +1738,7 @@ void NetworkConnectionToWebProcess::serviceWorkerServerToContextConnectionNoLong
 {
     CONNECTION_RELEASE_LOG(ServiceWorker, "serviceWorkerServerToContextConnectionNoLongerNeeded: WebProcess no longer useful for running service workers");
     protect(m_networkProcess->parentProcessConnection())->send(Messages::NetworkProcessProxy::RemoteWorkerContextConnectionNoLongerNeeded { RemoteWorkerType::ServiceWorker, webProcessIdentifier() }, 0);
-
-    if (RefPtr connection = std::exchange(m_swContextConnection, nullptr))
-        connection->stop();
+    closeSWContextConnection();
 }
 
 void NetworkConnectionToWebProcess::terminateSWContextConnectionDueToUnresponsiveness()


### PR DESCRIPTION
#### a3c2559f0df096e9e3b66bed4f49fbd6713b52c7
<pre>
[WebKit] Use-after-free in ServiceWorkerDownloadTask via stale FunctionDispatcherQueue after second EstablishSWContextConnection
<a href="https://rdar.apple.com/176481482">rdar://176481482</a>

Reviewed by Chris Dumez.

WebContent process could at any time try to establish a new service worker context connection.
In that case, NetworkConnectionToWebProcess would destroy any existing service worker context connection without closing it.
While this should not happen in practice, a compromised WebContent process can trigger this code path.

To prevent this, NetworkConnectionToWebProcess is now message checking whether service worker has a pending connection for that domain.
This prevents logic failures further in networking process and UI process which might not expect the creation of a new connection.

As a further defense, we are closing any existing service worker context connection that is pre-existing.
A future patch should MESSAGE_CHECK that there is no pre-existing service worker context connection.

Test: http/tests/workers/service/service-worker-download-task-uaf.https.html

* LayoutTests/http/tests/workers/service/resources/service-worker-download-task-uaf-worker.js: Added.
(event.const.stream.new.ReadableStream.start):
* LayoutTests/http/tests/workers/service/service-worker-download-task-uaf.https-expected.txt: Added.
* LayoutTests/http/tests/workers/service/service-worker-download-task-uaf.https.html: Added.
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::hasPendingConnectionDomain const):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::establishSWContextConnection):
(WebKit::NetworkConnectionToWebProcess::serviceWorkerServerToContextConnectionNoLongerNeeded):

Originally-landed-as: 305413.893@safari-7624-branch (e4baf2c41a05). <a href="https://rdar.apple.com/180437431">rdar://180437431</a>
Canonical link: <a href="https://commits.webkit.org/316362@main">https://commits.webkit.org/316362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42ad5ea27fa2a1b3163ce3570c774ad114c9ac98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34051 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29995 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146219 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinAuthBlockedError (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183914 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142475 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142366 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38465 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46206 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110866 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37465 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117894 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44724 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8721 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44124 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->