### PR TITLE
[CoreIPC] [GPUP] off-main-thread ~CDMSessionAVContentKeySession mutates unlocked LegacyCDMPrivateAVFObjC::m_sessions Vector

### DIFF
--- a/LayoutTests/ipc/legacy-cdm-session-avcontentkeysession-destruction-race-expected.txt
+++ b/LayoutTests/ipc/legacy-cdm-session-avcontentkeysession-destruction-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/legacy-cdm-session-avcontentkeysession-destruction-race.html
+++ b/LayoutTests/ipc/legacy-cdm-session-avcontentkeysession-destruction-race.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html><body>
+<p>This test passes if it does not crash.</p>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+}
+
+function failTest(error) {
+    document.body.textContent = `Fail: ${error.message}`;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+async function main() {
+    if (!window.IPC) {
+        window.testRunner?.notifyDone();
+        return;
+    }
+
+    const {CoreIPC} = await import('./coreipc.js');
+    CoreIPC.default_timeout = 30;
+
+    function makeSharedBuffer(bytes) {
+        return { optionalValue: { "asFragmentedSharedBuffer": { "toIPCData": {
+            variantType: "Vector<std::span<const uint8_t>>", variant: [ Array.from(bytes) ]
+        } } } };
+    }
+
+    let initSB = makeSharedBuffer(new TextEncoder().encode(JSON.stringify({
+        sinf: ["AAAADGZybWFtcDRhAAAAFHNjaG0AAAAAY2JjcwABAAAAAAA5c2NoaQAAADF0ZW5jAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAENwoLj77jCjwCAAw3SqKao8="]
+    })));
+    let certSB = makeSharedBuffer(new Uint8Array(64));
+
+    CoreIPC.GPU.RemoteLegacyCDMFactoryProxy.SupportsKeySystem(0,
+        { keySystem: "com.apple.fps.3_0", mimeType: {} }, ()=>{});
+
+    let cdmId;
+    CoreIPC.GPU.RemoteLegacyCDMFactoryProxy.CreateCDM(0,
+        { keySystem: "com.apple.fps.3_0", playerId: {} },
+        (r,_,t) => { cdmId = t.identifier.parsedValue?.optionalValue?.parsedValue; });
+    if (cdmId === undefined)
+        throw new Error('CreateCDM failed');
+
+    for (let i = 0; i < 3; i++) {
+        let sessA;
+        CoreIPC.GPU.RemoteLegacyCDMProxy.CreateSession(Number(cdmId), { logIdentifier: 1n },
+            (r,_,t) => { sessA = t.identifier.parsedValue?.optionalValue?.parsedValue; });
+        if (sessA === undefined)
+            break;
+
+        CoreIPC.GPU.RemoteLegacyCDMSessionProxy.GenerateKeyRequest(Number(sessA),
+            { mimeType: "video/mp4", initData: initSB, mediaKeysHashSalt: "x" }, ()=>{});
+
+        // Creates AVContentKeySession + bg delegate queue + fires didProvideContentKeyRequest
+        // (bg thread takes RefPtr parent).
+        CoreIPC.GPU.RemoteLegacyCDMSessionProxy.Update(Number(sessA), { update: certSB }, ()=>{});
+
+        // Drop the only main-thread RefPtr; bg's `parent` may become last owner.
+        CoreIPC.GPU.RemoteLegacyCDMFactoryProxy.RemoveSession(0, { identifier: sessA }, ()=>{});
+
+        // Burst CreateSession to drive m_sessions.append concurrently with any deferred destruction.
+        let burst = [];
+        for (let k = 0; k < 32; k++) {
+            let s;
+            CoreIPC.GPU.RemoteLegacyCDMProxy.CreateSession(Number(cdmId), { logIdentifier: BigInt(100 + k) },
+                (r,_,t) => { s = t.identifier.parsedValue?.optionalValue?.parsedValue; });
+            if (s !== undefined)
+                burst.push(s);
+        }
+        for (const s of burst)
+            CoreIPC.GPU.RemoteLegacyCDMFactoryProxy.RemoveSession(0, { identifier: s }, ()=>{});
+    }
+
+    await sleep(200);
+   
+    window.testRunner?.notifyDone();
+}
+
+main().catch(error =>  failTest(error));
+
+</script>
+</body></html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3456,6 +3456,7 @@ media/adopt-node-after-showing-picker-crash.html [ Skip ]
 
 # LEGACY_ENCRYPTED_MEDIA is deprecated
 fast/events/webkit-media-key-events-constructor.html [ Skip ]
+ipc/legacy-cdm-session-avcontentkeysession-destruction-race.html [ Skip ]
 
 # NowPlaying is macOS and iOS only.
 http/tests/media/now-playing-info-private-browsing.html [ Skip ]

--- a/Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm
@@ -138,6 +138,7 @@ bool LegacyCDMPrivateAVFObjC::supportsMIMEType(const String& mimeType) const
 
 RefPtr<LegacyCDMSession> LegacyCDMPrivateAVFObjC::createSession(LegacyCDMSessionClient& client)
 {
+    ASSERT(isMainThread());
     String keySystem = m_cdm->keySystem(); // Local copy for StringView usage
     auto parameters = parseKeySystem(m_cdm->keySystem());
     ASSERT(parameters);
@@ -152,6 +153,7 @@ RefPtr<LegacyCDMSession> LegacyCDMPrivateAVFObjC::createSession(LegacyCDMSession
 
 void LegacyCDMPrivateAVFObjC::invalidateSession(CDMSessionAVContentKeySession* session)
 {
+    ASSERT(isMainThread());
     ASSERT(m_sessions.contains(session));
     m_sessions.removeAll(session);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@ class LegacyCDMPrivateAVFObjC;
 class MediaSampleAVFObjC;
 class SharedBuffer;
 
-class CDMSessionAVContentKeySession final : public LegacyCDMSession, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CDMSessionAVContentKeySession> {
+class CDMSessionAVContentKeySession final : public LegacyCDMSession, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CDMSessionAVContentKeySession, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED(CDMSessionAVContentKeySession);
 public:
     static Ref<CDMSessionAVContentKeySession> create(Vector<int>&& protocolVersions, int cdmVersion, LegacyCDMPrivateAVFObjC& parent, LegacyCDMSessionClient& client)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -143,6 +143,7 @@ CDMSessionAVContentKeySession::CDMSessionAVContentKeySession(Vector<int>&& proto
 
 CDMSessionAVContentKeySession::~CDMSessionAVContentKeySession()
 {
+    ASSERT(isMainThread());
     ALWAYS_LOG(LOGIDENTIFIER);
     [m_contentKeySessionDelegate invalidate];
 


### PR DESCRIPTION
#### e5439f454fea7c3e56f167b4e55d66c8289b7024
<pre>
[CoreIPC] [GPUP] off-main-thread ~CDMSessionAVContentKeySession mutates unlocked LegacyCDMPrivateAVFObjC::m_sessions Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=314134">https://bugs.webkit.org/show_bug.cgi?id=314134</a>
<a href="https://rdar.apple.com/175519844">rdar://175519844</a>

Reviewed by Jean-Yves Avenard.

CDMSessionAVContentKeySession is ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr
with the default DestructionThread::Any. Its WebCDMSessionAVContentKeySessionDelegate
runs on a per-session background WorkQueue and holds a strong RefPtr to the session
for the duration of -contentKeySession:didProvideContentKeyRequest:. If the main
thread drops its last Ref while that background RefPtr is live, the destructor runs
on the background queue.

~CDMSessionAVContentKeySession then resolves a non-thread-safe
WeakPtr&lt;LegacyCDMPrivateAVFObjC&gt; and calls invalidateSession(this) -&gt;
m_sessions.removeAll(this) on the unlocked Vector&lt;CDMSessionAVContentKeySession*&gt;,
racing main-thread createSession() -&gt; m_sessions.append(). Under ASan this surfaces
as container-overflow in Vector::reserveCapacity. Taking RefPtr cdm = m_cdm.get()
off-main also performs non-atomic ref()/deref() on LegacyCDM via
LegacyCDMPrivateAVFObjC::ref().

Pin destruction to the main thread with WTF::DestructionThread::Main so the
destructor (and therefore the WeakPtr resolution, the LegacyCDM ref/deref, and
invalidateSession) always run on the main thread. Add main-thread asserts to the
destructor and to LegacyCDMPrivateAVFObjC::createSession/invalidateSession to
document and enforce the invariant.

Test: ipc/legacy-cdm-session-avcontentkeysession-destruction-race.html

* LayoutTests/ipc/legacy-cdm-session-avcontentkeysession-destruction-race-expected.txt: Added.
* LayoutTests/ipc/legacy-cdm-session-avcontentkeysession-destruction-race.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/LegacyCDMPrivateAVFObjC.mm:
(WebCore::LegacyCDMPrivateAVFObjC::createSession):
(WebCore::LegacyCDMPrivateAVFObjC::invalidateSession):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::~CDMSessionAVContentKeySession):

Originally-landed-as: 305413.856@safari-7624-branch (190b07df83bc). <a href="https://rdar.apple.com/180429393">rdar://180429393</a>
Canonical link: <a href="https://commits.webkit.org/316483@main">https://commits.webkit.org/316483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2635cb4fa9cdcb71704df14cfac8aa54de04c69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134091 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36148 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184391 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142858 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142739 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38563 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46672 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111400 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37787 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118423 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45189 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9074 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->