### PR TITLE
Data race in JSTextTrackCue::visitAdditionalChildrenInGCThread leading to use-after-free (variant of bug 311800)

### DIFF
--- a/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
@@ -57,14 +57,13 @@ bool JSTextTrackCueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> h
     if (reason) [[unlikely]]
         *reason = "TextTrack is an opaque root"_s;
 
-    return containsWebCoreOpaqueRoot(visitor, textTrackCue.track());
+    SUPPRESS_UNCHECKED_ARG return containsWebCoreOpaqueRoot(visitor, textTrackCue.track());
 }
 
 template<typename Visitor>
 void JSTextTrackCue::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    if (auto* textTrack = wrapped().track())
-        addWebCoreOpaqueRoot(visitor, *textTrack);
+    wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTextTrackCue);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5594,7 +5594,7 @@ void HTMLMediaElement::configureTextTrackGroup(const TrackGroup& group)
     // track if it is less suitable, and we do want to disable it if another track is more suitable.
     int alreadyVisibleTrackScore = 0;
     if (group.visibleTrack && captionPreferences) {
-        alreadyVisibleTrackScore = captionPreferences->textTrackSelectionScore(*group.visibleTrack, protect(*this));
+        alreadyVisibleTrackScore = captionPreferences->textTrackSelectionScore(protect(*group.visibleTrack), protect(*this));
         currentlyEnabledTracks.append(protect(*group.visibleTrack));
     }
 

--- a/Source/WebCore/html/track/InbandDataTextTrack.h
+++ b/Source/WebCore/html/track/InbandDataTextTrack.h
@@ -36,6 +36,7 @@ class DataCue;
 
 class InbandDataTextTrack final : public InbandTextTrack {
     WTF_MAKE_TZONE_ALLOCATED(InbandDataTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandDataTextTrack);
 public:
     static Ref<InbandDataTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandDataTextTrack();

--- a/Source/WebCore/html/track/InbandGenericTextTrack.h
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.h
@@ -52,6 +52,7 @@ private:
 
 class InbandGenericTextTrack final : public InbandTextTrack, private WebVTTParserClient {
     WTF_MAKE_TZONE_ALLOCATED(InbandGenericTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandGenericTextTrack);
 public:
     static Ref<InbandGenericTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandGenericTextTrack();

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class InbandTextTrack : public TextTrack, private InbandTextTrackPrivateClient {
     WTF_MAKE_TZONE_ALLOCATED(InbandTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandTextTrack);
 public:
     static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandTextTrack();

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.h
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class InbandWebVTTTextTrack final : public InbandTextTrack, private WebVTTParserClient {
     WTF_MAKE_TZONE_ALLOCATED(InbandWebVTTTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandWebVTTTextTrack);
 public:
     static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandWebVTTTextTrack();

--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -36,6 +36,7 @@ namespace WebCore {
 
 class LoadableTextTrack final : public TextTrack, private TextTrackLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED(LoadableTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LoadableTextTrack);
 public:
     static Ref<LoadableTextTrack> create(HTMLTrackElement&, const AtomString& kind, const AtomString& label, const AtomString& language);
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -32,6 +32,7 @@
 #include <WebCore/PlatformTimeRanges.h>
 #include <WebCore/TextTrackCue.h>
 #include <WebCore/TrackBase.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -43,8 +44,9 @@ class TextTrackClient;
 class TextTrackCueList;
 class VTTRegionList;
 
-class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
+class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject, public CanMakeCheckedPtr<TextTrack> {
     WTF_MAKE_TZONE_ALLOCATED(TextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextTrack);
 public:
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -53,8 +53,10 @@
 #include "UserAgentParts.h"
 #include "VTTCue.h"
 #include "VTTRegionList.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <limits.h>
 #include <wtf/HexNumber.h>
+#include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/OptionSet.h>
@@ -229,6 +231,8 @@ TextTrackCue::TextTrackCue(Document& document, const MediaTime& start, const Med
 {
 }
 
+TextTrackCue::~TextTrackCue() = default;
+
 void TextTrackCue::didMoveToNewDocument(Document& newDocument)
 {
     ActiveDOMObject::didMoveToNewDocument(newDocument);
@@ -253,7 +257,7 @@ void TextTrackCue::willChange()
     if (++m_processingCueChanges > 1)
         return;
 
-    if (RefPtr track = m_track.get())
+    if (RefPtr track = this->track())
         track->cueWillChange(*this);
 }
 
@@ -265,7 +269,7 @@ void TextTrackCue::didChange(bool affectOrder)
 
     m_displayTreeNeedsUpdate = true;
 
-    if (RefPtr track = m_track.get())
+    if (RefPtr track = this->track())
         track->cueDidChange(*this, affectOrder);
 }
 
@@ -276,6 +280,7 @@ TextTrack* TextTrackCue::track() const
 
 void TextTrackCue::setTrack(TextTrack* track)
 {
+    Locker locker { m_trackLockForGC };
     m_track = track;
 }
 
@@ -350,10 +355,11 @@ void TextTrackCue::setIsActive(bool active)
 
 unsigned TextTrackCue::cueIndex() const
 {
-    ASSERT(m_track && m_track->cuesInternal());
-    if (!m_track)
+    RefPtr track = this->track();
+    ASSERT(track && track->cuesInternal());
+    if (!track)
         return std::numeric_limits<unsigned>::max();
-    RefPtr cuesInternal = m_track->cuesInternal();
+    RefPtr cuesInternal = track->cuesInternal();
     if (!cuesInternal)
         return std::numeric_limits<unsigned>::max();
 
@@ -391,7 +397,7 @@ bool TextTrackCue::isEqual(const TextTrackCue& other, TextTrackCue::CueMatchRule
 bool TextTrackCue::hasEquivalentStartTime(const TextTrackCue& cue) const
 {
     MediaTime startTimeVariance = MediaTime::zeroTime();
-    if (RefPtr track = m_track.get())
+    if (RefPtr track = this->track())
         startTimeVariance = track->startTimeVariance();
     else if (RefPtr track = cue.track())
         startTimeVariance = track->startTimeVariance();
@@ -533,6 +539,16 @@ void TextTrackCue::rebuildDisplayTree()
 
     m_displayTreeNeedsUpdate = false;
 }
+
+template<typename Visitor>
+void TextTrackCue::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    Locker locker { m_trackLockForGC };
+    if (m_track)
+        SUPPRESS_UNCHECKED_ARG addWebCoreOpaqueRoot(visitor, *m_track);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(TextTrackCue);
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -38,6 +38,7 @@
 #include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/HTMLElement.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
 
 namespace WebCore {
@@ -70,6 +71,7 @@ class TextTrackCue : public RefCounted<TextTrackCue>, public EventTarget, public
     WTF_MAKE_TZONE_ALLOCATED(TextTrackCue);
 public:
     static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);
+    ~TextTrackCue();
 
     // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
@@ -80,6 +82,8 @@ public:
 
     TextTrack* NODELETE track() const;
     void setTrack(TextTrack*);
+
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
     const AtomString& id() const LIFETIME_BOUND { return m_id; }
     void setId(const AtomString&);
@@ -163,7 +167,8 @@ private:
     MediaTime m_endTime;
     int m_processingCueChanges { 0 };
 
-    WeakPtr<TextTrack, WeakPtrImplWithEventTargetData> m_track;
+    Lock m_trackLockForGC;
+    CheckedPtr<TextTrack> m_track;
 
     const RefPtr<DocumentFragment> m_cueNode;
     const RefPtr<TextTrackCueBox> m_displayTree;


### PR DESCRIPTION
#### e37953123ad26f8d04ee26239b50297fbc87554e
<pre>
Data race in JSTextTrackCue::visitAdditionalChildrenInGCThread leading to use-after-free (variant of bug 311800)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314952">https://bugs.webkit.org/show_bug.cgi?id=314952</a>
<a href="https://rdar.apple.com/177248996">rdar://177248996</a>

Reviewed by Geoffrey Garen.

JSTextTrackCue::visitAdditionalChildrenInGCThread() was accessing
`TrackTraceCue::m_track` from the GC thread, even though it is a WeakPtr
which can get nulled out on the main thread.

To address the issue:
- Turn `TrackTraceCue::m_track` into a CheckedPtr. This is OK because the
  ~Track() destructor takes care of nulling out its cues&apos; m_track pointer
  explicitly.
- Add a Lock to synchronize setting m_track on the main thread in
  `TextTrackCue::setTrack()` and accessing it on the GC thread.

* Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp:
(WebCore::JSTextTrackCue::visitAdditionalChildren):
* Source/WebCore/html/track/InbandDataTextTrack.h:
* Source/WebCore/html/track/InbandGenericTextTrack.h:
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/InbandWebVTTTextTrack.h:
* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::willChange):
(WebCore::TextTrackCue::didChange):
(WebCore::TextTrackCue::track const):
(WebCore::TextTrackCue::protectedTrack const):
(WebCore::TextTrackCue::setTrack):
(WebCore::TextTrackCue::cueIndex const):
(WebCore::TextTrackCue::hasEquivalentStartTime const):
(WebCore::TextTrackCue::visitAdditionalChildren):
* Source/WebCore/html/track/TextTrackCue.h:

Originally-landed-as: 305413.937@safari-7624-branch (133b57500c3a). <a href="https://rdar.apple.com/180437357">rdar://180437357</a>
Canonical link: <a href="https://commits.webkit.org/316337@main">https://commits.webkit.org/316337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b686fc0162a4b22fa398760a0fa5222c801335

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133629 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33870 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183691 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36307 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38069 "Found 1 new test failure: http/tests/inspector/target/pause-on-inline-debugger-statement.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142298 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45304 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142189 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38441 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110618 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37311 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117672 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44502 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8557 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->