### PR TITLE
[WebKit Process Model] missing MESSAGE_CHECK_URL on error.failingURL() in WebPageProxy::didFailLoadForFrame

### DIFF
--- a/LayoutTests/http/tests/ipc/webpageproxy-didfailload-failingurl-message-check-expected.txt
+++ b/LayoutTests/http/tests/ipc/webpageproxy-didfailload-failingurl-message-check-expected.txt
@@ -1,0 +1,2 @@
+PASS: WebPageProxy::didFailLoadForFrame MESSAGE_CHECK rejected file:// failingURL
+

--- a/LayoutTests/http/tests/ipc/webpageproxy-didfailload-failingurl-message-check.html
+++ b/LayoutTests/http/tests/ipc/webpageproxy-didfailload-failingurl-message-check.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<pre id="log"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function log(s) { document.getElementById('log').textContent += s + '\n'; }
+
+function S(v)    { return {type: 'String', value: v}; }
+function U8(v)   { return {type: 'uint8_t', value: v}; }
+function I64(v)  { return {type: 'int64_t', value: v}; }
+function U64(v)  { return {type: 'uint64_t', value: v}; }
+function B(v)    { return {type: 'bool', value: v}; }
+function DBL(v)  { return {type: 'double', value: v}; }
+function URLv(v) { return {type: 'URL', value: v}; }
+
+function resourceRequest(url) {
+    return [
+        U8(0),                      // Variant<RequestData,PlatformData> index
+        URLv(url),                  // m_url
+        URLv(url),                  // m_firstPartyForCookies
+        DBL(60.0),                  // m_timeoutInterval
+        S('GET'),                   // m_httpMethod
+        U64(0n), U64(0n),           // HTTPHeaderMap: commonHeaders, uncommonHeaders sizes
+        U64(0n),                    // m_responseContentDispositionEncodingFallbackArray size
+        U8(0),                      // m_cachePolicy
+        U8(0),                      // m_sameSiteDisposition
+        U8(0),                      // m_priority
+        U8(0),                      // m_requester
+        B(1),                       // m_allowCookies
+        B(0),                       // m_isTopSite
+        B(1),                       // m_isAppInitiated
+        B(0),                       // m_privacyProxyFailClosedForUnreachableNonMainHosts
+        B(0),                       // m_useAdvancedPrivacyProtections
+        B(0),                       // m_didFilterLinkDecoration
+        B(0),                       // m_isPrivateTokenUsageByThirdPartyAllowed
+        B(0),                       // m_wasSchemeOptimisticallyUpgraded
+        B(0),                       // m_targetAddressSpace
+        B(0),                       // shouldBlockThirdPartyStorage
+        B(0),                       // hiddenFromInspector
+    ];
+}
+
+function coreIPCError(domain, code, failingURL) {
+    return [
+        S(domain),                  // m_domain
+        I64(code),                  // m_code
+        B(0),                       // m_underlyingError
+        B(0),                       // m_clientCertificateChain
+        B(0),                       // m_peerCertificateChain
+        S('repro'),                 // m_localizedDescription
+        S(null),                    // m_localizedFailureReasonError
+        S(null),                    // m_localizedRecoverySuggestionError
+        B(0),                       // m_localizedRecoveryOptionsError
+        S(null),                    // m_localizedFailureError
+        S(null),                    // m_helpAnchorError
+        S(null),                    // m_debugDescriptionError
+        B(0),                       // m_stringEncodingError
+        B(0),                       // m_failingURLPeerTrustError
+        B(0),                       // m_urlError
+        B(1), B(1), URLv(failingURL), // m_failingURLError = NSURL(failingURL)
+        S(null),                    // m_filePathError
+        S(null),                    // m_networkTaskDescription
+        S(null),                    // m_networkTaskMetricsPrivacyStance
+        S(null),                    // m_description
+    ];
+}
+
+function resourceError(domain, code, failingURL) {
+    return [
+        B(1),                       // std::optional<ResourceError::IPCData> engaged
+        U8(1),                      // IPCData.type = General
+        B(1), B(1),                 // RetainPtr<NSError> engaged, std::optional<CoreIPCError> engaged
+        ...coreIPCError(domain, code, failingURL),
+        B(0),                       // IPCData.isSanitized
+    ];
+}
+
+function takeInvalidMessageString() {
+    let reply = IPC.sendSyncMessage('UI', 0, IPC.messages.WebProcessProxy_TakeInvalidMessageStringForTesting.name, 1000, []);
+    return reply && reply.arguments && reply.arguments[0] ? reply.arguments[0].value : '';
+}
+
+function sendDidFailLoad(failingURL) {
+    // Use a generic error code (not -1001 NSURLErrorTimedOut or -999 NSURLErrorCancelled)
+    // so ResourceError::fromIPCData's mapPlatformError() leaves m_type as General, matching
+    // the IPC-supplied type and avoiding ResourceErrorBase::setType's debug assertion.
+    IPC.sendMessage('UI', IPC.webPageProxyID, IPC.messages.WebPageProxy_DidFailLoadForFrame.name, [
+        {type: 'FrameID', value: IPC.frameID},      // frameID
+        {type: 'FrameInfoData', value: IPC},        // frameInfo
+        ...resourceRequest(location.href),          // request
+        B(0),                                       // navigationID = nullopt
+        ...resourceError('NSURLErrorDomain', -2, failingURL),
+        B(0),                                       // userData
+    ]);
+}
+
+if (window.IPC) {
+    takeInvalidMessageString(); // clear any prior error string
+
+    sendDidFailLoad('file:///private/var/x');
+    let error = takeInvalidMessageString();
+
+    if (error.includes('Message check failed') && error.includes('error.failingURL'))
+        log('PASS: WebPageProxy::didFailLoadForFrame MESSAGE_CHECK rejected file:// failingURL');
+    else if (error)
+        log('FAIL: message rejected for unexpected reason: ' + error);
+    else
+        log('FAIL: WebPageProxy::didFailLoadForFrame accepted file:// failingURL without MESSAGE_CHECK');
+} else
+    log('PASS: WebPageProxy::didFailLoadForFrame MESSAGE_CHECK rejected file:// failingURL');
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3607,6 +3607,7 @@ ipc/pasteboard-write-custom-data.html [ Skip ]
 ipc/remotedisplaylistrecorder-drawcontrolpart-slidertrackpart-crash.html [ Skip ]
 ipc/media-containment-bypass-create-player.html [ Skip ]
 http/tests/ipc/gpu-load-error-empty-user-info-crssh.html [ Skip ]
+http/tests/ipc/webpageproxy-didfailload-failingurl-message-check.html [ Skip ]
 ipc/usermedia-capture-start-producing-data-race.html [ Skip ]
 # Hardcodes Cocoa's WebCore::CertificateInfo::trust field in the IPC payload; SOUP's
 # CertificateInfo serializes a GRefPtr<GTlsCertificate> that coreipc.js cannot construct.

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8952,6 +8952,8 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
 
     WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "didFailLoadForFrame: frameID=%" PRIu64 ", isMainFrame=%d, domain=%s, code=%d", frameID.toUInt64(), frame->isMainFrame(), error.domain().utf8().data(), error.errorCode());
 
+    MESSAGE_CHECK_URL(process, error.failingURL());
+
     // FIXME: We should message check that navigationID is not zero here, but it's currently zero for some navigations through the back/forward cache.
     RefPtr<API::Navigation> navigation;
     if (frame->isMainFrame() && navigationID)


### PR DESCRIPTION
#### 248f89aa4518e99734efa4e0b897a7def9f2bcfa
<pre>
[WebKit Process Model] missing MESSAGE_CHECK_URL on error.failingURL() in WebPageProxy::didFailLoadForFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=314873">https://bugs.webkit.org/show_bug.cgi?id=314873</a>
<a href="https://rdar.apple.com/176912820">rdar://176912820</a>

Reviewed by Ryosuke Niwa.

WebPageProxy::didFailLoadForFrame accepts a WebCore::ResourceError from the WebContent
process and forwards it to the embedding client without validating error.failingURL()
against the sending process&apos;s allowed URL set. The sibling handler
didFailProvisionalLoadForFrameShared already performs this check. On iOS, MobileSafari
feeds the unchecked failingURL back into
`-[WKWebView _loadAlternateHTMLString:baseURL:forUnreachableURL:]`, which causes
WebPageProxy::loadAlternateHTML to grant the sending WebContent process read access to
an attacker-chosen file:// directory in both the UI process and the Network process.

Add MESSAGE_CHECK_URL(process, error.failingURL()) to WebPageProxy::didFailLoadForFrame,
mirroring didFailProvisionalLoadForFrameShared, so a compromised WebContent process that
forges a file:// failingURL is terminated before the error reaches the navigation client.

Test: http/tests/ipc/webpageproxy-didfailload-failingurl-message-check.html

* LayoutTests/http/tests/ipc/webpageproxy-didfailload-failingurl-message-check-expected.txt: Added.
* LayoutTests/http/tests/ipc/webpageproxy-didfailload-failingurl-message-check.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didFailLoadForFrame):

Originally-landed-as: 305413.916@safari-7624-branch (e6341887dd92). <a href="https://rdar.apple.com/180438310">rdar://180438310</a>
Canonical link: <a href="https://commits.webkit.org/316472@main">https://commits.webkit.org/316472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b1ff6a87a8578402c10fbbceb81317099f87272

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181836 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129939 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36129 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34112 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184370 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142843 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142724 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46651 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111379 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37767 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45168 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9054 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44627 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->