### PR TITLE
use-after-free in WebCodecsAudioData::memoryCost() via concurrent GC marker / close()

### DIFF
--- a/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<body>
+<script>
+// WebCodecsAudioData::memoryCost() is called from JSWebCodecsAudioData::visitChildren on a
+// concurrent GC marker thread. It must not dereference m_data.audioData, since close() on the
+// main thread may concurrently null and free it.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const POOL = 200;
+const DURATION_MS = 2000;
+const startTime = Date.now();
+
+const buf = new Float32Array(4096);
+for (let i = 0; i < buf.length; i++)
+    buf[i] = Math.random();
+
+const init = {
+    format: "f32-planar",
+    sampleRate: 48000,
+    timestamp: 0,
+    data: buf,
+    numberOfFrames: 2048,
+    numberOfChannels: 2,
+};
+
+window.pool = new Array(POOL);
+for (let i = 0; i < POOL; i++)
+    pool[i] = new AudioData(init);
+
+let idx = 0;
+
+function closeOne() {
+    if (Date.now() - startTime > DURATION_MS) {
+        document.body.textContent = "Test passes if it does not crash.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    pool[idx].close();
+    pool[idx] = new AudioData(init);
+    idx = (idx + 1) % POOL;
+
+    Promise.resolve().then(closeOne);
+}
+
+function pressureGC() {
+    if (Date.now() - startTime > DURATION_MS)
+        return;
+    for (let i = 0; i < 20; i++) {
+        let tmp = new AudioData(init);
+        tmp.close();
+    }
+    setTimeout(pressureGC, 10);
+}
+
+closeOne();
+pressureGC();
+</script>
+</body>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -65,6 +65,7 @@ WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context)
 WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context, WebCodecsAudioInternalData&& data)
     : ContextDestructionObserver(&context)
     , m_data(WTF::move(data))
+    , m_memoryCost(m_data.memoryCost())
 {
 }
 
@@ -151,6 +152,7 @@ ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::clone(ScriptExecutionCo
 // https://www.w3.org/TR/webcodecs/#dom-audiodata-close
 void WebCodecsAudioData::close()
 {
+    m_memoryCost.store(0, std::memory_order_relaxed);
     m_data.audioData = nullptr;
 
     m_isDetached = true;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
@@ -84,13 +84,16 @@ public:
 
     const WebCodecsAudioInternalData& data() const LIFETIME_BOUND { return m_data; }
 
-    size_t memoryCost() const { return m_data.memoryCost(); }
+    // memoryCost() may be called from a GC thread by the JS wrapper's visitChildren, so it must
+    // not touch m_data.audioData (which close() may concurrently null on the main thread).
+    size_t memoryCost() const { return m_memoryCost.load(std::memory_order_relaxed); }
 
 private:
     explicit WebCodecsAudioData(ScriptExecutionContext&);
     WebCodecsAudioData(ScriptExecutionContext&, WebCodecsAudioInternalData&&);
 
     WebCodecsAudioInternalData m_data;
+    std::atomic<size_t> m_memoryCost { 0 };
     bool m_isDetached { false };
 };
 


### PR DESCRIPTION
#### e147963ac4e9a6cf2bb7c40c23d26b85637db828
<pre>
use-after-free in WebCodecsAudioData::memoryCost() via concurrent GC marker / close()
<a href="https://rdar.apple.com/175520011">rdar://175520011</a>

Reviewed by Jean-Yves Avenard

WebCodecsAudioData is annotated with ReportExtraMemoryCost, so the generated
JS wrapper&apos;s visitChildren calls WebCodecsAudioData::memoryCost() from a
concurrent GC marker thread. memoryCost() dereferenced m_data.audioData (a
RefPtr&lt;PlatformRawAudioData&gt;) without synchronization while close() on the
main thread assigns m_data.audioData = nullptr and frees the
PlatformRawAudioData, leading to a heap-use-after-free in
PlatformRawAudioDataCocoa::memoryCost().

Cache the memory cost in a std::atomic&lt;size_t&gt; on WebCodecsAudioData,
computed once at construction time on the main thread and zeroed in close(),
so the GC-thread memoryCost() never touches the RefPtr. This matches the
existing pattern in ImageBitmap.

* LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp:
(WebCore::WebCodecsAudioData::WebCodecsAudioData):
(WebCore::WebCodecsAudioData::close):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h:
(WebCore::WebCodecsAudioData::memoryCost const):

Originally-landed-as: 305413.845@safari-7624-branch (2102c1dad1d3). <a href="https://rdar.apple.com/180438342">rdar://180438342</a>
Canonical link: <a href="https://commits.webkit.org/316135@main">https://commits.webkit.org/316135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7229014d6dc0e1ba8c6ea8d7ed897a56a15ffde0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133351 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33506 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29041 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182946 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141809 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141618 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45252 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109957 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36877 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117143 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43763 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->