### PR TITLE
Heap use-after-free of XSLStyleSheet::m_stylesheetDoc after libxslt frees imported doc on compile failure

### DIFF
--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-child.xsl
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-child.xsl
@@ -1,0 +1,4 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="xslt-import-delayed-subresource-grandchild.py"/>
+  <xsl:template match="/"/>
+</xsl:stylesheet>

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-grandchild.py
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-grandchild.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+import time
+
+# Delay must be longer than 500ms (the initial setTimeout in the HTML
+# test) so the grandchild has not yet arrived when the PI injection
+# triggers compilation, but shorter than 3500ms (500ms + 3000ms total
+# test timeout). After the delay, this response arrives and
+# XSLImportRule::setXSLStyleSheet() -> parseString() runs on the
+# grandchild -- which, without the fix, dereferences the freed
+# m_stylesheetDoc of the parent (child.xsl).
+time.sleep(1)
+
+sys.stdout.write('Content-Type: text/xml\r\n\r\n')
+sys.stdout.write('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>')

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-root.xsl
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-root.xsl
@@ -1,0 +1,4 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="xslt-import-delayed-subresource-child.xsl"/>
+  <xsl:template match="/"/>
+</xsl:stylesheet>

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-target.xml
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-target.xml
@@ -1,0 +1,2 @@
+<?xml-stylesheet type="text/xsl" href="xslt-import-delayed-subresource-root.xsl"?>
+<root/>

--- a/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt
+++ b/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash.html
+++ b/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<!-- Test that compiling an XSL stylesheet with a still-loading import subresource does not
+     cause a use-after-free when the delayed subresource later arrives. -->
+<p>This test passes if it does not crash.</p>
+<iframe id="f" src="resources/xslt-import-delayed-subresource-target.xml"></iframe>
+<script>
+// Wait for root.xsl and child.xsl to load (but not the delayed grandchild).
+// Then inject and immediately remove an embedded XSL processing instruction
+// to trigger scheduleToApplyXSLTransforms(), which will attempt to compile
+// the partially-loaded import chain.
+setTimeout(() => {
+    try {
+        const doc = document.getElementById('f').contentDocument;
+        // Create an embedded XSL PI (href="#x") which unconditionally calls
+        // scheduleToApplyXSLTransforms() via the embedded branch of
+        // ProcessingInstruction::checkStyleSheet().
+        const pi = doc.createProcessingInstruction("xml-stylesheet", 'type="text/xsl" href="#x"');
+        doc.insertBefore(pi, doc.firstChild);
+        pi.remove();
+    } catch (e) {
+        // Cross-origin or other access error is OK - test still verifies no crash.
+    }
+
+    // Wait long enough for the delayed grandchild to arrive and trigger
+    // parseString() on the grandchild stylesheet. Without the fix, this
+    // dereferences a freed m_stylesheetDoc in the parent (child.xsl).
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 3000);
+}, 500);
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Document is empty
+
+This test passes if it does not crash.
+
+

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7967,6 +7967,12 @@ void Document::applyPendingXSLTransformsTimerFired()
         if (transformSourceDocument() || !processingInstruction->sheet())
             return;
 
+        // Don't attempt to compile a stylesheet whose import chain is still loading.
+        // Compiling a partially-loaded tree can cause libxslt to free imported docs
+        // that WebKit still references, leading to use-after-free.
+        if (processingInstruction->sheet()->isLoading())
+            continue;
+
         // If the Document has already been detached from the frame, or the frame is currently in the process of
         // changing to a new document, don't attempt to create a new Document from the XSLT.
         if (!frame() || frame()->documentIsBeingReplaced())

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -150,13 +150,16 @@ bool XSLStyleSheet::parseString(const String& string)
     if (!ctxt)
         return false;
 
-    if (m_parentStyleSheet && m_parentStyleSheet->m_stylesheetDoc) {
+    if (m_parentStyleSheet && m_parentStyleSheet->m_stylesheetDoc && !m_parentStyleSheet->m_stylesheetDocTaken) {
         // The XSL transform may leave the newly-transformed document
         // with references to the symbol dictionaries of the style sheet
         // and any of its children. XML document disposal can corrupt memory
         // if a document uses more than one symbol dictionary, so we
         // ensure that all child stylesheets use the same dictionaries as their
         // parents.
+        // Only share the parent's dict if the parent still owns the document.
+        // Once m_stylesheetDocTaken is set, libxslt owns the doc and may free
+        // it at any time (e.g. on compilation failure), making the pointer unsafe.
         SUPPRESS_FORWARD_DECL_ARG xmlDictFree(ctxt->dict);
         ctxt->dict = m_parentStyleSheet->m_stylesheetDoc->dict;
         SUPPRESS_FORWARD_DECL_ARG xmlDictReference(ctxt->dict);

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -303,6 +303,13 @@ bool XSLTProcessor::transformToString(Node& sourceNode, String& mimeType, String
     xsltStylesheetPtr sheet = xsltStylesheetPointer(m_stylesheet, m_stylesheetRootNode.get());
     if (!sheet) {
         setXSLTLoadCallBack(nullptr, nullptr, nullptr);
+        // Clear dangling document pointers in the stylesheet tree. When compilation
+        // fails, libxslt may have already freed imported child docs via
+        // xsltParseStylesheetImport() → xmlFreeDoc(). Without this call, child
+        // stylesheets retain dangling m_stylesheetDoc pointers that can be
+        // dereferenced if a delayed subresource later triggers parseString().
+        if (RefPtr stylesheet = m_stylesheet)
+            stylesheet->clearDocuments();
         m_stylesheet = nullptr;
         return false;
     }


### PR DESCRIPTION
#### a8459d453b2b90948bcfd1d8620c8a1ceb266eab
<pre>
Heap use-after-free of XSLStyleSheet::m_stylesheetDoc after libxslt frees imported doc on compile failure
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312337">https://bugs.webkit.org/show_bug.cgi?id=312337</a>&gt;
&lt;<a href="https://rdar.apple.com/174646751">rdar://174646751</a>&gt;

Reviewed by David Kilzer and Ryosuke Niwa.

When libxslt fails to compile an imported stylesheet, it frees the
imported doc. The child XSLStyleSheet&apos;s m_stylesheetDoc becomes
dangling. If a delayed subresource later arrives and triggers
parseString(), it dereferences the freed pointer

Fix with three layers of defense:

1. Call clearDocuments() on the failure path in transformToString(),
  matching the success path, to null out dangling doc pointers.
2. Skip dict-sharing in parseString() when the parent&apos;s doc has been
  handed to libxslt (m_stylesheetDocTaken), since libxslt may have
  freed it.
3. Check isLoading() in applyPendingXSLTransformsTimerFired() to
  avoid compiling partially-loaded import chains in the first place.

* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-child.xsl: Added.
* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-grandchild.py: Added.
* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-root.xsl: Added.
* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-target.xml: Added.
* LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt: Added.
* LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::applyPendingXSLTransformsTimerFired):
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::parseString):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::XSLTProcessor::transformToString):

Originally-landed-as: 305413.786@safari-7624-branch (3d12363860e5). <a href="https://rdar.apple.com/180438169">rdar://180438169</a>
Canonical link: <a href="https://commits.webkit.org/316377@main">https://commits.webkit.org/316377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d85039c77c09acf7497b3b5744c6fa2078f91ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133819 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114292 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35864 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34126 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30083 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184002 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142560 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142440 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38477 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46294 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110957 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37531 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117982 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44812 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44212 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->