### PR TITLE
Fix Cross-thread use-after-free in RemoteScrollingTree::m_progressBasedTimelineRegistry

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body { margin: 0; height: 2000000px; }
+  @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+  #t {
+    position: fixed;
+    top: 10px; left: 10px;
+    width: 100px; height: 100px;
+    background: red;
+    will-change: transform;
+    animation: spin linear;
+    animation-timeline: scroll(root);
+  }
+  #t.noanim { animation: none; }
+</style>
+</head>
+<body>
+<div id="t"></div>
+<script>
+  window.testRunner?.waitUntilDone();
+  window.testRunner?.dumpAsText();
+  let t = document.getElementById('t');
+  let toggle = 0;
+  let iterations = 0;
+  function doScroll() {
+    let target = (window.scrollY < 1000000) ? 1900000 : 100;
+    window.scrollTo({ top: target, behavior: 'smooth' });
+  }
+  window.addEventListener('load', () => {
+    document.body.offsetHeight;
+    requestAnimationFrame(() => {
+      doScroll();
+      (function loop() {
+        if (toggle++ & 1) t.classList.remove('noanim');
+        else t.classList.add('noanim');
+        document.body.offsetHeight;
+        if ((toggle & 0xf) == 0) doScroll();
+        if (++iterations < 120)
+          setTimeout(loop, 8);
+        else {
+          document.body.textContent = 'PASS if no crash.';
+          window.testRunner?.notifyDone();
+        }
+      })();
+    });
+  });
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -325,6 +325,8 @@ void RemoteScrollingTree::tryToApplyLayerPositions()
 #if ENABLE(THREADED_ANIMATIONS)
 void RemoteScrollingTree::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate)
 {
+    ASSERT(isMainRunLoop());
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (!m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry = makeUnique<RemoteProgressBasedTimelineRegistry>();
     m_progressBasedTimelineRegistry->update(*this, processIdentifier, timelinesUpdate);
@@ -334,6 +336,7 @@ void RemoteScrollingTree::updateTimelinesRegistration(WebCore::ProcessIdentifier
 
 RefPtr<const RemoteAnimationTimeline> RemoteScrollingTree::timeline(const TimelineID& timelineID) const
 {
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (m_progressBasedTimelineRegistry)
         return m_progressBasedTimelineRegistry->get(timelineID);
     return nullptr;
@@ -341,12 +344,14 @@ RefPtr<const RemoteAnimationTimeline> RemoteScrollingTree::timeline(const Timeli
 
 void RemoteScrollingTree::updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode& node)
 {
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry->updateTimelinesForNode(node);
 }
 
 HashSet<Ref<RemoteProgressBasedTimeline>> RemoteScrollingTree::timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID scrollingNodeID) const
 {
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (m_progressBasedTimelineRegistry)
         return m_progressBasedTimelineRegistry->timelinesForScrollingNodeIDForTesting(scrollingNodeID);
     return { };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -110,7 +110,7 @@ public:
 
 #if ENABLE(THREADED_ANIMATIONS)
     void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
-    RefPtr<const RemoteAnimationTimeline> NODELETE timeline(const TimelineID&) const;
+    RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 #endif
 
@@ -139,7 +139,8 @@ protected:
 private:
     void didAddPendingScrollUpdate() override;
 
-    std::unique_ptr<RemoteProgressBasedTimelineRegistry> m_progressBasedTimelineRegistry;
+    mutable Lock m_progressBasedTimelineRegistryLock;
+    std::unique_ptr<RemoteProgressBasedTimelineRegistry> m_progressBasedTimelineRegistry WTF_GUARDED_BY_LOCK(m_progressBasedTimelineRegistryLock);
 #endif
 };
 


### PR DESCRIPTION
#### 6a97574d77c8f44a8ceca22d7a2647b1b0b99c5b
<pre>
Fix Cross-thread use-after-free in RemoteScrollingTree::m_progressBasedTimelineRegistry
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=314585">https://bugs.webkit.org/show_bug.cgi?id=314585</a>&gt;
&lt;<a href="https://rdar.apple.com/176483524">rdar://176483524</a>&gt;

Reviewed by Antoine Quint.

m_progressBasedTimelineRegistry was freed on the main thread by
updateTimelinesRegistration() while the ScrollingThread read it via
serviceScrollAnimations -&gt; updateProgressBasedTimelinesForNode,
producing an ASan heap-use-after-free. The reader held m_treeLock; the
writer held only m_animationLock, so the two paths were not serialized.

Add a dedicated m_progressBasedTimelineRegistryLock that guards the
registry pointer and is acquired by every reader and writer. A separate
lock avoids self-deadlock when scrollingTreeNodeDidScroll() reaches
updateProgressBasedTimelinesForNode from the commit path with
m_treeLock already held.

Test: webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html

* LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::updateTimelinesRegistration):
(WebKit::RemoteScrollingTree::timeline const):
(WebKit::RemoteScrollingTree::updateProgressBasedTimelinesForNode):
(WebKit::RemoteScrollingTree::timelinesForScrollingNodeIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:

Originally-landed-as: 305413.960@safari-7624-branch (3bff1cc45724). <a href="https://rdar.apple.com/180438667">rdar://180438667</a>
Canonical link: <a href="https://commits.webkit.org/316438@main">https://commits.webkit.org/316438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f071e862b2ab59e6761d4ab17cf92cd48cbc3db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181689 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129794 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133967 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37398 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154511 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicy (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36032 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184223 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36836 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142730 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38523 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46506 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111220 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37684 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45023 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8970 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->