### PR TITLE
[WebKit Process Model] Use-after-free in WebExtensionContext::storageSet from HashMap mutation during keys() iteration

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
@@ -149,12 +149,8 @@ void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifi
             if (!keysSuccessfullySet.size())
                 return;
 
-            if (keysSuccessfullySet.size() != data.size()) {
-                for (const auto& key : data.keys()) {
-                    if (!keysSuccessfullySet.contains(key))
-                        data.remove(key);
-                }
-            }
+            if (keysSuccessfullySet.size() != data.size())
+                data.removeIf([&](auto& entry) { return !keysSuccessfullySet.contains(entry.key); });
 
             fireStorageChangedEventIfNeeded(existingKeysAndValues, data, dataType);
         });


### PR DESCRIPTION
#### d9783c3c13e7b9da3ff3cdb8947022f377b20c62
<pre>
[WebKit Process Model] Use-after-free in WebExtensionContext::storageSet from HashMap mutation during keys() iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=315538">https://bugs.webkit.org/show_bug.cgi?id=315538</a>
<a href="https://rdar.apple.com/177375129">rdar://177375129</a>

Reviewed by Timothy Hatcher.

When WebExtensionStorageSQLiteStore::setKeyedData hits an INSERT error
mid-batch (e.g. SQLITE_FULL), it returns a keysSuccessfullySet vector
that is non-empty but smaller than the input map. The completion lambda
in storageSet then iterated `data.keys()` while calling `data.remove()`
inside the loop. `keys()` returns a live iterator range backed by raw
pointers into the HashTable buffer, and remove() can shrink/rehash and
free that buffer, leaving the iterator dangling — a heap UAF in the UI
Process driven by IPC from the WebContent process.

Replace the iterate-and-mutate loop with HashMap::removeIf, which walks
the table safely.

* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp:
(WebKit::WebExtensionContext::storageSet):

Originally-landed-as: 305413.961@safari-7624-branch (de9fb008197a). <a href="https://rdar.apple.com/180427449">rdar://180427449</a>
Canonical link: <a href="https://commits.webkit.org/316136@main">https://commits.webkit.org/316136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/974920fc1030d2c0f2af4dd99b26c44d4cfc0f5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170986 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128702 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133359 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35190 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33510 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182951 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37685 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141813 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44568 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141622 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45257 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109962 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36881 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117148 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43768 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43172 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->