### PR TITLE
[JSC] TypedArray.from() Out-of-Bounds Read via Resizable ArrayBuffer resize/transfer in mapFn callback.

### DIFF
--- a/JSTests/stress/typedarray-from-oob.js
+++ b/JSTests/stress/typedarray-from-oob.js
@@ -1,0 +1,47 @@
+function testResize(ctor, bytesPerElement, initialBytes, shrinkBytes, resizeAt) {
+    const newCount = shrinkBytes / bytesPerElement;
+    const resizableArrayBuffer = new ArrayBuffer(initialBytes, { maxByteLength: initialBytes * 4 });
+    const source = new ctor(resizableArrayBuffer);
+    source[Symbol.iterator] = null;
+
+    let callbacks = 0;
+    ctor.from(source, (val, index) => {
+        if (index === resizeAt)
+            resizableArrayBuffer.resize(shrinkBytes);
+        callbacks++;
+        return val;
+    });
+
+    const expected = Math.max(resizeAt + 1, newCount);
+    if (callbacks > expected)
+        throw new Error(ctor.name + ": " + callbacks + " callbacks (expected <= " + expected + ")");
+}
+
+function testDetach(detachAt) {
+    const arrayBuffer = new ArrayBuffer(256);
+    const source = new Int32Array(arrayBuffer);
+    source[Symbol.iterator] = null;
+
+    let callbacks = 0;
+    try {
+        Int32Array.from(source, (val, index) => {
+            if (index === detachAt)
+                arrayBuffer.transfer();
+            callbacks++;
+            return val;
+        });
+    } catch (e) {
+        return;
+    }
+
+    if (callbacks > detachAt + 1)
+        throw new Error("detach: " + callbacks + " callbacks (expected <= " + (detachAt + 1) + ")");
+}
+
+testResize(Int32Array,   4, 4096, 16, 4);
+testResize(Int32Array,   4, 4096,  8, 8);
+testResize(Float64Array, 8, 8192, 32, 8);
+testResize(Uint8Array,   1, 1024,  4, 8);
+testResize(Int32Array,   4, 4096,  8, 0);
+testDetach(4);
+testDetach(0);

--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -109,11 +109,17 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
         @throwTypeError("TypedArray.from constructed typed array of insufficient length");
 
     for (var k = 0; k < arrayLikeLength; k++) {
+        if (@isTypedArrayView(arrayLike) && (@isDetached(arrayLike) || k >= @typedArrayLength(arrayLike)))
+            break;
         var value = arrayLike[k];
         if (mapFn === @undefined)
             result[k] = value;
-        else
-            result[k] = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
+        else {
+            var mapped = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
+            if (@isTypedArrayView(result) && (k >= @typedArrayLength(result) || @isDetached(result)))
+                break;
+            result[k] = mapped;
+        }
     }
 
     return result;


### PR DESCRIPTION
#### f3c5606d9143ddd382033faa4efdf08faa8f1f3e
<pre>
[JSC] TypedArray.from() Out-of-Bounds Read via Resizable ArrayBuffer resize/transfer in mapFn callback.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312513">https://bugs.webkit.org/show_bug.cgi?id=312513</a>
<a href="https://rdar.apple.com/174428778">rdar://174428778</a>

Reviewed by Yusuke Suzuki.

Adjusts TypedArray.from to properly handle cases where the map function changes the bounds of the arraylike input.

Test: JSTests/stress/typedarray-from-oob.js

* JSTests/stress/typedarray-from-oob.js: Added.
(testResize):
(testDetach):
* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
(from):

Originally-landed-as: 305413.702@safari-7624-branch (e99a325bb9b8). <a href="https://rdar.apple.com/180429231">rdar://180429231</a>
Canonical link: <a href="https://commits.webkit.org/316137@main">https://commits.webkit.org/316137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5a93410810e1092df915a6ca3a830224f8d8dad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128704 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133360 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35191 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29048 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2202 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182953 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32245 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141816 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44570 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141625 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38238 "Failed to push commit to Webkit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45259 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109964 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36882 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117150 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203667 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43770 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54508 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->