### PR TITLE
Cherry-pick(s) 6ad36f6ec1a7. rdar://180438444

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.cc
@@ -787,6 +787,43 @@ bool LegacyStatsCollector::IsValidTrack(const std::string& track_id) {
              StatsReport::kStatsReportTypeTrack, track_id)) != nullptr;
 }
 
+#if WEBRTC_WEBKIT_BUILD
+StatsReport::Id LegacyStatsCollector::AddCertificateReports(
+    std::unique_ptr<SSLCertificateStats> cert_stats) {
+  RTC_DCHECK_RUN_ON(pc_->signaling_thread());
+
+  StatsReport::Id first_id;
+  StatsReport::Id prev_id;
+  for (SSLCertificateStats* stats = cert_stats.get(); stats;
+       stats = stats->issuer.get()) {
+    StatsReport::Id id(StatsReport::NewTypedId(
+        StatsReport::kStatsReportTypeCertificate, stats->fingerprint));
+
+    StatsReport* report = reports_.ReplaceOrAddNew(id);
+    report->set_timestamp(stats_gathering_started_);
+    report->AddString(StatsReport::kStatsValueNameFingerprint,
+                      stats->fingerprint);
+    report->AddString(StatsReport::kStatsValueNameFingerprintAlgorithm,
+                      stats->fingerprint_algorithm);
+    report->AddString(StatsReport::kStatsValueNameDer,
+                      stats->base64_certificate);
+    // `report` MUST NOT be used after the next ReplaceOrAddNew below: a
+    // later iteration whose `id` Equals an earlier-inserted entry would
+    // delete that entry and invalidate any captured `StatsReport*`.
+    if (!first_id.get()) {
+      first_id = id;
+    } else if (StatsReport* prev_report = reports_.Find(prev_id)) {
+      // Re-look-up the previous report through the collection now, instead
+      // of holding a `StatsReport*` across the ReplaceOrAddNew above.
+      // `prev_id` is a refcounted `scoped_refptr<IdBase>` that survives any
+      // deletion of the StatsReport that owned it.
+      prev_report->AddId(StatsReport::kStatsValueNameIssuerId, id);
+    }
+    prev_id = id;
+  }
+  return first_id;
+}
+#else
 StatsReport* LegacyStatsCollector::AddCertificateReports(
     std::unique_ptr<SSLCertificateStats> cert_stats) {
   RTC_DCHECK_RUN_ON(pc_->signaling_thread());
@@ -819,6 +856,7 @@ StatsReport* LegacyStatsCollector::AddCertificateReports(
   }
   return first_report;
 }
+#endif
 
 StatsReport* LegacyStatsCollector::AddConnectionInfoReport(
     const std::string& content_name,
@@ -1054,17 +1092,27 @@ void LegacyStatsCollector::ExtractSessionInfo_s(SessionStats& session_stats) {
     //
     StatsReport::Id local_cert_report_id, remote_cert_report_id;
     if (transport.local_cert_stats) {
+#if WEBRTC_WEBKIT_BUILD
+      local_cert_report_id =
+          AddCertificateReports(std::move(transport.local_cert_stats));
+#else
       StatsReport* r =
           AddCertificateReports(std::move(transport.local_cert_stats));
       if (r)
         local_cert_report_id = r->id();
+#endif
     }
 
     if (transport.remote_cert_stats) {
+#if WEBRTC_WEBKIT_BUILD
+      remote_cert_report_id =
+          AddCertificateReports(std::move(transport.remote_cert_stats));
+#else
       StatsReport* r =
           AddCertificateReports(std::move(transport.remote_cert_stats));
       if (r)
         remote_cert_report_id = r->id();
+#endif
     }
 
     for (const auto& channel_iter : transport.stats.channel_stats) {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.h
@@ -114,10 +114,17 @@ class LegacyStatsCollector : public LegacyStatsCollectorInterface {
 
   bool UseStandardBytesStats() const { return use_standard_bytes_stats_; }
 
+#if WEBRTC_WEBKIT_BUILD
+  StatsReport::Id AddCertificateReportsForTest(
+      std::unique_ptr<SSLCertificateStats> cert_stats) {
+    return AddCertificateReports(std::move(cert_stats));
+  }
+#else
   StatsReport* AddCertificateReportsForTest(
       std::unique_ptr<SSLCertificateStats> cert_stats) {
     return AddCertificateReports(std::move(cert_stats));
   }
+#endif
 
  private:
   // Struct that's populated on the network thread and carries the values to
@@ -158,10 +165,17 @@ class LegacyStatsCollector : public LegacyStatsCollectorInterface {
   StatsReport* AddCandidateReport(const CandidateStats& candidate_stats,
                                   bool local);
 
+#if WEBRTC_WEBKIT_BUILD
   // Adds a report for this certificate and every certificate in its chain, and
-  // returns the leaf certificate's report (`cert_stats`'s report).
+  // returns the leaf certificate's report Id (`cert_stats`'s report Id).
+  // Returns a null Id if the chain is empty.
+  StatsReport::Id AddCertificateReports(
+      std::unique_ptr<SSLCertificateStats> cert_stats);
+#else
+  // Adds a report for this certificate and every certificate in its chain.
   StatsReport* AddCertificateReports(
       std::unique_ptr<SSLCertificateStats> cert_stats);
+#endif
 
   StatsReport* AddConnectionInfoReport(const std::string& content_name,
                                        int component,

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector_unittest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector_unittest.cc
@@ -668,6 +668,29 @@ class LegacyStatsCollectorTest : public ::testing::Test {
     return Clock::NtpToUtc(clock_.CurrentNtpTime()).ms();
   }
 
+#if WEBRTC_WEBKIT_BUILD
+  // Drives a single UpdateStats() pass with a controlled local certificate
+  // chain.  Used by tests that assert survival under ASan (no return-value
+  // checks); see the AddCertificateReports tests at the end of this file.
+  void RunUpdateStatsWithLocalCertChain(
+      const std::vector<std::string>& local_ders) {
+    const std::string kTransportName = "transport";
+
+    auto pc = CreatePeerConnection();
+    auto stats = CreateStatsCollector(pc.get());
+
+    pc->AddVoiceChannel("audio", kTransportName);
+    pc->SetTransportStats(kTransportName, TransportChannelStats());
+
+    FakeSSLIdentity local_identity(DersToPems(local_ders));
+    scoped_refptr<RTCCertificate> local_certificate(
+        RTCCertificate::Create(local_identity.Clone()));
+    pc->SetLocalCertificate(kTransportName, local_certificate);
+
+    stats->UpdateStats(PeerConnectionInterface::kStatsOutputLevelStandard);
+  }
+#endif  // WEBRTC_WEBKIT_BUILD
+
  protected:
   // Slight enhancement to SimulatedClock.
   // SimulatedClock uses a simplified model where its internal monotonic time is
@@ -1534,6 +1557,35 @@ TEST_F(LegacyStatsCollectorTest, UnsupportedDigestIgnored) {
   TestCertificateReports(local_identity, std::vector<std::string>(1, local_der),
                          remote_identity, std::vector<std::string>());
 }
+
+#if WEBRTC_WEBKIT_BUILD
+// AddCertificateReports() must not return a `StatsReport*` that has been
+// freed by a subsequent ReplaceOrAddNew() in the same loop, and must not
+// dereference an in-loop `prev_report` that has been freed by a
+// subsequent ReplaceOrAddNew().  These tests drive a single UpdateStats()
+// pass with a controlled local certificate chain and rely on ASan to
+// flag the heap-use-after-free; survival is the assertion.
+
+// Covers the in-loop dereference site: chain entries 1 and 2 share a
+// fingerprint, so iteration 2's ReplaceOrAddNew() frees iteration 1's
+// report, then the loop dereferences the captured `prev_report`.
+TEST_F(LegacyStatsCollectorTest,
+       AddCertificateReportsConsecutiveDuplicateInChain) {
+  RunUpdateStatsWithLocalCertChain({"duplicate", "duplicate"});
+  SUCCEED() << "AddCertificateReports() did not deref a freed StatsReport*.";
+}
+
+// Covers the caller-side dereference site: chain entry 3 shares a
+// fingerprint with the leaf (entry 1), so iteration 3's
+// ReplaceOrAddNew() frees the leaf's report, then
+// AddCertificateReports() returns that freed pointer to
+// ExtractSessionInfo_s() which calls `r->id()` on it.
+TEST_F(LegacyStatsCollectorTest,
+       AddCertificateReportsNonConsecutiveDuplicateInChain) {
+  RunUpdateStatsWithLocalCertChain({"leaf", "intermediate", "leaf"});
+  SUCCEED() << "AddCertificateReports() did not return a freed StatsReport*.";
+}
+#endif  // WEBRTC_WEBKIT_BUILD
 
 // This test verifies that the audio/video related stats which are -1 initially
 // will be filtered out.

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/test/mock_rtp_sender_internal.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/test/mock_rtp_sender_internal.h
@@ -116,6 +116,13 @@ class MockRtpSenderInternal : public RtpSenderInternal {
               (override));
   MOCK_METHOD(void, SetObserver, (RtpSenderObserverInterface*), (override));
 
+#if defined(WEBRTC_WEBKIT_BUILD)
+  MOCK_METHOD(RTCError,
+              GenerateKeyFrame,
+              (const std::vector<std::string>&),
+              (override));
+#endif
+
   // RtpSenderInternal methods.
   MOCK_METHOD(void,
               SetMediaChannel,


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180438444 to main. [6ad36f6ec1a7] caused a merge conflict. 

```
[libwebrtc] Use-after-free crash in webrtc::LegacyStatsCollector::AddCertificateReports
<https://bugs.webkit.org/show_bug.cgi?id=314981>
<rdar://177160102>

Reviewed by Youenn Fablet.

WebKit's WebContent process crashes due to use-after-free of
`webrtc::StatsReport` during `webrtc::PeerConnection::Close()` when a
certificate chain repeats a fingerprint or a fingerprint already present
in the per-connection stats collection from a prior `UpdateStats()`
round.

`StatsCollection::ReplaceOrAddNew()` is a delete-then-allocate primitive.
When an entry with an equal `Id` already exists, it deletes the prior
`StatsReport` and replaces it with a freshly allocated one, invalidating
any `StatsReport*` the caller holds.
`LegacyStatsCollector::AddCertificateReports()` violated that contract by
capturing `first_report` on iteration 1 and holding it across subsequent
`ReplaceOrAddNew()` calls in the same loop, then returning it to a caller
in `ExtractSessionInfo_s()` that immediately dereferenced `r->id()`.  The
same loop also held `prev_report` across the next `ReplaceOrAddNew()`,
exposing a hidden second use-after-free under the same conditions.

Fix the bug by returning `StatsReport::Id` -- a refcounted
`scoped_refptr<IdBase>` handle whose lifetime is independent of any
`StatsReport` -- so the function never returns a pointer that may have
been freed by its own loop, and the caller never has to dereference one.

Tests:
- LegacyStatsCollectorTest.AddCertificateReportsConsecutiveDuplicateInChain
- LegacyStatsCollectorTest.AddCertificateReportsNonConsecutiveDuplicateInChain

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.cc:
(webrtc::LegacyStatsCollector::AddCertificateReports):
(webrtc::LegacyStatsCollector::ExtractSessionInfo_s):
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/legacy_stats_collector_unittest.cc:
(LegacyStatsCollectorTest::RunUpdateStatsWithLocalCertChain): Add.
(TEST_F(LegacyStatsCollectorTest, AddCertificateReportsConsecutiveDuplicateInChain)): Add.
(TEST_F(LegacyStatsCollectorTest, AddCertificateReportsNonConsecutiveDuplicateInChain)): Add.
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/test/mock_rtp_sender_internal.h:
- Add a `MOCK_METHOD` for the `WEBRTC_WEBKIT_BUILD`-only pure virtual
  `RtpSenderInterface::GenerateKeyFrame()` so the mock is concrete and
  can be instantiated by the new unit tests.

Originally-landed-as: 305413.930@safari-7624-branch (6ad36f6ec1a7). rdar://180438444


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d46ee8275e3c50a4889abaec1889d4cc023b02e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38571 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180606 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44788 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174185 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113934 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29286 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183191 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141954 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44808 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45498 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110202 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37004 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44008 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43412 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->