### PR TITLE
Dynamic content scaling display lists should not be requested while preparing for display

### DIFF
--- a/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display-expected.txt
+++ b/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteImageBufferSet rejects DynamicContentScalingDisplayList during prepare-for-display
+

--- a/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html
+++ b/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html
@@ -1,0 +1,93 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>RemoteImageBufferSet rejects DynamicContentScalingDisplayList during prepare-for-display</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ipc.js"></script>
+<body>
+<script>
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+    if (!IPC.messages.RemoteImageBufferSet_DynamicContentScalingDisplayList)
+        return;
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const streamConnection = CoreIPC.newStreamConnection();
+    const renderingBackendIdentifier = randomIPCID();
+
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = streamConnection.connection.waitForMessage(
+        renderingBackendIdentifier,
+        IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name,
+        1
+    );
+    streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    const imageBufferSetIdentifier = randomIPCID();
+    const graphicsContextIdentifier = randomIPCID();
+
+    remoteRenderingBackend.CreateImageBufferSet({
+        identifier: imageBufferSetIdentifier,
+        contextIdentifier: graphicsContextIdentifier,
+    });
+
+    const remoteImageBufferSet = streamConnection.newInterface("RemoteImageBufferSet", imageBufferSetIdentifier);
+
+    remoteImageBufferSet.UpdateConfiguration({
+        configuration: {
+            logicalSize: { width: 128, height: 128 },
+            resolutionScale: 1.0,
+            colorSpace: {
+                serializableColorSpace: {
+                    alias: {
+                        optionalValue: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: 'WebCore::ColorSpace',
+                                    variant: 19
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            contentsFormat: 1,
+            bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+            renderingMode: 1,
+            renderingPurpose: 3,
+            includeDisplayList: 1,
+        },
+    });
+
+    // Begin prepare-for-display: this allocates the front buffer as a
+    // DynamicContentScalingBifurcatedImageBuffer and creates the
+    // RemoteImageBufferGraphicsContext receiver. We do not send EndPrepareForDisplay,
+    // so RemoteImageBufferSet::m_context (and the raw GraphicsContext& it holds via
+    // RemoteGraphicsContext::m_context) is still live for the assertion below.
+    remoteRenderingBackend.PrepareImageBufferSetsForDisplaySync({
+        swapBuffersInput: [{
+            remoteBufferSet: imageBufferSetIdentifier,
+            dirtyRegion: { data: { m_segments: [], m_spans: [] } },
+            supportsPartialRepaint: false,
+            hasEmptyDirtyRegion: false,
+            requiresClearedPixels: false,
+        }],
+    });
+
+    try {
+        assert_throws_js(TypeError,
+            () => remoteImageBufferSet.DynamicContentScalingDisplayList({}),
+            "DynamicContentScalingDisplayList during prepare-for-display must be rejected by MESSAGE_CHECK");
+    } finally {
+        streamConnection.connection.invalidate();
+    }
+}, "RemoteImageBufferSet rejects DynamicContentScalingDisplayList during prepare-for-display");
+</script>
+</body>

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -90,6 +90,7 @@ model-element [ Pass ]
 model-element/model-element-animations-loop.html [ Slow ]
 model-element/model-element-lazy-loading-unloading.html [ Slow ]
 model-element/model-element-suspend-before-ready.html [ Slow ]
+ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html [ Pass ]
 
 imported/w3c/web-platform-tests/webxr [ Pass ]
 http/wpt/webxr [ Pass ]

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -202,6 +202,7 @@ bool RemoteImageBufferSet::makeBuffersVolatile(OptionSet<BufferInSetType> reques
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 void RemoteImageBufferSet::dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&& completionHandler)
 {
+    MESSAGE_CHECK(!isPreparingForDisplay(), "DynamicContentScalingDisplayList requested while preparing for display");
     std::optional<WebCore::DynamicContentScalingDisplayList> displayList;
     if (m_frontBuffer)
         displayList = m_frontBuffer->dynamicContentScalingDisplayList();


### PR DESCRIPTION
#### b63b114edafb1fcf440ef17c473a316dc9081c01
<pre>
Dynamic content scaling display lists should not be requested while preparing for display
<a href="https://bugs.webkit.org/show_bug.cgi?id=313460">https://bugs.webkit.org/show_bug.cgi?id=313460</a>
<a href="https://rdar.apple.com/174414109">rdar://174414109</a>

Reviewed by Simon Fraser.

The WebProcess can send DynamicContentScalingDisplayList while prepareBufferForDisplay
is still active on the GPU Process. This is semantically invalid.

DynamicContentScalingDisplayList calls dynamicContentScalingDisplayList() on the
front buffer, which calls releaseGraphicsContext() — destroying the graphics context
that prepareBufferForDisplay is actively using through m_context. This leads to a
dangling reference.

This is a variant of <a href="https://rdar.apple.com/167565825">rdar://167565825</a> (939a2f7876f3) that survives the existing
MESSAGE_CHECK on markSurfacesVolatile. Only reachable on PLATFORM(VISION) where
ENABLE(RE_DYNAMIC_CONTENT_SCALING) is defined.

To fix, we add a MESSAGE_CHECK to reject when dynamicContentScalingDisplayList is
called while drawing is ongoing, mirroring the existing guard on markSurfacesVolatile.

Test: ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html

* LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display-expected.txt: Added.
* LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html: Added.
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::dynamicContentScalingDisplayList):

Originally-landed-as: 305413.743@safari-7624-branch (5364d0966d20). <a href="https://rdar.apple.com/180437851">rdar://180437851</a>
Canonical link: <a href="https://commits.webkit.org/316256@main">https://commits.webkit.org/316256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb143664d66ad2e5522c9eec15c0e0031e565892

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129147 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133594 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33769 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29645 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183564 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142173 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142067 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38369 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45856 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110491 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37272 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117545 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44375 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8513 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->