### PR TITLE
Validate several ITP and storage access IPC messages

### DIFF
--- a/LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt
+++ b/LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt
@@ -1,0 +1,4 @@
+Test that a WebContent process cannot forge a persistent storage-access grant by sending storageAccessUnderTopFrameDomains via NetworkConnectionToWebProcess::ResourceLoadStatisticsUpdated.
+
+PASS: no storage-access grant was created from forged statistics
+

--- a/LayoutTests/ipc/forged-resource-load-statistics-storage-access.html
+++ b/LayoutTests/ipc/forged-resource-load-statistics-storage-access.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<p>Test that a WebContent process cannot forge a persistent storage-access grant by sending
+storageAccessUnderTopFrameDomains via NetworkConnectionToWebProcess::ResourceLoadStatisticsUpdated.</p>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText(); }
+function out(s) { document.getElementById('log').textContent += s + '\n'; }
+function J(v) { return JSON.stringify(v, (k, x) => typeof x === 'bigint' ? x.toString() + 'n' : x); }
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function main() {
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+    const fix = (o) => {
+        if (Array.isArray(o))
+            o.forEach(fix); 
+        else if (o && typeof o === 'object') {
+            for (const k in o) {
+                if (o[k] === 'std::monostate')
+                    o[k] = 'std::nullptr_t';
+                else
+                    fix(o[k]);
+            }
+        }
+    };
+    fix(CoreIPC.typeInfo);
+    const so = ArgumentSerializer.serializeOptional;
+    ArgumentSerializer.serializeOptional = (t, a) => so.call(ArgumentSerializer, t, a ?? { });
+
+    const VICTIM = 'victim.example';
+    const ATTACKER = 'attacker.example';
+    const frameID = Array.isArray(IPC.frameID) ? IPC.frameID[0] : IPC.frameID;
+    const pageID = IPC.pageID;
+    const now = Date.now() / 1000;
+    const RD = (d) => ({ "string": d });
+    const WT = (t) => ({ "secondsSinceEpochSeconds": t });
+
+    const stat = (dom, storageAccessUnder) => ({
+        registrableDomain: RD(dom),
+        lastSeen: WT(now),
+        hadUserInteraction: true,
+        mostRecentUserInteractionTime: WT(now),
+        grandfathered: true,
+        storageAccessUnderTopFrameDomains: (storageAccessUnder || []).map(RD),
+        topFrameUniqueRedirectsTo: [],
+        topFrameUniqueRedirectsToSinceSameSiteStrictEnforcement: [],
+        topFrameUniqueRedirectsFrom: [],
+        topFrameLinkDecorationsFrom: [],
+        gotLinkDecorationFromPrevalentResource: false,
+        topFrameLoadedThirdPartyScripts: [],
+        subframeUnderTopFrameDomains: [],
+        subresourceUnderTopFrameDomains: [],
+        subresourceUniqueRedirectsTo: [],
+        subresourceUniqueRedirectsFrom: [],
+        isPrevalentResource: true,
+        isVeryPrevalentResource: false,
+        dataRecordsRemoved: 0,
+        timesAccessedAsFirstPartyDueToUserInteraction: 0,
+        timesAccessedAsFirstPartyDueToStorageAccessAPI: 0,
+        topFrameRegistrableDomainsWhichAccessedWebAPIs: [],
+        fontsFailedToLoad: [],
+        fontsSuccessfullyLoaded: [],
+        canvasActivityRecord: { textWritten: [], wasDataRead: false },
+        navigatorFunctionsAccessed: 0,
+        screenFunctionsAccessed: 0,
+    });
+
+    let rlsDone = false;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.ResourceLoadStatisticsUpdated(0, {
+        statistics: [stat(ATTACKER), stat(VICTIM, [ATTACKER])]
+    }, () => { rlsDone = true; });
+    for (let i = 0; i < 40 && !rlsDone; i++) await sleep(100);
+
+    let rsaReply = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.RequestStorageAccess(0, {
+        subFrameDomain: RD(VICTIM),
+        topFrameDomain: RD(ATTACKER),
+        frameID: frameID,
+        webPageID: pageID,
+        webPageProxyID: IPC.webPageProxyID,
+        scope: 1,
+        hasOrShouldIgnoreUserGesture: 1,
+    }, (r) => { rsaReply = r; });
+    for (let i = 0; i < 40 && !rsaReply; i++) await sleep(100);
+
+    let hsaReply = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.HasStorageAccess(0, {
+        subFrameDomain: RD(VICTIM),
+        topFrameDomain: RD(ATTACKER),
+        frameID: frameID,
+        pageID: pageID,
+    }, (r) => { hsaReply = r; });
+    for (let i = 0; i < 40 && !hsaReply; i++) await sleep(100);
+
+    if (hsaReply && hsaReply.hasStorageAccess)
+        out('FAIL: forged storageAccessUnderTopFrameDomains produced a live storage-access grant');
+    else
+        out('PASS: no storage-access grant was created from forged statistics');
+}
+
+if (window.IPC)
+    main().catch(e => out('FAIL: ' + e)).finally(() => testRunner.notifyDone());
+else {
+    out('PASS: no storage-access grant was created from forged statistics');
+    testRunner?.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1341,14 +1341,32 @@ void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier 
 
 void NetworkConnectionToWebProcess::logUserInteraction(RegistrableDomain&& domain)
 {
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domain) == NetworkProcess::AllowCookieAccess::Allow);
+
     if (CheckedPtr networkSession = this->networkSession()) {
         if (RefPtr resourceLoadStatistics = networkSession->resourceLoadStatistics())
             resourceLoadStatistics->logUserInteraction(WTF::move(domain), [] { });
     }
 }
 
+// Validate that the WebContent process is not setting fields it has no authority over. The WCP-side ResourceLoadObserver
+// never populates these; only the network grocess grant/classification paths should write them.
+static bool resourceLoadStatisticsContainsOnlyObservableFields(const ResourceLoadStatistics& statistics)
+{
+    return statistics.storageAccessUnderTopFrameDomains.isEmpty()
+        && !statistics.grandfathered
+        && !statistics.isPrevalentResource
+        && !statistics.isVeryPrevalentResource
+        && !statistics.dataRecordsRemoved
+        && !statistics.timesAccessedAsFirstPartyDueToUserInteraction
+        && !statistics.timesAccessedAsFirstPartyDueToStorageAccessAPI;
+}
+
 void NetworkConnectionToWebProcess::resourceLoadStatisticsUpdated(Vector<ResourceLoadStatistics>&& statistics, CompletionHandler<void()>&& completionHandler)
 {
+    for (auto& statistic : statistics)
+        MESSAGE_CHECK_COMPLETION(resourceLoadStatisticsContainsOnlyObservableFields(statistic), completionHandler());
+
     if (CheckedPtr networkSession = this->networkSession()) {
         if (networkSession->sessionID().isEphemeral()) {
             completionHandler();
@@ -1436,6 +1454,9 @@ void NetworkConnectionToWebProcess::storageAccessQuirkForTopFrameDomain(URL&& to
 
 void NetworkConnectionToWebProcess::requestStorageAccessUnderOpener(WebCore::RegistrableDomain&& domainInNeedOfStorageAccess, PageIdentifier openerPageID, WebCore::RegistrableDomain&& openerDomain)
 {
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domainInNeedOfStorageAccess) == NetworkProcess::AllowCookieAccess::Allow);
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, openerDomain) == NetworkProcess::AllowCookieAccess::Allow);
+
     if (CheckedPtr networkSession = this->networkSession()) {
         if (RefPtr resourceLoadStatistics = networkSession->resourceLoadStatistics())
             resourceLoadStatistics->requestStorageAccessUnderOpener(WTF::move(domainInNeedOfStorageAccess), openerPageID, WTF::move(openerDomain));


### PR DESCRIPTION
#### 5044a542fff2e6738265591c28b44eedf72c6bd8
<pre>
Validate several ITP and storage access IPC messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=312798">https://bugs.webkit.org/show_bug.cgi?id=312798</a>
<a href="https://rdar.apple.com/174708437">rdar://174708437</a>

Reviewed by Matthew Finkel.

ResourceLoadStatisticsUpdated, LogUserInteraction, and RequestStorageAccessUnderOpener accept
WebContent-supplied data with no validation. A WCP can forge storageAccessUnderTopFrameDomains and
isPrevalentResource in the ITP database, then obtain cross-origin cookie access without a user
prompt.

Verify that ResourceLoadStatisticsUpdated only contains fields the WebContent process legitimately
observes, and that LogUserInteraction and RequestStorageAccessUnderOpener are called with domains
the process owns.

Test: ipc/forged-resource-load-statistics-storage-access.html

* LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt: Added.
* LayoutTests/ipc/forged-resource-load-statistics-storage-access.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::logUserInteraction):
(WebKit::resourceLoadStatisticsContainsOnlyObservableFields):
(WebKit::NetworkConnectionToWebProcess::resourceLoadStatisticsUpdated):
(WebKit::NetworkConnectionToWebProcess::requestStorageAccessUnderOpener):

Originally-landed-as: 305413.716@safari-7624-branch (9d8f969c538a). <a href="https://rdar.apple.com/180428563">rdar://180428563</a>
Canonical link: <a href="https://commits.webkit.org/316149@main">https://commits.webkit.org/316149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b89d22c363af7da3701554925b0c0a86ec370a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133362 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113834 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33515 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182959 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141819 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141628 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45265 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30172 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109970 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36885 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117156 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43776 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43422 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->