### PR TITLE
Streaming compiler does not reject mixed legacy and spec-correct EH

### DIFF
--- a/JSTests/wasm/stress/streaming-compile-try-table-agreement.js
+++ b/JSTests/wasm/stress/streaming-compile-try-table-agreement.js
@@ -1,0 +1,106 @@
+// Streaming and non-streaming WebAssembly compilation should agree on the
+// outcome of a given module: both succeed, or both fail with
+// WebAssembly.CompileError. This test pins that equivalence for a couple of
+// modules that exercise try_table together with other exception handling
+// constructs.
+
+// (module
+//   (tag $e)
+//   (func (export "run")
+//     block $h
+//       try_table (catch_all $h)
+//         throw $e
+//       end
+//     end
+//   )
+// )
+const tryTableOnly = new Uint8Array([
+    0x00,0x61,0x73,0x6d, 0x01,0x00,0x00,0x00,
+    0x01,0x04, 0x01, 0x60,0x00,0x00,
+    0x03,0x02, 0x01, 0x00,
+    0x0d,0x03, 0x01, 0x00,0x00,
+    0x07,0x07, 0x01, 0x03,0x72,0x75,0x6e, 0x00,0x00,
+    0x0a,0x0f, 0x01, 0x0d,
+        0x00,
+        0x02,0x40,
+        0x1f,0x40, 0x01, 0x02,0x00,
+        0x08,0x00,
+        0x0b,
+        0x0b,
+        0x0b,
+]);
+
+// (module
+//   (tag $e)
+//   (func (export "run")
+//     try
+//       nop
+//     catch_all
+//       rethrow 0
+//     end
+//     block $h
+//       try_table (catch_all $h)
+//         throw $e
+//       end
+//     end
+//   )
+// )
+const mixedEH = new Uint8Array([
+    0x00,0x61,0x73,0x6d, 0x01,0x00,0x00,0x00,
+    0x01,0x04, 0x01, 0x60,0x00,0x00,
+    0x03,0x02, 0x01, 0x00,
+    0x0d,0x03, 0x01, 0x00,0x00,
+    0x07,0x07, 0x01, 0x03,0x72,0x75,0x6e, 0x00,0x00,
+    0x0a,0x16, 0x01, 0x14,
+        0x00,
+        0x06,0x40,
+        0x01,
+        0x19,
+        0x09,0x00,
+        0x0b,
+        0x02,0x40,
+        0x1f,0x40, 0x01, 0x02,0x00,
+        0x08,0x00,
+        0x0b,
+        0x0b,
+        0x0b,
+]);
+
+const cases = [tryTableOnly, mixedEH];
+
+function compileNonStreaming(bytes) {
+    try { new WebAssembly.Module(bytes); return null; }
+    catch (e) { return e; }
+}
+
+async function compileStreaming(bytes) {
+    try {
+        await $vm.createWasmStreamingCompilerForInstantiate(
+            (compiler) => { compiler.addBytes(bytes); });
+        return null;
+    } catch (e) { return e; }
+}
+
+async function main() {
+    for (const bytes of cases) {
+        const ns = compileNonStreaming(bytes);
+        const s = await compileStreaming(bytes);
+
+        const nsFailed = ns !== null;
+        const sFailed = s !== null;
+        if (nsFailed !== sFailed)
+            throw new Error(`compile-path mismatch: non-streaming=${ns}, streaming=${s}`);
+        if (nsFailed) {
+            if (!(ns instanceof WebAssembly.CompileError))
+                throw new Error("non-streaming threw non-CompileError: " + ns);
+            if (!(s instanceof WebAssembly.CompileError))
+                throw new Error("streaming threw non-CompileError: " + s);
+        }
+    }
+}
+
+main().catch(e => {
+    print(String(e));
+    print(String(e.stack));
+    $vm.abort();
+});

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -229,10 +229,10 @@ void EntryPlan::compileFunctions()
     for (uint32_t index = functionIndex; index < functionIndexEnd; ++index)
         compileFunction(FunctionCodeIndex(index));
 
-    if (m_moduleInformation->m_usesModernExceptions.loadRelaxed() && m_moduleInformation->m_usesLegacyExceptions.loadRelaxed()) {
+    {
         Locker locker { m_lock };
-        fail(makeString("Module uses both legacy exceptions and try_table"_s));
-        return;
+        if (failIfMixedExceptionHandlingProposals())
+            return;
     }
 
     if (!areWasmToWasmStubsCompiled) {
@@ -265,6 +265,16 @@ void EntryPlan::complete()
         moveToState(State::Completed);
         runCompletionTasks();
     }
+}
+
+bool EntryPlan::failIfMixedExceptionHandlingProposals()
+{
+    if (m_moduleInformation->m_usesModernExceptions.loadRelaxed()
+        && m_moduleInformation->m_usesLegacyExceptions.loadRelaxed()) {
+        fail(makeString("Module uses both legacy exceptions and try_table"_s));
+        return true;
+    }
+    return false;
 }
 
 bool EntryPlan::completeSyncIfPossible()

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -123,6 +123,8 @@ protected:
     bool isComplete() const override { return m_state == State::Completed; }
     void complete() WTF_REQUIRES_LOCK(m_lock) override;
 
+    bool failIfMixedExceptionHandlingProposals() WTF_REQUIRES_LOCK(m_lock);
+
     virtual bool prepareImpl() = 0;
     virtual void compileFunction(FunctionCodeIndex functionIndex) = 0;
     virtual void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) = 0;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -166,6 +166,8 @@ void IPIntPlan::didCompleteCompilation()
 void IPIntPlan::completeInStreaming()
 {
     Locker locker { m_lock };
+    if (failIfMixedExceptionHandlingProposals())
+        return;
     complete();
 }
 


### PR DESCRIPTION
#### 0f0de8f2a05829881df46dc2ac7e2799da0696ce
<pre>
Streaming compiler does not reject mixed legacy and spec-correct EH
<a href="https://bugs.webkit.org/show_bug.cgi?id=315365">https://bugs.webkit.org/show_bug.cgi?id=315365</a>
<a href="https://rdar.apple.com/177030377">rdar://177030377</a>

Reviewed by Yijia Huang.

Legacy EH instructions are not defined in the wasm spec but are still
supported for backwards compatibility. Functions must either use legacy
or standards compliant EH instructions but not both, and the streaming
compiler needs to be updated to enforce this.

Test: JSTests/wasm/stress/streaming-compile-try-table-agreement.js

* JSTests/wasm/stress/streaming-compile-try-table-agreement.js: Added.
(compileNonStreaming):
(async compileStreaming):
(async main):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::compileFunctions):
(JSC::Wasm::EntryPlan::failIfMixedExceptionHandlingProposals):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::completeInStreaming):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::rethrowSlotForDepth):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Originally-landed-as: 305413.963@safari-7624-branch (55fe8eb4c2a9). <a href="https://rdar.apple.com/180437856">rdar://180437856</a>
Canonical link: <a href="https://commits.webkit.org/316259@main">https://commits.webkit.org/316259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf212b833077cad1ba509b6b9f3a902991511cbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129210 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114080 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35560 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29709 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2626 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183627 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32915 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142238 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45240 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142129 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38373 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45920 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110554 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37293 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117608 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44438 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8534 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54600 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->