### PR TITLE
FormDataReference validator accepts invalid sandbox extensions

### DIFF
--- a/Source/WebKit/Platform/IPC/FormDataReference.cpp
+++ b/Source/WebKit/Platform/IPC/FormDataReference.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "FormDataReference.h"
+
+#if PLATFORM(COCOA)
+#include "PathsBlockedForSandboxExtensions.h"
+#endif
+
+namespace IPC {
+
+FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<WebKit::SandboxExtensionHandle>&& sandboxExtensionHandles)
+    : m_data(WTF::move(data))
+{
+    if (!m_data)
+        return;
+
+    unsigned fileCount = 0;
+    for (auto& element : m_data->elements()) {
+        if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
+            ++fileCount;
+#if PLATFORM(COCOA)
+            const String& path = fileData->filename;
+            if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
+                RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
+                m_data = nullptr;
+                break;
+            }
+#else
+            UNUSED_VARIABLE(fileData);
+#endif // !PLATFORM(COCOA)
+        }
+    }
+
+    if (!m_data)
+        return;
+
+    unsigned consumedExtensions = 0;
+    for (auto& handle : sandboxExtensionHandles) {
+        if (WebKit::SandboxExtension::consumePermanently(handle))
+            consumedExtensions++;
+    }
+
+    if (consumedExtensions != fileCount) {
+        RELEASE_LOG_ERROR(IPC, "FormDataReference: dropping body because a file sandbox extension could not be consumed");
+        m_data = nullptr;
+    }
+}
+
+Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensionHandles() const
+{
+    if (!m_data)
+        return { };
+
+    return WTF::compactMap(m_data->elements(), [](auto& element) -> std::optional<WebKit::SandboxExtensionHandle> {
+        if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
+            const String& path = fileData->filename;
+#if PLATFORM(COCOA)
+            if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
+                RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
+                return std::nullopt;
+            }
+#endif // PLATFORM(COCOA)
+            if (auto handle = WebKit::SandboxExtension::createHandle(path, WebKit::SandboxExtension::Type::ReadOnly))
+                return { WTF::move(*handle) };
+        }
+        return std::nullopt;
+    });
+}
+
+} // namespace IPC

--- a/Source/WebKit/Platform/IPC/FormDataReference.h
+++ b/Source/WebKit/Platform/IPC/FormDataReference.h
@@ -31,10 +31,6 @@
 #include "SandboxExtension.h"
 #include <WebCore/FormData.h>
 
-#if PLATFORM(COCOA)
-#include "PathsBlockedForSandboxExtensions.h"
-#endif
-
 namespace IPC {
 
 class FormDataReference {
@@ -55,51 +51,5 @@ public:
 private:
     RefPtr<WebCore::FormData> m_data;
 };
-
-inline FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<WebKit::SandboxExtensionHandle>&& sandboxExtensionHandles)
-    : m_data(WTF::move(data))
-{
-    if (!m_data)
-        return;
-
-#if PLATFORM(COCOA)
-    for (auto& element : m_data->elements()) {
-        if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
-            const String& path = fileData->filename;
-            if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
-                RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
-                m_data = nullptr;
-                break;
-            }
-        }
-    }
-#endif // PLATFORM(COCOA)
-
-    if (m_data && !WebKit::SandboxExtension::consumePermanently(sandboxExtensionHandles)) {
-        RELEASE_LOG_ERROR(IPC, "FormDataReference: dropping body because a file sandbox extension could not be consumed");
-        m_data = nullptr;
-    }
-}
-
-inline Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensionHandles() const
-{
-    if (!m_data)
-        return { };
-
-    return WTF::compactMap(m_data->elements(), [](auto& element) -> std::optional<WebKit::SandboxExtensionHandle> {
-        if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
-            const String& path = fileData->filename;
-#if PLATFORM(COCOA)
-            if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
-                RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
-                return std::nullopt;
-            }
-#endif // PLATFORM(COCOA)
-            if (auto handle = WebKit::SandboxExtension::createHandle(path, WebKit::SandboxExtension::Type::ReadOnly))
-                return { WTF::move(*handle) };
-        }
-        return std::nullopt;
-    });
-}
 
 } // namespace IPC

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -215,6 +215,7 @@ NetworkProcess/webtransport/NetworkTransportSession.cpp
 NetworkProcess/webtransport/NetworkTransportStream.cpp
 
 Platform/IPC/DaemonCoders.cpp
+Platform/IPC/FormDataReference.cpp
 
 Shared/ActivityAssertion.cpp
 Shared/AuxiliaryProcess.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8778,6 +8778,7 @@
 		E3EA8F0D2F439059006CC6B3 /* ProcessActivityGroup.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessActivityGroup.cpp; sourceTree = "<group>"; };
 		E3EFB02C2550617C003C2F96 /* WebSystemSoundDelegate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSystemSoundDelegate.cpp; sourceTree = "<group>"; };
 		E3EFB02D2550617C003C2F96 /* WebSystemSoundDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSystemSoundDelegate.h; sourceTree = "<group>"; };
+		E3F9E68F2FBCDADA007E5C25 /* FormDataReference.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FormDataReference.cpp; sourceTree = "<group>"; };
 		E404907121DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollingTreeFrameScrollingNodeRemoteMac.cpp; sourceTree = "<group>"; };
 		E404907321DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeFrameScrollingNodeRemoteMac.h; sourceTree = "<group>"; };
 		E40C1F9321F0B96E00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeFrameScrollingNodeRemoteIOS.h; sourceTree = "<group>"; };
@@ -10978,6 +10979,7 @@
 				BC032D9E10F437D10058C15A /* Decoder.h */,
 				BC032D9F10F437D10058C15A /* Encoder.cpp */,
 				BC032DA010F437D10058C15A /* Encoder.h */,
+				E3F9E68F2FBCDADA007E5C25 /* FormDataReference.cpp */,
 				4151E5C31FBB90A900E47E2D /* FormDataReference.h */,
 				465237FA2B055C41005B3097 /* FormDataReference.serialization.in */,
 				C0CE72AC1247E78D00BC0EC4 /* HandleMessage.h */,


### PR DESCRIPTION
#### 7e6fba53a8a624ce9d7271bbf57b0cde89238e00
<pre>
FormDataReference validator accepts invalid sandbox extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=314948">https://bugs.webkit.org/show_bug.cgi?id=314948</a>
<a href="https://rdar.apple.com/176912134">rdar://176912134</a>

Reviewed by Alex Christensen.

Check that sandbox extensions are not empty in FormDataReference::sandboxExtensionsAreSufficient.
We are checking that all extensions are successfully consumed in the FormDataReference constructor.
This patch is also removing the validator, since all validation is performed in the constructor.

* Source/WebKit/Platform/IPC/FormDataReference.serialization.in:
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::sandboxExtensionsAreSufficient):
* Source/WebKit/Platform/IPC/FormDataReference.cpp: Added.
(IPC::FormDataReference::FormDataReference):
(IPC::FormDataReference::sandboxExtensionHandles const):
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::sandboxExtensionsAreSufficient): Deleted.
(IPC::FormDataReference::sandboxExtensionHandles const): Deleted.
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Originally-landed-as: 305413.939@safari-7624-branch (2427c3fef353). <a href="https://rdar.apple.com/180428726">rdar://180428726</a>
Canonical link: <a href="https://commits.webkit.org/316378@main">https://commits.webkit.org/316378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/346f9bb94d775e324958c3ab416ece9e60bc1387

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181633 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133922 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37363 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114395 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35994 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30243 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184168 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142677 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45771 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142561 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46451 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111141 "Hash 346f9bb9 for PR 68212 does not build (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37653 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44969 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8919 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44369 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->