### PR TITLE
Type confusion in ReadableStream.cancel() via jsCast<JSPromise*>

### DIFF
--- a/LayoutTests/streams/readable-stream-cancel-fake-promise-crash-expected.txt
+++ b/LayoutTests/streams/readable-stream-cancel-fake-promise-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not hit assertions or crash under ASAN.
+
+

--- a/LayoutTests/streams/readable-stream-cancel-fake-promise-crash.html
+++ b/LayoutTests/streams/readable-stream-cancel-fake-promise-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if WebKit does not hit assertions or crash under ASAN.</p>
+<div id="result"></div>
+<script>
+
+function FakePromise(executor) {
+    executor(() => {}, () => {});
+    return { }
+}
+
+const stream = new ReadableStream({
+    cancel(reason) {
+        Object.defineProperty(Promise, Symbol.species, {
+            configurable: true,
+            get() {
+                return FakePromise;
+            }
+        });
+        return new Promise(() => {});
+    }
+});
+stream.cancel("test reason");
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    setTimeout(() => testRunner.notifyDone(), 100);
+}
+</script>

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -534,7 +534,7 @@ Ref<DOMPromise> ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSV
             return promise;
         }
 
-        auto* jsPromise = downcast<JSC::JSPromise>(result);
+        auto* jsPromise = dynamicDowncast<JSC::JSPromise>(result);
         if (!jsPromise)
             return promise;
 

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -104,7 +104,7 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
         auto value = internalReader->readForBindings(globalObject);
         if (!value)
             return;
-        auto* promise = downcast<JSC::JSPromise>(value);
+        auto* promise = dynamicDowncast<JSC::JSPromise>(value);
         if (!promise)
             return;
 


### PR DESCRIPTION
#### 87d203651d8a2fd077eebd5d18b7dc1492fa0f6b
<pre>
Type confusion in ReadableStream.cancel() via jsCast&lt;JSPromise*&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=313706">https://bugs.webkit.org/show_bug.cgi?id=313706</a>
<a href="https://rdar.apple.com/174938744">rdar://174938744</a>

Reviewed by Chris Dumez and Mark Lam.

Replaced the use of unconditional jsCast with jsDynamicCast to fix the bug.

Test: streams/readable-stream-cancel-fake-promise-crash.html

* LayoutTests/streams/readable-stream-cancel-fake-promise-crash-expected.txt: Added.
* LayoutTests/streams/readable-stream-cancel-fake-promise-crash.html: Added.
* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::cancel):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
(WebCore::ReadableStreamDefaultReader::read):

Originally-landed-as: 305413.806@safari-7624-branch (3f06c62bc271). <a href="https://rdar.apple.com/180429254">rdar://180429254</a>
Canonical link: <a href="https://commits.webkit.org/316449@main">https://commits.webkit.org/316449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f6e4ffc542ce522b56e3e2727763887c6d9e19c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181708 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133978 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36045 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184242 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142740 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154106 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38533 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46525 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111239 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37695 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45042 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8976 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44442 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->