### PR TITLE
RemoteMediaPlayerProxy::createAudioSourceProvider should reject duplicate IPC

### DIFF
--- a/LayoutTests/ipc/create-audio-source-provider-twice-expected.txt
+++ b/LayoutTests/ipc/create-audio-source-provider-twice-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/create-audio-source-provider-twice.html
+++ b/LayoutTests/ipc/create-audio-source-provider-twice.html
@@ -1,0 +1,49 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done() { window.testRunner?.notifyDone(); }
+
+async function run() {
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+
+    let playerId = null;
+    const playerIdPromise = new Promise(resolve => {
+        const tap = new IPCWireTap('GPU', 'Outgoing');
+        tap.tapNext(CoreIPC.messages['RemoteMediaPlayerManagerProxy_CreateMediaPlayer'].name,
+            (proc, connId, msgName, typed, parsed) => {
+                playerId = parsed.identifier;
+                resolve();
+            });
+    });
+
+    const video = document.createElement('video');
+    video.style.display = 'none';
+    video.src = '../media/content/test.mp4';
+    document.body.appendChild(video);
+    const metadataPromise = new Promise(resolve =>
+        video.addEventListener('loadedmetadata', resolve, { once: true }));
+
+    const timeout = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 10000));
+
+    await Promise.race([Promise.all([playerIdPromise, metadataPromise]), timeout]);
+
+    for (let i = 0; i < 5; i++) {
+        CoreIPC.GPU.RemoteMediaPlayerProxy.SetShouldEnableAudioSourceProvider(playerId, { shouldEnable: true });
+        CoreIPC.GPU.RemoteMediaPlayerProxy.CreateAudioSourceProvider(playerId, {});
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+
+    done();
+}
+
+if (!window.IPC)
+    done();
+else
+    run().catch(done);
+</script>

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -84,6 +84,8 @@
 
 #include <wtf/NativePromise.h>
 
+#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_webProcessConnection.get(), message)
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -1225,6 +1227,8 @@ void RemoteMediaPlayerProxy::setPlatformDynamicRangeLimit(PlatformDynamicRangeLi
 void RemoteMediaPlayerProxy::createAudioSourceProvider()
 {
 #if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
+    MESSAGE_CHECK(!m_remoteAudioSourceProvider, "RemoteAudioSourceProvider already created.");
+
     RefPtr player = m_player;
     if (!player)
         return;
@@ -1375,5 +1379,7 @@ void RemoteMediaPlayerProxy::screenReservedChanged(bool reserved)
 #endif
 
 } // namespace WebKit
+
+#undef MESSAGE_CHECK
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)


### PR DESCRIPTION
#### 0181991daacad1d59eb2207a50070c8f487772bb
<pre>
RemoteMediaPlayerProxy::createAudioSourceProvider should reject duplicate IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=313571">https://bugs.webkit.org/show_bug.cgi?id=313571</a>
<a href="https://rdar.apple.com/175035393">rdar://175035393</a>

Reviewed by Eric Carlson.

A well-behaved WebContent process sends CreateAudioSourceProvider at most once per
RemoteMediaPlayerProxy. A second message reaches AudioSourceProviderAVFObjC&apos;s
setConfigureAudioStorageCallback / setAudioCallback, which overwrite the callbacks
without taking tapStorage-&gt;lock while a MediaToolbox thread may be invoking them
under that lock, freeing the captured RemoteAudioSourceProviderProxy mid-use.
Reject the duplicate message with a MESSAGE_CHECK.

* LayoutTests/ipc/create-audio-source-provider-twice-expected.txt: Added.
* LayoutTests/ipc/create-audio-source-provider-twice.html: Added.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::createAudioSourceProvider):

Originally-landed-as: 305413.810@safari-7624-branch (c5c267219314). <a href="https://rdar.apple.com/180429279">rdar://180429279</a>
Canonical link: <a href="https://commits.webkit.org/316568@main">https://commits.webkit.org/316568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c5316f893260332f7a7da80b1b0d04752035be6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130344 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134385 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34738 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30845 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184779 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143181 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38626 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47056 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112054 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38056 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118808 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45573 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->