### PR TITLE
[libpas] Fix OoBable code-paths in MAR code

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
@@ -210,23 +210,22 @@ struct pas_mar_exported_allocation_record pas_mar_get_allocation_record(pas_mar_
 
     void* base_object_address = NULL;
     for (unsigned i = 0; i < PAS_MAR_TRACKED_ALLOCATIONS; ++i) {
-        unsigned index = (pas_mar_allocation_table_head_index(registry) + i) % PAS_MAR_TRACKED_ALLOCATIONS;
-        if ((registry->allocation_record_table_head + i) % MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS == registry->allocation_record_table_tail)
+        struct pas_mar_memory_action_record* art_entry = pas_mar_registry_get_memory_action(registry, i);
+        if (!art_entry)
             break;
-        struct pas_mar_memory_action_record* art_entry = &registry->allocation_record_table[index];
         if (art_entry->is_allocation) {
             // Check if the allocation was within the range
             if ((uintptr_t) address >= (uintptr_t) pas_mar_canonicalize_address(art_entry->address) && (uintptr_t) address < ((uintptr_t) pas_mar_canonicalize_address(art_entry->address)) + art_entry->allocation_size_bytes) {
                 // Check that we have a valid backtrace
                 unsigned registry_index = art_entry->backtrace_registry_index;
-                if (registry->backtrace_registry[registry_index].hash != art_entry->backtrace_hash)
+                pas_mar_backtrace_record* backtrace = pas_mar_registry_get_backtrace(registry, registry_index);
+                if (backtrace->hash != art_entry->backtrace_hash)
                     continue;
-
-                pas_mar_backtrace_record* backtrace = &registry->backtrace_registry[registry_index];
 
                 result.allocation_size_bytes = art_entry->allocation_size_bytes;
                 result.is_valid = true;
-                result.allocation_trace.num_frames= backtrace->num_frames;
+                result.allocation_trace.num_frames = backtrace->num_frames;
+                PAS_ASSERT(backtrace->num_frames < PAS_MAR_BACKTRACE_MAX_SIZE);
                 memcpy(result.allocation_trace.backtrace_buffer, backtrace->backtrace_buffer, backtrace->num_frames * sizeof(void*));
 
                 base_object_address = art_entry->address;
@@ -235,12 +234,12 @@ struct pas_mar_exported_allocation_record pas_mar_get_allocation_record(pas_mar_
         if (result.is_valid && !art_entry->is_allocation && art_entry->address == base_object_address) {
             // Check that we have a valid backtrace
             unsigned registry_index = art_entry->backtrace_registry_index;
-            if (registry->backtrace_registry[registry_index].hash != art_entry->backtrace_hash)
+            pas_mar_backtrace_record* backtrace = pas_mar_registry_get_backtrace(registry, registry_index);
+            if (backtrace->hash != art_entry->backtrace_hash)
                 continue;
 
-            pas_mar_backtrace_record* backtrace = &registry->backtrace_registry[registry_index];
-
-            result.deallocation_trace.num_frames= backtrace->num_frames;
+            result.deallocation_trace.num_frames = backtrace->num_frames;
+            PAS_ASSERT(backtrace->num_frames < PAS_MAR_BACKTRACE_MAX_SIZE);
             memcpy(result.deallocation_trace.backtrace_buffer, backtrace->backtrace_buffer, backtrace->num_frames * sizeof(void*));
 
             base_object_address = NULL;

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.h
@@ -147,6 +147,29 @@ PAS_ALWAYS_INLINE static void pas_mar_increment_allocation_record_table_tail(pas
     registry->allocation_record_table_tail %= MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS;
 }
 
+/* Bounds-checking accessors */
+PAS_ALWAYS_INLINE static pas_mar_memory_action_record* pas_mar_registry_get_memory_action(pas_mar_registry* registry, unsigned i)
+{
+    PAS_ASSERT(registry);
+    unsigned index = (pas_mar_allocation_table_head_index(registry) + i) % PAS_MAR_TRACKED_ALLOCATIONS;
+    if ((registry->allocation_record_table_head + i) % MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS == registry->allocation_record_table_tail)
+        return NULL;
+
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN;
+    return &registry->allocation_record_table[index];
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
+}
+
+PAS_ALWAYS_INLINE static pas_mar_backtrace_record* pas_mar_registry_get_backtrace(pas_mar_registry* registry, size_t idx)
+{
+    PAS_ASSERT(registry);
+    PAS_ASSERT(idx < PAS_MAR_TRACKED_BACKTRACES);
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN;
+    return &registry->backtrace_registry[idx];
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
+}
+
+
 PAS_BEGIN_EXTERN_C;
 
 void* pas_mar_record_allocation(pas_mar_registry*, void* address, size_t allocation_size_bytes, unsigned num_stack_frames, void** backtrace);


### PR DESCRIPTION
#### 6cccd5ef64eea5636933ece6f19de4571396828c
<pre>
[libpas] Fix OoBable code-paths in MAR code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311600">https://bugs.webkit.org/show_bug.cgi?id=311600</a>
<a href="https://rdar.apple.com/173772317">rdar://173772317</a>

Reviewed by Yusuke Suzuki.

In the case that the allocation record table is controlled by an
attacker, we cannot trust the offsets contained inside, and should
assert that we do not read out-of-bounds based on them.

Originally-landed-as: 305413.727@safari-7624-branch (729d412ab091). <a href="https://rdar.apple.com/180429014">rdar://180429014</a>
Canonical link: <a href="https://commits.webkit.org/316329@main">https://commits.webkit.org/316329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/728db5c33d1e0cb79aa4e3a2f26b7fc00ab92d14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171814 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133665 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114137 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35692 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29867 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2707 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183785 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33073 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142367 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45398 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38432 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46078 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110713 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37360 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204492 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44596 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8615 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54617 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Found 13 jsc stress test failures: stress/promise-prototype-catch-on-non-promise.js.default, stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/regexp-prototype-symbol-search-on-non-regexp.js.default, stress/regexp-prototype-test-on-non-regexp.js.default, stress/resizable-array-constant-folding.js.default ..., JSC test binary failure: testapi; Compiled JSC; Found 13 jsc stress test failures: stress/promise-prototype-catch-on-non-promise.js.default, stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache, stress/regexp-prototype-symbol-search-on-non-regexp.js.default, stress/regexp-prototype-test-on-non-regexp.js.default, stress/resizable-array-constant-folding.js.default ..., JSC test binary failure: testapi; Passed JSC tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->