### PR TITLE
[WebXR] Use-after-free of WebXRSystem in callbacks re-posted from ensureImmersiveXRDeviceIsSelected

### DIFF
--- a/LayoutTests/webxr/xr-isSessionSupported-detached-iframe-crash-expected.txt
+++ b/LayoutTests/webxr/xr-isSessionSupported-detached-iframe-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/webxr/xr-isSessionSupported-detached-iframe-crash.html
+++ b/LayoutTests/webxr/xr-isSessionSupported-detached-iframe-crash.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.internals)
+    internals.settings.setWebXREnabled(true);
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function gc() {
+    if (window.GCController)
+        GCController.collect();
+}
+
+(function () {
+    let f = document.createElement('iframe');
+    document.body.appendChild(f);
+    let xr = f.contentWindow.navigator.xr;
+    // Queue many async EnumerateImmersiveXRDevices IPCs whose replies and the
+    // re-posted callbacks land across multiple RunLoop iterations.
+    for (let i = 0; i < 50; i++)
+        xr.isSessionSupported('immersive-vr').catch(() => {});
+    // Detach the frame so the WebXRSystem becomes collectable once any
+    // in-flight IPC reply lambda drops its protecting Ref.
+    f.remove();
+})();
+
+(function gcLoop(n) {
+    for (let i = 0; i < 5; i++)
+        gc();
+    if (n > 0) {
+        setTimeout(() => gcLoop(n - 1), 0);
+        return;
+    }
+    if (window.testRunner)
+        testRunner.notifyDone();
+})(50);
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -140,8 +140,8 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
 void WebXRSystem::obtainCurrentDevice(XRSessionMode mode, const Vector<String>& requiredFeatures, const Vector<String>& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&& callback)
 {
     if (isImmersive(mode)) {
-        ensureImmersiveXRDeviceIsSelected([this, callback = WTF::move(callback)]() mutable {
-            callback(m_activeImmersiveDevice);
+        ensureImmersiveXRDeviceIsSelected([protectedThis = protect(*this), callback = WTF::move(callback)]() mutable {
+            callback(protectedThis->m_activeImmersiveDevice);
         });
         return;
     }
@@ -174,9 +174,9 @@ void WebXRSystem::isSessionSupported(XRSessionMode mode, IsSessionSupportedPromi
 
     // 4. Run the following steps in parallel:
     // 4.1 Ensure an immersive XR device is selected.
-    ensureImmersiveXRDeviceIsSelected([this, promise = WTF::move(promise), mode]() mutable {
+    ensureImmersiveXRDeviceIsSelected([protectedThis = protect(*this), promise = WTF::move(promise), mode]() mutable {
         // 4.2 If the immersive XR device is null, resolve promise with false and abort these steps.
-        RefPtr activeImmersiveDevice { m_activeImmersiveDevice };
+        RefPtr activeImmersiveDevice = protectedThis->m_activeImmersiveDevice.get();
         if (!activeImmersiveDevice) {
             promise.resolve(false);
             return;
@@ -536,7 +536,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
     // 5.2 Let optionalFeatures be options' optionalFeatures.
     // 5.3 Set device to the result of obtaining the current device for mode, requiredFeatures, and optionalFeatures.
     // 5.4 Queue a task to perform the following steps:
-    obtainCurrentDevice(mode, init.requiredFeatures, init.optionalFeatures, [this, protectedDocument, immersive, init, mode, promise = WTF::move(promise)](ThreadSafeWeakPtr<PlatformXR::Device> weakDevice) mutable {
+    obtainCurrentDevice(mode, init.requiredFeatures, init.optionalFeatures, [this, protectedThis = protect(*this), protectedDocument, immersive, init, mode, promise = WTF::move(promise)](ThreadSafeWeakPtr<PlatformXR::Device> weakDevice) mutable {
         auto rejectPromiseWithNotSupportedError = makeScopeExit([&]() {
             promise.reject(Exception { ExceptionCode::NotSupportedError });
             m_pendingImmersiveSession = false;
@@ -562,7 +562,12 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         // 5.4.6 Request the xr permission with descriptor and status.
         // 5.4.7 If status' state is "denied" run the following steps: (same as above in 5.4.1)
         resolveFeaturePermissions(mode, init, device, [this, weakThis = WeakPtr { *this }, protectedDocument, device, immersive, mode, promise](std::optional<FeatureList>&& requestedFeatures) mutable {
-            if (!weakThis || !requestedFeatures) {
+            RefPtr strongThis = weakThis;
+            if (!strongThis) {
+                promise.reject(Exception { ExceptionCode::NotSupportedError });
+                return;
+            }
+            if (!requestedFeatures) {
                 promise.reject(Exception { ExceptionCode::NotSupportedError });
                 m_pendingImmersiveSession = false;
                 return;


### PR DESCRIPTION
#### 2b68a6816f173200ec2e6e6c87b034e8431e7d6d
<pre>
[WebXR] Use-after-free of WebXRSystem in callbacks re-posted from ensureImmersiveXRDeviceIsSelected
<a href="https://rdar.apple.com/175674581">rdar://175674581</a>

Reviewed by Mike Wyrzykowski.

WebXRSystem::ensureImmersiveXRDeviceIsSelected sends an async
EnumerateImmersiveXRDevices IPC whose reply lambda holds protectedThis = Ref
{ *this }, but inside that lambda a makeScopeExit re-posts the caller&apos;s callback
via callOnMainThread(). The reply lambda is then destroyed and protectedThis
drops. The callbacks supplied by isSessionSupported, obtainCurrentDevice and
requestSession capture only raw |this|, so the queued main-thread task holds no
ownership of the WebXRSystem. If iframe removal + GC tears down
NavigatorWebXR::m_xr between the protectedThis drop and the pending
callOnMainThread task, the task reads freed memory.

Separately, the RequestPermissionOnSessionFeatures reply lambda in
requestSession writes m_pendingImmersiveSession through raw |this| in its
!weakThis branch.

Fix by capturing protectedThis = protect(*this) in the isSessionSupported,
obtainCurrentDevice and requestSession callbacks so they keep the WebXRSystem
alive across the callOnMainThread re-post, and by splitting the !weakThis
early-return in the inner requestSession permission reply so it does not touch
members after the object is gone.

Test: webxr/xr-isSessionSupported-detached-iframe-crash.html

* LayoutTests/webxr/xr-isSessionSupported-detached-iframe-crash-expected.txt: Added.
* LayoutTests/webxr/xr-isSessionSupported-detached-iframe-crash.html: Added.
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::obtainCurrentDevice):
(WebCore::WebXRSystem::isSessionSupported):
(WebCore::WebXRSystem::requestSession):

Originally-landed-as: 305413.841@safari-7624-branch (0e75e33398b8). <a href="https://rdar.apple.com/180429045">rdar://180429045</a>
Canonical link: <a href="https://commits.webkit.org/316451@main">https://commits.webkit.org/316451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f93c54d8315bb2f02b3438291a8a7b8123c0e79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133966 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36035 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184222 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142729 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38536 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46505 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111219 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37682 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204915 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45022 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8957 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/204915 "Build is in progress. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->