### PR TITLE
[JSC] Disallow defining private names on WasmGC objects

### DIFF
--- a/JSTests/wasm/gc/private-fields-and-methods.js
+++ b/JSTests/wasm/gc/private-fields-and-methods.js
@@ -1,0 +1,170 @@
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+function testPrivateMethodOnStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    #m() {}
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot add private method to a WebAssembly GC object"
+  );
+
+  // Struct must remain usable after the rejected attempt.
+  assert.eq(m.exports.use(s), 42);
+}
+
+function testPrivateFieldOnStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    #x = 1;
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot define private field on a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(s), 42);
+}
+
+function testPrivateMethodOnArray() {
+  let m = instantiate(`
+    (module
+      (type (array i32))
+      (func (export "make") (result anyref)
+        (array.new 0 (i32.const 7) (i32.const 3)))
+      (func (export "use") (param (ref 0) i32) (result i32)
+        (array.get 0 (local.get 0) (local.get 1)))
+    )
+  `);
+  const a = m.exports.make();
+
+  class B { constructor() { return a; } }
+  class D extends B {
+    #m() {}
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot add private method to a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(a, 0), 7);
+}
+
+function testPrivateFieldOnArray() {
+  let m = instantiate(`
+    (module
+      (type (array i32))
+      (func (export "make") (result anyref)
+        (array.new 0 (i32.const 7) (i32.const 3)))
+      (func (export "use") (param (ref 0) i32) (result i32)
+        (array.get 0 (local.get 0) (local.get 1)))
+    )
+  `);
+  const a = m.exports.make();
+
+  class B { constructor() { return a; } }
+  class D extends B {
+    #x = 1;
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot define private field on a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(a, 0), 7);
+}
+
+function testPrivateGetterOnStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    get #x() { return 1; }
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot add private method to a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(s), 42);
+}
+
+function testGCSurvival() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    #m() {}
+    constructor() { super(); }
+  }
+
+  try { new D(); } catch {}
+
+  // The struct must survive GC with its structure intact.
+  gc();
+  assert.eq(m.exports.use(s), 42);
+}
+
+testPrivateMethodOnStruct();
+testPrivateFieldOnStruct();
+testPrivateMethodOnArray();
+testPrivateFieldOnArray();
+testPrivateGetterOnStruct();
+testGCSurvival();

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -919,7 +919,7 @@ inline bool JSObject::getPrivateField(JSGlobalObject* globalObject, PropertyName
     ASSERT(!slot.isVMInquiry());
     if (!JSObject::getPrivateFieldSlot(this, globalObject, propertyName, slot)) {
         throwException(globalObject, scope, createInvalidPrivateNameError(globalObject));
-        RELEASE_AND_RETURN(scope, false);
+        return false;
     }
     EXCEPTION_ASSERT(!scope.exception());
     RELEASE_AND_RETURN(scope, true);
@@ -932,7 +932,7 @@ inline void JSObject::setPrivateField(JSGlobalObject* globalObject, PropertyName
     PropertySlot slot(this, PropertySlot::InternalMethodType::HasProperty);
     if (!JSObject::getPrivateFieldSlot(this, globalObject, propertyName, slot)) {
         throwException(globalObject, scope, createInvalidPrivateNameError(globalObject));
-        RELEASE_AND_RETURN(scope, void());
+        return;
     }
     EXCEPTION_ASSERT(!scope.exception());
 
@@ -944,10 +944,16 @@ inline void JSObject::definePrivateField(JSGlobalObject* globalObject, PropertyN
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (type() == WebAssemblyGCObjectType) {
+        throwTypeError(globalObject, scope, "Cannot define private field on a WebAssembly GC object"_s);
+        return;
+    }
+
     PropertySlot slot(this, PropertySlot::InternalMethodType::HasProperty);
     if (JSObject::getPrivateFieldSlot(this, globalObject, propertyName, slot)) {
         throwException(globalObject, scope, createRedefinedPrivateNameError(globalObject));
-        RELEASE_AND_RETURN(scope, void());
+        return;
     }
     EXCEPTION_ASSERT(!scope.exception());
 
@@ -1008,9 +1014,14 @@ inline void JSObject::setPrivateBrand(JSGlobalObject* globalObject, JSValue bran
     Structure* structure = this->structure();
     if (structure->isBrandedStructure() && uncheckedDowncast<BrandedStructure>(structure)->checkBrand(asSymbol(brand))) {
         throwException(globalObject, scope, createReinstallPrivateMethodError(globalObject));
-        RELEASE_AND_RETURN(scope, void());
+        return;
     }
     EXCEPTION_ASSERT(!scope.exception());
+
+    if (type() == WebAssemblyGCObjectType) {
+        throwTypeError(globalObject, scope, "Cannot add private method to a WebAssembly GC object"_s);
+        return;
+    }
 
     scope.release();
 


### PR DESCRIPTION
#### 736ce62a5254f322562cf1ee8f4e12c98a913029
<pre>
[JSC] Disallow defining private names on WasmGC objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=314438">https://bugs.webkit.org/show_bug.cgi?id=314438</a>
<a href="https://rdar.apple.com/176445615">rdar://176445615</a>

Reviewed by Yusuke Suzuki.

While the spec currently technically allows for defining private fields and
methods on WasmGC objects, this is against the spirit of those objects being
fixed-layout.

For compat, both V8 and SpiderMonkey also disallow addition of private names on
WasmGC objects.

Test: JSTests/wasm/gc/private-fields-and-methods.js

* JSTests/wasm/gc/private-fields-and-methods.js: Added.
(testPrivateMethodOnStruct.B):
(testPrivateMethodOnStruct.D.prototype.m):
(testPrivateMethodOnStruct.D):
(testPrivateMethodOnStruct):
(testPrivateFieldOnStruct.B):
(testPrivateFieldOnStruct.D):
(testPrivateFieldOnStruct):
(testPrivateMethodOnArray.B):
(testPrivateMethodOnArray.D.prototype.m):
(testPrivateMethodOnArray.D):
(testPrivateMethodOnArray):
(testPrivateFieldOnArray.B):
(testPrivateFieldOnArray.D):
(testPrivateFieldOnArray):
(testPrivateGetterOnStruct.B):
(testPrivateGetterOnStruct.D.prototype.get x):
(testPrivateGetterOnStruct.D):
(testPrivateGetterOnStruct):
(testGCSurvival.B):
(testGCSurvival.D.prototype.m):
(testGCSurvival.D):
(testGCSurvival):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getPrivateField):
(JSC::JSObject::setPrivateField):
(JSC::JSObject::definePrivateField):
(JSC::JSObject::setPrivateBrand):

Originally-landed-as: 305413.881@safari-7624-branch (525600a227a6). <a href="https://rdar.apple.com/180438063">rdar://180438063</a>
Canonical link: <a href="https://commits.webkit.org/316152@main">https://commits.webkit.org/316152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6664162c67389414dbb4220744fefc7e7efa0cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128724 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133366 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29068 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2214 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182973 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32265 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141823 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44590 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141632 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45279 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109984 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36892 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117170 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43790 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54513 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->