### PR TITLE
[JSC] Insert barrier for MultiPutByOffset when it can reallocate storage

### DIFF
--- a/JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js
+++ b/JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js
@@ -1,0 +1,32 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.1", "--useConcurrentGC=false", "--verifyGC=true", "--gcMaxHeapSize=500000")
+
+var g_value = {};
+
+function makeObj() { return {}; }
+
+function foo(cond) {
+    let a = makeObj();
+    a.p1 = 1;
+    a.p2 = 1;
+    a.p3 = 1;
+    a.p4 = 1;
+    a.p5 = 1;
+    if (cond)
+        a.y = 1;
+    else
+        a.z = 1;
+    a.x = g_value;
+    return a;
+}
+noInline(foo);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    g_value = {};
+    foo(i & 1);
+}
+
+var holder = new Array(100000).fill(null);
+fullGC();
+
+for (let i = 0; i < testLoopCount * 10; ++i)
+    holder[i % 100000] = foo(i & 1);

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -68,6 +68,8 @@ enum class PhaseMode {
     Global
 };
 
+// FIXME(rdar://177100632): Document barrier placement invariants expected of nodes for this phase
+// and improve barrier-related phases overall.
 template<PhaseMode mode>
 class StoreBarrierInsertionPhase : public Phase {
 public:
@@ -369,9 +371,20 @@ private:
                 break;
             }
                 
-            case MultiPutByOffset:
+            case MultiPutByOffset: {
+                // This node may cause a transition before performing a store if it reallocates
+                // storage. This is different from the usual assumption in this phase a node's fast
+                // path either does GC or performs a store, but not both within the same node (a
+                // slow path call to an operation always performs its own barrier). In this special
+                // case, bump the epoch before considering the barrier.
+                if (m_node->multiPutByOffsetData().reallocatesStorage())
+                    m_currentEpoch.bump();
+                considerBarrier(m_node->child1());
+                break;
+            }
+
             case MultiDeleteByOffset: {
-                // These nodes may cause transition too.
+                // This node may cause a transition but does not GC.
                 considerBarrier(m_node->child1());
                 break;
             }


### PR DESCRIPTION
#### 2620d0dbd518fe150e430667996aeb2d94ecd75d
<pre>
[JSC] Insert barrier for MultiPutByOffset when it can reallocate storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=314747">https://bugs.webkit.org/show_bug.cgi?id=314747</a>
<a href="https://rdar.apple.com/176792407">rdar://176792407</a>

Reviewed by Keith Miller.

The DFG barrier insertion phase works by tracking an &quot;epoch&quot; serial number,
which is bumped every time it encounters a node that can GC. The assumption is
that each DFG node either does a store, which would need to be considered for
barrier insertion, or performs a GC.

MultiPutByOffset is a &quot;fat&quot; node that can GC and perform a store after that GC,
in sequence. The current analysis therefore incorrectly elides the barrier for
it. This PR fixes by special casing.

Test: JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js

* JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js: Added.
(foo):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:

Originally-landed-as: 305413.909@safari-7624-branch (2b4933eb1658). <a href="https://rdar.apple.com/180427769">rdar://180427769</a>
Canonical link: <a href="https://commits.webkit.org/316139@main">https://commits.webkit.org/316139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04f8eb3565202bf371a28b4cfcbe88af689403fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180390 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128726 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133367 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35201 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29070 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2206 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182975 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32267 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141821 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44592 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141630 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45281 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109986 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36890 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203689 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43792 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54515 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->