### PR TITLE
Cherry-pick(s) cf6a686e2e58. rdar://180427451

### DIFF
--- a/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash-expected.txt
+++ b/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html
+++ b/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CloseWatcherEnabled=true ] -->
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let first = new CloseWatcher();
+let second;
+internals.withUserGesture(() => { second = new CloseWatcher(); });
+first.destroy();
+second.destroy();
+
+document.write("PASS if no crash.");
+</script>

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
@@ -52,13 +52,16 @@ void CloseWatcherManager::add(Ref<CloseWatcher> watcher)
 
 void CloseWatcherManager::remove(CloseWatcher& watcher)
 {
-    for (auto& group : m_groups) {
-        group.removeFirstMatching([&watcher] (const Ref<CloseWatcher>& current) {
+    m_groups.removeAllMatching([&watcher](auto& group) {
+        group.removeFirstMatching([&watcher](const Ref<CloseWatcher>& current) {
             return current.ptr() == &watcher;
         });
+<<<<<<< HEAD
     }
 
     m_groups.removeAllMatching([] (const Vector<Ref<CloseWatcher>>& group) {
+=======
+>>>>>>> cf6a686e2e58 (Crash in CloseWatcherManager::remove)
         return group.isEmpty();
     });
 }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180427451 to main. [cf6a686e2e58] caused a merge conflict. 

```
Crash in CloseWatcherManager::remove
https://bugs.webkit.org/show_bug.cgi?id=315591
rdar://177972424

Reviewed by Darin Adler and Geoffrey Garen.

Don't mutate m_groups while iterating over it.

Test: fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html

* LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash-expected.txt: Added.
* LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html: Added.
* Source/WebCore/html/closewatcher/CloseWatcherManager.cpp:
(WebCore::CloseWatcherManager::remove):

Originally-landed-as: 305413.973@safari-7624-branch (cf6a686e2e58). rdar://180427451


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ef284eda46f89faca29ed5faa7b200d16ebcab4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171012 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44938 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180392 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128728 "") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172878 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46210 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44573 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/180392 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/128728 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173971 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/46210 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/180392 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/46210 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/44573 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29072 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/46210 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182977 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35772 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/44573 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/182977 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44594 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/182977 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45283 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109988 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/45283 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117174 "") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43794 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/38357 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43198 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43440 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43329 "") | | | 
<!--EWS-Status-Bubble-End-->