### PR TITLE
Gate CacheStorageRepresentation IPC behind AllowTestOnlyIPC

### DIFF
--- a/LayoutTests/http/tests/cache-storage/cache-clearing-origin.https.html
+++ b/LayoutTests/http/tests/cache-storage/cache-clearing-origin.https.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/http/tests/cache-storage/cache-origins.https.html
+++ b/LayoutTests/http/tests/cache-storage/cache-origins.https.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/http/tests/cache-storage/cache-representation.https.html
+++ b/LayoutTests/http/tests/cache-storage/cache-representation.https.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!-- webkit-test-runner [ useEphemeralSession=true allowTestOnlyIPC=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -101,7 +101,7 @@
     CacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
     CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord> records) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
     CacheStorageClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> ()
-    CacheStorageRepresentation() -> (String representation)
+    [EnabledBy=AllowTestOnlyIPC] CacheStorageRepresentation() -> (String representation)
 
     ResetQuotaUpdatedBasedOnUsageForTesting(struct WebCore::ClientOrigin origin)
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ServiceWorkerBasic.mm
@@ -2010,6 +2010,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageDefaultDirectories)
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAllowTestOnlyIPC:YES];
     setConfigurationInjectedBundlePath(configuration.get());
 
     RetainPtr<DirectoryPageMessageHandler> directoryPageMessageHandler = adoptNS([[DirectoryPageMessageHandler alloc] init]);
@@ -2055,6 +2056,7 @@ TEST(ServiceWorkers, ServiceWorkerAndCacheStorageSpecificDirectories)
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAllowTestOnlyIPC:YES];
     setConfigurationInjectedBundlePath(configuration.get());
     RetainPtr dataStoreConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
     NSString* tempDirectory = @"/var/tmp";
@@ -5259,6 +5261,7 @@ TEST(ServiceWorkers, ServiceWorkerCacheReference)
     [[WKWebsiteDataStore defaultDataStore] _setResourceLoadStatisticsEnabled:NO];
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAllowTestOnlyIPC:YES];
 
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
     [configuration setProcessPool:(WKProcessPool *)context.get()];


### PR DESCRIPTION
#### a90c33d29e3a223df7d7420f48c51f429e429751
<pre>
Gate CacheStorageRepresentation IPC behind AllowTestOnlyIPC
<a href="https://rdar.apple.com/176915104">rdar://176915104</a>

Reviewed by Per Arne Vollan.

Add [EnabledBy=AllowTestOnlyIPC] so the generated dispatcher rejects this message outside of test configurations,
matching other test-only endpoints such as GeneralStoragePathForTesting.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:

Originally-landed-as: 305413.938@safari-7624-branch (40dbe4d64205). <a href="https://rdar.apple.com/180437831">rdar://180437831</a>
Canonical link: <a href="https://commits.webkit.org/316201@main">https://commits.webkit.org/316201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d660ab0805d1ece11504d636b66d9f12c2094533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133391 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35224 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33555 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183031 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141852 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141662 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38321 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45337 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110042 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36918 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117228 "Build was cancelled. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 28155 issues") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43848 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->