### PR TITLE
Cross-Thread Destruction of BlobData Races Non-Thread-Safe RefCounted<BlobDataFileReference> Leads to UAF

### DIFF
--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -57,19 +57,26 @@ public:
     MappedFileData(MappedFileData&&) = default;
     MappedFileData& operator=(MappedFileData&&) = default;
 
+    static MappedFileData emptyFile()
+    {
+        MappedFileData result;
+        result.m_isValid = true;
+        return result;
+    }
+
+    explicit operator bool() const { return m_isValid; }
+
 #if HAVE(MMAP)
     explicit MappedFileData(MmapSpan<uint8_t>&&);
 
     [[nodiscard]] std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
-    explicit operator bool() const { return !!m_fileData; }
     size_t size() const { return m_fileData.span().size(); }
     std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData.span(); }
     std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData.mutableSpan(); }
 #elif OS(WINDOWS)
     MappedFileData(std::span<uint8_t>, Win32Handle&&);
-
+    
     const Win32Handle& fileMapping() const LIFETIME_BOUND { return m_fileMapping; }
-    explicit operator bool() const { return !!m_fileData.data(); }
     size_t size() const { return m_fileData.size(); }
     std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData; }
     std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData; }
@@ -82,6 +89,7 @@ private:
     std::span<uint8_t> m_fileData;
     Win32Handle m_fileMapping;
 #endif
+    bool m_isValid { false };
 };
 
 } // namespace FileSystemImpl

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -160,7 +160,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode mapMode, FileOpenMo
         return { };
 
     if (!size)
-        return MappedFileData { };
+        return MappedFileData::emptyFile();
 
     int pageProtection = PROT_READ;
     switch (openMode) {

--- a/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
+++ b/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
@@ -31,6 +31,7 @@ namespace WTF::FileSystemImpl {
 #if HAVE(MMAP)
 MappedFileData::MappedFileData(MmapSpan<uint8_t>&& fileData)
     : m_fileData(WTF::move(fileData))
+    , m_isValid(true)
 { }
 
 MappedFileData::~MappedFileData() = default;

--- a/Source/WTF/wtf/win/FileHandleWin.cpp
+++ b/Source/WTF/wtf/win/FileHandleWin.cpp
@@ -152,7 +152,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode, FileOpenMode openM
         return { };
 
     if (!*size)
-        return MappedFileData { };
+        return MappedFileData::emptyFile();
 
     DWORD pageProtection = PAGE_READONLY;
     DWORD desiredAccess = FILE_MAP_READ;

--- a/Source/WTF/wtf/win/MappedFileDataWin.cpp
+++ b/Source/WTF/wtf/win/MappedFileDataWin.cpp
@@ -33,6 +33,7 @@ namespace WTF::FileSystemImpl {
 MappedFileData::MappedFileData(std::span<uint8_t> fileData, Win32Handle&& fileMapping)
     : m_fileData(fileData)
     , m_fileMapping(WTF::move(fileMapping))
+    , m_isValid(true)
 {
 }
 

--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -39,6 +39,7 @@ namespace WebCore {
 BlobData::BlobData(const String& contentType)
     : m_contentType(contentType)
 {
+    ASSERT(isMainThread());
 }
 
 const long long BlobDataItem::toEndOfFile = -1;

--- a/Source/WebCore/platform/network/BlobData.h
+++ b/Source/WebCore/platform/network/BlobData.h
@@ -95,7 +95,7 @@ private:
 
 typedef Vector<BlobDataItem> BlobDataItemList;
 
-class BlobData : public ThreadSafeRefCounted<BlobData> {
+class BlobData : public ThreadSafeRefCounted<BlobData, WTF::DestructionThread::Main> {
 public:
     static Ref<BlobData> create(const String& contentType)
     {

--- a/Source/WebCore/platform/network/BlobDataFileReference.cpp
+++ b/Source/WebCore/platform/network/BlobDataFileReference.cpp
@@ -35,6 +35,7 @@ BlobDataFileReference::BlobDataFileReference(const String& path, const String& r
     : m_path(path)
     , m_replacementPath(replacementPath)
 {
+    ASSERT(isMainThread());
 }
 
 BlobDataFileReference::~BlobDataFileReference()

--- a/Source/WebCore/platform/network/BlobDataFileReference.h
+++ b/Source/WebCore/platform/network/BlobDataFileReference.h
@@ -28,13 +28,13 @@
 
 #include <optional>
 #include <wtf/Markable.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class WEBCORE_EXPORT BlobDataFileReference : public RefCounted<BlobDataFileReference> {
+class WEBCORE_EXPORT BlobDataFileReference : public ThreadSafeRefCounted<BlobDataFileReference, WTF::DestructionThread::Main> {
 public:
     static Ref<BlobDataFileReference> create(const String& path, const String& replacementPath = { })
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -130,7 +130,8 @@ TEST_F(FileSystemTest, MappingExistingEmptyFile)
 {
     auto mappedFileData = FileSystem::mapFile(tempEmptyFilePath(), FileSystem::MappedFileMode::Shared);
     EXPECT_TRUE(!!mappedFileData);
-    EXPECT_TRUE(!*mappedFileData);
+    EXPECT_TRUE(!!*mappedFileData);
+    EXPECT_EQ(mappedFileData->size(), 0u);
 }
 
 TEST_F(FileSystemTest, FilesHaveSameVolume)


### PR DESCRIPTION
#### d643555ed4f5ce21f793190d467008b2e0754ccf
<pre>
Cross-Thread Destruction of BlobData Races Non-Thread-Safe RefCounted&lt;BlobDataFileReference&gt; Leads to UAF
<a href="https://bugs.webkit.org/show_bug.cgi?id=312734">https://bugs.webkit.org/show_bug.cgi?id=312734</a>
<a href="https://rdar.apple.com/174674094">rdar://174674094</a>

Reviewed by Ryosuke Niwa.

BlobData was ThreadSafeRefCounted but contained data members that were
not safe to destroy on other threads like a String and a
`RefPtr&lt;BlobDataFileReference&gt;` (BlobDataFileReference only subclasses
RefCounted). For thread safety, both BlobData and BlobDataFileReference
now subclass `ThreadSafeRefCounted&lt;T, WTF::DestructionThread::Main&gt;` so
that not only their ref-counting is atomic but also to guarantee that
they get destroyed on the main thread (since they are always constructed
on the main thread). This is important given that they have String
data members.

Also, as further hardening recommended by the AI, update MappedFileData
to be able to distinguish empty data and invalid data.

* Source/WTF/wtf/MappedFileData.h:
(WTF::FileSystemImpl::MappedFileData::emptyFile):
(WTF::FileSystemImpl::MappedFileData::operator bool const):
(WTF::FileSystemImpl::MappedFileData::leakHandle):
(WTF::FileSystemImpl::MappedFileData::fileMapping const):
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp:
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/win/MappedFileDataWin.cpp:
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
* Source/WebCore/platform/network/BlobData.cpp:
(WebCore::BlobData::BlobData):
* Source/WebCore/platform/network/BlobData.h:
* Source/WebCore/platform/network/BlobDataFileReference.cpp:
(WebCore::BlobDataFileReference::BlobDataFileReference):
* Source/WebCore/platform/network/BlobDataFileReference.h:

Originally-landed-as: 305413.709@safari-7624-branch (5b1739a247ed). <a href="https://rdar.apple.com/180438123">rdar://180438123</a>
Canonical link: <a href="https://commits.webkit.org/316216@main">https://commits.webkit.org/316216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e57e38a0ce66be4242ba9a1b2fcc87f4a45b35f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171198 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38543 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180578 "Build was cancelled. Recent messages:Printed configuration") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133472 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113933 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35334 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29258 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2317 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183163 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32455 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37791 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141933 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44780 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141742 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38334 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45469 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30252 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110174 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37000 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117328 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203877 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43980 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8348 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54541 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->