### PR TITLE
[libpas] Fix race in pas_segregated_heap_medium_size_directory_for_index

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
@@ -33,7 +33,8 @@ PAS_BEGIN_EXTERN_C;
 enum pas_race_test_hook_kind {
     pas_race_test_hook_local_allocator_stop_before_did_stop_allocating,
     pas_race_test_hook_local_allocator_stop_before_unlock,
-    pas_race_test_hook_bitfit_directory_take_last_empty_after_loop
+    pas_race_test_hook_bitfit_directory_take_last_empty_after_loop,
+    pas_race_test_hook_medium_directory_after_directory_store
 };
 
 typedef enum pas_race_test_hook_kind pas_race_test_hook_kind;
@@ -47,6 +48,8 @@ static inline const char* pas_race_test_hook_kind_get_string(pas_race_test_hook_
         return "local_allocator_stop_before_unlock";
     case pas_race_test_hook_bitfit_directory_take_last_empty_after_loop:
         return "bitfit_directory_take_last_empty_after_loop";
+    case pas_race_test_hook_medium_directory_after_directory_store:
+        return "medium_directory_after_directory_store";
     }
     PAS_ASSERT_NOT_REACHED();
     return NULL;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -38,6 +38,7 @@
 #include "pas_large_expendable_memory.h"
 #include "pas_large_utility_free_heap.h"
 #include "pas_min_heap.h"
+#include "pas_race_test_hooks.h"
 #include "pas_segregated_heap_inlines.h"
 #include "pas_segregated_size_directory.h"
 #include "pas_segregated_page.h"
@@ -324,7 +325,8 @@ pas_segregated_size_directory* pas_segregated_heap_size_directory_for_index_slow
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    const pas_heap_config* config)
+    const pas_heap_config* config,
+    pas_lock_hold_mode heap_lock_hold_mode)
 {
     if (pas_segregated_heap_index_is_cached_index_and_cached_index_is_set(heap, cached_index, index, config)) {
         pas_segregated_size_directory* result;
@@ -340,7 +342,7 @@ pas_segregated_size_directory* pas_segregated_heap_size_directory_for_index_slow
     return pas_segregated_heap_medium_size_directory_for_index(
         heap, index,
         pas_segregated_heap_medium_size_directory_search_within_size_class_progression,
-        pas_lock_is_held);
+        heap_lock_hold_mode);
 }
 
 typedef struct {
@@ -1506,7 +1508,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
 
     ensure_size_lookup_if_necessary(heap, size_lookup_mode, config, cached_index, index);
 
-    result = pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config);
+    result = pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config, pas_lock_is_held);
 
     if (verbose && result) {
         pas_log("Found result = %p, object_size = %u, min_index = %u\n",
@@ -2183,6 +2185,8 @@ pas_segregated_heap_ensure_size_directory_for_size(
                     &medium_directory->directory, result);
                 medium_directory->allocator_index = 0;
 
+                pas_race_test_hook(pas_race_test_hook_medium_directory_after_directory_store);
+
                 if (verbose) {
                     pas_log("In rare_data = %p, Installing medium tuple %zu...%zu\n",
                             rare_data, index, medium_install_index);
@@ -2222,7 +2226,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
             }
         }
 
-        PAS_ASSERT(pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config)
+        PAS_ASSERT(pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config, pas_lock_is_held)
                    == result);
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h
@@ -37,28 +37,30 @@ PAS_API pas_segregated_size_directory* pas_segregated_heap_size_directory_for_in
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    const pas_heap_config* config);
+    const pas_heap_config* config,
+    pas_lock_hold_mode heap_lock_hold_mode);
 
 static PAS_ALWAYS_INLINE pas_segregated_size_directory*
 pas_segregated_heap_size_directory_for_index(
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    const pas_heap_config* config)
+    const pas_heap_config* config,
+    pas_lock_hold_mode heap_lock_hold_mode)
 {
     pas_compact_atomic_segregated_size_directory_ptr* index_to_size_directory;
     pas_segregated_size_directory* result;
-    
+
     if (index >= (size_t)heap->small_index_upper_bound)
         goto slow;
-    
+
     index_to_size_directory = heap->index_to_small_size_directory;
     if (!index_to_size_directory) {
         /* Code that holds no locks may see this since we have no ordering between when the
            upper_bound is set and when this is set. */
         goto slow;
     }
-    
+
     result = pas_compact_atomic_segregated_size_directory_ptr_load(index_to_size_directory + index);
     if (result)
         return result;
@@ -67,7 +69,7 @@ pas_segregated_heap_size_directory_for_index(
        for the entry corresponding to the basic_size_directory to be unset in the lookup table! */
 
 slow:
-    return pas_segregated_heap_size_directory_for_index_slow(heap, index, cached_index, config);
+    return pas_segregated_heap_size_directory_for_index_slow(heap, index, cached_index, config, heap_lock_hold_mode);
 }
 
 static PAS_ALWAYS_INLINE pas_segregated_size_directory*
@@ -78,10 +80,15 @@ pas_segregated_heap_size_directory_for_size(
     unsigned* cached_index)
 {
     size_t index;
-    
+
     index = pas_segregated_heap_index_for_size(size, config);
-    
-    return pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config.config_ptr);
+
+    /* This entry point is reached on the lock-free allocation slow path
+       (pas_heap_ensure_size_directory_for_size), so the heap lock cannot be
+       held here. The medium-tuple lookup uses the seqlock to validate
+       against concurrent writers. */
+    return pas_segregated_heap_size_directory_for_index(
+        heap, index, cached_index, config.config_ptr, pas_lock_is_not_held);
 }
 
 static PAS_ALWAYS_INLINE bool pas_segregated_heap_touch_lookup_tables(

--- a/Source/bmalloc/libpas/src/test/RaceTests.cpp
+++ b/Source/bmalloc/libpas/src/test/RaceTests.cpp
@@ -28,9 +28,14 @@
 #include <functional>
 #include "iso_heap.h"
 #include "iso_heap_config.h"
+#include "iso_heap_ref.h"
 #include <map>
 #include <mutex>
+#include "pas_heap.h"
+#include "pas_primitive_heap_ref.h"
 #include "pas_race_test_hooks.h"
+#include "pas_segregated_heap_inlines.h"
+#include "pas_segregated_size_directory.h"
 #include "pas_thread_local_cache.h"
 #include <set>
 #include <thread>
@@ -251,6 +256,82 @@ void testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_kind kindToSto
     CHECK(shrinkDidFinish);
 }
 
+void testMediumDirectoryTornInsertRace()
+{
+    pas_scavenger_suspend();
+
+    pas_primitive_heap_ref heap = ISO_PRIMITIVE_HEAP_REF_INITIALIZER;
+    constexpr size_t kBigSize = 8192;
+    constexpr size_t kNewSize = 1024;
+
+    /* This is a bit of a hack: we want to catch a race on the medium-tuple
+       insertion path, but in order to set up the race we need to go through
+       the insertion path once without getting stopped by the hook.
+       So we start with a no-op hook and only afterwards install the effectful one. */
+    hookCallback = [] (pas_race_test_hook_kind) { };
+    void* seedBig = iso_allocate_primitive(&heap, kBigSize, pas_non_compact_allocation_mode);
+    CHECK(seedBig);
+
+    bool didGetToHook = false;
+    bool hookShouldStop = false;
+    bool hookDidStop = false;
+
+    hookCallback =
+        [&] (pas_race_test_hook_kind kind) {
+            if (kind != pas_race_test_hook_medium_directory_after_directory_store)
+                return;
+
+            unique_lock<mutex> locker(globalLock);
+            didGetToHook = true;
+            globalCond.notify_all();
+            while (!hookShouldStop && !isHoldingContendedLocks())
+                globalCond.wait(locker);
+            hookDidStop = true;
+        };
+
+    thread writer = thread(
+        [&] () {
+            /* Inserts a smaller medium tuple at slot 0, shifting the original
+               tuple to slot 1.
+               Once the hook fires, slot[0]'s directory ptr will have been overwritten,
+               but its begin_index/end_index fields won't yet have been.
+               If there is a race here, then the reader will see
+               { new_directory_ptr, old_begin_index, old_end_index } */
+            void* small = iso_allocate_primitive(&heap, kNewSize, pas_non_compact_allocation_mode);
+            CHECK(small);
+        });
+
+    {
+        unique_lock<mutex> locker(globalLock);
+        while (!didGetToHook)
+            globalCond.wait(locker);
+    }
+
+    /* A NULL cached_index forces the lookup to skip the
+       basic-size-directory path, which ensures we take the medium path.
+       Since the slot-write hasn't finished yet, we should expect to see
+       the original directory, with object_size == kBigSize.
+       If we see a directory with kNewSize, then there is a race.
+       If the lock-free medium path doesn't respect the seqlock, it will
+       observe the torn slot we created above. */
+    size_t bigIndex = pas_segregated_heap_index_for_size(kBigSize, iso_heap_config);
+    pas_segregated_size_directory* observed =
+        pas_segregated_heap_size_directory_for_index(
+            &heap.base.heap->segregated_heap, bigIndex, NULL, &iso_heap_config,
+            pas_lock_is_not_held);
+
+    {
+        unique_lock<mutex> locker(globalLock);
+        hookShouldStop = true;
+        globalCond.notify_all();
+    }
+    writer.join();
+
+    CHECK(hookDidStop);
+    CHECK(observed);
+    CHECK_GREATER_EQUAL((size_t)observed->object_size, kBigSize);
+}
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_TESTING && PAS_ENABLE_ISO
@@ -268,6 +349,8 @@ void addRaceTests()
         ADD_TEST(testLocalAllocatorStopRace(pas_race_test_hook_local_allocator_stop_before_unlock));
         ADD_TEST(testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_local_allocator_stop_before_did_stop_allocating));
         ADD_TEST(testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_local_allocator_stop_before_unlock));
+
+        ADD_TEST(testMediumDirectoryTornInsertRace());
     }
 #endif // PAS_ENABLE_TESTING && PAS_ENABLE_ISO
 }


### PR DESCRIPTION
#### 82b692fc69fc58e128e35db1a2d0d5e5ae3bbec5
<pre>
[libpas] Fix race in pas_segregated_heap_medium_size_directory_for_index
<a href="https://bugs.webkit.org/show_bug.cgi?id=314829">https://bugs.webkit.org/show_bug.cgi?id=314829</a>
<a href="https://rdar.apple.com/175683224">rdar://175683224</a>

Reviewed by Dan Hecht and Yijia Huang.

The medium-size directory is protected by both the heap-lock and a
seqlock (i.e. pas_mutation_count on rare_data-&gt;mutation_count).
The seqlock allows for readers to access the rare_data without
acquiring a lock; if the mutation-count shows that the object is being
mutated, then the reader is supposed to fall-back to acquiring the
heap-lock. However, as an optimization, if the heap-lock is already
held, the reader skips the seqlock step.
Previously, pas_segregated_heap_size_directory_for_index_slow would
always call pas_segregated_heap_medium_size_directory_for_index with
pas_lock_is_held. This meant that in certain cases, slow-path calls
will hit a race that results in a malloc call being given a slot within
segregated-heap slot that is actually too small for the requested size.

Operationally, what would happen is more or less
  1. ThreadA tries allocating an object X and searches for a
     matching medium-size-directory, but fails to find one.
  2. This means it needs to create a new medium-size-directory.
     This requires inserting a new entry into the medium-tuple array.
     ThreadA determines that the new tuple should live at index M.
  3. The medium-tuple array is sorted and packed, so inserting into the
     middle requires `memmove`&apos;ing all tuples down one slot --
     so ThreadA does so.
     At this point, slot[M] still points to the old entry,
     and still has the old begin/end.
  3. ThreadA then begins overwriting the slot[M], first
     overwriting the directory-pointer.
     At this point, slot[M] still has the old begin/end,
     but points to the new directory.
  4. ThreadB tries allocating an object Y. It should take the seqlock
     here, but incorrectly assumes that it holds the heap-lock and thus
     doesn&apos;t need to.
  5. ThreadB searches for a matching medium-size-directory, and finds
     slot[M] has a begin/end pair that matches its expectations.
  6. ThreadB then reads slot[M]&apos;s directory pointer, thus
     getting a directory with a mismatched size.
  7. ThreadB then asks that directory for an allocation-slot,
     and gets one back: however, the size of this slot is
     necessarily too small (because of the sorted-insertion
     requirement in #3 above).
     Therefore, the caller thinks that it got e.g. an 8192B
     slot but in fact only got a 7162B slot. A write to the
     latter bytes of the slot will corrupt the memory of the
     subsequent allocation.
N.b. step #3 is also a race on its own, but it&apos;s harder to capture
since we can&apos;t hook in the middle of the memmove.

Best as I can tell, at some point this hardcoded heap-lock hold mode
was actually correct, since the primary path to get here does acquire
the lock. However, there&apos;s another path (perhaps added later?
unfortunately it&apos;s all lumped into the commit that added libpas to the
repo) that doesn&apos;t do so. So the correct fix is to pipe the heap-lock
hold status up far enough that we either get to a function that takes
the hold-mode as a parameter, or one which asserts that the heap-lock
is held.

* Source/bmalloc/libpas/src/libpas/test/RaceTests.cpp: added
  new test to exhibit the race described above.

Originally-landed-as: 305413.966@safari-7624-branch (58ebed1e9cec). <a href="https://rdar.apple.com/180436276">rdar://180436276</a>
Canonical link: <a href="https://commits.webkit.org/316275@main">https://commits.webkit.org/316275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40cd29b99f01789e0e7ba9f41ebc523400da53e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171118 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180498 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128834 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133417 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94141 "1 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153865 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35258 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33571 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29178 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2259 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183083 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32375 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37759 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141883 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44700 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141692 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45389 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110094 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36942 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203797 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43900 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8318 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54529 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->