### PR TITLE
Add size limit to Yarr generated code

### DIFF
--- a/JSTests/stress/regexp-many-non-greedy-paren-groups.js
+++ b/JSTests/stress/regexp-many-non-greedy-paren-groups.js
@@ -1,0 +1,25 @@
+// Test that regular expressions with many sequential non-greedy quantified
+// parenthesized groups produce correct results at various sizes.
+
+function testLargeNonGreedyParens(n) {
+    let s = '(?:a){0,2}?'.repeat(n);
+
+    let r = new RegExp(s);
+
+    let result = 'aaa'.match(r);
+    if (result === null)
+        throw new Error("Expected match for n=" + n);
+    if (result.index !== 0)
+        throw new Error("Expected index 0 for n=" + n + ", got " + result.index);
+
+    let replaced = 'a'.replace(r, 'x');
+    if (typeof replaced !== 'string')
+        throw new Error("replace failed for n=" + n);
+}
+
+testLargeNonGreedyParens(10);
+testLargeNonGreedyParens(100);
+testLargeNonGreedyParens(1000);
+testLargeNonGreedyParens(2000);
+testLargeNonGreedyParens(4000);
+testLargeNonGreedyParens(8193);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -335,6 +335,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumBinaryStringSwitchCaseLength, 50, Normal, nullptr) \
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
     v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
+    v(Unsigned, maximumRegExpJITCodeSize, 16 * MB, Normal, "Maximum generated code size in bytes for RegExp JIT compilation before falling back to the interpreter."_s) \
     \
     v(Unsigned, wasmInliningMaximumDepth, 7, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
     v(Unsigned, wasmInliningMaximumWasmCalleeSize, 500, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4525,7 +4525,7 @@ class YarrGenerator final : public YarrJITInfo {
             }
 
             ++opIndex;
-        } while (opIndex < m_ops.size());
+        } while (opIndex < m_ops.size() && !hasExceededCodeSizeLimit());
 
         termMatchTargets.takeLast();
     }
@@ -5332,7 +5332,18 @@ class YarrGenerator final : public YarrJITInfo {
             case YarrOpCode::MatchFailed:
                 break;
             }
-        } while (opIndex);
+        } while (opIndex && !hasExceededCodeSizeLimit());
+    }
+
+    bool hasExceededCodeSizeLimit()
+    {
+        if (m_failureReason)
+            return true;
+        if (m_jit.m_assembler.buffer().codeSize() > Options::maximumRegExpJITCodeSize()) [[unlikely]] {
+            m_failureReason = JITFailureReason::GeneratedCodeSizeTooLarge;
+            return true;
+        }
+        return false;
     }
 
     // Compilation methods:
@@ -6951,9 +6962,17 @@ public:
         generate();
         if (m_disassembler)
             m_disassembler->setEndOfGenerate(m_jit.label());
+        if (m_failureReason) {
+            codeBlock.setFallBackWithFailureReason(*m_failureReason);
+            return;
+        }
         backtrack();
         if (m_disassembler)
             m_disassembler->setEndOfBacktrack(m_jit.label());
+        if (m_failureReason) {
+            codeBlock.setFallBackWithFailureReason(*m_failureReason);
+            return;
+        }
 
         ptrdiff_t codeSize = MacroAssembler::differenceBetween(startOfMainCode, m_jit.label());
         bool canInline = ([&] -> bool {
@@ -7584,6 +7603,9 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::OffsetTooLarge:
         dataLog("Can't JIT because pattern exceeds string length limits\n");
+        break;
+    case JITFailureReason::GeneratedCodeSizeTooLarge:
+        dataLog("Can't JIT because generated code size exceeds limit\n");
         break;
     }
 }

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -63,6 +63,7 @@ enum class JITFailureReason : uint8_t {
     ParenthesisNestedTooDeep,
     ExecutableMemoryAllocationFailure,
     OffsetTooLarge,
+    GeneratedCodeSizeTooLarge,
 };
 
 class BoyerMooreFastCandidates {


### PR DESCRIPTION
#### 0012e6118d87c33aaae3c342375566b32762093c
<pre>
Add size limit to Yarr generated code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314589">https://bugs.webkit.org/show_bug.cgi?id=314589</a>
<a href="https://rdar.apple.com/176137052">rdar://176137052</a>

Reviewed by Yusuke Suzuki.

Patterns with many sequential non-greedy quantified parenthesized groups
(e.g. (?:a){0,2}? repeated thousands of times) cause O(N^2) code emission
in saveParenContext/restoreParenContext, as each group saves/restores all
frame slots for the entire pattern. This patch adds a code size limit in
VM options above which the code bails out to the interpreter.

Test: JSTests/stress/regexp-many-non-greedy-paren-groups.js

* JSTests/stress/regexp-many-non-greedy-paren-groups.js: Added.
(testLargeNonGreedyParens):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):
* Source/JavaScriptCore/yarr/YarrJIT.h:

Originally-landed-as: 305413.923@safari-7624-branch (e6d449d59b50). <a href="https://rdar.apple.com/180427748">rdar://180427748</a>
Canonical link: <a href="https://commits.webkit.org/316157@main">https://commits.webkit.org/316157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09ebd46427b5a3df69f3b52520c6c55a11f1f712

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128748 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35228 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33536 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29092 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2227 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182997 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32289 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141839 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44614 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141649 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45303 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110008 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36908 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117194 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203711 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43814 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43460 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->