### PR TITLE
WasmGC should reject reserved bits in br_on_cast/br_on_cast_fail flags byte

### DIFF
--- a/JSTests/wasm/stress/br-on-cast-reserved-flags.js
+++ b/JSTests/wasm/stress/br-on-cast-reserved-flags.js
@@ -1,0 +1,54 @@
+import * as assert from "../assert.js";
+import { watToWasm } from "../gc/wast-wrapper.js";
+
+// Regression test: br_on_cast must reject flags bytes with reserved bits set.
+//
+// Bug: the validator only extracts bits 0-1 from the flags byte without
+// rejecting bits 2-7. The IPInt interpreter reloads the raw flags byte and
+// computes allowNull = (flags >> 1), so setting bit 2 makes the runtime
+// treat a non-null target cast as nullable. This allows null to be typed as
+// a non-null reference — a type-system violation.
+
+// Compile a valid module with br_on_cast, then patch the flags byte to 0x05.
+// Valid flags=0x01 means: source nullable, target non-null.
+// Patched flags=0x05: same from validator's perspective (bits 0-1 unchanged in
+// the way that matters), but bit 2 set causes IPInt to derive allowNull=true.
+
+let wat = `
+(module
+  (type (struct))
+  (func (export "test") (result i32)
+    (block (result (ref 0))
+      (ref.null none)
+      (br_on_cast 0 (ref null any) (ref 0))
+      (drop)
+      (struct.new 0)
+    )
+    (ref.is_null)
+  )
+)
+`;
+
+let binary = watToWasm(wat);
+let bytes = new Uint8Array(binary);
+
+// Find the br_on_cast opcode (0xFB 0x18) and patch its flags byte.
+// The flags byte immediately follows the two-byte opcode: [0xFB, 0x18, flags, ...]
+let patched = false;
+for (let i = 0; i < bytes.length - 2; i++) {
+    if (bytes[i] === 0xFB && bytes[i + 1] === 0x18) {
+        let flagsOffset = i + 2;
+        assert.eq(bytes[flagsOffset], 0x01, "expected valid flags=0x01 (src nullable, tgt non-null)");
+        bytes[flagsOffset] = 0x05; // set reserved bit 2
+        patched = true;
+        break;
+    }
+}
+assert.truthy(patched, "should have found br_on_cast opcode in binary");
+
+// The module should be REJECTED because reserved bits are set.
+assert.throws(
+    () => new WebAssembly.Module(binary),
+    WebAssembly.CompileError,
+    "reserved bits"
+);

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -2982,6 +2982,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
             WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
+            WASM_VALIDATOR_FAIL_IF(flags & 0xFC, "reserved bits set in flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 
@@ -4502,6 +4503,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
             WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
+            WASM_VALIDATOR_FAIL_IF(flags & 0xFC, "reserved bits set in flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 


### PR DESCRIPTION
#### 5df8b0b81bf5a7ca7513fb5b61fcaf64e936dae0
<pre>
WasmGC should reject reserved bits in br_on_cast/br_on_cast_fail flags byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=315223">https://bugs.webkit.org/show_bug.cgi?id=315223</a>
<a href="https://rdar.apple.com/176190526">rdar://176190526</a>

Reviewed by Dan Hecht.

In br_on_cast and br_on_cast_fail flag bits other than 0 and 1 are
reserved. The validator currently does not check that reserved bits are
0 and IPInt assumes reserved bits are 0. This patch makes the validator
check the reserved bits.

Test: JSTests/wasm/stress/br-on-cast-reserved-flags.js

* JSTests/wasm/stress/br-on-cast-reserved-flags.js: Added.
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Originally-landed-as: 305413.945@safari-7624-branch (6d5ae0fc9aa1). <a href="https://rdar.apple.com/180437388">rdar://180437388</a>
Canonical link: <a href="https://commits.webkit.org/316266@main">https://commits.webkit.org/316266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50c145ec051b7098d57b5334736e9008745f93d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133378 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94123 "1 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33533 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29094 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2218 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145671 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.NoPanelHidSuccess, TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinInvalidErrorAndRetry, TestWebKitAPI.WebAuthenticationPanel.PanelTwice (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182999 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32291 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141833 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44616 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45305 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110010 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36904 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117196 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203713 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43816 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8298 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54519 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43220 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->