### PR TITLE
Validate EncodedFileData filenames in decidePolicyForNavigationAction

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4267,6 +4267,9 @@ void WebPageProxy::performDragOperation(DragData& dragData, const String& dragSt
     if (!hasRunningProcess())
         return;
 
+    for (auto& fileName : dragData.fileNames())
+        protect(legacyMainFrameProcess())->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(fileName));
+
 #if PLATFORM(GTK)
     URL url { dragData.asURL() };
     if (url.protocolIsFile())
@@ -9429,6 +9432,13 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
 
     MESSAGE_CHECK_URL(process, originalRequest.url());
 
+    if (RefPtr body = request.httpBody()) {
+        for (auto& element : body->elements()) {
+            if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data))
+                MESSAGE_CHECK_COMPLETION(process, process->hasGrantedSandboxExtensionForFile(URL::fileURLWithFileSystemPath(fileData->filename)), completionHandler(PolicyDecision { isNavigatingToAppBoundDomain() }));
+        }
+    }
+
     navigationID = navigation->navigationID();
 
     // Make sure the provisional page always has the latest navigationID.
@@ -12473,6 +12483,8 @@ void WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vect
         if (!protectedThis)
             return;
         if (RefPtr process = openPanelResultListener->process()) {
+            for (auto& fileURL : fileURLs)
+                process->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(fileURL));
 #if ENABLE(SANDBOX_EXTENSIONS)
             auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon"_s, fileURLs);
             process->send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTF::move(sandboxExtensionHandles)), protectedThis->webPageIDInProcess(*process));
@@ -12518,6 +12530,8 @@ bool WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding(const Vector<S
             Vector<String> sandboxExtensionFiles;
             for (size_t i = 0, size = fileURLs.size(); i < size; ++i)
                 sandboxExtensionFiles.append(!transcodedURLs[i].isNull() ? transcodedURLs[i] : fileURLs[i]);
+            for (auto& file : sandboxExtensionFiles)
+                protect(legacyMainFrameProcess())->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(file));
             auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanel"_s, sandboxExtensionFiles);
             send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTF::move(sandboxExtensionHandles)));
 #endif
@@ -12551,6 +12565,8 @@ void WebPageProxy::didChooseFilesForOpenPanel(const Vector<String>& fileURLs, co
             return;
         if (RefPtr process = openPanelResultListener->process()) {
             if (!protectedThis->didChooseFilesForOpenPanelWithImageTranscoding(fileURLs, allowedMIMETypes)) {
+                for (auto& fileURL : fileURLs)
+                    process->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(fileURL));
 #if ENABLE(SANDBOX_EXTENSIONS)
                 auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanel"_s, fileURLs);
                 process->send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTF::move(sandboxExtensionHandles)), protectedThis->webPageIDInProcess(*process));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ProcessSwapOnNavigation.mm
@@ -5342,6 +5342,79 @@ TEST(ProcessSwap, SwapOnFormSubmission)
     EXPECT_WK_STREQ(@"pson://www.webkit.org/main.html", [[webView URL] absoluteString]);
 }
 
+#if PLATFORM(MAC)
+
+static constexpr auto crossSiteFormSubmissionWithFileUploadBytes = R"PSONRESOURCE(
+<body>
+<form id="uploadForm" action="pson://www.apple.com/upload.html" method="post" enctype="multipart/form-data">
+<input id="fileInput" style="width: 100vw; height: 100vh;" type="file" name="file">
+</form>
+</body>
+)PSONRESOURCE"_s;
+
+static bool fileUploadPSONFileSelected;
+
+@interface FileUploadPSONUIDelegate : NSObject <WKUIDelegate>
+@end
+
+@implementation FileUploadPSONUIDelegate
+
+- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray<NSURL *> *))completionHandler
+{
+    NSString *tempFile = [NSTemporaryDirectory() stringByAppendingPathComponent:@"pson-test-upload.txt"];
+    [@"test file content" writeToFile:tempFile atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    completionHandler(@[ [NSURL fileURLWithPath:tempFile] ]);
+    fileUploadPSONFileSelected = true;
+}
+
+@end
+
+// Verify that cross-site form submission with a file upload succeeds with PSON.
+// This ensures that file paths selected via the open panel are properly tracked
+// in m_previouslyApprovedFilePaths and pass the EncodedFileData validation in
+// decidePolicyForNavigationAction.
+TEST(ProcessSwap, SwapOnFormSubmissionWithFileUpload)
+{
+    RetainPtr processPoolConfiguration = psonProcessPoolConfiguration();
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    RetainPtr webViewConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [webViewConfiguration setProcessPool:processPool.get()];
+    RetainPtr handler = adoptNS([[PSONScheme alloc] init]);
+    [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:crossSiteFormSubmissionWithFileUploadBytes];
+    [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+    RetainPtr navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    RetainPtr uiDelegate = adoptNS([[FileUploadPSONUIDelegate alloc] init]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]]];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+    auto webkitPID = [webView _webProcessIdentifier];
+
+    // Click the file input to trigger the open panel.
+    fileUploadPSONFileSelected = false;
+    [webView clickOnElementID:@"fileInput"];
+    TestWebKitAPI::Util::run(&fileUploadPSONFileSelected);
+
+    // Submit the form to a cross-origin URL, triggering PSON.
+    [webView evaluateJavaScript:@"document.getElementById('uploadForm').submit()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    // Verify PSON occurred and navigation succeeded.
+    EXPECT_NE(webkitPID, [webView _webProcessIdentifier]);
+    EXPECT_WK_STREQ(@"pson://www.apple.com/upload.html", [[webView URL] absoluteString]);
+
+    // Clean up temp file.
+    [[NSFileManager defaultManager] removeItemAtPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"pson-test-upload.txt"] error:nil];
+}
+
+#endif // PLATFORM(MAC)
+
 TEST(ProcessSwap, ClosePageAfterCrossSiteProvisionalLoad)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();


### PR DESCRIPTION
#### 198d4dbb7907f973cc0f697e50b425ee32506a9b
<pre>
Validate EncodedFileData filenames in decidePolicyForNavigationAction
<a href="https://rdar.apple.com/174662982">rdar://174662982</a>

Reviewed by Chris Dumez.

A compromised WebContent process can inject arbitrary file paths in
EncodedFileData within the HTTP body of DecidePolicyForNavigationActionAsync,
causing the UIProcess to mint sandbox extension tokens for those paths during
PSON. Add MESSAGE_CHECK_COMPLETION to validate each EncodedFileData filename
against hasGrantedSandboxExtensionForFile().

Register user-selected file paths via addPreviouslyApprovedFileURL() in
didChooseFilesForOpenPanel (3 variants) and performDragOperation (covers
both macOS and iOS drag-and-drop). Use URL::fileURLWithFileSystemPath()
since these parameters are file system paths, not file URLs.

The API test is a regression test verifying that cross-site form submission
with file upload succeeds after the fix — it does not test the negative
(MESSAGE_CHECK failure) path.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::hasGrantedSandboxExtensionForFile const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[FileUploadPSONUIDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):
((ProcessSwap, SwapOnFormSubmissionWithFileUpload)):

Originally-landed-as: 305413.699@safari-7624-branch (3dad3d258fe6). <a href="https://rdar.apple.com/180436266">rdar://180436266</a>
Canonical link: <a href="https://commits.webkit.org/316384@main">https://commits.webkit.org/316384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/455e1be396e37fdd74cc562773545c40f4135ff9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114262 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34089 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183954 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142511 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45566 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142402 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38484 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46246 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30658 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110909 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37497 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117934 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44764 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8752 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44164 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->