### PR TITLE
Validate EncodedFileData sandbox extensions in FormDataReference decode

### DIFF
--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -118,6 +118,16 @@ Ref<FormData> FormData::isolatedCopy() const
     return formData;
 }
 
+unsigned FormData::filesCount() const
+{
+    unsigned filesCount = 0;
+    for (auto& element : m_elements) {
+        if (std::holds_alternative<WebCore::FormDataElement::EncodedFileData>(element.data))
+            ++filesCount;
+    }
+    return filesCount;
+}
+
 unsigned FormData::imageOrMediaFilesCount() const
 {
     unsigned imageOrMediaFilesCount = 0;

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -168,6 +168,7 @@ public:
     void setIdentifier(int64_t identifier) { m_identifier = identifier; }
     int64_t identifier() const { return m_identifier; }
 
+    WEBCORE_EXPORT unsigned filesCount() const;
     unsigned imageOrMediaFilesCount() const;
 
     static EncodingType parseEncodingType(const String& type)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -563,6 +563,17 @@ NetworkSession* NetworkConnectionToWebProcess::networkSession()
     return m_networkProcess->networkSession(m_sessionID);
 }
 
+#if ENABLE(SANDBOX_EXTENSIONS)
+static bool sandboxExtensionsInRequestAreSufficient(const NetworkResourceLoadParameters& loadParameters)
+{
+    RefPtr body = loadParameters.request.httpBody();
+    if (!body)
+        return true;
+
+    return loadParameters.requestBodySandboxExtensions.size() == body->filesCount();
+}
+#endif
+
 Vector<Ref<WebCore::BlobDataFileReference>> NetworkConnectionToWebProcess::resolveBlobReferences(const NetworkResourceLoadParameters& loadParameters)
 {
     CONNECTION_RELEASE_LOG(Loading, "resolveBlobReferences: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
@@ -598,6 +609,10 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
         RELEASE_LOG_ERROR(Loading, "scheduleResourceLoad: Web process does not have cookie access to url %" SENSITIVE_LOG_STRING " for request %" SENSITIVE_LOG_STRING, loadParameters.request.firstPartyForCookies().string().utf8().data(), loadParameters.request.url().string().utf8().data());
 
     MESSAGE_CHECK(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate);
+
+#if ENABLE(SANDBOX_EXTENSIONS)
+    MESSAGE_CHECK(sandboxExtensionsInRequestAreSufficient(loadParameters));
+#endif
 
     CONNECTION_RELEASE_LOG(Loading, "scheduleResourceLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", existingLoaderToResume=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0, existingLoaderToResume ? existingLoaderToResume->toUInt64() : 0);
 
@@ -649,6 +664,9 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
 void NetworkConnectionToWebProcess::performSynchronousLoad(NetworkResourceLoadParameters&& loadParameters, CompletionHandler<void(const ResourceError&, const ResourceResponse, Vector<uint8_t>&&)>&& reply)
 {
     MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
+#if ENABLE(SANDBOX_EXTENSIONS)
+    MESSAGE_CHECK(sandboxExtensionsInRequestAreSufficient(loadParameters));
+#endif
     CONNECTION_RELEASE_LOG(Loading, "performSynchronousLoad: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto identifier = loadParameters.identifier;
@@ -671,6 +689,9 @@ void NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingFo
 void NetworkConnectionToWebProcess::loadPing(NetworkResourceLoadParameters&& loadParameters)
 {
     MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, loadParameters.request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow);
+#if ENABLE(SANDBOX_EXTENSIONS)
+    MESSAGE_CHECK(sandboxExtensionsInRequestAreSufficient(loadParameters));
+#endif
     CONNECTION_RELEASE_LOG(Loading, "loadPing: (parentPID=%d, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ")", loadParameters.parentPID, loadParameters.webPageProxyID.toUInt64(), loadParameters.webPageID.toUInt64(), loadParameters.webFrameID.toUInt64(), loadParameters.identifier ? loadParameters.identifier->toUInt64() : 0);
 
     auto completionHandler = [connection = m_connection, identifier = *loadParameters.identifier] (const ResourceError& error, const ResourceResponse& response) {


### PR DESCRIPTION
#### 2140dfa132aaed51f72461c8b216c474231257ff
<pre>
Validate EncodedFileData sandbox extensions in FormDataReference decode
<a href="https://rdar.apple.com/174678878">rdar://174678878</a>

Reviewed by Per Arne Vollan.

A compromised WebContent process can send ScheduleResourceLoad with a
FormDataReference containing EncodedFileData pointing to arbitrary
NetworkProcess-readable files and zero sandbox extension handles.
NetworkProcess opens the file via CFReadStreamCreateWithFile and uploads
it as POST body to an attacker&apos;s server.

Add MESSAGE_CHECK in scheduleResourceLoad, performSynchronousLoad,
and loadPing that verifies requestBodySandboxExtensions count matches file
element count.

No new tests, existing IPC and file upload tests cover regression.

* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::filesCount const):
* Source/WebCore/platform/network/FormData.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::sandboxExtensionsInRequestAreSufficient):
(WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):
(WebKit::NetworkConnectionToWebProcess::performSynchronousLoad):
(WebKit::NetworkConnectionToWebProcess::loadPing):
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::sandboxExtensionsAreSufficient):
(IPC::FormDataReference::FormDataReference):
* Source/WebKit/Platform/IPC/FormDataReference.serialization.in:

Originally-landed-as: <a href="https://commits.webkit.org/305413.719@safari-7624-branch">305413.719@safari-7624-branch</a> (2fda958a73b4). rdar://180436249
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d266874182504e6f5729dbfe56e70ee309db933

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172286 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46204 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181737 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174151 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47497 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45846 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134004 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175244 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47497 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114475 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47497 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45846 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30343 "Built successfully") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47497 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184271 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45846 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142765 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45876 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142646 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46554 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111281 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46554 "Hash 1d266874 for PR 68236 does not build (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45071 "Hash 1d266874 for PR 68236 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39632 "Hash 1d266874 for PR 68236 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44471 "Hash 1d266874 for PR 68236 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44703 "Hash 1d266874 for PR 68236 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44530 "Hash 1d266874 for PR 68236 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->