### PR TITLE
Use-after-free in HistoryController::recursiveGoToItem — popstate-reentrant setChildItem reallocates iterated m_children

### DIFF
--- a/LayoutTests/fast/history/popstate-add-iframes-during-history-back-expected.txt
+++ b/LayoutTests/fast/history/popstate-add-iframes-during-history-back-expected.txt
@@ -1,0 +1,5 @@
+This test verifies that adding many iframes during a popstate event triggered by history.back() does not cause a crash.
+
+PASS: Did not crash.
+
+

--- a/LayoutTests/fast/history/popstate-add-iframes-during-history-back.html
+++ b/LayoutTests/fast/history/popstate-add-iframes-during-history-back.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function gc() {
+    if (typeof GCController !== 'undefined')
+        GCController.collect();
+    else {
+        for (let i = 0; i < 10000; i++)
+            new String("A".repeat(10000));
+    }
+}
+
+function step1() {
+    const childA = document.getElementById('childA').contentWindow;
+    childA.addEventListener('popstate', () => {
+        for (let i = 0; i < 40; i++) {
+            const f = document.createElement('iframe');
+            f.src = 'about:blank';
+            document.body.appendChild(f);
+        }
+        gc();
+    }, { once: true });
+
+    childA.history.pushState({k: 1}, '', '#x');
+
+    setTimeout(step2, 0);
+}
+
+function step2() {
+    history.back();
+    setTimeout(() => {
+        document.getElementById('result').textContent = 'PASS: Did not crash.';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 1000);
+}
+
+window.onload = () => {
+    setTimeout(step1, 0);
+};
+</script>
+</head>
+<body>
+<p>This test verifies that adding many iframes during a popstate event triggered by history.back() does not cause a crash.</p>
+<p id="result"></p>
+<iframe id="childA" src="resources/dummy.html"></iframe>
+<iframe id="childB" src="resources/dummy.html"></iframe>
+</body>
+</html>

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -965,7 +965,7 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
         m_provisionalItem = item;
     }
 
-    for (Ref childItem : item.children()) {
+    for (Ref childItem : copyToVector(item.children())) {
         auto frameID = childItem->frameID();
         if (!frameID)
             continue;
@@ -987,7 +987,7 @@ void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromIt
         return m_frame->loader().loadItem(item, fromItem, type, shouldTreatAsContinuingLoad, shouldRestoreFromBackForwardCache);
 
     // Just iterate over the rest, looking for frames to navigate.
-    for (Ref childItem : item.children()) {
+    for (Ref childItem : copyToVector(item.children())) {
         auto frameID = childItem->frameID();
         if (!frameID)
             continue;


### PR DESCRIPTION
#### efe49205d32cdfd396ca62f1b3b7452acdcfc176
<pre>
Use-after-free in HistoryController::recursiveGoToItem — popstate-reentrant setChildItem reallocates iterated m_children
<a href="https://bugs.webkit.org/show_bug.cgi?id=313623">https://bugs.webkit.org/show_bug.cgi?id=313623</a>
<a href="https://rdar.apple.com/175673154">rdar://175673154</a>

Reviewed by Ryosuke Niwa.

Iterate over a copy of the HistoryItem children vector since it can be
modified while looping.

Test: fast/history/popstate-add-iframes-during-history-back.html

* LayoutTests/fast/history/popstate-add-iframes-during-history-back-expected.txt: Added.
* LayoutTests/fast/history/popstate-add-iframes-during-history-back.html: Added.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::recursiveGoToItem):

Originally-landed-as: 305413.764@safari-7624-branch (9fd7e69ed2c4). <a href="https://rdar.apple.com/180437593">rdar://180437593</a>
Canonical link: <a href="https://commits.webkit.org/316272@main">https://commits.webkit.org/316272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/307ecdf90a33445d38e518e66e61e38062c532d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133387 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94126 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33542 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183021 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141845 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38387 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45327 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110032 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36915 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117218 "Build was cancelled. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 28155 issues") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43838 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->