### PR TITLE
[WebGPU] PipelineLayout::makeInvalid leaves m_bindGroupLayouts engaged, causing GPU OOB

### DIFF
--- a/LayoutTests/fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: PASS: dispatch with extra bind group beyond pipeline layout was accepted
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout.html
+++ b/LayoutTests/fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout.html
@@ -1,0 +1,55 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true ] -->
+<script>
+  // BindGroup::makeSubmitInvalid must NOT invalidate the 
+  // submit when PipelineLayout::optionalBindGroupLayout(i)
+  // returns nullptr for an extra bind group index.
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+
+    // Pipeline declares only group 0.
+    let bgl0 = device.createBindGroupLayout({ entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]});
+    let layout = device.createPipelineLayout({ bindGroupLayouts: [bgl0] });
+    let module = device.createShaderModule({ code: `
+      @group(0) @binding(0) var<storage, read_write> a: array<u32>;
+      @compute @workgroup_size(1) fn main() { a[0] = 1u; }
+    `});
+    let pipeline = device.createComputePipeline({ layout, compute: { module, entryPoint: 'main' } });
+
+    let buf0 = device.createBuffer({ size: 4, usage: GPUBufferUsage.STORAGE });
+    let bg0 = device.createBindGroup({ layout: bgl0, entries: [{ binding: 0, resource: { buffer: buf0 } }] });
+
+    // An "extra" bind group at index 1 — not declared by the pipeline layout.
+    // Per spec the pipeline ignores it; the dispatch must succeed without a
+    // validation error.
+    let bglExtra = device.createBindGroupLayout({ entries: [
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+    ]});
+    let bufExtra = device.createBuffer({ size: 4, usage: GPUBufferUsage.STORAGE });
+    let bgExtra = device.createBindGroup({ layout: bglExtra, entries: [{ binding: 0, resource: { buffer: bufExtra } }] });
+
+    let enc = device.createCommandEncoder();
+    let pass = enc.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bg0);
+    pass.setBindGroup(1, bgExtra);
+
+    device.pushErrorScope('validation');
+    pass.dispatchWorkgroups(1, 1, 1);
+    pass.end();
+    device.queue.submit([enc.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    let err = await device.popErrorScope();
+
+    if (err)
+      log('FAIL: dispatch with extra bind group beyond pipeline layout was rejected: ' + err.message);
+    else
+      log('PASS: dispatch with extra bind group beyond pipeline layout was accepted');
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: getBindGroupLayout error: yes
+CONSOLE MESSAGE: PASS: dispatch rejected after pipeline layout invalidation
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass.html
+++ b/LayoutTests/fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass.html
@@ -1,0 +1,59 @@
+<!-- webkit-test-runner [ WebGPUEnabled=true ] -->
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+
+    // Pipeline-side BGL: two storage buffers
+    let bglA = device.createBindGroupLayout({ entries: [
+      {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}},
+      {binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}},
+    ]});
+    let layoutL = device.createPipelineLayout({ bindGroupLayouts: [bglA] });
+    let module = device.createShaderModule({ code: `
+      @group(0) @binding(0) var<storage, read_write> a: array<u32>;
+      @group(0) @binding(1) var<storage, read_write> b: array<u32>;
+      @compute @workgroup_size(1) fn main() { a[0] = b[0]; }
+    `});
+    let pipeline = device.createComputePipeline({ layout: layoutL, compute: { module, entryPoint: 'main' }});
+
+    // Incompatible BGL: single uniform buffer at a different binding index
+    let bglB = device.createBindGroupLayout({ entries: [
+      {binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'uniform'}},
+    ]});
+    let buf = device.createBuffer({ size: 256, usage: GPUBufferUsage.UNIFORM });
+    let bgBad = device.createBindGroup({ layout: bglB, entries: [{binding: 7, resource: {buffer: buf}}] });
+
+    let enc = device.createCommandEncoder();
+    let pass = enc.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bgBad);
+
+    // Inner scope: consume the validation error from getBindGroupLayout(100) itself,
+    // so it doesn't mask whether the dispatch path generates its own error.
+    device.pushErrorScope('validation');
+    pipeline.getBindGroupLayout(100);
+    let bglError = await device.popErrorScope();
+    log('getBindGroupLayout error: ' + (bglError ? 'yes' : 'no'));
+
+    // Outer scope: now check whether dispatch/submit against the poisoned layout
+    // is properly rejected. Without the fix, no error is generated here and the
+    // Metal dispatch proceeds against a wrong-shape argument buffer (GPU OOB).
+    device.pushErrorScope('validation');
+    pass.dispatchWorkgroups(1, 1, 1);
+    pass.end();
+    device.queue.submit([enc.finish()]);
+    await device.queue.onSubmittedWorkDone();
+
+    let dispatchError = await device.popErrorScope();
+    if (dispatchError) {
+      log('PASS: dispatch rejected after pipeline layout invalidation');
+    } else {
+      log('FAIL: dispatch proceeded with invalidated pipeline layout');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -180,6 +180,11 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
         return;
     }
 
+    if (!pipeline->isValid()) {
+        makeInvalid(@"pipeline is not valid prior to dispatch");
+        return;
+    }
+
     if (NSString *error = protect(pipeline->pipelineLayout())->errorValidatingBindGroupCompatibility(m_bindGroups)) {
         makeInvalid(error);
         return;

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -223,8 +223,7 @@ BindGroupLayout* PipelineLayout::optionalBindGroupLayout(size_t i) const
 void PipelineLayout::makeInvalid()
 {
     m_isValid = false;
-    if (m_bindGroupLayouts)
-        m_bindGroupLayouts->clear();
+    m_bindGroupLayouts = std::nullopt;
 }
 
 static size_t NODELETE returnTotalSize(auto& container)
@@ -337,6 +336,9 @@ bool PipelineLayout::updateComputeOffsets(uint32_t bindGroupIndex, const Vector<
 
 NSString* PipelineLayout::errorValidatingBindGroupCompatibility(const PipelineLayout::BindGroupHashMap& bindGroups) const
 {
+    if (!m_isValid)
+        return @"pipeline layout is not valid";
+
     if (!m_bindGroupLayouts)
         return nil;
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -299,6 +299,11 @@ bool RenderBundleEncoder::executePreDrawCommands(bool needsValidationLayerWorkar
         return false;
     }
 
+    if (!pipeline->isValid()) {
+        makeInvalid(@"pipeline is not valid prior to draw");
+        return false;
+    }
+
     Ref pipelineLayout = pipeline->pipelineLayout();
     auto vertexDynamicOffsetSum = checkedSum<uint64_t>(m_vertexDynamicOffset, sizeof(uint32_t) * pipelineLayout->sizeOfVertexDynamicOffsets());
     if (vertexDynamicOffsetSum.hasOverflowed()) {

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -588,6 +588,11 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
         return false;
     }
 
+    if (!pipeline->isValid()) {
+        makeInvalid(@"pipeline is not valid prior to draw");
+        return false;
+    }
+
     if (checkedSum<uint64_t>(instanceCount, firstInstance) > std::numeric_limits<uint32_t>::max())
         return false;
 


### PR DESCRIPTION
#### 97e8c4b43c17c90c622ce09040fb40df0f2668f6
<pre>
[WebGPU] PipelineLayout::makeInvalid leaves m_bindGroupLayouts engaged, causing GPU OOB
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312336">https://bugs.webkit.org/show_bug.cgi?id=312336</a>&gt;
&lt;<a href="https://rdar.apple.com/174670323">rdar://174670323</a>&gt;

Reviewed by Mike Wyrzykowski.

PipelineLayout::makeInvalid() cleared the bind group layouts vector but left the
std::optional engaged. This caused errorValidatingBindGroupCompatibility() to see
an engaged-but-empty vector, skip its validation loop entirely, and return success.
A poisoned pipeline layout could then reach Metal dispatch with a structurally
incompatible argument buffer bound, causing GPU-side out-of-bounds access.

The trigger is getBindGroupLayout(index) with an index &gt;= maxBindGroups, which
calls makeInvalid() on the pipeline layout. This is reachable from web content
via the standard WebGPU API.

Applied three defense-in-depth fixes:

1. PipelineLayout::makeInvalid(): reset m_bindGroupLayouts to std::nullopt
   instead of clearing the vector, so the optional is fully disengaged.
2. PipelineLayout::errorValidatingBindGroupCompatibility(): early-return an
   error if !m_isValid, before inspecting the bind group layouts at all.
3. ComputePassEncoder::executePreDispatchCommands(),
   RenderPassEncoder::executePreDrawCommands(), and
   RenderBundleEncoder::executePreDrawCommands(): check pipeline-&gt;isValid()
   after the existing null check, rejecting pipelines whose layout has been
   invalidated between setPipeline and the dispatch/draw.

Tests:
- fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass.html
  exercises the security fix (poisoned layout must not reach Metal).
- fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout.html guards
  the spec-permitted case where bind groups are bound at indices beyond the
  pipeline&apos;s numberOfBindGroupLayouts() — these must continue to be silently
  ignored at dispatch time. (Caught a transient regression of this case
  during development; added to prevent recurrence.)

* LayoutTests/fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/extra-bind-group-beyond-pipeline-layout.html: Added.
* LayoutTests/fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/pipeline-layout-make-invalid-bind-group-bypass.html: Added.
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::makeInvalid):
(WebGPU::PipelineLayout::errorValidatingBindGroupCompatibility const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):

Originally-landed-as: 305413.848@safari-7624-branch (f4805607466f). <a href="https://rdar.apple.com/180436205">rdar://180436205</a>
Canonical link: <a href="https://commits.webkit.org/316387@main">https://commits.webkit.org/316387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bb9fb6a499bb715ed466bc4ad334f2b846753d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35916 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184065 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142612 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38485 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46356 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111019 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37577 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44874 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8842 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->