### PR TITLE
Data race in JSStyleSheet::visitAdditionalChildren during GC leading to use-after-free

### DIFF
--- a/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet-expected.txt
+++ b/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet-expected.txt
@@ -1,0 +1,12 @@
+Test that a parent stylesheet wrapper is not collected when only the @import child stylesheet is alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS parentSheet instanceof CSSStyleSheet is true
+PASS parentSheet.cssRules[0].type is CSSRule.IMPORT_RULE
+PASS childSheet.parentStyleSheet.foo is "bar"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet.html
+++ b/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+window.jsTestIsAsync = true;
+description("Test that a parent stylesheet wrapper is not collected when only the @import child stylesheet is alive.");
+
+var style = document.createElement("style");
+style.textContent = '@import url("resources/detached-style.css");';
+document.head.appendChild(style);
+
+var parentSheet = style.sheet;
+shouldBeTrue("parentSheet instanceof CSSStyleSheet");
+shouldBe("parentSheet.cssRules[0].type", "CSSRule.IMPORT_RULE");
+
+// Set a custom property on the parent stylesheet wrapper.
+parentSheet.foo = "bar";
+
+// Hold onto the imported (child) stylesheet only.
+window.onload = () => {
+    window.childSheet = parentSheet.cssRules[0].styleSheet;
+
+    // Release all direct references to the parent.
+    parentSheet = null;
+    style.remove();
+    style = null;
+
+    gc();
+    setTimeout(function() {
+        gc();
+        // The parent wrapper should survive because the child's opaque root
+        // should group it with the parent. If it doesn't, the parent wrapper
+        // is collected and a new one is created without the custom property.
+        shouldBeEqualToString('childSheet.parentStyleSheet.foo', 'bar');
+        finishJSTest();
+    }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSStyleSheetCustom.h
+++ b/Source/WebCore/bindings/js/JSStyleSheetCustom.h
@@ -35,11 +35,7 @@ namespace WebCore {
 
 inline WebCoreOpaqueRoot root(StyleSheet* styleSheet)
 {
-    if (SUPPRESS_UNCOUNTED_LOCAL CSSImportRule* ownerRule = styleSheet->ownerRule())
-        return root(ownerRule);
-    if (SUPPRESS_UNCOUNTED_LOCAL Node* ownerNode = styleSheet->ownerNode())
-        return root(ownerNode);
-    return WebCoreOpaqueRoot { styleSheet };
+    return styleSheet->opaqueRootForGCThread();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSImportRule);
+
 CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CSSStyleSheet* parent)
     : CSSRule(parent)
     , m_importRule(importRule)
@@ -45,7 +47,7 @@ CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CSSStyleSheet* parent)
 CSSImportRule::~CSSImportRule()
 {
     if (m_styleSheetCSSOMWrapper)
-        m_styleSheetCSSOMWrapper->clearOwnerRule();
+        protect(m_styleSheetCSSOMWrapper)->clearOwnerRule();
     if (m_mediaCSSOMWrapper)
         protect(m_mediaCSSOMWrapper)->detachFromParent();
 }

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <WebCore/CSSRule.h>
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -33,7 +34,9 @@ struct MediaQuery;
 using MediaQueryList = Vector<MediaQuery>;
 }
 
-class CSSImportRule final : public CSSRule {
+class CSSImportRule final : public CSSRule, public CanMakeCheckedPtr<CSSImportRule> {
+    WTF_MAKE_TZONE_ALLOCATED(CSSImportRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSImportRule);
 public:
     static Ref<CSSImportRule> create(StyleRuleImport& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSImportRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -31,6 +31,7 @@
 #include "JSCSSStyleSheet.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSNodeCustomInlines.h"
 #include "Logging.h"
 #include "MediaList.h"
 #include "MediaQueryParser.h"
@@ -278,12 +279,31 @@ void CSSStyleSheet::forEachStyleScope(NOESCAPE const Function<void(Style::Scope&
 
 void CSSStyleSheet::clearOwnerNode()
 {
+    Locker locker { m_opaqueRootLockForGC };
     m_ownerNode = nullptr;
+}
+
+WebCoreOpaqueRoot CSSStyleSheet::opaqueRootForGCThread()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    if (m_ownerNode)
+        return root(m_ownerNode.get());
+    if (SUPPRESS_UNCOUNTED_LOCAL SUPPRESS_UNCHECKED_LOCAL CSSImportRule* ownerRule = m_ownerRule.get()) {
+        if (auto* parentSheet = ownerRule->parentStyleSheet())
+            return parentSheet->opaqueRootForGCThread();
+    }
+    return WebCoreOpaqueRoot { this };
 }
 
 CSSImportRule* CSSStyleSheet::ownerRule() const
 {
     return m_ownerRule.get();
+}
+
+void CSSStyleSheet::clearOwnerRule()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    m_ownerRule = nullptr;
 }
 
 void CSSStyleSheet::reattachChildRuleCSSOMWrappers()

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -26,8 +26,10 @@
 #include <WebCore/MediaList.h>
 #include <WebCore/MediaQuery.h>
 #include <WebCore/StyleSheet.h>
+#include <WebCore/WebCoreOpaqueRoot.h>
 #include <memory>
 #include <wtf/CheckedPtr.h>
+#include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
@@ -105,7 +107,7 @@ public:
     URL NODELETE baseURL() const final;
     bool isLoading() const final;
 
-    void clearOwnerRule() { m_ownerRule = nullptr; }
+    void clearOwnerRule();
 
     void removeAdoptingTreeScope(ContainerNode&);
     void addAdoptingTreeScope(ContainerNode&);
@@ -161,6 +163,8 @@ public:
     String cssText(const CSS::SerializationContext&);
     void getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>&);
 
+    WebCoreOpaqueRoot opaqueRootForGCThread() override;
+
     bool NODELETE isDetached() const;
 
 private:
@@ -187,8 +191,9 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_constructorDocument;
     WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
-    WeakPtr<CSSImportRule> m_ownerRule;
+    mutable Lock m_opaqueRootLockForGC;
+    CheckedPtr<Node> m_ownerNode;
+    CheckedPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;
 

--- a/Source/WebCore/css/StyleSheet.h
+++ b/Source/WebCore/css/StyleSheet.h
@@ -34,6 +34,7 @@ class CSSImportRule;
 class MediaList;
 class Node;
 class StyleSheet;
+class WebCoreOpaqueRoot;
 
 class StyleSheet : public RefCounted<StyleSheet> {
 public:
@@ -50,6 +51,7 @@ public:
 
     virtual CSSImportRule* ownerRule() const { return nullptr; }
     virtual void clearOwnerNode() = 0;
+    virtual WebCoreOpaqueRoot opaqueRootForGCThread() = 0;
     virtual URL baseURL() const = 0;
     virtual bool isLoading() const = 0;
     virtual bool isCSSStyleSheet() const { return false; }

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -28,6 +28,8 @@
 #include "StyleSheet.h"
 #include <libxml/parser.h>
 #include <libxslt/transform.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/Lock.h>
 #include <wtf/Ref.h>
 #include <wtf/TypeCasts.h>
 
@@ -93,7 +95,8 @@ public:
     String href() const override { return m_originalURL; }
     String title() const override { return { }; }
 
-    void clearOwnerNode() override { m_ownerNode = nullptr; }
+    void clearOwnerNode() override;
+    WebCoreOpaqueRoot opaqueRootForGCThread() override;
     URL baseURL() const override { return m_finalURL; }
     bool isLoading() const override;
 
@@ -106,7 +109,8 @@ private:
 
     void clearXSLStylesheetDocument();
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
+    mutable Lock m_opaqueRootLockForGC;
+    CheckedPtr<Node> m_ownerNode;
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -26,6 +26,7 @@
 #include "DocumentResourceLoader.h"
 #include "FrameConsoleClient.h"
 #include "FrameDestructionObserverInlines.h"
+#include "JSNodeCustomInlines.h"
 #include "LocalFrame.h"
 #include "NodeDocument.h"
 #include "Page.h"
@@ -44,8 +45,7 @@
 namespace WebCore {
 
 XSLStyleSheet::XSLStyleSheet(XSLStyleSheet* parentSheet, const String& originalURL, const URL& finalURL)
-    : m_ownerNode(nullptr)
-    , m_originalURL(originalURL)
+    : m_originalURL(originalURL)
     , m_finalURL(finalURL)
     , m_embedded(false)
     , m_processed(false) // Child sheets get marked as processed when the libxslt engine has finally seen them.
@@ -70,6 +70,20 @@ XSLStyleSheet::~XSLStyleSheet()
         ASSERT(import->parentStyleSheet() == this);
         import->setParentStyleSheet(nullptr);
     }
+}
+
+void XSLStyleSheet::clearOwnerNode()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    m_ownerNode = nullptr;
+}
+
+WebCoreOpaqueRoot XSLStyleSheet::opaqueRootForGCThread()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    if (m_ownerNode)
+        return root(m_ownerNode.get());
+    return WebCoreOpaqueRoot { this };
 }
 
 bool XSLStyleSheet::isLoading() const

--- a/Source/WebKitLegacy/mac/DOM/DOMCSSImportRule.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMCSSImportRule.mm
@@ -52,13 +52,15 @@
 - (DOMMediaList *)media
 {
     WebCore::JSMainThreadNullState state;
-    return kit(WTF::getPtr(IMPL->media()));
+    CheckedPtr impl = IMPL;
+    return kit(WTF::getPtr(impl->media()));
 }
 
 - (DOMCSSStyleSheet *)styleSheet
 {
     WebCore::JSMainThreadNullState state;
-    return kit(WTF::getPtr(IMPL->styleSheet()));
+    CheckedPtr impl = IMPL;
+    return kit(WTF::getPtr(impl->styleSheet()));
 }
 
 @end


### PR DESCRIPTION
#### b1a42efa6ce00e8d6cabcf8faff005e734a54190
<pre>
Data race in JSStyleSheet::visitAdditionalChildren during GC leading to use-after-free
<a href="https://bugs.webkit.org/show_bug.cgi?id=312540">https://bugs.webkit.org/show_bug.cgi?id=312540</a>
<a href="https://rdar.apple.com/174207086">rdar://174207086</a>

Reviewed by Antti Koivisto.

JSStyleSheet::visitAdditionalChildren is called by the JSC garbage collector on a GC thread.
It calls addWebCoreOpaqueRoot(visitor, wrapped()) with root(StyleSheet*), which reads
styleSheet-&gt;ownerNode() and styleSheet-&gt;ownerRule(). Both are WeakPtr member variables on
CSSStyleSheet or XSLStyleSheet with .get() returning a raw pointer with no ref count increment,
and the backing WeakPtrImpl can be freed by the main thread between the read and the subsequent
dereference, causing a heap use-after-free.

The same root(StyleSheet*) function is the convergence point for JSCSSRule&apos;s
visitAdditionalChildren and JSCSSStyleDeclaration&apos;s visitAdditionalChildren, so all three GC
visitor paths are affected.

To address this bug, this PR adds a pure virtual opaqueRootForGCThread() to so root(StyleSheet*)
becomes a single virtual dispatch, eliminating the unsafe inline chain traversal. This function
then uses a newly added lock (m_opaqueRootLockForGC in CSSStyleSheet and XSLStyleSheet) to
guard against m_ownerNode being modified while the main thread is mutating it.

In addition, we had a GC correctness bug that @import child stylesheets (which have m_ownerRule
but no m_ownerNode) would not keep its parent stylesheet&apos;s JS wrapper alive even though it&apos;s
accessible via parentStyleSheet property.

To implement these changes and to avoid thread safety issues, this PR changes the type of
m_ownerNode and m_ownerRule in CSSStyleSheet and XSLStyleSheet from WeakPtr to CheckedPtr since
WeakPtr loads the pointee address via WeakPtrImpl, which may be concurrently free&apos;ed in the main
thread while we&apos;re accessing it in a GC thread. Note that all owner element destructors
(HTMLStyleElement, HTMLLinkElement, SVGStyleElement, ProcessingInstruction) call clearOwnerNode()
before the Node base-class destructor, so the CheckedPtr count reaches zero in time. Similarly,
learOwnerRule() is called from the CSSImportRule and StyleRuleImport destructors before
CSSImportRule is freed so CheckedPtr&apos;s assertion should not fire.

No new tests for the data race issue itself since there is no reliable way of testing it.

Test: fast/dom/StyleSheet/gc-import-rule-stylesheet.html

* LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet-expected.txt: Added.
* LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet.html: Added.
* Source/WebCore/bindings/js/JSStyleSheetCustom.h:
(WebCore::root):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::~CSSImportRule):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::clearOwnerNode):
(WebCore::CSSStyleSheet::opaqueRootForGCThread):
(WebCore::CSSStyleSheet::clearOwnerRule):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/StyleSheet.h:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::XSLStyleSheet):
(WebCore::XSLStyleSheet::clearOwnerNode):
(WebCore::XSLStyleSheet::opaqueRootForGCThread):
* Source/WebKitLegacy/mac/DOM/DOMCSSImportRule.mm:
(-[DOMCSSImportRule media]):
(-[DOMCSSImportRule styleSheet]):

Originally-landed-as: 305413.691@safari-7624-branch (f41030176464). <a href="https://rdar.apple.com/180436921">rdar://180436921</a>
Canonical link: <a href="https://commits.webkit.org/316485@main">https://commits.webkit.org/316485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fa04d042f790881f1fb6b405dd2d6ea6bbac033

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37525 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154634 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114575 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36160 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34146 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/184822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38660 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/184822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154216 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/184822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46689 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111439 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37799 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118440 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45206 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9088 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->