### PR TITLE
[WebCore] use-after-free in Style::TreeResolver — XMLDocumentParser::startElementNs missing parentNode re-check after custom-element upgrade

### DIFF
--- a/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash-expected.txt
+++ b/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml
+++ b/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<script><![CDATA[
+if (window.testRunner)
+    testRunner.dumpAsText();
+customElements.define('x-a', class extends HTMLElement {
+    constructor() {
+        super();
+        document.documentElement.appendChild(this);
+    }
+});
+]]></script>
+</head>
+<body>
+<p>This test passes if it does not crash.</p>
+<div id="container"><x-a></x-a></div>
+</body>
+</html>

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -910,6 +910,23 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     if (willConstructCustomElement) [[unlikely]] {
         customElementReactionStack.reset();
         markupInsertionCountIncrementer.reset();
+        // Draining the reaction stack runs the custom element constructor, which may
+        // have re-parented newElement, adopted it into another document, or detached
+        // the current parser node. parserAppendChild requires its argument to have no
+        // parent and to share our document.
+        // FIXME: We are misusing the upgrade-an-element machinery here to emulate
+        // synchronous custom element construction. Per HTML's "create an element for
+        // a token" with willExecuteScript=true we should run the constructor inside
+        // Document::createElement (via constructElementWithFallback), which post-
+        // validates parent/children/attributes/document and falls back to
+        // HTMLUnknownElement on violation, like HTMLDocumentParser does in
+        // runScriptsForPausedTreeBuilder. Switching to that would also fix the
+        // spec-incorrect attribute-ordering above (we currently set attributes before
+        // the constructor runs).
+        if (!m_currentNode || newElement->parentNode() || &newElement->document() != &m_currentNode->document()) {
+            stopParsing();
+            return;
+        }
     }
 
     newElement->beginParsingChildren();


### PR DESCRIPTION
#### ba3be26a064abdfdcc87698f202ff0be33452663
<pre>
[WebCore] use-after-free in Style::TreeResolver — XMLDocumentParser::startElementNs missing parentNode re-check after custom-element upgrade
<a href="https://rdar.apple.com/177479772">rdar://177479772</a>

Reviewed by Ryosuke Niwa.

Draining the custom element reaction stack in startElementNs runs the
constructor synchronously, which can re-parent newElement, adopt it into
another document, or detach the current parser node. parserAppendChild
requires its argument to have no parent and to share our document, so
falling through into it leaves the tree linked into two child lists.

Re-check those invariants after the reaction stack drains and stop
parsing if any of them no longer holds. A spec-aligned follow-up should
route XML element creation through constructElementWithFallback like
HTMLDocumentParser does, which post-validates and falls back to
HTMLUnknownElement; a FIXME records that.

Test: fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml
* LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash-expected.txt: Added.
* LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml: Added.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):

Originally-landed-as: 305413.947@safari-7624-branch (19beaaec03d0). <a href="https://rdar.apple.com/180436996">rdar://180436996</a>
Canonical link: <a href="https://commits.webkit.org/316181@main">https://commits.webkit.org/316181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2b1f3cd84dc88c32c6bcaaee9a48cf45e4d6a79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133400 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35246 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33561 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29136 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145720 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183041 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37752 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141855 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44658 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38308 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45347 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110052 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117281 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43858 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->