### PR TITLE
[WebCore] Use-after-free in InternalAudioEncoderCocoa on ASBD change because converter->finish() promise is discarded

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/audio-encoder-pcm-format-change-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/audio-encoder-pcm-format-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS AudioEncoder handles switching PCM sample format from f32-planar to s16 mid-stream
+

--- a/LayoutTests/http/wpt/webcodecs/audio-encoder-pcm-format-change.html
+++ b/LayoutTests/http/wpt/webcodecs/audio-encoder-pcm-format-change.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    if (!('AudioEncoder' in window))
+        return;
+
+    const encoder = new AudioEncoder({
+        output: () => { },
+        error: e => { assert_unreached('Unexpected error: ' + e); }
+    });
+    t.add_cleanup(() => { if (encoder.state !== 'closed') encoder.close(); });
+
+    encoder.configure({
+        codec: 'mp4a.40.2',
+        sampleRate: 48000,
+        numberOfChannels: 1,
+    });
+
+    const sampleRate = 48000;
+    const numberOfChannels = 1;
+    const numberOfFrames = 1024;
+
+    const f32Data = new Float32Array(numberOfFrames);
+    for (let i = 0; i < numberOfFrames; i++)
+        f32Data[i] = Math.sin(2 * Math.PI * 440 * i / sampleRate);
+    const f32Frame = new AudioData({ timestamp: 0, data: f32Data, numberOfChannels, numberOfFrames, sampleRate, format: 'f32-planar' });
+    t.add_cleanup(() => { if (!f32Frame.closed) f32Frame.close(); });
+
+    const s16Data = new Int16Array(numberOfFrames);
+    for (let i = 0; i < numberOfFrames; i++)
+        s16Data[i] = Math.round(Math.sin(2 * Math.PI * 440 * i / sampleRate) * 32767);
+    const s16Frame = new AudioData({ timestamp: 21333, data: s16Data, numberOfChannels, numberOfFrames, sampleRate, format: 's16' });
+    t.add_cleanup(() => { if (!s16Frame.closed) s16Frame.close(); });
+
+    encoder.encode(f32Frame);
+    f32Frame.close();
+    encoder.encode(s16Frame);
+    s16Frame.close();
+
+    await encoder.flush();
+    encoder.close();
+}, 'AudioEncoder handles switching PCM sample format from f32-planar to s16 mid-stream');
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -314,7 +314,7 @@ Ref<AudioEncoder::EncodePromise> InternalAudioEncoderCocoa::encode(AudioEncoder:
 
     if (*asbd != m_inputDescription) {
         if (RefPtr converter = std::exchange(m_converter, { }))
-            converter->finish();
+            converter->finish()->whenSettled(queueSingleton(), [protectedThis = Ref { *this }] { });
         m_inputDescription = *asbd;
 
         AudioSampleBufferConverter::Options options = {


### PR DESCRIPTION
#### b48b4d4d4034d4a207ba2e0d61570ecc051f30a4
<pre>
[WebCore] Use-after-free in InternalAudioEncoderCocoa on ASBD change because converter-&gt;finish() promise is discarded
<a href="https://bugs.webkit.org/show_bug.cgi?id=314107">https://bugs.webkit.org/show_bug.cgi?id=314107</a>
<a href="https://rdar.apple.com/175402146">rdar://175402146</a>

Reviewed by Youenn Fablet and David Kilzer.

When WebCodecs AudioEncoder receives consecutive AudioData frames whose PCM
format differs (e.g. f32-planar then s16) but whose sampleRate and
numberOfChannels are unchanged, encode() replaces the AudioSampleBufferConverter
and calls finish() on the old one. The returned Ref&lt;GenericPromise&gt; was
dropped, so nothing kept the encoder alive while the old converter&apos;s async
drain ran on its own serial queue. If the client then called close(), which
keeps the encoder alive for the new converter only, the old converter could
fire its CMBufferQueueTrigger into a freed InternalAudioEncoderCocoa,
producing a heap use-after-free in compressedAudioOutputBufferCallback.

Apply the same whenSettled keep-alive that close() already uses, so the
encoder stays alive on queueSingleton() until the old converter has finished
draining.

Test: http/wpt/webcodecs/audio-encoder-pcm-format-change.html

* LayoutTests/http/wpt/webcodecs/audio-encoder-pcm-format-change-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/audio-encoder-pcm-format-change.html: Added.
* Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp:
(WebCore::InternalAudioEncoderCocoa::encode):

Originally-landed-as: 305413.864@safari-7624-branch (8230e88bd918). <a href="https://rdar.apple.com/180436545">rdar://180436545</a>
Canonical link: <a href="https://commits.webkit.org/316188@main">https://commits.webkit.org/316188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f17a4dbe4e9ed2d49ca8f38cfffcc84ce823d38e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133402 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33563 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183043 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141861 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141672 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38314 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45349 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110054 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36927 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117282 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43860 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->