### PR TITLE
Compromised web content processes can use percent-encoded path separators in PDF suggested filenames to write outside temporary directory

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -35,6 +35,7 @@
 #import "FrameInfoData.h"
 #import "ImageAnalysisUtilities.h"
 #import "InsertTextOptions.h"
+#import "Logging.h"
 #import "MenuUtilities.h"
 #import "MessageSenderInlines.h"
 #import "NativeWebKeyboardEvent.h"
@@ -619,9 +620,7 @@ static RetainPtr<NSString> pathToPDFOnDisk(const String& suggestedFilename)
         return nil;
     }
 
-    // The NSFileManager expects a path string, while NSWorkspace uses file URLs, and will decode any percent encoding
-    // in its passed URLs before loading from disk. Create the files using decoded file paths so they match up.
-    RetainPtr path = [[pdfDirectoryPath stringByAppendingPathComponent:suggestedFilename.createNSString().get()] stringByRemovingPercentEncoding];
+    RetainPtr path = [pdfDirectoryPath stringByAppendingPathComponent:suggestedFilename.createNSString().get()];
 
     RetainPtr fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:path.get()]) {
@@ -635,6 +634,10 @@ static RetainPtr<NSString> pathToPDFOnDisk(const String& suggestedFilename)
         path = [fileManager stringWithFileSystemRepresentation:pathTemplateRepresentation.data() length:pathTemplateRepresentation.length()];
     }
 
+    // Reject any path that resolves outside the temporary PDF directory.
+    if (![[path stringByStandardizingPath] hasPrefix:[pdfDirectoryPath stringByStandardizingPath]])
+        return nil;
+
     return path;
 }
 
@@ -645,11 +648,23 @@ void WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication(const St
         return;
     }
 
-    auto sanitizedFilename = ResourceResponseBase::sanitizeSuggestedFilename(suggestedFilename);
+    // Encoded path separator should get stripped rather than decoded into the assembled path after sanitisation.
+    // Otherwise, any encoded slash produces a path traversal on post-join decodes. (rdar://174079512)
+    RetainPtr nsSuggestedFilename = suggestedFilename.createNSString();
+    if (RetainPtr decoded = [nsSuggestedFilename stringByRemovingPercentEncoding])
+        nsSuggestedFilename = WTF::move(decoded);
+
+    auto sanitizedFilename = ResourceResponseBase::sanitizeSuggestedFilename(nsSuggestedFilename.get());
     if (!sanitizedFilename.endsWithIgnoringASCIICase(".pdf"_s)) {
         WTFLogAlways("Cannot save file without .pdf extension to the temporary directory.");
         return;
     }
+
+    if (sanitizedFilename != FileSystem::lastComponentOfPathIgnoringTrailingSlash(sanitizedFilename)) {
+        RELEASE_LOG(PDF, "Cannot save PDF whose sanitized filename is not a single path component.");
+        return;
+    }
+
     RetainPtr nsPath = pathToPDFOnDisk(sanitizedFilename);
 
     if (!nsPath)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UIDelegate.mm
@@ -1478,6 +1478,115 @@ TEST(WebKit, SaveDataToFile)
     TestWebKitAPI::Util::run(&done);
 }
 
+@interface OpenPDFWithPreviewDelegate : NSObject <WKUIDelegatePrivate>
+@property (nonatomic, readonly) RetainPtr<NSURL> capturedFileURL;
+@property (nonatomic, readonly) BOOL receivedCallback;
+@end
+
+@implementation OpenPDFWithPreviewDelegate
+
+- (void)_webView:(WKWebView *)webView shouldAllowPDFAtURL:(NSURL *)fileURL toOpenFromFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL))completionHandler
+{
+    _capturedFileURL = fileURL;
+    _receivedCallback = YES;
+    completionHandler(NO);
+}
+
+@end
+
+#if ENABLE(IPC_TESTING_API)
+
+static void runOpenPDFWithPreviewTraversalTest(NSString *injectedFilename, NSString *traversalTargetPath)
+{
+    [[NSFileManager defaultManager] removeItemAtPath:traversalTargetPath error:nil];
+
+    RetainPtr pdfURL = [NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"];
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"PDFPluginHUDEnabled"] || [feature.key isEqualToString:@"IPCTestingAPIEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setWindowOcclusionDetectionEnabled:NO];
+
+    RetainPtr delegate = adoptNS([OpenPDFWithPreviewDelegate new]);
+    [webView setUIDelegate:delegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:pdfURL.get()]];
+    [webView _test_waitForDidFinishNavigation];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([webView] {
+        return !![webView _pdfHUDs].count;
+    }));
+
+    RetainPtr listenerScript = [NSString stringWithFormat:@R"JS(
+        IPC.addIncomingMessageListener('UI', (message) => {
+            const replyMsgInfo = IPC.messages.WebPage_OpenPDFWithPreviewReply;
+            if (!replyMsgInfo)
+                return;
+            const requestMsgInfo = IPC.messages.WebPage_OpenPDFWithPreview;
+            if (!requestMsgInfo || message.name !== requestMsgInfo.name)
+                return;
+            if (typeof message.listenerID === 'undefined')
+                return;
+
+            IPC.sendMessage('UI', message.listenerID, replyMsgInfo.name, [
+                {type: 'String', value: '%@'},
+                {type: 'bool', value: 1},
+                {type: 'FrameInfoData', value: IPC},
+                {type: 'uint64_t', value: 4},
+                new Uint8Array([0x25, 0x50, 0x44, 0x46])
+            ]);
+        });
+        'listener installed';
+    )JS", injectedFilename];
+
+    bool listenerInstalled = false;
+    [webView evaluateJavaScript:listenerScript.get() completionHandler:[&listenerInstalled](id, NSError *error) {
+        EXPECT_NULL(error);
+        listenerInstalled = true;
+    }];
+    TestWebKitAPI::Util::run(&listenerInstalled);
+
+    [[webView _pdfHUDs].anyObject performSelector:NSSelectorFromString(@"_performActionForControl:") withObject:@"preview"];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([delegate] {
+        return [delegate receivedCallback];
+    }));
+
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:traversalTargetPath]);
+
+    RetainPtr writtenPath = [[[delegate capturedFileURL] path] stringByStandardizingPath];
+    RetainPtr temporaryDirectory = [NSTemporaryDirectory() stringByStandardizingPath];
+
+    EXPECT_TRUE([writtenPath hasPrefix:temporaryDirectory.get()]);
+    EXPECT_TRUE([writtenPath containsString:@"/WebKitPDFs-"]);
+    EXPECT_FALSE([writtenPath containsString:@"/../"]);
+
+    [[NSFileManager defaultManager] removeItemAtURL:[delegate capturedFileURL].get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:traversalTargetPath error:nil];
+}
+
+TEST(WebKit, OpenPDFWithPreviewIPCTraversalEncodedFilename)
+{
+    int pid = [[NSProcessInfo processInfo] processIdentifier];
+    RetainPtr traversalTarget = [NSString stringWithFormat:@"/tmp/DEEP-TRAVERSAL-%d-encoded.pdf", pid];
+    RetainPtr injectedFilename = [NSString stringWithFormat:@"..%%2F..%%2F..%%2F..%%2F..%%2F..%%2F..%%2Ftmp%%2FDEEP-TRAVERSAL-%d-encoded.pdf", pid];
+    runOpenPDFWithPreviewTraversalTest(injectedFilename.get(), traversalTarget.get());
+}
+
+TEST(WebKit, OpenPDFWithPreviewIPCTraversalUnencodedFilename)
+{
+    int pid = [[NSProcessInfo processInfo] processIdentifier];
+    RetainPtr traversalTarget = [NSString stringWithFormat:@"/tmp/DEEP-TRAVERSAL-%d-unencoded.pdf", pid];
+    RetainPtr injectedFilename = [NSString stringWithFormat:@"../../../../../../../tmp/DEEP-TRAVERSAL-%d-unencoded.pdf", pid];
+    runOpenPDFWithPreviewTraversalTest(injectedFilename.get(), traversalTarget.get());
+}
+
+#endif // ENABLE(IPC_TESTING_API)
+
 #endif // ENABLE(PDF_HUD)
 
 #define RELIABLE_DID_NOT_HANDLE_WHEEL_EVENT 0


### PR DESCRIPTION
#### b12f122d84409745fa49aa45e2776aa59fdda5aa
<pre>
Compromised web content processes can use percent-encoded path separators in PDF suggested filenames to write outside temporary directory
<a href="https://rdar.apple.com/174079512">rdar://174079512</a>

Reviewed by Wenson Hsieh.

The pdfOpenWithPreview IPC response sanitizes the WCP supplied filename
while it is still percent encoded. Then, pathToPDFOnDisk percent decodes
the assembled path. As such, a %2F (`/`) sequence can pass through
sanitization but still decodes to `/` after assembly.

This means that a compromised web content process could write to a PDF
file outside of the temporary WebKit PDF directory with a properly
crafted IPC message.

In this patch, we address this asymmetry by percent decoding the
filename before sanitization. We also remove the percent decoding that
happens post joining. Instead, we enforce an invariant that rejects any
sanitized filename that is not its own last path component.

Tests: TestWebKitAPI.WebKit.OpenPDFWithPreviewIPCTraversalEncodedFilename
       TestWebKitAPI.WebKit.OpenPDFWithPreviewIPCTraversalUnencodedFilename

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):
(WebKit::WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[OpenPDFWithPreviewDelegate _webView:shouldAllowPDFAtURL:toOpenFromFrame:completionHandler:]):
((WebKit, OpenPDFWithPreviewIPCTraversalEncodedFilename)):
((WebKit, OpenPDFWithPreviewIPCTraversalUnencodedFilename)):

Originally-landed-as: 305413.948@safari-7624-branch (06ccfa7d7a2d). <a href="https://rdar.apple.com/180438093">rdar://180438093</a>
Canonical link: <a href="https://commits.webkit.org/316182@main">https://commits.webkit.org/316182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/caaf39e2d88b9aa0df8c777db37a2031ae52ad16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171080 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128796 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35239 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33564 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183045 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141860 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44662 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38309 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110056 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36929 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117283 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43862 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->