### PR TITLE
Removing positioned element from DOM with a focused input can jump to the bottom of the page

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Removing a programmatically-focused element does not scroll the document
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Removing a focused element must not scroll the document</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div style="height: 200vh"></div>
+<div id="belowFold" style="height: 50px"></div>
+<div id="portal"></div>
+
+<script>
+const portal = document.getElementById("portal");
+
+function makeDialog() {
+  const dialog = document.createElement("div");
+  dialog.style.cssText = "position: absolute; top: 0; margin: 20px; padding: 20px;";
+  const input = document.createElement("input");
+  dialog.appendChild(input);
+  return dialog;
+}
+
+function twoFrames() {
+  return new Promise(resolve =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+promise_test(async t => {
+  window.scrollTo(0, 0);
+  assert_equals(window.scrollY, 0, "precondition: document starts at the top");
+
+  // Insert an absolutely-positioned element containing a programmatically
+  // focused input. Focusing schedules a deferred selection reveal that has not
+  // run yet (no user interaction, no rendering update has happened).
+  const dialog = makeDialog();
+  portal.append(dialog);
+  t.add_cleanup(() => dialog.remove());
+  dialog.querySelector("input").focus();
+
+  // Remove the element (as a key handler might) before the reveal runs. The
+  // caret is relocated by the removal, but that is not a user-initiated caret
+  // movement and must not scroll the document.
+  dialog.remove();
+
+  // Allow the rendering update / any deferred reveal to run.
+  await twoFrames();
+
+  assert_equals(window.scrollY, 0,
+      "removing the focused element must not scroll to the bottom");
+}, "Removing a programmatically-focused element does not scroll the document");
+</script>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -757,6 +757,8 @@ void FrameSelection::respondToNodeModification(Node& node, bool anchorRemoved, b
 
             // Trigger a selection update so the selection will be set again.
             m_selectionRevealIntent = AXTextStateChangeIntent();
+            // Relocating the selection due to node removal is not user-initiated, so don't scroll to follow it.
+            m_selectionRevealMode = SelectionRevealMode::DoNotReveal;
             m_pendingSelectionUpdate = true;
             protect(renderView->frameView())->scheduleSelectionUpdate();
         }


### PR DESCRIPTION
#### 2004b36ac486a2069867a423d7d66ec0bec6ac2f
<pre>
Removing positioned element from DOM with a focused input can jump to the bottom of the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=257217">https://bugs.webkit.org/show_bug.cgi?id=257217</a>
<a href="https://rdar.apple.com/110018370">rdar://110018370</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Programmatically focusing an input schedules a deferred selection reveal that
runs on the next rendering update. If the element containing the focused input
is removed before that reveal runs (and before any user interaction consumes
it), FrameSelection::respondToNodeModification relocates the orphaned caret to
a surviving position -- often the end-of-document container -- and schedules a
selection update to rebuild the render-tree selection. It left
m_selectionRevealMode at the stale Reveal value set by the earlier focus(), so
updateAndRevealSelection() then scrolled that relocated caret into view,
jerking the page to the bottom.

Relocating the selection because a node was removed from the DOM is not a
user-initiated caret movement and must not scroll. Force DoNotReveal when
scheduling the node-removal selection update. updateAndRevealSelection() still
calls updateAppearance() unconditionally, so the render-tree selection is
repositioned correctly; only the spurious reveal scroll is suppressed.

Test: imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/remove-focused-element-does-not-scroll.html: Added.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::respondToNodeModification):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2004b36ac486a2069867a423d7d66ec0bec6ac2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128808 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c6a5ed0-3fad-411a-acf0-5e7f30614838) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172958 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46290 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133413 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94137 "1 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f75fdc6-7e2f-459b-b16a-f65e31147af9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113881 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a87908e-92e2-4043-8c7f-64e80798e595) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35247 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33568 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29152 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183057 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38007 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141873 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153300 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141682 "Found 1 new API test failure: WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/editable/editable (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45363 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30218 "344 new passes 6 flakes 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110068 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36935 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117285 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43874 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8314 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43278 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->