### PR TITLE
Use-after-free in SVGGeometryElement::getPointAtLength — raw renderer pointer held across nested updateLayout

### DIFF
--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -49,45 +49,54 @@ SVGGeometryElement::SVGGeometryElement(const QualifiedName& tagName, Document& d
     }
 }
 
-float SVGGeometryElement::getTotalLength() const
+float SVGGeometryElement::calculateTotalLength() const
 {
-    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
-
-    auto* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return 0;
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(*renderer))
         return renderSVGShape->getTotalLength();
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(*renderer))
         return renderSVGShape->getTotalLength();
 
     ASSERT_NOT_REACHED();
     return 0;
 }
 
-ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
+float SVGGeometryElement::getTotalLength() const
 {
     protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    return calculateTotalLength();
+}
 
-    auto* renderer = this->renderer();
+ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::calculatePointAtLength(float distance) const
+{
+    CheckedPtr renderer = this->renderer();
     // Spec: If current element is a non-rendered element, throw an InvalidStateError.
     if (!renderer)
         return Exception { ExceptionCode::InvalidStateError };
 
-    // Spec: Clamp distance to [0, length].
-    distance = clampTo<float>(distance, 0, getTotalLength());
-
     // Spec: Return a newly created, detached SVGPoint object.
-    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(*renderer))
         return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(*renderer))
         return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 
     ASSERT_NOT_REACHED();
     return Exception { ExceptionCode::InvalidStateError };
+}
+
+ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
+{
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+
+    // Spec: Clamp distance to [0, length].
+    distance = clampTo<float>(distance, 0, calculateTotalLength());
+
+    return calculatePointAtLength(distance);
 }
 
 bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -56,6 +56,9 @@ protected:
 private:
     bool isSVGGeometryElement() const override { return true; }
 
+    float calculateTotalLength() const;
+    ExceptionOr<Ref<SVGPoint>> calculatePointAtLength(float distance) const;
+
     const Ref<SVGAnimatedNumber> m_pathLength { SVGAnimatedNumber::create(this) };
 };
 


### PR DESCRIPTION
#### a3291b5940238a60a7a739bea1f1874de5973dbd
<pre>
Use-after-free in SVGGeometryElement::getPointAtLength — raw renderer pointer held across nested updateLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=314326">https://bugs.webkit.org/show_bug.cgi?id=314326</a>
<a href="https://rdar.apple.com/175670940">rdar://175670940</a>

Reviewed by Simon Fraser.

Between the call to `updateLayoutIgnorePendingStylesheets()` and the call to
`SVGGeometryElement::getTotalLength()`, `SVGGeometryElement::getPointAtLength()`
caches its renderer() in a raw pointer. The problem is `getTotalLength()` also
calls `updateLayoutIgnorePendingStylesheets()` which may delete the renderer.
This will make `getPointAtLength()` use-after-free the cached raw pointer renderer.

Rearrange the code such that `updateLayoutIgnorePendingStylesheets()` is called
only once per `getPointAtLength()` and read `this-&gt;renderer()` exactly before it
is referenced.

* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::calculateTotalLength const):
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::calculatePointAtLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
* Source/WebCore/svg/SVGGeometryElement.h:

Originally-landed-as: 305413.857@safari-7624-branch (d1e59347508c). <a href="https://rdar.apple.com/180437982">rdar://180437982</a>
Canonical link: <a href="https://commits.webkit.org/316151@main">https://commits.webkit.org/316151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73303cb94cf223ed75481bbe51293d053c8db8da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180582 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44764 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133459 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174161 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113922 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29262 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183167 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141938 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44784 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38258 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45475 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110178 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36990 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43984 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->