### PR TITLE
[libpas] bmalloc_try_allocate_zeroed_inline calls PAS_MAR_TRACK_ALLOCATION instead of PAS_MAR_TRACK_ALLOCATION_AND_ZERO on MAR branch, returning unzeroed memory

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -293,7 +293,7 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_zeroed_inline(size_t size, p
 
     result = bmalloc_try_allocate_impl(size, 1, allocation_mode);
     if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
-        return PAS_MAR_TRACK_ALLOCATION((void*)result.begin, size);
+        return PAS_MAR_TRACK_ALLOCATION_AND_ZERO(result, size);
     return (void*)pas_allocation_result_zero(result, size).begin;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if !USE(SYSTEM_MALLOC) && BUSE(LIBPAS) && OS(DARWIN)
+
+#include <bmalloc/bmalloc.h>
+#include <bmalloc/pas_mar_registry.h>
+#include <cstring>
+#include <vector>
+
+namespace TestWebKitAPI {
+
+static unsigned pageIndexOf(void* p)
+{
+    return static_cast<unsigned>((reinterpret_cast<uintptr_t>(p) >> PAS_MAR_PAGE_SHIFT) % PAS_MAR_PROBABILITY);
+}
+
+static void testZeroedAllocationAfterPriming(bool marEnabled)
+{
+    pas_mar_initialize();
+
+    constexpr size_t size = 128;
+    constexpr int warmup = 8192;
+    constexpr int retries = 8192;
+
+    // Warm up: prime many equally sized slots with 0xAB, then free them all so
+    // their bytes stay at 0xAB in the backing memory. Subsequent allocations
+    // at the same size will reuse these slots from bmalloc's free list.
+    std::vector<void*> primed;
+    primed.reserve(warmup);
+    for (int i = 0; i < warmup; ++i) {
+        void* p = bmalloc::api::tryZeroedMalloc(size, bmalloc::CompactAllocationMode::NonCompact);
+        ASSERT_TRUE(p);
+        WTF::memsetSpan(std::span { reinterpret_cast<uint8_t*>(p), size }, 0xAB);
+        primed.push_back(p);
+    }
+    for (void* p : primed)
+        bmalloc::api::free(p);
+
+    // Discover the page bmalloc will actually serve subsequent allocations
+    // from: ask it for one and see where it lands, then free that slot so
+    // it goes back on the free list.
+    void* probe = bmalloc::api::tryZeroedMalloc(size, bmalloc::CompactAllocationMode::NonCompact);
+    ASSERT_TRUE(probe);
+    const unsigned targetPage = pageIndexOf(probe);
+    bmalloc::api::free(probe);
+
+    pas_mar_enabled = marEnabled;
+    pas_mar_qualifying_page_index = targetPage;
+
+    // Reallocate and inspect. For every allocation that lands in the MAR qualifying page,
+    // the MAR branch of bmalloc_try_allocate_zeroed_inline runs (when enabled).
+    // If that branch fails to zero, we'll see the 0xAB pattern from the previous occupant.
+    int runsInTargetPage = 0;
+    for (int i = 0; i < retries; ++i) {
+        void* buf = bmalloc::api::tryZeroedMalloc(size, bmalloc::CompactAllocationMode::NonCompact);
+        std::span bufSpan { reinterpret_cast<uint8_t*>(buf), size };
+        ASSERT_TRUE(buf);
+
+        if (pageIndexOf(buf) == targetPage) {
+            for (size_t j = 0; j < size; ++j) {
+                uint8_t byte { };
+                WTF::memcpySpan(std::span { &byte, 1 }, bufSpan.subspan(j, 1));
+                EXPECT_EQ(byte, 0u) << " at offset " << j << " in iteration " << i;
+            }
+            ++runsInTargetPage;
+        }
+
+        bmalloc::api::free(buf);
+    }
+
+    // Fail loudly if we never exercised the target page. The test would be vacuous otherwise.
+    EXPECT_GT(runsInTargetPage, 0);
+
+    pas_mar_enabled = false;
+}
+
+TEST(bmalloc, MARZeroedAllocationWithMARDisabled)
+{
+    testZeroedAllocationAfterPriming(false);
+}
+
+TEST(bmalloc, MARZeroedAllocationWithMAREnabled)
+{
+    testZeroedAllocationAfterPriming(true);
+}
+
+} // namespace TestWebKitAPI
+
+#endif


### PR DESCRIPTION
#### dce31d0f206f8608085256c0ef15e337ce4a1710
<pre>
[libpas] bmalloc_try_allocate_zeroed_inline calls PAS_MAR_TRACK_ALLOCATION instead of PAS_MAR_TRACK_ALLOCATION_AND_ZERO on MAR branch, returning unzeroed memory
<a href="https://rdar.apple.com/175683200">rdar://175683200</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314679">https://bugs.webkit.org/show_bug.cgi?id=314679</a>

Reviewed by Yusuke Suzuki.

This patch changes `bmalloc_try_allocate_zeroed_inline` so that it
zeroes the returned memory in the case where the MAR predicate matches.

Tests: Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp

* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
(bmalloc_try_allocate_zeroed_inline): Zero the returned memory.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp: Added.
(TestWebKitAPI::pageIndexOf):
(TestWebKitAPI::testZeroedAllocationAfterPriming):
(TestWebKitAPI::TEST(bmalloc, MARZeroedAllocationWithMARDisabled)):
(TestWebKitAPI::TEST(bmalloc, MARZeroedAllocationWithMAREnabled)):

Originally-landed-as: 305413.946@safari-7624-branch (d945beacb08e). <a href="https://rdar.apple.com/180428128">rdar://180428128</a>
Canonical link: <a href="https://commits.webkit.org/316277@main">https://commits.webkit.org/316277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc76371cdc97a8fcb83f776a39f683e1bf4de28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133601 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35577 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33806 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29695 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2613 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183614 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32902 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142222 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45227 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38391 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45907 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110541 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37289 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204321 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44425 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8521 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54596 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->