### PR TITLE
ANGLE: EnsureLoopForwardProgress misses nested loop inititializers, expressions

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.cpp
@@ -158,6 +158,10 @@ const TVariable *computeFiniteLoopVariable(TIntermLoop *loop)
                 return nullptr;
         }
     }
+    else
+    {
+        return nullptr;
+    }
     return variable;
 }
 

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLOutputTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLOutputTest.cpp
@@ -600,6 +600,7 @@ TEST_P(GLSLOutputMSLTest_EnsureLoopForwardProgress, InfiniteFors)
 precision highp int;
 uniform int a;
 uniform uint b;
+void noop() { }
 void main() {
 
 )";
@@ -617,6 +618,8 @@ void main() {
         "for (int i = 0; float(i) < 10e10; ++i) { }",
         "for (int i = 0; i < 10; i++) { for (int j = 0; j < 1000; ++i) { }}",
         "for (int i = 0; i != 1; i+=2) { }",
+        "for (int i = 0; i < 1; noop()) { }",
+        "uint i; for (i = 0u; i < 10u; i++) { for (i = 0u; i < 0u; i++) { } }",
         "for (int i = 0; i < 10; i++) { int j; for (j = 0, i = 0; j < 10; j++) { } }",
         "for (int i = 0; i < 10; i++) { for (int j = 0; i = 0, j < 10; j++) { } }",
         "for (int i = 0; i < 10; i++) { for (int j = 0; j < 10; i = 0, j++) { } }",
@@ -625,6 +628,7 @@ void main() {
 
     for (const char *test : kTests)
     {
+        SCOPED_TRACE(testing::Message() << "test: " << test);
         std::string shader = (std::stringstream() << kShaderPrefix << test << kShaderSuffix).str();
         compileShader(GL_FRAGMENT_SHADER, shader.c_str());
         verifyIsInTranslation(GL_FRAGMENT_SHADER, "loopForwardProgress");


### PR DESCRIPTION
#### 6d057b78639f6b8b413c1593dfc5c686e64fad16
<pre>
ANGLE: EnsureLoopForwardProgress misses nested loop inititializers, expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=312970">https://bugs.webkit.org/show_bug.cgi?id=312970</a>
<a href="https://rdar.apple.com/174740081">rdar://174740081</a>

Reviewed by Dan Glastonbury.

Nested loops would not be categorized as potentially infinite if the
write to the condition variable happened inside the loop initializer,
condition or expression.

Also, loops would not be categorized as potentially infinite if the
expression was a simple function call.

Fix first by traversing the loop initializer, condition and expression.

Fix the second by adding the missing case for all unhandled patterns
in the expression to mark the loop as potentially infinite.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
* Source/ThirdParty/ANGLE/Configurations/utils.xcconfig:
* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/EnsureLoopForwardProgress.cpp:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/GLSLOutputTest.cpp:

Originally-landed-as: 305413.720@safari-7624-branch (58b3c28331a0). <a href="https://rdar.apple.com/180429427">rdar://180429427</a>
Canonical link: <a href="https://commits.webkit.org/316248@main">https://commits.webkit.org/316248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1456bf002475071cd861f416075f46cf1e21d50f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180746 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129013 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174320 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153959 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114030 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33667 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29421 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183330 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142057 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44943 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141886 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110340 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37130 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8410 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43547 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->