### PR TITLE
[JSC] Do not cache property absence on dictionaries

### DIFF
--- a/JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js
+++ b/JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js
@@ -1,0 +1,87 @@
+function createObject1() {
+    const tmp = {
+        toJSON: 1,
+        a: 1,
+    };
+
+    Object.create(tmp);
+
+    return tmp;
+}
+
+function createObject2() {
+    const tmp = {
+        b: 1,
+        toJSON: {}
+    };
+
+    Object.create(tmp);
+
+    return tmp;
+}
+
+function opt(container1, object2, array, thenable, flags) {
+    const promise = new Promise(() => {});
+
+    container1.x;
+    thenable.x;
+
+    const object1 = Object.getPrototypeOf(container1);
+
+    let tmp = object1;
+    object1.a;
+
+    if (flags & 1) {
+        tmp = object2;
+        tmp.b;
+
+        0[0];
+    }
+
+    +tmp.toJSON;
+    +tmp.toJSON;
+
+    array[0];
+    Promise.resolve(+tmp.toJSON === 1 ? thenable : promise);
+
+    array[0] = 2.3023e-320;
+}
+
+function main() {
+    noDFG(main);
+
+    const object1 = createObject1();
+    const object2 = createObject2();
+
+    createObject1().z = 1;
+
+    const container1 = Object.create(object1);
+
+    const thenable = {
+        x: 1
+    };
+
+    for (let i = 0; i < 100; i++) {
+        thenable['a' + i] = 1;
+    }
+
+    const array = {
+        0: 1.1
+    };
+
+    JSON.stringify(container1);
+
+    for (let i = 0; i < 200; i++) {
+        opt(container1, object2, array, thenable, i);
+    }
+
+    thenable.__defineGetter__('then', () => {
+        array[0] = {};
+    });
+
+    opt(container1, object2, array, thenable, 0);
+
+    array[0].x;
+}
+
+main();

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1540,6 +1540,10 @@ ObjectPropertyConditionSet Graph::tryEnsureAbsence(JSGlobalObject* globalObject,
         return ObjectPropertyConditionSet::invalid();
 
     auto isAbsenceCacheable = [&](Structure* structure) {
+        // Absences cannot be cached on any dictionaries, including CachedDictionaryKind, because
+        // new properties can be added without structure transitions.
+        if (structure->isDictionary())
+            return false;
         if (structure->typeInfo().overridesGetOwnPropertySlot())
             return false;
         if (!structure->propertyAccessesAreCacheable())

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -338,6 +338,8 @@ public:
 
     bool propertyAccessesAreCacheableForAbsence()
     {
+        // FIXME: dictionaries cannot be cached for absence, so check for dictionaries here instead
+        // of at all call sites.
         return !typeInfo().getOwnPropertySlotIsImpureForPropertyAbsence();
     }
 


### PR DESCRIPTION
#### d75a9fda98e0e3033e8e7060fd341f0bf1c01d21
<pre>
[JSC] Do not cache property absence on dictionaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=313265">https://bugs.webkit.org/show_bug.cgi?id=313265</a>
<a href="https://rdar.apple.com/175520268">rdar://175520268</a>

Reviewed by Yusuke Suzuki.

Structures with CachedDictionaryKind can add new properties without
transitioning structures. Therefore, property absences are not cacheable. This
PR fixes a bug in DFG which incorrectly caches property absences on structures
with CachedDictionaryKind.

Test: JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js

* JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js: Added.
(createObject1):
(createObject2):
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::tryEnsureAbsence):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::propertyAccessesAreCacheableForAbsence):

Originally-landed-as: 305413.731@safari-7624-branch (343b8326d944). <a href="https://rdar.apple.com/180437776">rdar://180437776</a>
Canonical link: <a href="https://commits.webkit.org/316189@main">https://commits.webkit.org/316189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31d6ecd31c5283d9be9ff948c2f1945e027b47b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128832 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36649 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153869 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33573 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29176 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2263 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183081 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32373 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35876 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37763 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141888 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44698 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141697 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38312 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45387 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110092 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36952 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117287 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203795 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43898 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54527 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->