### PR TITLE
[WebKit Process Model] WebPageProxy::createNewPage missing hasGrantedSandboxExtensionForFile check on NavigationActionData.request httpBody

### DIFF
--- a/LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension-expected.txt
+++ b/LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension-expected.txt
@@ -1,0 +1,4 @@
+Test that WebPageProxy::createNewPage rejects request bodies referencing files for which the WebContent process has no sandbox extension.
+
+PASS: createNewPage rejected unauthorized EncodedFileData
+

--- a/LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension.html
+++ b/LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html><body>
+<p>Test that WebPageProxy::createNewPage rejects request bodies referencing files for which the WebContent process has no sandbox extension.</p>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.preventPopupWindows();
+}
+const log = (s) => { document.getElementById("log").textContent += s + "\n"; };
+
+if (!window.IPC) {
+    log("PASS: createNewPage rejected unauthorized EncodedFileData");
+    if (window.testRunner)
+        testRunner.notifyDone();
+} else {
+    import('./coreipc.js').then(({ CoreIPC }) => {
+        CoreIPC.default_timeout = 30;
+
+        const NULLOPT = {};
+        const frameID = IPC.frameID[0];
+        const url = location.href;
+
+        function makeURL(s) { return { string: s }; }
+        function makeRequest(u) {
+            return {
+                getRequestDataToSerialize: {
+                    variantType: 'WebCore::ResourceRequest::RequestData',
+                    variant: {
+                        m_url: makeURL(u), m_firstPartyForCookies: makeURL(''),
+                        m_timeoutInterval: 0.0, m_httpMethod: 'GET',
+                        m_httpHeaderFields: { commonHeaders: [], uncommonHeaders: [] },
+                        m_responseContentDispositionEncodingFallbackArray: [],
+                        m_cachePolicy: 0, m_sameSiteDisposition: 0, m_priority: 2, m_requester: 0,
+                        m_allowCookies: false, m_isTopSite: false, m_isAppInitiated: false,
+                        m_privacyProxyFailClosedForUnreachableNonMainHosts: false,
+                        m_useAdvancedPrivacyProtections: false, m_didFilterLinkDecoration: false,
+                        m_isPrivateTokenUsageByThirdPartyAllowed: false,
+                        m_wasSchemeOptimisticallyUpgraded: false, m_targetAddressSpace: 0,
+                    }
+                },
+                shouldBlockThirdPartyStorage: false, hiddenFromInspector: false,
+            };
+        }
+        function makeOrigin() {
+            return { data: {
+                variantType: 'WebCore::SecurityOriginData::Tuple',
+                variant: { protocol: location.protocol.slice(0, -1), host: location.hostname, port: location.port ? { optionalValue: Number(location.port) } : NULLOPT }
+            } };
+        }
+        function makeFrameInfo() {
+            return {
+                isMainFrame: true, frameType: 0, request: makeRequest(url),
+                securityOrigin: makeOrigin(), topOrigin: makeOrigin(), frameName: '', frameID: frameID,
+                webPageProxyID: NULLOPT,
+                parentFrameID: NULLOPT, documentID: NULLOPT,
+                certificateInfo: { trust: NULLOPT },
+                processID: { alias: 0 }, isFocused: false, errorOccurred: false,
+                frameMetrics: { isScrollable: 0, contentSize: { width: 0, height: 0 },
+                    visibleContentSize: { width: 0, height: 0 },
+                    visibleContentSizeExcludingScrollbars: { width: 0, height: 0 } }
+            };
+        }
+
+        try {
+            CoreIPC.UI.WebPageProxy.CreateNewPage(IPC.webPageProxyID, {
+                windowFeatures: {
+                    hasAdditionalFeatures: false,
+                    x: NULLOPT, y: NULLOPT, width: NULLOPT, height: NULLOPT,
+                    popup: NULLOPT, menuBarVisible: NULLOPT, statusBarVisible: NULLOPT,
+                    toolBarVisible: NULLOPT, locationBarVisible: NULLOPT, scrollbarsVisible: NULLOPT,
+                    resizable: NULLOPT, fullscreen: NULLOPT, dialog: NULLOPT,
+                    noopener: { optionalValue: true },
+                },
+                navigationActionData: {
+                    navigationType: 5, modifiers: 0, mouseButton: 254, syntheticClickType: 0,
+                    userGestureTokenIdentifier: NULLOPT, userGestureAuthorizationToken: NULLOPT,
+                    canHandleRequest: true, shouldOpenExternalURLsPolicy: 0,
+                    downloadAttribute: '',
+                    clickLocationInRootViewCoordinates: { x: 0.0, y: 0.0 },
+                    redirectResponse: { getResponseData: NULLOPT },
+                    isRequestFromClientOrUserInput: false, treatAsSameOriginNavigation: false,
+                    hasOpenedFrames: false, openedByDOMWithOpener: false, hasOpener: false,
+                    navigationUpgradeToHTTPSBehavior: 0,
+                    isInitialFrameSrcLoad: false, isContentRuleListRedirect: false,
+                    openedMainFrameName: '',
+                    targetBackForwardItemIdentifier: NULLOPT, sourceBackForwardItemIdentifier: NULLOPT,
+                    lockHistory: 0, lockBackForwardList: 0, clientRedirectSourceForHistory: '',
+                    effectiveSandboxFlags: { alias: 0 }, effectiveReferrerPolicy: 0,
+                    ownerPermissionsPolicy: NULLOPT, privateClickMeasurement: NULLOPT,
+                    advancedPrivacyProtections: 0, originatorAdvancedPrivacyProtections: NULLOPT,
+                    webHitTestResultData: NULLOPT,
+                    originatingFrameInfoData: makeFrameInfo(),
+                    originatingPageID: { optionalValue: IPC.webPageProxyID },
+                    frameInfo: makeFrameInfo(), navigationID: NULLOPT,
+                    originalRequest: makeRequest(url), request: makeRequest(url),
+                    requestBody: {
+                        data: { optionalValue: {
+                            m_elements: [ { data: {
+                                variantType: 'WebCore::FormDataElement::EncodedFileData',
+                                variant: { filename: '/private/etc/passwd', fileStart: 0, fileLength: -1, expectedFileModificationTime: NULLOPT }
+                            } } ],
+                            m_identifier: 0, m_alwaysStream: false, m_boundary: []
+                        } },
+                        sandboxExtensionHandles: [ { takeImpl: NULLOPT } ]
+                    },
+                    invalidURLString: '', requester: NULLOPT,
+                }
+            }, () => { });
+        } catch (e) {
+            log("send threw: " + e);
+        }
+
+        CoreIPC.UI.WebProcessProxy.TakeInvalidMessageStringForTesting(0, {}, (reply) => {
+            const error = reply ? String(reply.error || "") : "";
+            if (error.includes("hasGrantedSandboxExtensionForFile"))
+                log("PASS: createNewPage rejected unauthorized EncodedFileData");
+            else
+                log("FAIL: expected MESSAGE_CHECK on hasGrantedSandboxExtensionForFile, got: " + JSON.stringify(reply));
+        });
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }).catch((e) => {
+        log("import failed: " + e);
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+}
+</script>
+</body></html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3607,6 +3607,9 @@ ipc/remotedisplaylistrecorder-drawcontrolpart-slidertrackpart-crash.html [ Skip 
 ipc/media-containment-bypass-create-player.html [ Skip ]
 http/tests/ipc/gpu-load-error-empty-user-info-crssh.html [ Skip ]
 ipc/usermedia-capture-start-producing-data-race.html [ Skip ]
+# Hardcodes Cocoa's WebCore::CertificateInfo::trust field in the IPC payload; SOUP's
+# CertificateInfo serializes a GRefPtr<GTlsCertificate> that coreipc.js cannot construct.
+http/tests/ipc/createnewpage-file-body-sandbox-extension.html [ Skip ]
 
 # These tests are specific to Cocoa's definition of WebCore::PlatformColorSpace which is different from Skia's.
 ipc/decode-feConvolveMatrix-kernelSize-overflow.html [ Skip ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -248,6 +248,7 @@
 #include <WebCore/FocusDirection.h>
 #include <WebCore/FocusOptions.h>
 #include <WebCore/FontAttributeChanges.h>
+#include <WebCore/FormData.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/FrameLoaderClient.h>


### PR DESCRIPTION
#### 826d21ff7df9be21b09789edffd57dba86b3cc5e
<pre>
[WebKit Process Model] WebPageProxy::createNewPage missing hasGrantedSandboxExtensionForFile check on NavigationActionData.request httpBody
<a href="https://bugs.webkit.org/show_bug.cgi?id=315167">https://bugs.webkit.org/show_bug.cgi?id=315167</a>
<a href="https://rdar.apple.com/177367508">rdar://177367508</a>

Reviewed by Per Arne Vollan.

A compromised WebContent process can send WebPageProxy::CreateNewPage with
an arbitrary file path in the request body&apos;s EncodedFileData. When the UI
process re-emits that request via loadRequest(), encoding the
LoadParameters runs FormDataReference::sandboxExtensionHandles() in the UI
process, which calls SandboxExtension::createHandle() on the
attacker-supplied path and serializes a live com.apple.app-sandbox.read
token to a WebContent process — a full sandbox escape to arbitrary host
filesystem read.

Add a MESSAGE_CHECK_COMPLETION at the top of createNewPage() that calls
WebProcessProxy::hasGrantedSandboxExtensionForFile() on every
EncodedFileData filename in the request body, rejecting any path the
sending WebContent process was never granted access to. This mirrors the
equivalent check <a href="https://rdar.apple.com/174662982">rdar://174662982</a> added to decidePolicyForNavigationAction().

Test: http/tests/ipc/createnewpage-file-body-sandbox-extension.html

* LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension-expected.txt: Added.
* LayoutTests/http/tests/ipc/createnewpage-file-body-sandbox-extension.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage):

Originally-landed-as: 305413.942@safari-7624-branch (77fa86c2ea4d). <a href="https://rdar.apple.com/180435897">rdar://180435897</a>
Canonical link: <a href="https://commits.webkit.org/316388@main">https://commits.webkit.org/316388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b2da09ef49fb20f1fd1b4373490c68eb096fc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129659 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133871 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114344 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35925 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184079 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142616 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142502 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38487 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46369 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111040 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37586 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44887 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8852 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->