### PR TITLE
Heap UaF in GPU Process via MediaStreamTrack.clone() + ImageCapture.takePhoto() + applyConstraints()

### DIFF
--- a/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto-expected.txt
+++ b/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto-expected.txt
@@ -1,0 +1,3 @@
+
+PASS applyConstraints while takePhoto is happening on a cloned track
+

--- a/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async t => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 320 } });
+    const originalTrack = stream.getVideoTracks()[0];
+    const clonedTrack = originalTrack.clone();
+    const imageCapture = new ImageCapture(originalTrack);
+
+    for (let round = 0; round < 5; round++) {
+        const promises = [];
+        for (let i = 0; i < 10; i++) {
+            promises.push(imageCapture.takePhoto({imageWidth:1280, imageHeight:720}).catch(()=>{}));
+            promises.push(clonedTrack.applyConstraints({
+                width:{ideal:320+(i*100)}, height:{ideal:240+(i*75)}, frameRate:{ideal:15+i}
+            }).catch(()=>{}));
+        }
+        await Promise.allSettled(promises);
+    }
+
+    originalTrack.stop();
+    clonedTrack.stop();
+}, "applyConstraints while takePhoto is happening on a cloned track");
+        </script>
+    </body>
+</html>

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -234,7 +234,7 @@ public:
             bool isObservingMedia = protectedThis->isObservingMedia();
             protectedThis->unobserveMedia();
 
-            source->applyConstraints(WTF::move(constraints), [weakThis = WTF::move(weakThis), &constraints, isObservingMedia, callback = WTF::move(callback)](auto&& error) mutable {
+            source->applyConstraints(constraints, [weakThis = WTF::move(weakThis), constraints, isObservingMedia, callback = WTF::move(callback)](auto&& error) mutable {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis) {
                     callback(RealtimeMediaSource::ApplyConstraintsError { { }, { } });


### PR DESCRIPTION
#### 54b8e49ebf3396dbcea92fcbbcec2a0233264291
<pre>
Heap UaF in GPU Process via MediaStreamTrack.clone() + ImageCapture.takePhoto() + applyConstraints()
<a href="https://rdar.apple.com/176025005">rdar://176025005</a>

Reviewed by Eric Carlson.

We store constraints in the callback by value instead of reference to make sure that the constraints are valid if the callback is called asynchronously.

Test: fast/mediastream/applyConstraints-with-takePhoto.html

* LayoutTests/fast/mediastream/applyConstraints-with-takePhoto-expected.txt: Added.
* LayoutTests/fast/mediastream/applyConstraints-with-takePhoto.html: Added.
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:

Originally-landed-as: 305413.816@safari-7624-branch (207238632262). <a href="https://rdar.apple.com/180436666">rdar://180436666</a>
Canonical link: <a href="https://commits.webkit.org/316184@main">https://commits.webkit.org/316184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91aefc7534452972042602b601086c5b578e09fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38467 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180502 "Build was cancelled. Recent messages:Printed configuration") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128838 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44684 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180502 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153866 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180502 "Build was cancelled. Recent messages:Printed configuration") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35260 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29182 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183087 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35882 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37761 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141885 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38311 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45393 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110098 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36944 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43904 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->