### PR TITLE
GetPixelBuffer should zeroFill the destination if any error happens

### DIFF
--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -208,6 +208,16 @@ bool DestinationColorSpace::supportsOutput() const
 #endif
 }
 
+bool DestinationColorSpace::usesRGBColorModel() const
+{
+#if USE(CG)
+    // Avoid refing color space here as this is performance-sensitive.
+    SUPPRESS_UNRETAINED_ARG return CGColorSpaceGetModel(platformColorSpace()) == kCGColorSpaceModelRGB;
+#else
+    return true;
+#endif
+}
+
 bool DestinationColorSpace::usesExtendedRange() const
 {
 #if USE(CG)

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -73,6 +73,7 @@ public:
 
     WEBCORE_EXPORT bool supportsOutput() const;
 
+    WEBCORE_EXPORT bool usesRGBColorModel() const;
     WEBCORE_EXPORT bool usesExtendedRange() const;
     bool usesITUR_2100TF() const;
 

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -113,6 +113,12 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
     auto sourceVImageBuffer = makeVImageBuffer(source, destinationSize);
     auto destinationVImageBuffer = makeVImageBuffer(destination, destinationSize);
 
+    auto zeroFillDestination = [&] {
+        size_t rowFillBytes = static_cast<size_t>(destinationSize.width()) * 4;
+        for (int y = 0; y < destinationSize.height(); ++y)
+            zeroSpan(destination.rows.subspan(static_cast<size_t>(y) * destination.bytesPerRow, rowFillBytes));
+    };
+
     if (source.format.colorSpace != destination.format.colorSpace) {
         // FIXME: Consider using vImageConvert_AnyToAny for all conversions, not just ones that need a color space conversion,
         // after judiciously performance testing them against each other.
@@ -122,11 +128,20 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
 
         vImage_Error converterCreateError = kvImageNoError;
         auto converter = adoptCF(vImageConverter_CreateWithCGImageFormat(&sourceCGImageFormat, &destinationCGImageFormat, nullptr, kvImageNoFlags, &converterCreateError));
-        if (converterCreateError != kvImageNoError)
+        if (converterCreateError != kvImageNoError) {
+            RELEASE_LOG_ERROR(Images, "%s: vImageConverter_CreateWithCGImageFormat() failed with error: %zd", __FUNCTION__, converterCreateError);
+            // The destination may be uninitialized; ensure no stale heap is exposed to callers.
+            zeroFillDestination();
             return;
+        }
 
         vImage_Error converterConvertError = vImageConvert_AnyToAny(converter.get(), &sourceVImageBuffer, &destinationVImageBuffer, nullptr, kvImageNoFlags);
-        ASSERT_WITH_MESSAGE_UNUSED(converterConvertError, converterConvertError == kvImageNoError, "vImageConvert_AnyToAny failed conversion with error: %zd", converterConvertError);
+        if (converterConvertError != kvImageNoError) {
+            RELEASE_LOG_ERROR(Images, "%s: vImageConvert_AnyToAny() failed with error: %zd", __FUNCTION__, converterConvertError);
+            // The destination may be uninitialized; ensure no stale heap is exposed to callers.
+            zeroFillDestination();
+        }
+
         return;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1066,8 +1066,6 @@ struct WebCore::ClientOrigin {
 
 enum class WebCore::AdjustViewSize : bool;
 
-enum class WebCore::UseLosslessCompression : bool;
-
 [RefCounted] class WebCore::TextIndicator {
     WebCore::TextIndicatorData data();
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
@@ -651,6 +651,8 @@ enum class WebCore::PixelFormat : uint8_t {
 #endif
 };
 
+enum class WebCore::UseLosslessCompression : bool;
+
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ImageBufferFormat {
     WebCore::PixelFormat pixelFormat;
     WebCore::UseLosslessCompression useLosslessCompression;
@@ -659,7 +661,7 @@ enum class WebCore::PixelFormat : uint8_t {
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PixelBufferFormat {
     WebCore::AlphaPremultiplication alphaFormat;
     WebCore::PixelFormat pixelFormat;
-    WebCore::DestinationColorSpace colorSpace;
+    [Validator='colorSpace->usesRGBColorModel()'] WebCore::DestinationColorSpace colorSpace;
 };
 
 #if USE(SOUP)

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -326,4 +326,41 @@ INSTANTIATE_TEST_SUITE_P(ImageBufferTests,
         testing::Values(RenderingMode::Unaccelerated, RenderingMode::Accelerated)),
     TestParametersToStringFormatter());
 
+#if USE(CG)
+
+TEST(ImageBufferTests, GetPixelBufferAllZeros)
+{
+    auto sourceColorSpace = DestinationColorSpace::SRGB();
+    auto sourcePixelFormat = PixelFormat::BGRA8;
+    FloatSize size { 1000, 1000 };
+    FloatRect fillRect = FloatRect { { }, size };
+    float scale = 1.f;
+
+    RefPtr<ImageBuffer> imageBuffer = ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, scale, sourceColorSpace, sourcePixelFormat);
+    EXPECT_NE(nullptr, imageBuffer);
+
+    auto& context = imageBuffer->context();
+    context.fillRect(fillRect, Color::green);
+
+    auto getPixelBufferAllZeros = [&](const FloatRect& rect) {
+        RetainPtr platformColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceGenericCMYK));
+        auto destinationColorSpace = DestinationColorSpace(WTF::move(platformColorSpace));
+        PixelBufferFormat destinationPixelFormat { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, destinationColorSpace };
+
+        RefPtr pixelBuffer = imageBuffer->getPixelBuffer(destinationPixelFormat, enclosingIntRect(rect));
+        EXPECT_NE(nullptr, pixelBuffer);
+
+        auto bytes = pixelBuffer->bytes();
+        return std::none_of(bytes.begin(), bytes.end(), [](auto byte) {
+            return byte;
+        });
+    };
+
+    EXPECT_TRUE(getPixelBufferAllZeros({ { }, size }));
+    EXPECT_TRUE(getPixelBufferAllZeros({ { }, size / 10 }));
+    EXPECT_TRUE(getPixelBufferAllZeros({ FloatPoint { size - size / 10 }, size / 10 }));
+}
+
+#endif
+
 }


### PR DESCRIPTION
#### 0f857107ffab578c2c25cb74afd5c68e22fc3a33
<pre>
GetPixelBuffer should zeroFill the destination if any error happens
<a href="https://bugs.webkit.org/show_bug.cgi?id=312945">https://bugs.webkit.org/show_bug.cgi?id=312945</a>
<a href="https://rdar.apple.com/174640273">rdar://174640273</a>

Reviewed by Kimmo Kinnunen.

RemoteImageBuffer fails to GetPixelBuffer if the destination colorSpace is non-RGB
model (e.g. kCGColorSpaceGenericCMYK). In this case the PixelBuffer is allocated
but never be initialized. So stale heap can be exposed to callers.

To fix this an IPC validator is needed to ensure the colorSpace is indeed RGB model.
And to handle other possible unknown failures, the destination PixelBuffer will
be zero-filled if vImage fails to do the conversion the colorSpace conversion.

* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::usesRGBColorModel const):
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertImagePixelsAccelerated):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::TEST(ImageBufferTests, GetPixelBufferAllZeros)):

Originally-landed-as: 305413.874@safari-7624-branch (8e2784fd0807). <a href="https://rdar.apple.com/180429216">rdar://180429216</a>
* Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316159@main">https://commits.webkit.org/316159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14bfb658bc7cadf67d5c68a42646468bdb14f83f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38765 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44982 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174379 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29481 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183389 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45002 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/141953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45692 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37200 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44202 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43849 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->