### PR TITLE
ANGLE: Metal: Dangling mOcclusionQuery pointer if visibility buffer allocation fails

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2309,6 +2309,8 @@ webkit.org/b/315877 [ Sequoia Debug x86_64 ] webgl/2.0.y/conformance2/textures/m
 webkit.org/b/315877 [ Sequoia Debug x86_64 ] webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r11f_g11f_b10f-rgb-float.html [ Pass Timeout ]
 webkit.org/b/315877 [ Sequoia Debug x86_64 ] webgl/2.0.y/conformance2/textures/image_bitmap_from_video/tex-2d-rgba32f-rgba-float.html [ Pass Failure ]
 
+webkit.org/b/318751 [ Debug arm64 ] webgl/2.0.y/conformance2/textures/misc/tex-unpack-params.html [ Pass Failure ]
+
 webkit.org/b/315881 [ Sequoia Release x86_64 ] fast/attachment/cocoa/wide-attachment-class.html [ Pass ImageOnlyFailure ]
 webkit.org/b/315881 [ Sequoia Release x86_64 ] fast/attachment/cocoa/wide-attachment-default-icon.html [ Pass ImageOnlyFailure ]
 webkit.org/b/315881 [ Sequoia Release x86_64 ] fast/attachment/cocoa/wide-attachment-folder-icon.html [ Pass ImageOnlyFailure ]

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h
@@ -31,6 +31,7 @@ namespace rx
 {
 class DisplayMtl;
 class FramebufferMtl;
+class QueryMtl;
 class VertexArrayMtl;
 class ProgramMtl;
 class ProgramExecutableMtl;
@@ -301,20 +302,22 @@ class ContextMtl : public ContextImpl, public mtl::Context
                                        bool renderPassChanged);
     void onBackbufferResized(const gl::Context *context, WindowSurfaceMtl *backbuffer);
 
-    // Invoke by QueryMtl
-    angle::Result onOcclusionQueryBegin(const gl::Context *context, QueryMtl *query);
-    void onOcclusionQueryEnd(const gl::Context *context, QueryMtl *query);
-    void onOcclusionQueryDestroy(const gl::Context *context, QueryMtl *query);
+    angle::Result onOcclusionQueryBegin(QueryMtl &query);
+    void onOcclusionQueryEnd();
+    void onOcclusionQueryDestroy(QueryMtl &query);
 
     // Useful for temporarily pause then restart occlusion query during clear/blit with draw.
-    bool hasActiveOcclusionQuery() const { return mOcclusionQuery; }
+    bool isOcclusionQueryEnabledInRenderPass() const
+    {
+        return mOcclusionQueryIsEnabledInRenderPass;
+    }
     // Disable the occlusion query in the current render pass.
     // The render pass must already started.
-    void disableActiveOcclusionQueryInRenderPass();
+    void disableOcclusionQueryInRenderPass();
     // Re-enable the occlusion query in the current render pass.
     // The render pass must already started.
     // NOTE: the old query's result will be retained and combined with the new result.
-    angle::Result restartActiveOcclusionQueryInRenderPass();
+    angle::Result enableOcclusionQueryInRenderPass();
 
     // Invoke by TransformFeedbackMtl
     void onTransformFeedbackActive(const gl::Context *context, TransformFeedbackMtl *xfb);
@@ -536,8 +539,6 @@ class ContextMtl : public ContextImpl, public mtl::Context
                                          bool xfbPass,
                                          bool *pipelineDescChanged);
 
-    angle::Result startOcclusionQueryInRenderPass(QueryMtl *query, bool clearOldValue);
-
     angle::Result checkCommandBufferError();
 
     // Dirty bits.
@@ -607,7 +608,6 @@ class ContextMtl : public ContextImpl, public mtl::Context
     FramebufferMtl *mDrawFramebuffer  = nullptr;
     VertexArrayMtl *mVertexArray      = nullptr;
     ProgramExecutableMtl *mExecutable = nullptr;
-    QueryMtl *mOcclusionQuery         = nullptr;
 
     using DirtyBits = angle::BitSet<DIRTY_BIT_MAX>;
 
@@ -658,6 +658,9 @@ class ContextMtl : public ContextImpl, public mtl::Context
     id<MTLTexture> mRasterizationRateMapTexture;
 
     mtl::ContextDevice mContextDevice;
+
+    mtl::BufferRef mOcclusionQueryResultBuffer;
+    bool mOcclusionQueryIsEnabledInRenderPass{false};
 };
 
 }  // namespace rx

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -1823,7 +1823,7 @@ void ContextMtl::endEncoding(bool forceSaveRenderPassContent)
             mRenderEncoder.setStoreAction(MTLStoreActionStore);
         }
 
-        disableActiveOcclusionQueryInRenderPass();
+        disableOcclusionQueryInRenderPass();
 
         mOcclusionQueryPool.prepareRenderPassVisibilityPoolBuffer(this);
 
@@ -2281,84 +2281,67 @@ void ContextMtl::onBackbufferResized(const gl::Context *context, WindowSurfaceMt
     onDrawFrameBufferChangedState(context, framebuffer, true);
 }
 
-angle::Result ContextMtl::onOcclusionQueryBegin(const gl::Context *context, QueryMtl *query)
+angle::Result ContextMtl::onOcclusionQueryBegin(QueryMtl &query)
 {
-    ASSERT(mOcclusionQuery == nullptr);
-    mOcclusionQuery = query;
-
+    ASSERT(!mOcclusionQueryResultBuffer);  // Frontend guarantees none active at the time.
+    const mtl::BufferRef &resultBuffer = query.getVisibilityResultBuffer();
+    bool isEnabledInRenderPass;
     if (mRenderEncoder.valid())
     {
-        // if render pass has started, start the query in the encoder
-        return startOcclusionQueryInRenderPass(query, true);
+        size_t resultOffset;
+        ANGLE_TRY(mOcclusionQueryPool.beginQuery(this, resultBuffer, &resultOffset));
+        mRenderEncoder.setVisibilityResultMode(MTLVisibilityResultModeBoolean, resultOffset);
+        // Result is available after flush.
+        mCmdBuffer.setWriteDependency(resultBuffer, /*isRenderCommand=*/true);
+        isEnabledInRenderPass = true;
     }
     else
     {
-        query->resetVisibilityResult(this);
+        // Reset the occlusion query result stored in buffer to zero.
+        // Later draws will use continueQuery() to enable the visibility buffer writes.
+        auto blitEncoder = getBlitCommandEncoder();
+        blitEncoder->fillBuffer(resultBuffer, NSMakeRange(0, mtl::kOcclusionQueryResultSize), 0);
+        resultBuffer->syncContent(this, blitEncoder);
+        isEnabledInRenderPass = false;
     }
-
+    mOcclusionQueryResultBuffer          = resultBuffer;
+    mOcclusionQueryIsEnabledInRenderPass = isEnabledInRenderPass;
     return angle::Result::Continue;
 }
-void ContextMtl::onOcclusionQueryEnd(const gl::Context *context, QueryMtl *query)
-{
-    ASSERT(mOcclusionQuery == query);
 
-    if (mRenderEncoder.valid())
-    {
-        // if render pass has started, end the query in the encoder
-        disableActiveOcclusionQueryInRenderPass();
-    }
-
-    mOcclusionQuery = nullptr;
-}
-void ContextMtl::onOcclusionQueryDestroy(const gl::Context *context, QueryMtl *query)
+void ContextMtl::onOcclusionQueryEnd()
 {
-    if (query->getAllocatedVisibilityOffsets().empty())
-    {
-        return;
-    }
-    if (mOcclusionQuery == query)
-    {
-        onOcclusionQueryEnd(context, query);
-    }
-    mOcclusionQueryPool.deallocateQueryOffset(this, query);
+    ASSERT(mOcclusionQueryResultBuffer);  // Frontend guarantees one active at the time.
+    disableOcclusionQueryInRenderPass();
+    mOcclusionQueryResultBuffer = nullptr;
 }
 
-void ContextMtl::disableActiveOcclusionQueryInRenderPass()
+void ContextMtl::onOcclusionQueryDestroy(QueryMtl &query)
 {
-    if (!mOcclusionQuery || mOcclusionQuery->getAllocatedVisibilityOffsets().empty())
-    {
-        return;
-    }
-
-    ASSERT(mRenderEncoder.valid());
-    mRenderEncoder.setVisibilityResultMode(MTLVisibilityResultModeDisabled,
-                                           mOcclusionQuery->getAllocatedVisibilityOffsets().back());
+    // On normal operation frontend guaraantees that end is called before destroy.
+    // On context destruction, active query is destroyed without end.
+    // Discard is valid for both.
+    mOcclusionQueryPool.discardQuery(query.getVisibilityResultBuffer());
 }
 
-angle::Result ContextMtl::restartActiveOcclusionQueryInRenderPass()
+void ContextMtl::disableOcclusionQueryInRenderPass()
 {
-    if (!mOcclusionQuery || mOcclusionQuery->getAllocatedVisibilityOffsets().empty())
+    if (mOcclusionQueryResultBuffer && mOcclusionQueryIsEnabledInRenderPass)
     {
-        return angle::Result::Continue;
+        ASSERT(mRenderEncoder.valid());
+        mRenderEncoder.setVisibilityResultMode(MTLVisibilityResultModeDisabled, 0);
+        mOcclusionQueryIsEnabledInRenderPass = false;
     }
-
-    return startOcclusionQueryInRenderPass(mOcclusionQuery, false);
 }
 
-angle::Result ContextMtl::startOcclusionQueryInRenderPass(QueryMtl *query, bool clearOldValue)
+angle::Result ContextMtl::enableOcclusionQueryInRenderPass()
 {
     ASSERT(mRenderEncoder.valid());
-
-    ANGLE_TRY(mOcclusionQueryPool.allocateQueryOffset(this, query, clearOldValue));
-
-    mRenderEncoder.setVisibilityResultMode(MTLVisibilityResultModeBoolean,
-                                           query->getAllocatedVisibilityOffsets().back());
-
-    // We need to mark the query's buffer as being written in this command buffer now. Since the
-    // actual writing is deferred until the render pass ends and user could try to read the query
-    // result before the render pass ends.
-    mCmdBuffer.setWriteDependency(query->getVisibilityResultBuffer(), /*isRenderCommand=*/true);
-
+    size_t resultOffset;
+    ANGLE_TRY(mOcclusionQueryPool.continueQuery(this, mOcclusionQueryResultBuffer, &resultOffset));
+    mRenderEncoder.setVisibilityResultMode(MTLVisibilityResultModeBoolean, resultOffset);
+    mCmdBuffer.setWriteDependency(mOcclusionQueryResultBuffer, /*isRenderCommand=*/true);
+    mOcclusionQueryIsEnabledInRenderPass = true;
     return angle::Result::Continue;
 }
 
@@ -2586,11 +2569,11 @@ angle::Result ContextMtl::setupDrawImpl(const gl::Context *context,
         ANGLE_TRY(handleDirtyRenderPass(context));
     }
 
-    if (mOcclusionQuery && mOcclusionQueryPool.getNumRenderPassAllocatedQueries() == 0)
+    if (mOcclusionQueryResultBuffer && !mOcclusionQueryIsEnabledInRenderPass)
     {
         // The occlusion query is still active, and a new render pass has started.
         // We need to continue the querying process in the new render encoder.
-        ANGLE_TRY(startOcclusionQueryInRenderPass(mOcclusionQuery, false));
+        ANGLE_TRY(enableOcclusionQueryInRenderPass());
     }
 
     bool isPipelineDescChanged;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/QueryMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/QueryMtl.h
@@ -19,50 +19,6 @@ namespace rx
 
 class ContextMtl;
 
-// The class represents offset(s) allocated in the visiblity buffer for an occlusion query.
-// See doc/OcclusionQuery.md.
-// An occlusion query might have more than one offsets allocated, but all of them must be adjacent
-// to each other. Multiple offsets typically allocated when the query is paused and resumed during
-// viewport clear emulation with draw operations. In such case, Metal doesn't allow an offset to
-// be reused in a render pass, hence multiple offsets will be allocated, and their values will
-// be accumulated.
-class VisibilityBufferOffsetsMtl
-{
-  public:
-    void clear() { mStartOffset = mNumOffsets = 0; }
-    bool empty() const { return mNumOffsets == 0; }
-    uint32_t size() const { return mNumOffsets; }
-
-    // Return last offset
-    uint32_t back() const
-    {
-        ASSERT(!empty());
-        return mStartOffset + (mNumOffsets - 1) * mtl::kOcclusionQueryResultSize;
-    }
-
-    uint32_t front() const
-    {
-        ASSERT(!empty());
-        return mStartOffset;
-    }
-
-    void setStartOffset(uint32_t offset)
-    {
-        ASSERT(empty());
-        mStartOffset = offset;
-        mNumOffsets  = 1;
-    }
-    void addOffset()
-    {
-        ASSERT(!empty());
-        mNumOffsets++;
-    }
-
-  private:
-    uint32_t mStartOffset = 0;
-    uint32_t mNumOffsets  = 0;
-};
-
 class QueryMtl : public QueryImpl
 {
   public:
@@ -80,24 +36,9 @@ class QueryMtl : public QueryImpl
     angle::Result getResult(const gl::Context *context, GLuint64 *params) override;
     angle::Result isResultAvailable(const gl::Context *context, bool *available) override;
 
-    // Get allocated offsets in the render pass's occlusion query pool.
-    const VisibilityBufferOffsetsMtl &getAllocatedVisibilityOffsets() const
-    {
-        return mVisibilityBufferOffsets;
-    }
-    // Set first allocated offset in the render pass's occlusion query pool.
-    void setFirstAllocatedVisibilityOffset(uint32_t off)
-    {
-        mVisibilityBufferOffsets.setStartOffset(off);
-    }
-    // Add more offset allocated for the occlusion query
-    void addAllocatedVisibilityOffset() { mVisibilityBufferOffsets.addOffset(); }
-
-    void clearAllocatedVisibilityOffsets() { mVisibilityBufferOffsets.clear(); }
     // Returns the buffer containing the final occlusion query result.
     const mtl::BufferRef &getVisibilityResultBuffer() const { return mVisibilityResultBuffer; }
-    // Reset the occlusion query result stored in buffer to zero
-    void resetVisibilityResult(ContextMtl *contextMtl);
+
     void onTransformFeedbackEnd(const gl::Context *context);
 
     // If the timestamp query is still active upon context switch,
@@ -110,8 +51,7 @@ class QueryMtl : public QueryImpl
     template <typename T>
     angle::Result waitAndGetResult(const gl::Context *context, T *params);
 
-    // List of offsets in the render pass's occlusion query pool buffer allocated for this query
-    VisibilityBufferOffsetsMtl mVisibilityBufferOffsets;
+    // Buffer holding the final combined visibility result for this query.
     mtl::BufferRef mVisibilityResultBuffer;
 
     size_t mTransformFeedbackPrimitivesDrawn = 0;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/QueryMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/QueryMtl.mm
@@ -24,9 +24,9 @@ QueryMtl::~QueryMtl() {}
 void QueryMtl::onDestroy(const gl::Context *context)
 {
     ContextMtl *contextMtl = mtl::GetImpl(context);
-    if (!getAllocatedVisibilityOffsets().empty())
+    if (mVisibilityResultBuffer)
     {
-        contextMtl->onOcclusionQueryDestroy(context, this);
+        contextMtl->onOcclusionQueryDestroy(*this);
     }
     mVisibilityResultBuffer = nullptr;
 }
@@ -51,7 +51,7 @@ angle::Result QueryMtl::begin(const gl::Context *context)
                 }
             }
 
-            ANGLE_TRY(contextMtl->onOcclusionQueryBegin(context, this));
+            ANGLE_TRY(contextMtl->onOcclusionQueryBegin(*this));
             break;
         case gl::QueryType::TransformFeedbackPrimitivesWritten:
             mTransformFeedbackPrimitivesDrawn = 0;
@@ -85,7 +85,7 @@ angle::Result QueryMtl::end(const gl::Context *context)
     {
         case gl::QueryType::AnySamples:
         case gl::QueryType::AnySamplesConservative:
-            contextMtl->onOcclusionQueryEnd(context, this);
+            contextMtl->onOcclusionQueryEnd();
             break;
         case gl::QueryType::TransformFeedbackPrimitivesWritten:
             onTransformFeedbackEnd(context);
@@ -205,18 +205,6 @@ angle::Result QueryMtl::getResult(const gl::Context *context, GLint64 *params)
 angle::Result QueryMtl::getResult(const gl::Context *context, GLuint64 *params)
 {
     return waitAndGetResult(context, params);
-}
-
-void QueryMtl::resetVisibilityResult(ContextMtl *contextMtl)
-{
-    // Occlusion query buffer must be allocated in QueryMtl::begin
-    ASSERT(mVisibilityResultBuffer);
-
-    // Fill the query's buffer with zeros
-    auto blitEncoder = contextMtl->getBlitCommandEncoder();
-    blitEncoder->fillBuffer(mVisibilityResultBuffer, NSMakeRange(0, mtl::kOcclusionQueryResultSize),
-                            0);
-    mVisibilityResultBuffer->syncContent(contextMtl, blitEncoder);
 }
 
 void QueryMtl::onTransformFeedbackEnd(const gl::Context *context)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm
@@ -1542,8 +1542,7 @@ void RenderCommandEncoder::endEncodingImpl(bool considerDiscardSimulation)
                                 objCRenderPassDesc.stencilAttachment))
         hasAttachment = true;
 
-    // Set visibility result buffer
-    if (mOcclusionQueryPool.getNumRenderPassAllocatedQueries())
+    if (mOcclusionQueryPool.hasPendingVisibilityResults())
     {
         objCRenderPassDesc.visibilityResultBuffer =
             mOcclusionQueryPool.getRenderPassVisibilityPoolBuffer()->get();

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_occlusion_query_pool.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_occlusion_query_pool.h
@@ -20,10 +20,36 @@ namespace rx
 {
 
 class ContextMtl;
-class QueryMtl;
 
 namespace mtl
 {
+
+// Tracks allocations of visibility buffer offsets for a query within the render pass.
+// An occlusion query might have more than one offsets allocated, but all of them must be adjacent
+// to each other. Multiple offsets typically allocated when the query is paused and resumed during
+// viewport clear emulation with draw operations. In such case, Metal doesn't allow an offset to
+// be reused in a render pass, hence multiple offsets will be allocated, and their values will
+// be accumulated.
+class VisibilityBufferOffsetsMtl
+{
+  public:
+    VisibilityBufferOffsetsMtl(const BufferRef &buffer, size_t startOffset, size_t size)
+        : mResultBuffer(buffer), mFirstOffset(startOffset), mSize(size)
+    {
+        ASSERT(mSize > 0);
+    }
+    size_t size() const { return mSize; }
+    size_t lastOffset() const { return mFirstOffset + (mSize - 1) * kOcclusionQueryResultSize; }
+    size_t firstOffset() const { return mFirstOffset; }
+    void addOffset() { mSize++; }
+    const BufferRef &resultBuffer() const { return mResultBuffer; }
+    void discard() { mResultBuffer = nullptr; }
+
+  private:
+    BufferRef mResultBuffer;
+    size_t mFirstOffset {0};
+    size_t mSize {0};
+};
 
 class OcclusionQueryPool
 {
@@ -33,30 +59,36 @@ class OcclusionQueryPool
 
     void destroy(ContextMtl *contextMtl);
 
-    // Allocate an offset in visibility buffer for a query in a render pass.
-    // - clearOldValue = true, if the old value of query will be cleared before combining in the
-    // visibility resolve pass. This flag is only allowed to be false for the first allocation of
-    // the render pass or the query that already has an allocated offset.
-    // Note: a query might have more than one allocated offset. They will be combined in the final
-    // step.
-    angle::Result allocateQueryOffset(ContextMtl *contextMtl, QueryMtl *query, bool clearOldValue);
-    // Deallocate all offsets used for a query.
-    void deallocateQueryOffset(ContextMtl *contextMtl, QueryMtl *query);
-    // Retrieve a buffer that will contain the visibility results of all allocated queries for
-    // a render pass
+    // Begin a new occlusion query in the current render pass.
+    angle::Result beginQuery(ContextMtl *contextMtl,
+                             const BufferRef &resultBuffer,
+                             size_t *outResultOffset);
+
+    // Continue an already-active query after a render pass restart.
+    angle::Result continueQuery(ContextMtl *contextMtl,
+                                const BufferRef &resultBuffer,
+                                size_t *outResultOffset);
+
+    void discardQuery(const BufferRef &resultBuffer);
+
+    bool hasPendingVisibilityResults() const { return !mAllocatedQueries.empty(); }
+
+    // Returns the buffer that contains the visibility result writes for the current render pass.
     const BufferRef &getRenderPassVisibilityPoolBuffer() const { return mRenderPassResultsPool; }
-    size_t getNumRenderPassAllocatedQueries() const { return mAllocatedQueries.size(); }
+
     // This function is called at the end of render pass
     void resolveVisibilityResults(ContextMtl *contextMtl);
     // Clear visibility pool buffer to drop previous results
     void prepareRenderPassVisibilityPoolBuffer(ContextMtl *contextMtl);
 
   private:
+    angle::Result ensurePoolCapacity(ContextMtl *contextMtl, size_t requiredEnd);
+
     // Buffer to hold the visibility results for current render pass
     BufferRef mRenderPassResultsPool;
 
-    // List of allocated queries per render pass
-    std::vector<QueryMtl *> mAllocatedQueries;
+    // List of allocated queries per render pass.
+    std::vector<VisibilityBufferOffsetsMtl> mAllocatedQueries;
 
     bool mResetFirstQuery = false;
     bool mUsed            = false;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_occlusion_query_pool.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_occlusion_query_pool.mm
@@ -9,9 +9,10 @@
 
 #include "libANGLE/renderer/metal/mtl_occlusion_query_pool.h"
 
+#include <algorithm>
+
 #include "libANGLE/renderer/metal/ContextMtl.h"
 #include "libANGLE/renderer/metal/DisplayMtl.h"
-#include "libANGLE/renderer/metal/QueryMtl.h"
 
 namespace rx
 {
@@ -25,91 +26,93 @@ OcclusionQueryPool::~OcclusionQueryPool() {}
 void OcclusionQueryPool::destroy(ContextMtl *contextMtl)
 {
     mRenderPassResultsPool = nullptr;
-    for (QueryMtl *allocatedQuery : mAllocatedQueries)
-    {
-        if (!allocatedQuery)
-        {
-            continue;
-        }
-        allocatedQuery->clearAllocatedVisibilityOffsets();
-    }
     mAllocatedQueries.clear();
 }
 
-angle::Result OcclusionQueryPool::allocateQueryOffset(ContextMtl *contextMtl,
-                                                      QueryMtl *query,
-                                                      bool clearOldValue)
+angle::Result OcclusionQueryPool::ensurePoolCapacity(ContextMtl *contextMtl, size_t requiredEnd)
 {
-    // Only query that already has allocated offset or first query of the render pass is allowed to
-    // keep old value. Other queries must be reset to zero before counting the samples visibility in
-    // draw calls.
-    ASSERT(clearOldValue || mAllocatedQueries.empty() ||
-           !query->getAllocatedVisibilityOffsets().empty());
-
-    uint32_t currentOffset =
-        static_cast<uint32_t>(mAllocatedQueries.size()) * kOcclusionQueryResultSize;
-    if (!mRenderPassResultsPool)
+    if (mRenderPassResultsPool == nullptr || requiredEnd > mRenderPassResultsPool->size())
     {
-        ASSERT(!mUsed);
-        // First allocation
-        ANGLE_TRY(Buffer::MakeBufferWithStorageMode(
-            contextMtl, MTLStorageModePrivate, kOcclusionQueryResultSize, &mRenderPassResultsPool));
-        mRenderPassResultsPool->get().label = @"OcclusionQueryPool";
-    }
-    else if (currentOffset + kOcclusionQueryResultSize > mRenderPassResultsPool->size())
-    {
-        // Double the capacity
-        ANGLE_TRY(Buffer::MakeBufferWithStorageMode(contextMtl, MTLStorageModePrivate,
-                                                    mRenderPassResultsPool->size() * 2,
+        const size_t newSize = mRenderPassResultsPool == nullptr
+                                   ? 16 * kOcclusionQueryResultSize
+                                   : mRenderPassResultsPool->size() * 2;
+        ANGLE_TRY(Buffer::MakeBufferWithStorageMode(contextMtl, MTLStorageModePrivate, newSize,
                                                     &mRenderPassResultsPool));
         mUsed                               = false;
         mRenderPassResultsPool->get().label = @"OcclusionQueryPool";
     }
 
-    if (clearOldValue)
-    {
-        // If old value is not needed, deallocate any offset previously allocated for this query.
-        deallocateQueryOffset(contextMtl, query);
-    }
-    if (query->getAllocatedVisibilityOffsets().empty())
-    {
-        mAllocatedQueries.push_back(query);
-        query->setFirstAllocatedVisibilityOffset(currentOffset);
-    }
-    else
-    {
-        // Additional offset allocated for a query is only allowed if it is a continuous region.
-        ASSERT(currentOffset ==
-               query->getAllocatedVisibilityOffsets().back() + kOcclusionQueryResultSize);
-        // Just reserve an empty slot in the allocated query array
-        mAllocatedQueries.push_back(nullptr);
-        query->addAllocatedVisibilityOffset();
-    }
-
-    if (currentOffset == 0)
-    {
-        mResetFirstQuery = clearOldValue;
-        if (!clearOldValue && !contextMtl->getDisplay()->getFeatures().allowBufferReadWrite.enabled)
-        {
-            // If old value of first query needs to be retained and device doesn't support buffer
-            // read-write, we need an additional offset to store the old value of the query.
-            return allocateQueryOffset(contextMtl, query, false);
-        }
-    }
-
     return angle::Result::Continue;
 }
 
-void OcclusionQueryPool::deallocateQueryOffset(ContextMtl *contextMtl, QueryMtl *query)
+angle::Result OcclusionQueryPool::beginQuery(ContextMtl *contextMtl,
+                                             const BufferRef &resultBuffer,
+                                             size_t *outResultOffset)
 {
-    if (query->getAllocatedVisibilityOffsets().empty())
+    size_t resultOffset = mAllocatedQueries.empty()
+                              ? 0
+                              : (mAllocatedQueries.back().lastOffset() + kOcclusionQueryResultSize);
+
+    ANGLE_TRY(ensurePoolCapacity(contextMtl, resultOffset + kOcclusionQueryResultSize));
+    discardQuery(resultBuffer);
+
+    mAllocatedQueries.emplace_back(resultBuffer, resultOffset, 1);
+    if (resultOffset == 0)
     {
-        return;
+        mResetFirstQuery = true;
+    }
+    *outResultOffset = resultOffset;
+    return angle::Result::Continue;
+}
+
+angle::Result OcclusionQueryPool::continueQuery(ContextMtl *contextMtl,
+                                                const BufferRef &resultBuffer,
+                                                size_t *outResultOffset)
+{
+    ASSERT(resultBuffer);
+    if (mAllocatedQueries.empty() &&
+        !contextMtl->getDisplay()->getFeatures().allowBufferReadWrite.enabled)
+    {
+        // If we continue a query after a visibility results resolve, we need to load the
+        // intermediate visibility result. Use an extra slot for the read unless buffer
+        // read-write is possible.
+        ANGLE_TRY(ensurePoolCapacity(contextMtl, 2 * kOcclusionQueryResultSize));
+        mAllocatedQueries.emplace_back(resultBuffer, 0, 2);
+        mResetFirstQuery = false;
+        *outResultOffset = kOcclusionQueryResultSize;
+        return angle::Result::Continue;
     }
 
-    mAllocatedQueries[query->getAllocatedVisibilityOffsets().front() / kOcclusionQueryResultSize] =
-        nullptr;
-    query->clearAllocatedVisibilityOffsets();
+    size_t resultOffset = mAllocatedQueries.empty()
+                              ? 0
+                              : (mAllocatedQueries.back().lastOffset() + kOcclusionQueryResultSize);
+    ANGLE_TRY(ensurePoolCapacity(contextMtl, resultOffset + kOcclusionQueryResultSize));
+
+    if (mAllocatedQueries.empty())
+    {
+        mAllocatedQueries.emplace_back(resultBuffer, 0, 1);
+        mResetFirstQuery = false;
+    }
+    else
+    {
+        // Non-initial continues always continue the previous result.
+        ASSERT(mAllocatedQueries.back().resultBuffer() == resultBuffer);
+        mAllocatedQueries.back().addOffset();
+    }
+    *outResultOffset = resultOffset;
+    return angle::Result::Continue;
+}
+
+void OcclusionQueryPool::discardQuery(const BufferRef &resultBuffer)
+{
+    auto it = std::find_if(mAllocatedQueries.begin(), mAllocatedQueries.end(),
+                           [&](const VisibilityBufferOffsetsMtl &entry) {
+                               return entry.resultBuffer() == resultBuffer;
+                           });
+    if (it != mAllocatedQueries.end())
+    {
+        it->discard();
+    }
 }
 
 void OcclusionQueryPool::resolveVisibilityResults(ContextMtl *contextMtl)
@@ -121,61 +124,49 @@ void OcclusionQueryPool::resolveVisibilityResults(ContextMtl *contextMtl)
 
     RenderUtils &utils              = contextMtl->getDisplay()->getUtils();
     BlitCommandEncoder *blitEncoder = nullptr;
+
     // Combine the values stored in the offsets allocated for first query
-    if (mAllocatedQueries[0])
     {
-        const BufferRef &dstBuf = mAllocatedQueries[0]->getVisibilityResultBuffer();
-        const VisibilityBufferOffsetsMtl &allocatedOffsets =
-            mAllocatedQueries[0]->getAllocatedVisibilityOffsets();
-        if (!mResetFirstQuery &&
-            !contextMtl->getDisplay()->getFeatures().allowBufferReadWrite.enabled)
+        const auto &firstQuery        = mAllocatedQueries[0];
+        const BufferRef &resultBuffer = firstQuery.resultBuffer();
+        if (resultBuffer != nullptr)
         {
-            // If we cannot read and write to the same buffer in shader. We need to copy the old
-            // value of first query to first offset allocated for it.
-            blitEncoder = contextMtl->getBlitCommandEncoder();
-            blitEncoder->copyBuffer(dstBuf, 0, mRenderPassResultsPool, allocatedOffsets.front(),
-                                    kOcclusionQueryResultSize);
-            utils.combineVisibilityResult(contextMtl, false, allocatedOffsets,
-                                          mRenderPassResultsPool, dstBuf);
-        }
-        else
-        {
-            utils.combineVisibilityResult(contextMtl, !mResetFirstQuery, allocatedOffsets,
-                                          mRenderPassResultsPool, dstBuf);
+            bool keepOldValue = !mResetFirstQuery;
+            if (keepOldValue &&
+                !contextMtl->getDisplay()->getFeatures().allowBufferReadWrite.enabled)
+            {
+                blitEncoder = contextMtl->getBlitCommandEncoder();
+                blitEncoder->copyBuffer(resultBuffer, 0, mRenderPassResultsPool,
+                                        firstQuery.firstOffset(), kOcclusionQueryResultSize);
+                keepOldValue = false;
+            }
+            utils.combineVisibilityResult(contextMtl, keepOldValue, firstQuery.firstOffset(),
+                                          firstQuery.size(), mRenderPassResultsPool, resultBuffer);
         }
     }
 
     // Combine the values stored in the offsets allocated for each of the remaining queries
     for (size_t i = 1; i < mAllocatedQueries.size(); ++i)
     {
-        QueryMtl *query = mAllocatedQueries[i];
-        if (!query)
+        const auto &query = mAllocatedQueries[i];
+        if (query.resultBuffer() == nullptr)
         {
             continue;
         }
 
-        const BufferRef &dstBuf = mAllocatedQueries[i]->getVisibilityResultBuffer();
-        const VisibilityBufferOffsetsMtl &allocatedOffsets =
-            mAllocatedQueries[i]->getAllocatedVisibilityOffsets();
-        utils.combineVisibilityResult(contextMtl, false, allocatedOffsets, mRenderPassResultsPool,
-                                      dstBuf);
+        utils.combineVisibilityResult(contextMtl, false, query.firstOffset(), query.size(),
+                                      mRenderPassResultsPool, query.resultBuffer());
     }
 
     // Request synchronization and cleanup
     blitEncoder = contextMtl->getBlitCommandEncoder();
-    for (size_t i = 0; i < mAllocatedQueries.size(); ++i)
+    for (auto &entry : mAllocatedQueries)
     {
-        QueryMtl *query = mAllocatedQueries[i];
-        if (!query)
+        if (entry.resultBuffer() == nullptr)
         {
             continue;
         }
-
-        const BufferRef &dstBuf = mAllocatedQueries[i]->getVisibilityResultBuffer();
-
-        dstBuf->syncContent(contextMtl, blitEncoder);
-
-        query->clearAllocatedVisibilityOffsets();
+        entry.resultBuffer()->syncContent(contextMtl, blitEncoder);
     }
 
     mAllocatedQueries.clear();
@@ -201,9 +192,9 @@ void OcclusionQueryPool::prepareRenderPassVisibilityPoolBuffer(ContextMtl *conte
     // If the current visibility pool buffer was used before,
     // ensure that it does not contain previous results.
     auto blitEncoder = contextMtl->getBlitCommandEncoderWithoutEndingRenderEncoder();
-    blitEncoder->fillBuffer(mRenderPassResultsPool,
-                            NSMakeRange(0, mAllocatedQueries.size() * kOcclusionQueryResultSize),
-                            0);
+    blitEncoder->fillBuffer(
+        mRenderPassResultsPool,
+        NSMakeRange(0, mAllocatedQueries.back().lastOffset() + kOcclusionQueryResultSize), 0);
     blitEncoder->endEncoding();
 }
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
@@ -28,7 +28,6 @@ namespace rx
 class BufferMtl;
 class ContextMtl;
 class DisplayMtl;
-class VisibilityBufferOffsetsMtl;
 
 namespace mtl
 {
@@ -467,12 +466,12 @@ class IndexGeneratorUtils final : angle::NonCopyable
 class VisibilityResultUtils final : angle::NonCopyable
 {
   public:
-    angle::Result combineVisibilityResult(
-        ContextMtl *contextMtl,
-        bool keepOldValue,
-        const VisibilityBufferOffsetsMtl &renderPassResultBufOffsets,
-        const BufferRef &renderPassResultBuf,
-        const BufferRef &finalResultBuf);
+    angle::Result combineVisibilityResult(ContextMtl *contextMtl,
+                                          bool keepOldValue,
+                                          size_t startOffset,
+                                          size_t numOffsets,
+                                          const BufferRef &renderPassResultBuf,
+                                          const BufferRef &finalResultBuf);
 
   private:
     angle::Result getVisibilityResultCombinePipeline(
@@ -720,7 +719,8 @@ class RenderUtils : angle::NonCopyable
 
     void combineVisibilityResult(ContextMtl *contextMtl,
                                  bool keepOldValue,
-                                 const VisibilityBufferOffsetsMtl &renderPassResultBufOffsets,
+                                 size_t startOffset,
+                                 size_t numOffsets,
                                  const BufferRef &renderPassResultBuf,
                                  const BufferRef &finalResultBuf);
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -21,7 +21,6 @@
 #include "libANGLE/renderer/metal/ContextMtl.h"
 #include "libANGLE/renderer/metal/DisplayMtl.h"
 #include "libANGLE/renderer/metal/ProgramMtl.h"
-#include "libANGLE/renderer/metal/QueryMtl.h"
 #include "libANGLE/renderer/metal/mtl_common.h"
 #include "libANGLE/renderer/metal/mtl_utils.h"
 
@@ -234,25 +233,29 @@ struct ScopedDisableOcclusionQuery
     ScopedDisableOcclusionQuery(ContextMtl *contextMtl,
                                 RenderCommandEncoder *encoder,
                                 angle::Result *resultOut)
-        : mContextMtl(contextMtl), mEncoder(encoder), mResultOut(resultOut)
+        : mContextMtl(contextMtl),
+          mEncoder(encoder),
+          mResultOut(resultOut),
+          mOcclusionQueryIsEnabled(contextMtl->isOcclusionQueryEnabledInRenderPass())
     {
-#ifndef NDEBUG
-        if (contextMtl->hasActiveOcclusionQuery())
+        if (!mOcclusionQueryIsEnabled)
         {
-            encoder->pushDebugGroup(@"Disabled OcclusionQuery");
+            return;
         }
+#ifndef NDEBUG
+        encoder->pushDebugGroup(@"Disabled OcclusionQuery");
 #endif
-        // temporarily disable occlusion query
-        contextMtl->disableActiveOcclusionQueryInRenderPass();
+        contextMtl->disableOcclusionQueryInRenderPass();
     }
     ~ScopedDisableOcclusionQuery()
     {
-        *mResultOut = mContextMtl->restartActiveOcclusionQueryInRenderPass();
-#ifndef NDEBUG
-        if (mContextMtl->hasActiveOcclusionQuery())
+        if (!mOcclusionQueryIsEnabled)
         {
-            mEncoder->popDebugGroup();
+            return;
         }
+        *mResultOut = mContextMtl->enableOcclusionQueryInRenderPass();
+#ifndef NDEBUG
+        mEncoder->popDebugGroup();
 #else
         ANGLE_UNUSED_VARIABLE(mEncoder);
 #endif
@@ -263,6 +266,7 @@ struct ScopedDisableOcclusionQuery
     RenderCommandEncoder *mEncoder;
 
     angle::Result *mResultOut;
+    const bool mOcclusionQueryIsEnabled;
 };
 
 void GetBlitTexCoords(const NormalizedCoords &normalizedCoords,
@@ -924,17 +928,17 @@ angle::Result RenderUtils::generateLineLoopLastSegmentFromElementsArray(
     return mIndexUtils.generateLineLoopLastSegmentFromElementsArray(contextMtl, params);
 }
 
-void RenderUtils::combineVisibilityResult(
-    ContextMtl *contextMtl,
-    bool keepOldValue,
-    const VisibilityBufferOffsetsMtl &renderPassResultBufOffsets,
-    const BufferRef &renderPassResultBuf,
-    const BufferRef &finalResultBuf)
+void RenderUtils::combineVisibilityResult(ContextMtl *contextMtl,
+                                          bool keepOldValue,
+                                          size_t startOffset,
+                                          size_t numOffsets,
+                                          const BufferRef &renderPassResultBuf,
+                                          const BufferRef &finalResultBuf)
 {
     // TODO(geofflang): Propagate this error. It spreads to adding angle::Result return values in
     // most of the metal backend's files.
     (void)mVisibilityResultUtils.combineVisibilityResult(
-        contextMtl, keepOldValue, renderPassResultBufOffsets, renderPassResultBuf, finalResultBuf);
+        contextMtl, keepOldValue, startOffset, numOffsets, renderPassResultBuf, finalResultBuf);
 }
 
 // Compute based mipmap generation
@@ -2187,22 +2191,20 @@ angle::Result VisibilityResultUtils::getVisibilityResultCombinePipeline(
                                                              outComputePipeline);
 }
 
-angle::Result VisibilityResultUtils::combineVisibilityResult(
-    ContextMtl *contextMtl,
-    bool keepOldValue,
-    const VisibilityBufferOffsetsMtl &renderPassResultBufOffsets,
-    const BufferRef &renderPassResultBuf,
-    const BufferRef &finalResultBuf)
+angle::Result VisibilityResultUtils::combineVisibilityResult(ContextMtl *contextMtl,
+                                                             bool keepOldValue,
+                                                             size_t startOffset,
+                                                             size_t numOffsets,
+                                                             const BufferRef &renderPassResultBuf,
+                                                             const BufferRef &finalResultBuf)
 {
-    ASSERT(!renderPassResultBufOffsets.empty());
-
-    if (renderPassResultBufOffsets.size() == 1 && !keepOldValue)
+    if (numOffsets == 1 && !keepOldValue)
     {
         // Use blit command to copy directly
         BlitCommandEncoder *blitEncoder = contextMtl->getBlitCommandEncoder();
 
-        blitEncoder->copyBuffer(renderPassResultBuf, renderPassResultBufOffsets.front(),
-                                finalResultBuf, 0, kOcclusionQueryResultSize);
+        blitEncoder->copyBuffer(renderPassResultBuf, startOffset, finalResultBuf, 0,
+                                kOcclusionQueryResultSize);
         return angle::Result::Continue;
     }
 
@@ -2214,9 +2216,9 @@ angle::Result VisibilityResultUtils::combineVisibilityResult(
     cmdEncoder->setComputePipelineState(pipeline);
 
     CombineVisibilityResultUniform options;
-    // Offset is viewed as 64 bit unit in compute shader.
-    options.startOffset = renderPassResultBufOffsets.front() / kOcclusionQueryResultSize;
-    options.numOffsets  = renderPassResultBufOffsets.size();
+    // Offset is viewed as 64-bit unit (ushort4) in compute shader.
+    options.startOffset = static_cast<uint32_t>(startOffset / kOcclusionQueryResultSize);
+    options.numOffsets  = static_cast<uint32_t>(numOffsets);
 
     cmdEncoder->setData(options, 0);
     cmdEncoder->setBuffer(renderPassResultBuf, 0, 1);

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/OcclusionQueriesTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/OcclusionQueriesTest.cpp
@@ -1248,6 +1248,140 @@ TEST_P(OcclusionQueriesTestES3, QueryReuseWithMultipleFBOs)
     EXPECT_GL_TRUE(result);
 }
 
+// Test that deleting an occlusion query after a failed begin does not cause use-after-free.
+// A prior query primes the pool. The second query triggers pool doubling which under fault
+// injection fails with OOM. Deleting the query and flushing must not crash.
+TEST_P(OcclusionQueriesTestES3, OcclusionQueryDeleteAfterFailedBeginNoUAF)
+{
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::SimpleForPoints(), essl1_shaders::fs::Green());
+    glUseProgram(program);
+    glViewport(0, 0, getWindowWidth(), getWindowHeight());
+
+    // Start render pass and prime the pool with a successful query.
+    glDrawArrays(GL_POINTS, 0, 1);
+    GLQuery q1;
+    glBeginQuery(GL_ANY_SAMPLES_PASSED, q1);
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    ASSERT_GL_NO_ERROR();
+
+    // Second query triggers pool doubling. Under fault injection this fails with OOM.
+    GLuint q2;
+    glGenQueries(1, &q2);
+    glBeginQuery(GL_ANY_SAMPLES_PASSED, q2);
+    GLenum err = glGetError();
+    if (err == GL_OUT_OF_MEMORY)
+    {
+        // To get here, a OOM must be injected by hand in visibility buffer doubling.
+        fprintf(stderr, "got expected out of memory\n");
+    }
+    // Delete the query and flush — must not crash.
+    glDeleteQueries(1, &q2);
+    glFinish();
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2 - 1, getWindowHeight() / 2, GLColor::green);
+}
+
+// Test deleting a occlusion query while it is active.
+TEST_P(OcclusionQueriesTestES3, DeleteActiveOcclusionQueryLeavesValidState)
+{
+    GLuint queryId = 0;
+    glGenQueries(1, &queryId);
+    glBeginQuery(GL_ANY_SAMPLES_PASSED, queryId);
+    drawQuad(mProgram, essl1_shaders::PositionAttrib(), 0.5f);
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    ASSERT_GL_NO_ERROR();
+
+    GLuint queryResult = 0;
+    glGetQueryObjectuiv(queryId, GL_QUERY_RESULT, &queryResult);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_EQ(queryResult, static_cast<GLuint>(GL_TRUE));
+
+    glBeginQuery(GL_ANY_SAMPLES_PASSED, queryId);
+    EXPECT_GL_NO_ERROR();
+
+    drawQuad(mProgram, essl1_shaders::PositionAttrib(), 0.5f);
+    ASSERT_GL_NO_ERROR();
+
+    GLint activeQueryId = 0;
+    glGetQueryiv(GL_ANY_SAMPLES_PASSED, GL_CURRENT_QUERY, &activeQueryId);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_EQ(static_cast<GLuint>(activeQueryId), queryId);
+
+    glDeleteQueries(1, &queryId);
+    EXPECT_GL_NO_ERROR();
+
+    EXPECT_GL_FALSE(glIsQuery(queryId));
+
+    // NOTE: This is unspecified and confusing: what should the return value be
+    // if the query has been deleted? If 0, then it's confusing because EndQuery
+    // doesn't fail. If non-zero, how can it return deleted value?
+    // If EndQuery should fail and return should be 0?
+    GLint activeQueryAfterDelete = 0;
+    glGetQueryiv(GL_ANY_SAMPLES_PASSED, GL_CURRENT_QUERY, &activeQueryAfterDelete);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_EQ(static_cast<GLuint>(activeQueryAfterDelete), queryId);
+
+    drawQuad(mProgram, essl1_shaders::PositionAttrib(), 0.8f);
+    EXPECT_GL_NO_ERROR();
+
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    EXPECT_GL_NO_ERROR();  // NOTE: This is unspecified and confusing.
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
+    EXPECT_GL_NO_ERROR();
+}
+
+// Test that a query spanning two render passes (broken by glClear) accumulates results correctly.
+// First draw fails depth test (no samples pass), then glClear breaks the render pass, then
+// second draw passes. Query result must be TRUE.
+TEST_P(OcclusionQueriesTestES3, QuerySpansRenderPassBreak)
+{
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::SimpleForPoints(), essl1_shaders::fs::Green());
+    glUseProgram(program);
+    glViewport(0, 0, getWindowWidth(), getWindowHeight());
+
+    glEnable(GL_DEPTH_TEST);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    
+    // Draw with GL_NEVER does not pass samples.
+    glDepthFunc(GL_NEVER);
+
+    GLQuery query;
+    glBeginQuery(GL_ANY_SAMPLES_PASSED, query);
+    glDrawArrays(GL_POINTS, 0, 1);
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    GLuint result = GL_FALSE;
+    glGetQueryObjectuiv(query, GL_QUERY_RESULT, &result);
+    EXPECT_GL_NO_ERROR();
+
+    // Test setup validation: draw with GL_NEVER does not pass samples.
+    EXPECT_GL_FALSE(result);
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2 - 1, getWindowHeight() / 2, GLColor::black);
+
+    // Test the sample accumulation across render passes:
+    // Draw with GL_NEVER -> no samples pass yet.
+    // Break render pass
+    // Draw with GL_ALWAYS -> samples pass.
+    glBeginQuery(GL_ANY_SAMPLES_PASSED, query);
+    glDrawArrays(GL_POINTS, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glDepthFunc(GL_ALWAYS);
+    glDrawArrays(GL_POINTS, 0, 1);
+    glEndQuery(GL_ANY_SAMPLES_PASSED);
+    EXPECT_GL_NO_ERROR();
+
+    // Query should report TRUE because the second draw passed samples.
+    result = GL_FALSE;
+    glGetQueryObjectuiv(query, GL_QUERY_RESULT, &result);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_GL_TRUE(result);
+
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() / 2 - 1, getWindowHeight() / 2, GLColor::green);
+}
+
 ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(OcclusionQueriesTest);
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(OcclusionQueriesTestES3);


### PR DESCRIPTION
#### 9d2cc8c9895d51eb240b8f75575393b57bf1d478
<pre>
ANGLE: Metal: Dangling mOcclusionQuery pointer if visibility buffer allocation fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314398">https://bugs.webkit.org/show_bug.cgi?id=314398</a>
<a href="https://rdar.apple.com/176201738">rdar://176201738</a>

Reviewed by Dan Glastonbury.

ContextMtl would populate QueryMtl *ContextMtl::mOcclusionQuery before
visibility buffer allocation:
  mOcclusionQuery = query;
  ANGLE_TRY(startOcclusionQueryInRenderPass(...));
If the allocation failed, frontend would not keep the Query instance
alive.

Avoid pointing to GL object, QueryMtl *, in ContextMtl. Instead
point to the Metal buffer of QueryMtl.
Do not store render pass state in QueryMtl, rather store it in
the render pass state representation of the query implementation,
the OcclusionQueryPool. This simplifies the implementation a lot.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h:
(rx::ContextMtl::isOcclusionQueryEnabledInRenderPass const):
(rx::ContextMtl::hasActiveOcclusionQuery const): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::endEncoding):
(rx::ContextMtl::onOcclusionQueryBegin):
(rx::ContextMtl::onOcclusionQueryEnd):
(rx::ContextMtl::disableOcclusionQueryInRenderPass):
(rx::ContextMtl::enableOcclusionQueryInRenderPass):
(rx::ContextMtl::setupDrawImpl):
(rx::ContextMtl::onOcclusionQueryDestroy): Deleted.
(rx::ContextMtl::disableActiveOcclusionQueryInRenderPass): Deleted.
(rx::ContextMtl::restartActiveOcclusionQueryInRenderPass): Deleted.
(rx::ContextMtl::startOcclusionQueryInRenderPass): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/QueryMtl.h:
(rx::VisibilityBufferOffsetsMtl::clear): Deleted.
(rx::VisibilityBufferOffsetsMtl::empty const): Deleted.
(rx::VisibilityBufferOffsetsMtl::size const): Deleted.
(rx::VisibilityBufferOffsetsMtl::back const): Deleted.
(rx::VisibilityBufferOffsetsMtl::front const): Deleted.
(rx::VisibilityBufferOffsetsMtl::setStartOffset): Deleted.
(rx::VisibilityBufferOffsetsMtl::addOffset): Deleted.
(rx::QueryMtl::getAllocatedVisibilityOffsets const): Deleted.
(rx::QueryMtl::setFirstAllocatedVisibilityOffset): Deleted.
(rx::QueryMtl::addAllocatedVisibilityOffset): Deleted.
(rx::QueryMtl::clearAllocatedVisibilityOffsets): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/QueryMtl.mm:
(rx::QueryMtl::onDestroy):
(rx::QueryMtl::end):
(rx::QueryMtl::resetVisibilityResult): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm:
(rx::mtl::RenderCommandEncoder::endEncodingImpl):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_occlusion_query_pool.h:
(rx::mtl::VisibilityBufferOffsetsMtl::VisibilityBufferOffsetsMtl):
(rx::mtl::VisibilityBufferOffsetsMtl::size const):
(rx::mtl::VisibilityBufferOffsetsMtl::lastOffset const):
(rx::mtl::VisibilityBufferOffsetsMtl::firstOffset const):
(rx::mtl::VisibilityBufferOffsetsMtl::addOffset):
(rx::mtl::VisibilityBufferOffsetsMtl::resultBuffer const):
(rx::mtl::VisibilityBufferOffsetsMtl::discard):
(rx::mtl::OcclusionQueryPool::hasPendingVisibilityResults const):
(rx::mtl::OcclusionQueryPool::getNumRenderPassAllocatedQueries const): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_occlusion_query_pool.mm:
(rx::mtl::OcclusionQueryPool::destroy):
(rx::mtl::OcclusionQueryPool::ensurePoolCapacity):
(rx::mtl::OcclusionQueryPool::beginQuery):
(rx::mtl::OcclusionQueryPool::continueQuery):
(rx::mtl::OcclusionQueryPool::resolveVisibilityResults):
(rx::mtl::OcclusionQueryPool::prepareRenderPassVisibilityPoolBuffer):
(rx::mtl::OcclusionQueryPool::allocateQueryOffset): Deleted.
(rx::mtl::OcclusionQueryPool::deallocateQueryOffset): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm:
(rx::mtl::RenderUtils::combineVisibilityResult):
(rx::mtl::VisibilityResultUtils::combineVisibilityResult):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/OcclusionQueriesTest.cpp:

Originally-landed-as: 305413.883@safari-7624-branch (417b97d905b3). <a href="https://rdar.apple.com/180436178">rdar://180436178</a>
Canonical link: <a href="https://commits.webkit.org/316606@main">https://commits.webkit.org/316606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a463f3ed0c480bda0dbaf170e57f5ce71a1fa654

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182419 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134517 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37908 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114986 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31017 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184953 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143324 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46549 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143195 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38644 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47227 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112233 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38178 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45744 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9530 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->