### PR TITLE
uint32 Wraparound in vsUintIndexClamp Leads to GPU OOB Read

### DIFF
--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -733,8 +733,7 @@ id<MTLRenderPipelineState> Device::indexBufferClampPipeline(MTLIndexType indexTy
         device MTLDrawIndexedPrimitivesIndirectArguments& indexedOutput = wkindexedOutput.args;
         uint indexBufferValue = indexBuffer[min(indexId, data[indexCountMinusOne])];
         uint vertexIndex = data[primitiveRestart] + indexBufferValue;
-        bool negativeCondition = indexedOutput.baseVertex + data[primitiveRestart] < indexedOutput.baseVertex;
-        if (negativeCondition || (vertexIndex + indexedOutput.baseVertex >= data[vertexCount] + data[primitiveRestart])) {
+        if (addsat(vertexIndex, indexedOutput.baseVertex) >= data[vertexCount] + data[primitiveRestart]) {
             indexedOutput.indexCount = 0u;
             indexedOutput.instanceCount = 0u;
             indexedOutput.indexStart = 0u;
@@ -802,9 +801,9 @@ id<MTLRenderPipelineState> Device::indexedIndirectBufferClampPipeline(NSUInteger
         device MTLDrawIndexedPrimitivesIndirectArguments& indexedOutput = wkindexedOutput.args;
         bool lostCondition = input.indexCount > %u || input.instanceCount > %u || madsat(input.indexCount, input.instanceCount, 0u) > %u;
         bool condition = lostCondition
-            || input.indexCount + input.indexStart > indexBufferCount[0]
+            || addsat(input.indexCount, input.indexStart) > indexBufferCount[0]
             || input.indexStart >= indexBufferCount[0]
-            || input.instanceCount + input.baseInstance > indexBufferCount[1]
+            || addsat(input.instanceCount, input.baseInstance) > indexBufferCount[1]
             || input.baseInstance >= indexBufferCount[1];
 
         indexedOutput.indexCount = metal::select(input.indexCount, 0u, condition);
@@ -872,9 +871,9 @@ id<MTLRenderPipelineState> Device::indirectBufferClampPipeline(NSUInteger raster
         device MTLDrawPrimitivesIndirectArguments& output = wkoutput.args;
         bool lostCondition = input.vertexCount > %u || input.instanceCount > %u || madsat(input.vertexCount, input.instanceCount, 0u) > %u;
         bool vertexCondition = lostCondition
-            || input.vertexCount + input.vertexStart > minCounts[0]
+            || addsat(input.vertexCount, input.vertexStart) > minCounts[0]
             || input.vertexStart >= minCounts[0];
-        bool instanceCondition = input.baseInstance + input.instanceCount > minCounts[1] || input.baseInstance >= minCounts[1];
+        bool instanceCondition = addsat(input.baseInstance, input.instanceCount) > minCounts[1] || input.baseInstance >= minCounts[1];
         auto minVertexCountMinusVertexStart = minCounts[0] > input.vertexStart ? (minCounts[0] - input.vertexStart) : 0u;
         output.vertexCount = metal::select(input.vertexCount, minVertexCountMinusVertexStart, vertexCondition);
         auto minInstanceCountMinusInstanceStart = minCounts[1] > input.baseInstance ? (minCounts[1] - input.baseInstance) : 0u;
@@ -1009,8 +1008,7 @@ id<MTLFunction> Device::icbCommandClampFunction(MTLIndexType indexType)
         uint32_t k = (data.primitiveType == primitive_type::triangle_strip || data.primitiveType == primitive_type::line_strip) ? 1 : 0;
         uint32_t indexBufferValue = data.indexBuffer[min(data.indexBufferElementCountMinusOne, indexId + data.firstIndex)];
         uint32_t vertexIndex = indexBufferValue + k;
-        bool negativeCondition = data.baseVertex + k < data.baseVertex;
-        if (negativeCondition || (data.baseVertex + vertexIndex >= data.minVertexCount + k)) {
+        if (addsat(vertexIndex, data.baseVertex) >= data.minVertexCount + k) {
             *icb_container->outOfBoundsRead = 1;
             render_command cmd(icb_container->commandBuffer, data.renderCommand);
             cmd.draw_indexed_primitives(data.primitiveType,
@@ -1029,9 +1027,8 @@ id<MTLFunction> Device::icbCommandClampFunction(MTLIndexType indexType)
         device const IndexDataUshort& data = *indexData;
         uint32_t k = (data.primitiveType == primitive_type::triangle_strip || data.primitiveType == primitive_type::line_strip) ? 1 : 0;
         ushort indexBufferValue = data.indexBuffer[min(data.indexBufferElementCountMinusOne, indexId + data.firstIndex)];
-        ushort vertexIndex = indexBufferValue + k;
-        bool negativeCondition = data.baseVertex + k < data.baseVertex;
-        if (negativeCondition || (data.baseVertex + vertexIndex >= data.minVertexCount + k)) {
+        uint32_t vertexIndex = uint(indexBufferValue) + k;
+        if (addsat(vertexIndex, data.baseVertex) >= data.minVertexCount + k) {
             *icb_container->outOfBoundsRead = 1;
             render_command cmd(icb_container->commandBuffer, data.renderCommand);
             cmd.draw_indexed_primitives(data.primitiveType,


### PR DESCRIPTION
#### 0077500fa5bef9cbd92f0060aed5ec59fde533de
<pre>
uint32 Wraparound in vsUintIndexClamp Leads to GPU OOB Read
<a href="https://bugs.webkit.org/show_bug.cgi?id=313368">https://bugs.webkit.org/show_bug.cgi?id=313368</a>
<a href="https://rdar.apple.com/174662876">rdar://174662876</a>

Reviewed by Dan Glastonbury.

Correct wrapping logic while supporting wrap to zero for
triangle + line restart indices.

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::indexBufferClampPipeline):

Originally-landed-as: 305413.811@safari-7624-branch (a69633739677). <a href="https://rdar.apple.com/180436268">rdar://180436268</a>
Canonical link: <a href="https://commits.webkit.org/316276@main">https://commits.webkit.org/316276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a376aa53bad3c4d9c6f0b8c0d935430b92984683

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133427 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94147 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153873 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113893 "Found 1 new API test failure: WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-document-title (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33577 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183105 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35900 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 28340 issues") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37772 "Build was cancelled. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141897 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44722 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141706 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38392 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45411 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110116 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36965 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117299 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43922 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->