### PR TITLE
Change IPInt m_pendingOffset to std::optional and add metadata offset overflow assertions

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -180,7 +180,7 @@ private:
     BlockType m_blockType;
     CatchKind m_catchKind;
 
-    int32_t m_pendingOffset { -1 };
+    std::optional<uint32_t> m_pendingOffset;
 
     uint32_t m_index { 0 };
     uint32_t m_pc { 0 }; // where am i?
@@ -602,7 +602,7 @@ public:
         auto& target = m_controlStructuresAwaitingCoalescing[index];
         if (target.isLoop) {
             ASSERT(target.m_entryResolved);
-            IPInt::BlockMetadata md = { static_cast<int32_t>(target.m_entryTarget.pc - loc.pc), static_cast<int32_t>(target.m_entryTarget.mc - loc.mc) };
+            IPInt::BlockMetadata md = checkedDelta(target.m_entryTarget, loc);
             WRITE_TO_METADATA(metadata + loc.mc, md, IPInt::BlockMetadata);
             RECORD_NEXT_INSTRUCTION(loc.pc, target.m_entryTarget.pc);
         } else {
@@ -662,9 +662,21 @@ private:
     // all jumps that go to the top level and return
     Vector<IPIntLocation> m_jumpLocationsAwaitingEnd;
 
-    inline uint32_t NODELETE curPC() { return m_parser->currentOpcodeStartingOffset() - m_metadata->m_bytecodeOffset; }
-    inline uint32_t NODELETE nextPC() { return m_parser->offset() - m_metadata->m_bytecodeOffset; }
-    inline uint32_t NODELETE curMC() { return m_metadata->m_metadata.size(); }
+    inline uint32_t NODELETE curPC() { return Checked<uint32_t>(m_parser->currentOpcodeStartingOffset()) - m_metadata->m_bytecodeOffset; }
+    inline uint32_t NODELETE nextPC() { return Checked<uint32_t>(m_parser->offset()) - m_metadata->m_bytecodeOffset; }
+    // FIXME: Should return size_t, but BlockMetadata::deltaMC is int32_t and the interpreter loads it with loadpairi.
+    inline uint32_t NODELETE curMC()
+    {
+        Checked<uint32_t> size = m_metadata->m_metadata.size();
+        return size;
+    }
+
+    static ALWAYS_INLINE IPInt::BlockMetadata checkedDelta(IPIntLocation to, IPIntLocation from)
+    {
+        Checked<int32_t> dPC = static_cast<int64_t>(to.pc) - static_cast<int64_t>(from.pc);
+        Checked<int32_t> dMC = static_cast<int64_t>(to.mc) - static_cast<int64_t>(from.mc);
+        return { dPC, dMC };
+    }
 
     CallInformation m_cachedCallInformation { };
     const RTT* m_cachedSignature { nullptr };
@@ -2117,7 +2129,7 @@ void IPIntGenerator::coalesceControlFlow(bool force)
         m_controlStructuresAwaitingCoalescing.shrink(0);
 
     for (auto& src : m_exitHandlersAwaitingCoalescing) {
-        IPInt::BlockMetadata md = { static_cast<int32_t>(here.pc - src.pc), static_cast<int32_t>(here.mc - src.mc) };
+        IPInt::BlockMetadata md = checkedDelta(here, src);
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
         RECORD_NEXT_INSTRUCTION(src.pc, here.pc);
     }
@@ -2130,13 +2142,13 @@ void IPIntGenerator::resolveEntryTarget(unsigned index, IPIntLocation loc)
     ASSERT(!control.m_entryResolved);
     for (auto& src : control.m_awaitingEntryTarget) {
         // write delta PC and delta MC
-        IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+        IPInt::BlockMetadata md = checkedDelta(loc, src);
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
         RECORD_NEXT_INSTRUCTION(src.pc, loc.pc); // FIXME: coalescing sequential blocks - should update instead of adding
     }
     if (control.isLoop) {
         for (auto& src : control.m_awaitingBranchTarget) {
-            IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+            IPInt::BlockMetadata md = checkedDelta(loc, src);
             WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
             RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
         }
@@ -2153,13 +2165,13 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     ASSERT(!control.m_exitResolved);
     for (auto& src : control.m_awaitingExitTarget) {
         // write delta PC and delta MC
-        IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+        IPInt::BlockMetadata md = checkedDelta(loc, src);
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
         RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
     }
     if (!control.isLoop) {
         for (auto& src : control.m_awaitingBranchTarget) {
-            IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+            IPInt::BlockMetadata md = checkedDelta(loc, src);
             WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
             RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
         }
@@ -2213,7 +2225,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
 {
     block = ControlType(WTF::move(signature), m_stackSize.value() - args.size(), BlockType::Loop);
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
-    block.m_pendingOffset = -1; // no need to update!
+    block.m_pendingOffset = std::nullopt; // no need to update!
     block.m_pc = curPC();
     RECORD_NEXT_INSTRUCTION(block.m_pc, nextPC());
 
@@ -2246,7 +2258,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
     block.m_pc = curPC();
     block.m_mc = curMC();
-    block.m_pendingOffset = m_metadata->m_metadata.size();
+    block.m_pendingOffset = curMC();
     RECORD_NEXT_INSTRUCTION(block.m_pc, nextPC());
 
     m_coalesceQueue.append(QueuedCoalesceRequest { m_controlStructuresAwaitingCoalescing.size(), true });
@@ -2277,7 +2289,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     changeStackSize(blockSignature.argumentCount());
     auto ifIndex = block.m_index;
 
-    auto mdIf = reinterpret_cast<IPInt::IfMetadata*>(m_metadata->m_metadata.mutableSpan().data() + block.m_pendingOffset);
+    auto mdIf = reinterpret_cast<IPInt::IfMetadata*>(m_metadata->m_metadata.mutableSpan().data() + *block.m_pendingOffset);
 
     // delta PC
     mdIf->elseDeltaPC = nextPC() - block.m_pc;
@@ -2289,7 +2301,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
         mdIf->elseDeltaMC = curMC() - block.m_mc;
         block = ControlType(WTF::move(blockSignature), block.stackSize(), BlockType::Else);
         block.m_index = ifIndex;
-        block.m_pendingOffset = -1;
+        block.m_pendingOffset = std::nullopt;
         return { };
     }
 
@@ -2430,8 +2442,8 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         HandlerType::Catch,
         static_cast<uint32_t>(block.m_pc),
         static_cast<uint32_t>(block.m_pcEnd + 1), // + 1 since m_pcEnd is the PC of the catch bytecode, which should be included in the range
-        static_cast<uint32_t>(m_parser->offset() - m_metadata->m_bytecodeOffset),
-        static_cast<uint32_t>(m_metadata->m_metadata.size()),
+        nextPC(),
+        curMC(),
         m_tryDepth,
         exceptionIndex
     });
@@ -2469,8 +2481,8 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         HandlerType::CatchAll,
         static_cast<uint32_t>(block.m_pc),
         static_cast<uint32_t>(block.m_pcEnd + 1), // + 1 since m_pcEnd is the PC of the catch bytecode, which should be included in the range
-        static_cast<uint32_t>(m_parser->offset() - m_metadata->m_bytecodeOffset),
-        static_cast<uint32_t>(m_metadata->m_metadata.size()),
+        nextPC(),
+        curMC(),
         m_tryDepth,
         0
     });
@@ -2507,8 +2519,8 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         HandlerType::Delegate,
         static_cast<uint32_t>(data.m_pc),
         static_cast<uint32_t>(data.m_pcEnd + 1), // + 1 since m_pcEnd is the PC of the delegate bytecode, which should be included in the range
-        static_cast<uint32_t>(curPC()),
-        static_cast<uint32_t>(curMC()),
+        curPC(),
+        curMC(),
         m_tryDepth,
         targetDepth
     });
@@ -2745,7 +2757,7 @@ void IPIntGenerator::endTryTable(const ControlType& data)
         m_exitHandlersAwaitingCoalescing.append({ block.m_pc, block.m_mc });
     } else if (ControlType::isElse(block)) {
         // if it's not an if ... end, coalesce
-        if (block.m_pendingOffset != -1)
+        if (block.m_pendingOffset)
             m_exitHandlersAwaitingCoalescing.append({ block.m_pc, block.m_mc });
         m_coalesceQueue.append({ static_cast<unsigned>(block.m_index), false });
         --m_coalesceDebt;


### PR DESCRIPTION
#### b44e37ce8f99bf4f83f4d28f8a1e3ab9e99a93aa
<pre>
Change IPInt m_pendingOffset to std::optional and add metadata offset overflow assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=313590">https://bugs.webkit.org/show_bug.cgi?id=313590</a>
<a href="https://rdar.apple.com/175673870">rdar://175673870</a>

Reviewed by Dan Hecht.

IPIntControlType::m_pendingOffset was int32_t but stored values from
m_metadata-&gt;m_metadata.size(). A function within maxFunctionSize can
generate metadata exceeding INT32_MAX via repeated calls to functions
with large signatures.

Add overflow checks to the 32 bit computations to avoid silently
producing invalid metadata addresses, and change m_pendingOffset to use
std::optional instead of a sentinel value.

A practical test would take too long to include.

* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::tryToResolveBranchTarget):
(JSC::Wasm::IPIntGenerator::curPC):
(JSC::Wasm::IPIntGenerator::nextPC):
(JSC::Wasm::IPIntGenerator::curMC):
(JSC::Wasm::IPIntGenerator::checkedDelta):
(JSC::Wasm::IPIntGenerator::coalesceControlFlow):
(JSC::Wasm::IPIntGenerator::resolveEntryTarget):
(JSC::Wasm::IPIntGenerator::resolveExitTarget):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):

Originally-landed-as: 305413.828@safari-7624-branch (d446d220d636). <a href="https://rdar.apple.com/180428054">rdar://180428054</a>
Canonical link: <a href="https://commits.webkit.org/316298@main">https://commits.webkit.org/316298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5fce7b6f2754ca58b4073c46c8d3ec5c14e720

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133583 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35484 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33745 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29612 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2574 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183531 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32819 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36146 "Found 3 new failures in wasm/WasmIPIntGenerator.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142147 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45144 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142042 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45823 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110458 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37263 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117512 "Found 3 new failures in wasm/WasmIPIntGenerator.cpp") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204238 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44342 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8483 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54583 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43742 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->