### PR TITLE
com.apple.WebKit.Networking at Received an invalid message 'NetworkConnectionToWebProcess_LoadImageForDecoding'

### DIFF
--- a/LayoutTests/ipc/load-image-for-decoding-file-url-expected.txt
+++ b/LayoutTests/ipc/load-image-for-decoding-file-url-expected.txt
@@ -1,0 +1,2 @@
+PASS: file:// rejected by MESSAGE_CHECK
+

--- a/LayoutTests/ipc/load-image-for-decoding-file-url.html
+++ b/LayoutTests/ipc/load-image-for-decoding-file-url.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html><body>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+function log(s) { document.getElementById('log').textContent += s + '\n'; }
+
+async function main() {
+    if (!window.IPC) {
+        log('PASS: file:// rejected by MESSAGE_CHECK');
+        return;
+    }
+
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+
+    const fileRequest = {
+        getRequestDataToSerialize: {
+            variantType: 'WebCore::ResourceRequest::RequestData',
+            variant: {
+                m_url: { string: 'file:///private/etc/hosts' },
+                m_firstPartyForCookies: { string: 'file:///private/etc/hosts' },
+                m_timeoutInterval: 60.0,
+                m_httpMethod: 'GET',
+                m_httpHeaderFields: { commonHeaders: [], uncommonHeaders: [] },
+                m_responseContentDispositionEncodingFallbackArray: [],
+                m_cachePolicy: 0,
+                m_sameSiteDisposition: 1,
+                m_priority: 2,
+                m_requester: 0,
+                m_allowCookies: true,
+                m_isTopSite: true,
+                m_isAppInitiated: true,
+                m_privacyProxyFailClosedForUnreachableNonMainHosts: false,
+                m_useAdvancedPrivacyProtections: false,
+                m_didFilterLinkDecoration: false,
+                m_isPrivateTokenUsageByThirdPartyAllowed: false,
+                m_wasSchemeOptimisticallyUpgraded: false,
+                m_targetAddressSpace: 0,
+            },
+        },
+        cachePartition: '',
+        hiddenFromInspector: false,
+    };
+
+    const definition = IPC.messages.NetworkConnectionToWebProcess_LoadImageForDecoding;
+    const args = ArgumentSerializer.serializeArguments(definition.arguments,
+        { request: fileRequest, pageID: BigInt(IPC.webPageProxyID), maximumBytesFromNetwork: 1024n });
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    IPC.connectionForProcessTarget('Networking').sendWithAsyncReply(0, definition.name, args, () => { });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    if (messageCheck && messageCheck.includes('Message check failed') && messageCheck.includes('protocolIsInHTTPFamily'))
+        log('PASS: file:// rejected by MESSAGE_CHECK');
+    else
+        log('FAIL: expected MESSAGE_CHECK on protocolIsInHTTPFamily, got: "' + messageCheck + '"');
+}
+
+main().catch(e => log('FAIL: ' + e + '\n' + (e.stack || ''))).finally(() => window.testRunner?.notifyDone());
+</script>
+</body></html>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -241,7 +241,8 @@ void NetworkConnectionToWebProcess::hasUploadStateChanged(bool hasUpload)
 void NetworkConnectionToWebProcess::loadImageForDecoding(WebCore::ResourceRequest&& request, WebPageProxyIdentifier pageID, uint64_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&&)>&& completionHandler)
 {
     auto url = request.url();
-    MESSAGE_CHECK_COMPLETION(url.isValid(), completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
+    MESSAGE_CHECK_COMPLETION(url.isValid() && url.protocolIsInHTTPFamily(), completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
+    MESSAGE_CHECK_COMPLETION(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow, completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
     CheckedPtr networkSession = this->networkSession();
     if (!networkSession)
         return completionHandler(makeUnexpected<WebCore::ResourceError>({ }));

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -242,7 +242,11 @@ void NetworkConnectionToWebProcess::loadImageForDecoding(WebCore::ResourceReques
 {
     auto url = request.url();
     MESSAGE_CHECK_COMPLETION(url.isValid() && url.protocolIsInHTTPFamily(), completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
-    MESSAGE_CHECK_COMPLETION(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow, completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
+
+    if (request.firstPartyForCookies().isValid())
+        MESSAGE_CHECK_COMPLETION(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow, completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
+    else
+        request.setAllowCookies(false);
     CheckedPtr networkSession = this->networkSession();
     if (!networkSession)
         return completionHandler(makeUnexpected<WebCore::ResourceError>({ }));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5157,9 +5157,17 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
 - (void)_loadAndDecodeImage:(NSURLRequest *)request constrainedToSize:(CGSize)maxSize maximumBytesFromNetwork:(size_t)maximumBytesFromNetwork completionHandler:(void (^)(CocoaImage *, NSError *))completionHandler
 {
-    auto sizeConstraint = (maxSize.height || maxSize.width) ? std::optional(WebCore::FloatSize(maxSize)) : std::nullopt;
+    RetainPtr<NSMutableURLRequest> mutableRequest;
+    if (!request.mainDocumentURL) {
+        mutableRequest = adoptNS([request mutableCopy]);
+        [mutableRequest setMainDocumentURL:self.URL];
+        request = mutableRequest.get();
+    }
+
     WebCore::ResourceRequest resourceRequest(request);
     auto url = resourceRequest.url();
+    auto sizeConstraint = (maxSize.height || maxSize.width) ? std::optional(WebCore::FloatSize(maxSize)) : std::nullopt;
+
     _page->loadAndDecodeImage(request, sizeConstraint, maximumBytesFromNetwork, [completionHandler = makeBlockPtr(completionHandler), url](Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&& result) mutable {
         if (!result) {
             if (result.error().isNull())

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5157,13 +5157,6 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
 - (void)_loadAndDecodeImage:(NSURLRequest *)request constrainedToSize:(CGSize)maxSize maximumBytesFromNetwork:(size_t)maximumBytesFromNetwork completionHandler:(void (^)(CocoaImage *, NSError *))completionHandler
 {
-    RetainPtr<NSMutableURLRequest> mutableRequest;
-    if (!request.mainDocumentURL) {
-        mutableRequest = adoptNS([request mutableCopy]);
-        [mutableRequest setMainDocumentURL:self.URL];
-        request = mutableRequest.get();
-    }
-
     WebCore::ResourceRequest resourceRequest(request);
     auto url = resourceRequest.url();
     auto sizeConstraint = (maxSize.height || maxSize.width) ? std::optional(WebCore::FloatSize(maxSize)) : std::nullopt;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11542,7 +11542,7 @@ void WebPageProxy::dataTaskWithRequest(WebCore::ResourceRequest&& request, const
 
 void WebPageProxy::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::optional<WebCore::FloatSize> sizeConstraint, size_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&& completionHandler)
 {
-    if (isClosed() || !request.url().isValid())
+    if (isClosed() || !request.url().isValid() || !request.url().protocolIsInHTTPFamily())
         return completionHandler(makeUnexpected(decodeError(request.url())));
 
     if (!hasRunningProcess())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8405,7 +8405,12 @@ void WebPage::scheduleFullEditorStateUpdate()
 
 void WebPage::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::optional<WebCore::FloatSize> sizeConstraint, uint64_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&& completionHandler)
 {
-    URL url = request.url();
+    auto url = request.url();
+    RefPtr page = corePage();
+    if (!page)
+        return completionHandler(makeUnexpected(decodeError(url)));
+
+    request.setFirstPartyForCookies(page->mainFrameURL());
     WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::LoadImageForDecoding(WTF::move(request), m_webPageProxyIdentifier, maximumBytesFromNetwork), [completionHandler = WTF::move(completionHandler), sizeConstraint, url] (Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&& result) mutable {
         if (!result)
             return completionHandler(makeUnexpected(WTF::move(result.error())));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
@@ -456,4 +456,43 @@ TEST(WebKit, LoadAndDecodeImageInvalidURL)
     EXPECT_EQ(pid, [webView _webProcessIdentifier]);
 }
 
+TEST(WebKit, LoadAndDecodeImageNilMainDocumentURLAfterNavigation)
+{
+    auto pngData = makeVector([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]]);
+
+    HTTPServer server {
+        { "/"_s, { "<html></html>"_s } },
+        { "/image.png"_s, { WTF::move(pngData) } },
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+    [webView synchronouslyLoadRequest:server.request()];
+
+    __block bool completionHandlerCalled { false };
+    __block RetainPtr<Util::PlatformImage> resultImage;
+    __block RetainPtr<NSError> resultError;
+    __block bool processTerminated { false };
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
+        processTerminated = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    // This request has a nil mainDocumentURL.
+    [webView _loadAndDecodeImage:server.request("/image.png"_s) constrainedToSize:CGSizeZero maximumBytesFromNetwork:std::numeric_limits<size_t>::max() completionHandler:^(Util::PlatformImage *image, NSError *error) {
+        resultImage = image;
+        resultError = error;
+        completionHandlerCalled = true;
+    }];
+
+    Util::run(&completionHandlerCalled);
+    // Give webContentProcessDidTerminate enough time to get called before checking processTerminated.
+    Util::spinRunLoop(10);
+
+    EXPECT_NOT_NULL(resultImage);
+    EXPECT_NULL(resultError);
+    EXPECT_FALSE(processTerminated);
+}
+
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/LoadAndDecodeImage.mm
@@ -495,4 +495,79 @@ TEST(WebKit, LoadAndDecodeImageNilMainDocumentURLAfterNavigation)
     EXPECT_FALSE(processTerminated);
 }
 
+TEST(WebKit, LoadAndDecodeImageBeforeAnyNavigation)
+{
+    auto pngData = makeVector([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]]);
+
+    HTTPServer server {
+        { "/image.png"_s, { WTF::move(pngData) } },
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    __block bool processTerminated { false };
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
+        processTerminated = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    EXPECT_NULL([webView URL]);
+
+    __block bool completionHandlerCalled { false };
+    __block RetainPtr<Util::PlatformImage> resultImage;
+    __block RetainPtr<NSError> resultError;
+    [webView _loadAndDecodeImage:server.request("/image.png"_s) constrainedToSize:CGSizeZero maximumBytesFromNetwork:std::numeric_limits<size_t>::max() completionHandler:^(Util::PlatformImage *image, NSError *error) {
+        resultImage = image;
+        resultError = error;
+        completionHandlerCalled = true;
+    }];
+
+    Util::run(&completionHandlerCalled);
+    Util::spinRunLoop(10);
+
+    EXPECT_NOT_NULL(resultImage);
+    EXPECT_NULL(resultError);
+    EXPECT_FALSE(processTerminated);
+}
+
+TEST(WebKit, LoadAndDecodeImageWithCallerProvidedDisallowedMainDocumentURL)
+{
+    auto pngData = makeVector([NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]]);
+
+    HTTPServer server {
+        { "/"_s, { "<html></html>"_s } },
+        { "/image.png"_s, { WTF::move(pngData) } },
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] init]);
+    [webView synchronouslyLoadRequest:server.request()];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    __block bool processTerminated { false };
+    [navigationDelegate setWebContentProcessDidTerminate:^(WKWebView *, _WKProcessTerminationReason) {
+        processTerminated = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    RetainPtr request = adoptNS([[NSMutableURLRequest alloc] initWithURL:server.request("/image.png"_s).URL]);
+    [request setMainDocumentURL:[NSURL URLWithString:@"http://unrelated-domain.example/"]];
+
+    __block bool completionHandlerCalled { false };
+    __block RetainPtr<Util::PlatformImage> resultImage;
+    __block RetainPtr<NSError> resultError;
+    [webView _loadAndDecodeImage:request.get() constrainedToSize:CGSizeZero maximumBytesFromNetwork:std::numeric_limits<size_t>::max() completionHandler:^(Util::PlatformImage *image, NSError *error) {
+        resultImage = image;
+        resultError = error;
+        completionHandlerCalled = true;
+    }];
+
+    Util::run(&completionHandlerCalled);
+    Util::spinRunLoop(10);
+
+    EXPECT_NOT_NULL(resultImage);
+    EXPECT_NULL(resultError);
+    EXPECT_FALSE(processTerminated);
+}
+
 }


### PR DESCRIPTION
#### cf2d4056d8ec678955f4835232076c3b5194baff
<pre>
com.apple.WebKit.Networking at Received an invalid message &apos;NetworkConnectionToWebProcess_LoadImageForDecoding&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=315252">https://bugs.webkit.org/show_bug.cgi?id=315252</a>
<a href="https://rdar.apple.com/177568018">rdar://177568018</a>

Reviewed by Rupin Mittal.

There are two cases where the MESSAGE_CHECK in NetworkConnectionToWebProcess::loadImageForDecoding
can still fail after the fix in <a href="https://rdar.apple.com/176310702">rdar://176310702</a>:
 - A client set an incorrect or empty mainDocumentURL.
 - A client called _loadAndDecodeImage: on a WKWebView that has not loaded any content.

Set firstPartyForCookies in the web process from page-&gt;mainFrameURL(), which is the authoritative
value, and drop the WKWebView-side fallback added in the previous fix. When mainFrameURL is empty
(no navigation has happened yet, so there is no cookie context), disable cookies for the request
instead of failing the MESSAGE_CHECK.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::loadImageForDecoding):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _loadAndDecodeImage:constrainedToSize:maximumBytesFromNetwork:completionHandler:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadAndDecodeImage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm:
(TestWebKitAPI::TEST(WebKit, LoadAndDecodeImageBeforeAnyNavigation)):
(TestWebKitAPI::TEST(WebKit, LoadAndDecodeImageWithCallerProvidedDisallowedMainDocumentURL)):

Originally-landed-as: 305413.944@safari-7624-branch (bc7a427882d4). <a href="https://rdar.apple.com/181074279">rdar://181074279</a>
Canonical link: <a href="https://commits.webkit.org/316603@main">https://commits.webkit.org/316603@main</a>
</pre>
----------------------------------------------------------------------
#### 6287cb3802f3ff30f2ded80193898f11478b58f2
<pre>
Web content process gets terminated after loading various sites (invalid message &apos;NetworkConnectionToWebProcess_LoadImageForDecoding&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314261">https://bugs.webkit.org/show_bug.cgi?id=314261</a>
<a href="https://rdar.apple.com/176310702">rdar://176310702</a>

Reviewed by Abrar Rahman Protyasha.

When loading various sites (like github.com), we see that that site will
immediately reload with a message saying that the site reloaded because it
encountered a problem. The web process is crashing after hitting this:

MESSAGE_CHECK_COMPLETION(m_networkProcess-&gt;allowsFirstPartyForCookies
(m_webProcessIdentifier, request.firstPartyForCookies()) ==
NetworkProcess::AllowCookieAccess::Allow ...)

in NetworkConnectionToWebProcess::loadImageForDecoding().

The issue is that after the site is loaded, LinkPresentation calls
_loadAndDecodeImage on the WKWebView with a NSURLRequest whose mainDocumentURL
is nil. When _loadAndDecodeImage converts this to a ResourceRequest, the
firstPartyForCookies is null. This ResourceRequest ends up in
loadImageForDecoding where allowsFirstPartyForCookies() returns &quot;disallow&quot;
for a null firstPartyForCookies and so we terminate the web process.

In the past, some of these “== allow” checks we’ve added have caused crashes
like these and have been hard to reproduce since we often only have a stability
tracer crash. So we generally change the check to be “!= terminate” in those
cases. Doing that is not ideal but would fix this crash.

But here, we actually have a reproduction and the root cause. We can fix this
by amending _loadAndDecodeImage to ensure that the NSURLRequest has a
mainDocumentURL when one exists. This will cover LinkPresentation’s callsite
and possibly others.

New test: LoadAndDecodeImageNilMainDocumentURLAfterNavigation.
(Credit to Abrar Protyasha for coming up with the test).

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _loadAndDecodeImage:constrainedToSize:maximumBytesFromNetwork:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadAndDecodeImage.mm:
(TestWebKitAPI::TEST(WebKit, LoadAndDecodeImageNilMainDocumentURLAfterNavigation)):

Originally-landed-as: 7744f7322ebb. <a href="https://rdar.apple.com/181074236">rdar://181074236</a>
Canonical link: <a href="https://commits.webkit.org/316602@main">https://commits.webkit.org/316602@main</a>
</pre>
----------------------------------------------------------------------
#### ccf0c4874cb25ab1fac973a60d6f291bc204a44a
<pre>
Add scheme and cookie access validation to LoadImageForDecoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=312832">https://bugs.webkit.org/show_bug.cgi?id=312832</a>
<a href="https://rdar.apple.com/174708372">rdar://174708372</a>

Reviewed by Rupin Mittal.

LoadImageForDecoding accepted arbitrary ResourceRequest fields with only a url.isValid() check. This
allowed file:// reads of NetworkProcess-sandbox files and credentialed cross-origin body reads via
spoofed firstPartyForCookies.

Restrict the URL to HTTP(S) and enforce allowsFirstPartyForCookies, matching every other
cookie-touching IPC entry point.

Test: ipc/load-image-for-decoding-file-url.html

* LayoutTests/ipc/load-image-for-decoding-file-url-expected.txt: Added.
* LayoutTests/ipc/load-image-for-decoding-file-url.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::loadImageForDecoding):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadAndDecodeImage):

Originally-landed-as: 305413.744@safari-7624-branch (f118e35bcfa5). <a href="https://rdar.apple.com/180428370">rdar://180428370</a>
Canonical link: <a href="https://commits.webkit.org/316601@main">https://commits.webkit.org/316601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a9983fc28354f6a5c06838aeb78a5e402783d2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134480 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114949 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184910 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37666 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143288 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38645 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47184 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112186 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38142 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118944 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45701 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9490 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->