### PR TITLE
Cherry-pick 95c175bca8d0. rdar://176570738

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm
@@ -74,7 +74,10 @@ void WebExtensionContextProxy::dispatchDevToolsExtensionPanelShownEvent(Inspecto
         if (!extensionPanel)
             return;
 
-        for (auto& listener : extensionPanel->onShown().listeners()) {
+        // Copy the listeners since call() can trigger a mutation of the listeners.
+        auto listenersCopy = extensionPanel->onShown().listeners();
+
+        for (RefPtr listener : listenersCopy) {
             auto globalContext = listener->globalContext();
             listener->call(toWindowObject(globalContext, *frame));
         }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -161,7 +161,10 @@ void WebExtensionAPIPort::fireMessageEventIfNeeded(id message, bool userGesture)
 
     RELEASE_LOG_DEBUG(Extensions, "Fired port message event for channel %{public}llu in %{public}@ world", channelIdentifier().toUInt64(), toDebugString(contentWorldType()).createNSString().get());
 
-    for (auto& listener : m_onMessage->listeners()) {
+    // Copy the listeners since call() can trigger a mutation of the listeners.
+    auto listenersCopy = m_onMessage->listeners();
+
+    for (RefPtr listener : listenersCopy) {
         auto globalContext = listener->globalContext();
 
         std::optional<WebCore::UserGestureIndicator> gestureIndicator;
@@ -197,7 +200,10 @@ void WebExtensionAPIPort::fireDisconnectEventIfNeeded()
 
     RELEASE_LOG_DEBUG(Extensions, "Fired port disconnect event for channel %{public}llu in %{public}@ world", m_channelIdentifier ? m_channelIdentifier->toUInt64() : 0, toDebugString(contentWorldType()).createNSString().get());
 
-    for (auto& listener : m_onDisconnect->listeners()) {
+    // Copy the listeners since call() can trigger a mutation of the listeners.
+    auto listenersCopy = m_onDisconnect->listeners();
+
+    for (RefPtr listener : listenersCopy) {
         auto globalContext = listener->globalContext();
 
         listener->call(toJS(globalContext, this));

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
@@ -1724,6 +1724,57 @@ TEST(WKWebExtensionAPIRuntime, ConnectNative)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIRuntime, PortMutateListenersDuringDispatch)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const port = browser.runtime?.connectNative('test')",
+
+        @"const initialListenerCount = 64",
+        @"let messageDispatchCount = 0",
+        @"let disconnectDispatchCount = 0",
+
+        @"port?.onMessage.addListener(() => {",
+        @"  ++messageDispatchCount",
+        @"  for (let i = 0; i < 1024; ++i)",
+        @"    port?.onMessage.addListener(() => { })",
+        @"})",
+
+        @"for (let i = 0; i < initialListenerCount; ++i)",
+        @"  port?.onMessage.addListener(() => { ++messageDispatchCount })",
+
+        @"port?.onDisconnect.addListener(() => {",
+        @"  ++disconnectDispatchCount",
+        @"  for (let i = 0; i < 1024; ++i)",
+        @"    port?.onDisconnect.addListener(() => { })",
+        @"})",
+
+        @"for (let i = 0; i < initialListenerCount; ++i)",
+        @"  port?.onDisconnect.addListener(() => { ++disconnectDispatchCount })",
+
+        @"port?.onDisconnect.addListener(() => {",
+        @"  ++disconnectDispatchCount",
+        @"  browser.test.assertEq(messageDispatchCount, initialListenerCount + 1, 'Should dispatch to the listeners registered when onMessage fired')",
+        @"  browser.test.assertEq(disconnectDispatchCount, initialListenerCount + 2, 'Should dispatch to the listeners registered when onDisconnect fired')",
+        @"  browser.test.notifyPass()",
+        @"})",
+
+        @"port?.postMessage('Hello')"
+    ]);
+
+    auto manager = Util::loadExtension(runtimeManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionNativeMessaging];
+
+    manager.get().internalDelegate.connectUsingMessagePort = ^(WKWebExtensionMessagePort *messagePort) {
+        messagePort.messageHandler = ^(id message, NSError *error) {
+            [messagePort sendMessage:@"Received" completionHandler:^(NSError *) { }];
+            [messagePort disconnectWithError:nil];
+        };
+    };
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPIRuntime, ConnectNativeWithInvalidMessage)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### 1759ab219c63940ba1c80bae6ba3df1afa6eec43
<pre>
Cherry-pick 95c175bca8d0. <a href="https://rdar.apple.com/176570738">rdar://176570738</a>

    Extension WebContent process UAF via WebExtension port listener iterator invalidation.
    <a href="https://webkit.org/b/314642">https://webkit.org/b/314642</a>
    <a href="https://rdar.apple.com/176570738">rdar://176570738</a>

    Reviewed by Brian Weinstein.

    Calling a port&apos;s `onMessage` or `onDisconnect` listener back into JavaScript is not safe while iterating
    the live listener list, because extensions are allowed to add or remove listeners during dispatch. Adding
    a listener can reallocate the underlying vector, freeing the buffer the iterator still points into and
    causing a heap use-after-free. The same hazard existed in the DevTools panel `onShown` dispatch. The
    `WebExtensionAPIEvent::invokeListeners()` family already guards against this.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm

    * Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsExtensionPanelCocoa.mm:
    (WebKit::WebExtensionContextProxy::dispatchDevToolsExtensionPanelShownEvent): Copy `onShown().listeners()`
    before iterating so mutations during dispatch do not invalidate the loop.
    * Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
    (WebKit::WebExtensionAPIPort::fireMessageEventIfNeeded): Copy `m_onMessage-&gt;listeners()` before iterating.
    (WebKit::WebExtensionAPIPort::fireDisconnectEventIfNeeded): Copy `m_onDisconnect-&gt;listeners()` before iterating.
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
    (TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, PortMutateListenersDuringDispatch)): Added. Registers listeners
    on `onMessage` and `onDisconnect` that each add 1024 new listeners during dispatch to force vector reallocation,
    then asserts only the pre-dispatch listeners were invoked.

    Identifier: 305413.886@safari-7624-branch

Originally-landed-as: 305413.780@safari-7624.4-branch (b8d709d285c1). <a href="https://rdar.apple.com/180437594">rdar://180437594</a>
Canonical link: <a href="https://commits.webkit.org/316295@main">https://commits.webkit.org/316295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594398dbeb1e5d4c9da61ce6534dcf860f3da403

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133645 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35661 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183753 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36369 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142344 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45366 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142235 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38408 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46046 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110681 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37348 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117734 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44564 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43964 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->