### PR TITLE
heap-use-after-free in WebExtensionRegisteredScriptsSQLiteStore::addScripts

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp
@@ -126,10 +126,10 @@ void WebExtensionRegisteredScriptsSQLiteStore::deleteScriptsWithIDs(Vector<Strin
 void WebExtensionRegisteredScriptsSQLiteStore::addScripts(Vector<Ref<JSON::Object>> scripts, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
 {
     // Only save persistent scripts to storage
-    Vector<Ref<JSON::Object>> persistentScripts;
+    Vector<std::pair<String, String>> persistentScripts;
     for (Ref script : scripts) {
         if (auto persistent = script->getBoolean(persistAcrossSessionsKey); persistent && persistent.value())
-            persistentScripts.append(script);
+            persistentScripts.append({ script->getString(idKey), script->toJSONString() });
     }
 
     if (persistentScripts.isEmpty()) {
@@ -137,7 +137,7 @@ void WebExtensionRegisteredScriptsSQLiteStore::addScripts(Vector<Ref<JSON::Objec
         return;
     }
 
-    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, persistentScripts, completionHandler = WTF::move(completionHandler)]() mutable {
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, persistentScripts = crossThreadCopy(persistentScripts), completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler({ });
@@ -154,8 +154,8 @@ void WebExtensionRegisteredScriptsSQLiteStore::addScripts(Vector<Ref<JSON::Objec
 
         ASSERT(errorMessage.isEmpty());
 
-        for (Ref script : persistentScripts)
-            protectedThis->insertScript(script, *(protectedThis->database()), errorMessage);
+        for (auto& [scriptID, scriptData] : persistentScripts)
+            protectedThis->insertScript(scriptID, scriptData, *(protectedThis->database()), errorMessage);
 
         WorkQueue::mainSingleton().dispatch([errorMessage = crossThreadCopy(errorMessage), completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(errorMessage);
@@ -216,14 +216,11 @@ Vector<Ref<JSON::Object>> WebExtensionRegisteredScriptsSQLiteStore::getKeysAndVa
     return results;
 }
 
-void WebExtensionRegisteredScriptsSQLiteStore::insertScript(const JSON::Object& script, Ref<WebExtensionSQLiteDatabase> database, String& errorMessage)
+void WebExtensionRegisteredScriptsSQLiteStore::insertScript(const String& scriptID, const String& scriptData, Ref<WebExtensionSQLiteDatabase> database, String& errorMessage)
 {
     assertIsCurrent(queue());
-
-    auto scriptID = script.getString(idKey);
     ASSERT(!scriptID.isEmpty());
 
-    auto scriptData = script.toJSONString();
     DatabaseResult result = SQLiteDatabaseExecute(database, "INSERT INTO registered_scripts (key, script) VALUES (?, ?)"_s, scriptID, scriptData);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Extensions, "Failed to insert registered content script for extension %s.", uniqueIdentifier().utf8().data());

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.h
@@ -62,7 +62,7 @@ private:
 
     Vector<Ref<JSON::Object>> getScriptsWithErrorMessage(String& errorMessage);
     Vector<Ref<JSON::Object>> getKeysAndValuesFromRowIterator(Ref<WebExtensionSQLiteRowEnumerator> rows);
-    void insertScript(const JSON::Object& script, Ref<WebExtensionSQLiteDatabase>, String& errorMessage);
+    void insertScript(const String& scriptID, const String& scriptData, Ref<WebExtensionSQLiteDatabase>, String& errorMessage);
 
     void migrateData();
 };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
@@ -76,7 +76,20 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
         return;
     }
 
-    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, rules = WTF::move(rules), completionHandler = WTF::move(completionHandler)]() mutable {
+    Vector<std::pair<double, String>> serializedRules;
+    for (Ref ruleValue : rules.get()) {
+        RefPtr rule = ruleValue->asObject();
+        if (!rule || !rule->size()) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+
+        auto ruleID = rule->getInteger("id"_s);
+        ASSERT(ruleID);
+        serializedRules.append({ *ruleID, rule->toJSONString() });
+    }
+
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, serializedRules = crossThreadCopy(serializedRules), completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler({ });
@@ -94,17 +107,8 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
         ASSERT(errorMessage.isEmpty());
 
         Vector<double> rulesIDs;
-        for (Ref ruleValue : rules.get()) {
-            RefPtr rule = ruleValue->asObject();
-            if (!rule || !rule->size()) {
-                ASSERT_NOT_REACHED();
-                continue;
-            }
-
-            auto ruleID = rule->getInteger("id"_s);
-            ASSERT(ruleID);
-            rulesIDs.append(*ruleID);
-        }
+        for (auto& [ruleID, ruleData] : serializedRules)
+            rulesIDs.append(ruleID);
 
         ASSERT(rulesIDs.size());
 
@@ -130,14 +134,8 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
             }
         }
 
-        for (Ref ruleValue : rules.get()) {
-            RefPtr rule = ruleValue->asObject();
-            if (!rule || !rule->size()) {
-                ASSERT_NOT_REACHED();
-                continue;
-            }
-
-            errorMessage = protectedThis->insertRule(*rule, *(protectedThis->database()));
+        for (auto& [ruleID, ruleData] : serializedRules) {
+            errorMessage = protectedThis->insertRule(ruleID, ruleData, *(protectedThis->database()));
             if (!errorMessage.isEmpty())
                 break;
         }
@@ -259,15 +257,11 @@ Ref<JSON::Array> WebExtensionDeclarativeNetRequestSQLiteStore::getKeysAndValuesF
     return results;
 }
 
-String WebExtensionDeclarativeNetRequestSQLiteStore::insertRule(const JSON::Object& rule, Ref<WebExtensionSQLiteDatabase> database)
+String WebExtensionDeclarativeNetRequestSQLiteStore::insertRule(double ruleID, const String& ruleData, Ref<WebExtensionSQLiteDatabase> database)
 {
     assertIsCurrent(queue());
 
-    auto ruleData = rule.toJSONString();
-    auto ruleID = rule.getInteger("id"_s);
-    ASSERT(ruleID);
-
-    DatabaseResult result = SQLiteDatabaseExecute(database, makeString("INSERT INTO "_s, m_tableName, " (id, rule) VALUES (?, ?)"_s), *ruleID, ruleData);
+    DatabaseResult result = SQLiteDatabaseExecute(database, makeString("INSERT INTO "_s, m_tableName, " (id, rule) VALUES (?, ?)"_s), ruleID, ruleData);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Extensions, "Failed to insert %s rule for extension %s", toString(m_storageType).utf8().data(), uniqueIdentifier().utf8().data());
         return makeString("Failed to add "_s, toString(m_storageType), " rule."_s);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h
@@ -87,7 +87,7 @@ private:
 
     RefPtr<JSON::Array> getRulesWithRuleIDsInternal(Vector<double> ruleIDs, String& errorMessage);
     Ref<JSON::Array> getKeysAndValuesFromRowIterator(Ref<WebExtensionSQLiteRowEnumerator> rows);
-    String insertRule(const JSON::Object& rule, Ref<WebExtensionSQLiteDatabase>);
+    String insertRule(double ruleID, const String& ruleData, Ref<WebExtensionSQLiteDatabase>);
 
     WebExtensionDeclarativeNetRequestStorageType m_storageType;
     String m_tableName;


### PR DESCRIPTION
#### 6d6ea48e7ecfbfa18bfc0ae082227fbae7198d57
<pre>
heap-use-after-free in WebExtensionRegisteredScriptsSQLiteStore::addScripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=312319">https://bugs.webkit.org/show_bug.cgi?id=312319</a>
<a href="https://rdar.apple.com/174530074">rdar://174530074</a>

Reviewed by Timothy Hatcher.

WebExtensionRegisteredScriptsSQLiteStore::addScripts and WebExtensionDeclarativeNetRequestSQLiteStore::addRules
both captured Ref&lt;JSON::Value&gt; into lambdas dispatched to a background WorkQueue, while the main
thread still held live references to the same objects. Concurrent increments and decrements from the
two threads cause a lost update on the m_refCount. When the object is freed prematurely on the main
thread, the WorkQueue is left holding with a dangling reference, causing a heap-use-after-free on
the WorkQueue.

Fix this by serializing the data before dispatching it to the WorkQueue.

* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp:
(WebKit::WebExtensionRegisteredScriptsSQLiteStore::addScripts):
(WebKit::WebExtensionRegisteredScriptsSQLiteStore::insertScript):
* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp:
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::addRules):
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::insertRule):
* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h:

Originally-landed-as: 305413.675@safari-7624-branch (c85584f296ce). <a href="https://rdar.apple.com/180438305">rdar://180438305</a>
Canonical link: <a href="https://commits.webkit.org/316283@main">https://commits.webkit.org/316283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40d781cc604ca38fa30fb37f1f0dfb446ab8f32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181243 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114235 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29992 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183911 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45523 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38396 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46203 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110863 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37462 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44721 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->