### PR TITLE
[JSC] Add ArrayStorage + GetByVal specific operation

### DIFF
--- a/JSTests/microbenchmarks/get-by-val-array-storage-sparse-hole.js
+++ b/JSTests/microbenchmarks/get-by-val-array-storage-sparse-hole.js
@@ -1,0 +1,32 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+// Hole/miss-dominated reads of a large sparse array (ArrayStorage mode with a sparse map). Every read
+// hits an in-bounds hole that is absent from the sparse map, so the int-indexed GetByVal slow path
+// (operationGetByValArrayStorageInt) must resolve it to undefined via the (sane) prototype chain.
+function get(array, i)
+{
+    return array[i];
+}
+noInline(get);
+
+var maxIndex = 200000;
+var step = 16;
+
+var array = [];
+for (var i = maxIndex - step; i >= 0; i -= step)
+    array[i] = i + 1;
+
+var expectedPass = 0;
+for (var i = 1; i < maxIndex; i += step) // i = 1, 17, 33, ... are all holes (never written).
+    ++expectedPass;
+
+var iterations = 400;
+var holes = 0;
+for (var iter = 0; iter < iterations; ++iter) {
+    for (var i = 1; i < maxIndex; i += step) {
+        if (get(array, i) === void 0)
+            ++holes;
+    }
+}
+
+if (holes !== expectedPass * iterations)
+    throw "Error: bad hole count: " + holes;

--- a/JSTests/microbenchmarks/get-by-val-array-storage-sparse.js
+++ b/JSTests/microbenchmarks/get-by-val-array-storage-sparse.js
@@ -1,0 +1,31 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+// Hit-dominated reads of a large sparse array (ArrayStorage mode with a sparse map). Every read
+// resolves through the int-indexed GetByVal slow path (operationGetByValArrayStorageInt) and finds
+// its value in the sparse map.
+function get(array, i)
+{
+    return array[i];
+}
+noInline(get);
+
+var maxIndex = 200000;
+var step = 16; // 1/16 density (< 1/8) keeps the array in ArrayStorage with a sparse map.
+
+var array = [];
+// Descending writes: the first one is far beyond length, forcing ArrayStorage + sparse map.
+for (var i = maxIndex - step; i >= 0; i -= step)
+    array[i] = i + 1;
+
+var expectedPass = 0;
+for (var i = 0; i < maxIndex; i += step)
+    expectedPass += i + 1;
+
+var iterations = 800;
+var sum = 0;
+for (var iter = 0; iter < iterations; ++iter) {
+    for (var i = 0; i < maxIndex; i += step)
+        sum += get(array, i);
+}
+
+if (sum !== expectedPass * iterations)
+    throw "Error: bad sum: " + sum;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -847,6 +847,40 @@ ALWAYS_INLINE EncodedJSValue getByValCellInt(JSGlobalObject* globalObject, VM& v
     return JSValue::encode(JSValue(base).get(globalObject, static_cast<unsigned>(index)));
 }
 
+ALWAYS_INLINE EncodedJSValue getByValArrayStorageInt(JSGlobalObject* globalObject, VM& vm, JSObject* base, int32_t index)
+{
+    ASSERT(hasAnyArrayStorage(base->indexingType()));
+    if (index >= 0) [[likely]] {
+        unsigned i = static_cast<unsigned>(index);
+        ArrayStorage* storage = base->butterfly()->arrayStorage();
+        SparseArrayValueMap* map = storage->m_sparseMap.get();
+        // Only the standard ArrayStorage layout is handled here: indices < vectorLength live in the
+        // vector, overflow indices live in a non-sparse-mode map with no per-entry attributes. When the
+        // map is in sparse mode (frozen/sealed/read-only/accessor arrays), values for in-vector indices
+        // may have migrated into the map and entries carry attributes, so defer to the generic path.
+        if (!map || !map->sparseMode()) [[likely]] {
+            if (i < storage->vectorLength()) {
+                JSValue value = storage->m_vector[i].get();
+                if (value)
+                    return JSValue::encode(value);
+            } else if (map) {
+                SparseArrayValueMap::iterator it = map->find(i);
+                if (it != map->notFound()) {
+                    if (it->value.attributes()) [[unlikely]] // accessor / special: needs the full slot path.
+                        return JSValue::encode(JSValue(base).get(globalObject, i));
+                    return JSValue::encode(it->value.getNonSparseMode());
+                }
+            }
+
+            // Missing own indexed property: undefined unless the prototype chain can intercept it.
+            if (!base->structure()->holesMustForwardToPrototype(base))
+                return JSValue::encode(jsUndefined());
+        }
+    }
+    // Negative index, sparse/dictionary mode, accessor entry, or intercepting prototype chain.
+    return getByValCellInt(globalObject, vm, base, index);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationGetByValObjectInt, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* base, int32_t index))
 {
     VM& vm = globalObject->vm();
@@ -855,6 +889,16 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValObjectInt, EncodedJSValue, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     OPERATION_RETURN(scope, getByValCellInt(globalObject, vm, base, index));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationGetByValArrayStorageInt, EncodedJSValue, (JSGlobalObject* globalObject, JSObject* base, int32_t index))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, getByValArrayStorageInt(globalObject, vm, base, index));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByValStringInt, EncodedJSValue, (JSGlobalObject* globalObject, JSString* base, int32_t index))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -117,6 +117,7 @@ JSC_DECLARE_JIT_OPERATION(operationArithTrunc, EncodedJSValue, (JSGlobalObject*,
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArithMinMultipleDouble, double, (const double* buffer, unsigned elementCount));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArithMaxMultipleDouble, double, (const double* buffer, unsigned elementCount));
 JSC_DECLARE_JIT_OPERATION(operationGetByValObjectInt, EncodedJSValue, (JSGlobalObject*, JSObject*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationGetByValArrayStorageInt, EncodedJSValue, (JSGlobalObject*, JSObject*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByValStringInt, EncodedJSValue, (JSGlobalObject*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByValObjectString, EncodedJSValue, (JSGlobalObject*, JSCell*, JSCell* string));
 JSC_DECLARE_JIT_OPERATION(operationGetByValObjectSymbol, EncodedJSValue, (JSGlobalObject*, JSCell*, JSCell* symbol));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2112,7 +2112,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
         slowCases.append(hole);
         addSlowPathGenerator(
             slowPathCall(
-                slowCases, this, operationGetByValObjectInt,
+                slowCases, this, operationGetByValArrayStorageInt,
                 resultRegs, LinkableConstant::globalObject(*this, node), baseReg, propertyReg));
 
         jsValueResult(resultRegs, node);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3018,7 +3018,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
 
         addSlowPathGenerator(
             slowPathCall(
-                slowCases, this, operationGetByValObjectInt,
+                slowCases, this, operationGetByValArrayStorageInt,
                 resultReg, LinkableConstant::globalObject(*this, node), baseReg, propertyReg));
 
         jsValueResult(resultReg, node);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -6746,7 +6746,7 @@ IGNORE_CLANG_WARNINGS_END
 
             m_out.appendTo(slowCase, continuation);
             ValueFromBlock slowResult = m_out.anchor(
-                vmCall(Int64, operationGetByValObjectInt, weakPointer(globalObject), base, index));
+                vmCall(Int64, operationGetByValArrayStorageInt, weakPointer(globalObject), base, index));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);


### PR DESCRIPTION
#### 5dd6865434312c3def91b287b6faba33ba795833
<pre>
[JSC] Add ArrayStorage + GetByVal specific operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=318180">https://bugs.webkit.org/show_bug.cgi?id=318180</a>
<a href="https://rdar.apple.com/180990441">rdar://180990441</a>

Reviewed by Tadeu Zagallo.

This patch adds operationGetByValArrayStorageInt, which is tailored for
ArrayStorage slow path operation. DFG / FTL can use this when we already
speculate ArrayStorage, but it is a slow path.

                                                 ToT                     Patched

get-by-val-array-storage-sparse-hole      122.9244+-1.1533     ^     62.5947+-9.6089        ^ definitely 1.9638x faster
get-by-val-array-storage-sparse           117.8623+-0.4612     ^     84.7042+-0.5769        ^ definitely 1.3915x faster

Tests: JSTests/microbenchmarks/get-by-val-array-storage-sparse-hole.js
       JSTests/microbenchmarks/get-by-val-array-storage-sparse.js

* JSTests/microbenchmarks/get-by-val-array-storage-sparse-hole.js: Added.
(get array):
* JSTests/microbenchmarks/get-by-val-array-storage-sparse.js: Added.
(get array):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::getByValArrayStorageInt):
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByVal):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByVal):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):

Canonical link: <a href="https://commits.webkit.org/316142@main">https://commits.webkit.org/316142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e495115a21f3a86ef55c25f114a547eb3b5783d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38523 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180558 "Build was cancelled. Recent messages:Printed configuration") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f5274fa-9673-41f2-bf5a-d129920465aa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133450 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a87a36bf-ecbd-4b6d-9aef-900fc28b446b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174137 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113914 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bf93bfa-8374-46a0-8018-8e5334295ae6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29238 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2293 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183143 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32435 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/35938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141920 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44760 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141730 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45449 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110154 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26057 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36976 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203857 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43960 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54537 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43606 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->