### PR TITLE
[css-anchor-position-1] removeScrollerFromAnchorScrollAdjusters mutates array when iterating through it

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<title>WebKit crash in anchor scroll compensation code</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#scroll">
+
+<style>
+  #scroller {
+    overflow: scroll;
+    width: 500px;
+    height: 500px;
+  }
+
+  #anchor {
+    width: 50px;
+    height: 50px;
+    anchor-name: --anchor;
+  }
+
+  .anchored {
+    position: absolute;
+    /* Has to have a default anchor to trigger scroll compensation */
+    position-anchor: --anchor;
+    left: anchor(left);
+    width: 50px;
+    height: 50px;
+  }
+</style>
+
+<div id="scroller">
+  <div id="anchor"></div>
+</div>
+
+<div class="anchored"></div>
+<div class="anchored"></div>
+<div class="anchored"></div>
+<div class="anchored"></div>
+<div class="anchored"></div>
+
+<script>
+  scroller.scrollTop = 200;
+  // Force layout.
+  scroller.offsetTop;
+
+  scroller.remove();
+  // Force layout.
+  document.body.offsetTop;
+</script>


### PR DESCRIPTION
#### bdc84c14a8e6548918f4a62442cdcef2ac507495
<pre>
[css-anchor-position-1] removeScrollerFromAnchorScrollAdjusters mutates array when iterating through it
<a href="https://rdar.apple.com/175679565">rdar://175679565</a>

Reviewed by Elika Etemad.

LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters iterates
through m_anchorScrollAdjusters, and unregisters adjusters belonging to the
scroller by calling unregisterAnchorScrollAdjusterFor. unregisterAnchorScrollAdjusterFor
in turn removes adjusters also from m_anchorScrollAdjusters, which is being iterated on.
Vectors are not safe to modify when iterating through. Change the loop to save the list
of adjusters to be removed in a HashSet, then remove the saved adjusters after.

NOTE: this was fixed a while ago, but while waiting for a merge-back, it got fixed in
upstream in 316000@main. The fixes are equivalent, so this merge-back opts to keep the
upstreamed fix and adds a test.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html: Added.

Originally-landed-as: 305413.802@safari-7624-branch (444a849510b9). <a href="https://rdar.apple.com/180427816">rdar://180427816</a>
Canonical link: <a href="https://commits.webkit.org/316226@main">https://commits.webkit.org/316226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68c8eadf202cd986e05b4842134bc61ba080a463

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128977 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133532 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33636 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29350 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183258 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142024 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141828 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38344 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45562 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110266 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37067 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44072 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8379 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->