### PR TITLE
Padding bits defeat intended HTMLEntityTableEntry size optimization

### DIFF
--- a/Source/WebCore/html/parser/HTMLEntityTable.h
+++ b/Source/WebCore/html/parser/HTMLEntityTable.h
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2010-2014 Google, Inc. All rights reserved.
- * Copyright (C) 2023 Apple, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Apple, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,11 +36,12 @@ struct HTMLEntityTableEntry {
     unsigned nameLength() const { return nameLengthExcludingSemicolon + nameIncludesTrailingSemicolon; }
 
     unsigned firstCharacter : 21; // All Unicode characters fit in 21 bits.
-    unsigned optionalSecondCharacter : 16; // Two-character sequences are all BMP characters.
-    unsigned nameCharactersOffset : 14;
     unsigned nameLengthExcludingSemicolon : 5;
     unsigned nameIncludesTrailingSemicolon : 1;
+    unsigned nameCharactersOffset : 14;
+    unsigned optionalSecondCharacter : 16; // Two-character sequences are all BMP characters.
 };
+static_assert(sizeof(HTMLEntityTableEntry) == 8);
 
 class HTMLEntityTable {
 public:

--- a/Source/WebCore/html/parser/create-html-entity-table
+++ b/Source/WebCore/html/parser/create-html-entity-table
@@ -171,7 +171,7 @@ for entry in entries:
     assert entry[OFFSET] < (1 << 14)
     assert name_length < (1 << 5)
     output_file.write('    HTMLEntityTableEntry { %s, %s, %s, %s, %s }, // &%s\n' % (
-        first_character, second_character, entry[OFFSET], name_length, name_includes_trailing_semicolon, entry[ENTITY]))
+        first_character, name_length, name_includes_trailing_semicolon, entry[OFFSET], second_character, entry[ENTITY]))
 
 output_file.write("""};
 


### PR DESCRIPTION
#### 4b3bf5aaf43d212ba2aa4a91fbb3a36f6effb4c3
<pre>
Padding bits defeat intended HTMLEntityTableEntry size optimization
<a href="https://bugs.webkit.org/show_bug.cgi?id=295171">https://bugs.webkit.org/show_bug.cgi?id=295171</a>
<a href="https://rdar.apple.com/155138028">rdar://155138028</a>

Reviewed by Chris Dumez.

Reordered the bitfields so they pack into two 32-bit units (21+5+1, then
14+16) instead of straddling unit boundaries, bringing the struct down from
12 bytes to the intended 8. Updated create-html-entity-table to emit the
members in the new order, and added a static_assert to lock in the size.

Thanks to Darin for initial idea on how to map these.

* Source/WebCore/html/parser/HTMLEntityTable.h:
* Source/WebCore/html/parser/create-html-entity-table:

Canonical link: <a href="https://commits.webkit.org/316220@main">https://commits.webkit.org/316220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d945af86494172724dcc5da17fee515bfad4f0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128910 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29dcaa77-f374-487c-97ea-f8a671bb04a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133457 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83be20a1-ba7c-447a-ae29-d97dbaa401ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174153 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6eac065d-d11b-43d6-9940-ded471b41a60) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33595 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183159 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141930 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44776 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38338 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45465 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110170 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36988 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117326 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43976 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8340 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43380 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->