### PR TITLE
Safari & Chrome for iOS: Use-after-free in WebKit libwebrtc `RtpTransceiver` codec state reachable via `RTCRtpTransceiver.setCodecPreferences` after garbage-collected `RTCPeerConnection`

### DIFF
--- a/LayoutTests/webrtc/transceiver-setCodecPreferences-closed-expected.txt
+++ b/LayoutTests/webrtc/transceiver-setCodecPreferences-closed-expected.txt
@@ -1,0 +1,3 @@
+
+PASS transceiver-setCodecPreferences-closed
+

--- a/LayoutTests/webrtc/transceiver-setCodecPreferences-closed.html
+++ b/LayoutTests/webrtc/transceiver-setCodecPreferences-closed.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <script src="../resources/gc.js"></script>
+</head>
+<body>
+<script>
+promise_test(async () => {
+    const audioCodecs = RTCRtpSender.getCapabilities('audio').codecs;
+    const videoCodecs = RTCRtpSender.getCapabilities('video').codecs;
+
+    const transceivers = [];
+    for (let i = 0; i < 50; i++) {
+      const pc = new RTCPeerConnection();
+      transceivers.push(pc.addTransceiver('audio'));
+      transceivers.push(pc.addTransceiver('video'));
+      pc.close();
+      // Intentionally drop pc reference immediately.
+    }
+
+    // Let the event loop drain and run aggressive GC to destroy the PeerConnection objects behind the retained transceivers.
+    await new Promise(resolve => setTimeout(resolve, 30));
+    gc();
+
+    for (const transceiver of transceivers)
+        transceiver.setCodecPreferences(transceiver.receiver.track && transceiver.receiver.track.kind === 'video' ? videoCodecs : audioCodecs);
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
@@ -107,6 +107,10 @@ ExceptionOr<void> RTCRtpTransceiver::stop()
 
 ExceptionOr<void> RTCRtpTransceiver::setCodecPreferences(const Vector<RTCRtpCodec>& codecs)
 {
+    RefPtr connection = m_connection;
+    if (!connection || connection->isClosed())
+        return { };
+
     RELEASE_LOG_INFO(WebRTC, "RTCRtpTransceiver::setCodecPreferences");
     return m_backend->setCodecPreferences(codecs);
 }


### PR DESCRIPTION
#### a14d1c0731137bfcf330d8706fadd983b9834b17
<pre>
Safari &amp; Chrome for iOS: Use-after-free in WebKit libwebrtc `RtpTransceiver` codec state reachable via `RTCRtpTransceiver.setCodecPreferences` after garbage-collected `RTCPeerConnection`
<a href="https://rdar.apple.com/175625015">rdar://175625015</a>

Reviewed by Jean-Yves Avenard.

While we should fix the RtpTransceiver/PeerConnection relationship in libwebrtc, we instead do a short term fix in WebCore layer by making RTCRtpTransceiver.setCodecPreferences a no-op when peer connection is destroyed or closed.

Test: webrtc/transceiver-setCodecPreferences-closed.html

* LayoutTests/webrtc/transceiver-setCodecPreferences-closed-expected.txt: Added.
* LayoutTests/webrtc/transceiver-setCodecPreferences-closed.html: Added.
* Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp:
(WebCore::RTCRtpTransceiver::setCodecPreferences):

Originally-landed-as: 305413.781@safari-7624-branch (456c1826db44). <a href="https://rdar.apple.com/181076635">rdar://181076635</a>
Canonical link: <a href="https://commits.webkit.org/316356@main">https://commits.webkit.org/316356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0454909ee22cc7ef70ba5d50f1f0ae713abe67d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133750 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35772 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34035 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29976 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183894 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142460 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38460 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46187 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110845 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37445 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117875 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44705 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8700 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->