### PR TITLE
Remove invalidateStyle() call from HTMLInputElement::setChecked()

### DIFF
--- a/LayoutTests/fast/selectors/checked-subject-style-update-expected.txt
+++ b/LayoutTests/fast/selectors/checked-subject-style-update-expected.txt
@@ -1,0 +1,15 @@
+Toggling :checked must update the input's own style, now that HTMLInputElement::setChecked relies on PseudoClassChangeInvalidation instead of invalidateStyle().
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Unchecked.
+PASS getComputedStyle(document.getElementById("checkbox")).color is "rgb(0, 0, 0)"
+Checked.
+PASS getComputedStyle(document.getElementById("checkbox")).color is "rgb(255, 0, 0)"
+Unchecked again.
+PASS getComputedStyle(document.getElementById("checkbox")).color is "rgb(0, 0, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/selectors/checked-subject-style-update.html
+++ b/LayoutTests/fast/selectors/checked-subject-style-update.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+input { color: rgb(0, 0, 0); }
+input:checked { color: rgb(255, 0, 0); }
+</style>
+</head>
+<body>
+<input type="checkbox" id="checkbox">
+<script>
+description('Toggling :checked must update the input\'s own style, now that HTMLInputElement::setChecked relies on PseudoClassChangeInvalidation instead of invalidateStyle().');
+
+debug('Unchecked.');
+shouldBeEqualToString('getComputedStyle(document.getElementById("checkbox")).color', 'rgb(0, 0, 0)');
+
+debug('Checked.');
+document.getElementById('checkbox').checked = true;
+shouldBeEqualToString('getComputedStyle(document.getElementById("checkbox")).color', 'rgb(255, 0, 0)');
+
+debug('Unchecked again.');
+document.getElementById('checkbox').checked = false;
+shouldBeEqualToString('getComputedStyle(document.getElementById("checkbox")).color', 'rgb(0, 0, 0)');
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</html>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1093,8 +1093,6 @@ void HTMLInputElement::setChecked(bool isChecked, WasSetByJavaScript wasCheckedB
         if (CheckedPtr cache = renderer->document().existingAXObjectCache())
             cache->checkedStateChanged(*this);
     }
-
-    invalidateStyle();
 }
 
 void HTMLInputElement::setIndeterminate(bool newValue)


### PR DESCRIPTION
#### 8bf70588e2a902733a0e95f07571640bf1bb6e5b
<pre>
Remove invalidateStyle() call from HTMLInputElement::setChecked()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318181">https://bugs.webkit.org/show_bug.cgi?id=318181</a>
<a href="https://rdar.apple.com/176048636">rdar://176048636</a>

Reviewed by Antti Koivisto.

HTMLInputElement::setChecked updates an input element&apos;s checked state and
unconditionally calls invalidateStyle() that forces a full style
resolution of the input on every checked-state change. This explicit invalidateStyle() is not needed with the
PseudoClassChangeInvalidation already constructed at the top of the function, which invalidates
the elements whose style depends on :checked and does nothing when no :checked rule applies. The
invalidateStyle() adds only an unconditional self-invalidation, which produces no style change in the
case where the input matches no :checked rule. This is safe to remove because flipping the checked
bit can only change an element&apos;s computed style through :checked selector matching in SelectorChecker
when evaluating the :checked pseudo-class. Nowhere else in style resolution reads the checked state.
Before this change, if no :checked rule matches the input element, we were still doing style resolution,
but the resolved style was identical before vs after the toggle which wasted work.

The one checked state-dependent visual that isn&apos;t CSS is the painted checkmark, which setChecked()
already repaints via renderer-&gt;repaint() for native form controls,
so the painting of the checkmark does not depend on style invalidation either.

* LayoutTests/fast/selectors/checked-subject-style-update-expected.txt: Added.
* LayoutTests/fast/selectors/checked-subject-style-update.html: Added.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::setChecked):

Canonical link: <a href="https://commits.webkit.org/316293@main">https://commits.webkit.org/316293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37874a18d7a848912d22df6684c8cc2474c241ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45877 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a8a1c50-79c5-43ab-ab72-c054f4bd0d0b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45517 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/181264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9478cab-8810-4c02-97ce-0c5f1913ee9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174918 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf7ef367-bfec-4a2b-b7de-07c7968e3160) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30013 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183932 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45544 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142381 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46224 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110885 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37479 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44742 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44142 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->