### PR TITLE
[JSC] Handle `String#trim`, `String#trimStart` and `String#trimEnd` in DFG / FTL

### DIFF
--- a/JSTests/microbenchmarks/string-trim-end-unicode-whitespace.js
+++ b/JSTests/microbenchmarks/string-trim-end-unicode-whitespace.js
@@ -2,21 +2,20 @@
     // Non-Latin1 whitespace characters (Zs category + BOM)
     // These test the optimized isWhiteSpace path that avoids ICU calls
     // Longer whitespace sequences to better measure isWhiteSpace performance
-    var ideographicSpace = "\u3000".repeat(20) + "hello" + "\u3000".repeat(20);
-    var enQuad = "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5) + "hello" + "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5);
-    var thinSpaces = "\u2009\u200A".repeat(20) + "hello" + "\u2009\u200A".repeat(20);
-    var narrowNoBreak = "\u202F\u205F".repeat(20) + "hello" + "\u202F\u205F".repeat(20);
-    var ogham = "\u1680".repeat(20) + "hello" + "\u1680".repeat(20);
-    var bom = "\uFEFF".repeat(20) + "hello" + "\uFEFF".repeat(20);
-    var mixed = "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10) + "hello" + "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10);
+    var strings = [
+        "\u3000".repeat(20) + "hello" + "\u3000".repeat(20),
+        "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5) + "hello" + "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5),
+        "\u2009\u200A".repeat(20) + "hello" + "\u2009\u200A".repeat(20),
+        "\u202F\u205F".repeat(20) + "hello" + "\u202F\u205F".repeat(20),
+        "\u1680".repeat(20) + "hello" + "\u1680".repeat(20),
+        "\uFEFF".repeat(20) + "hello" + "\uFEFF".repeat(20),
+        "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10) + "hello" + "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10),
+    ];
 
-    for (var i = 0; i < 1e5; i++) {
-        ideographicSpace.trimEnd();
-        enQuad.trimEnd();
-        thinSpaces.trimEnd();
-        narrowNoBreak.trimEnd();
-        ogham.trimEnd();
-        bom.trimEnd();
-        mixed.trimEnd();
-    }
+    var sum = 0;
+    for (var i = 0; i < 7e5; i++)
+        sum += strings[i % 7].trimEnd().length;
+
+    if (sum < 0)
+        throw new Error("bad result: " + sum);
 })();

--- a/JSTests/microbenchmarks/string-trim-end.js
+++ b/JSTests/microbenchmarks/string-trim-end.js
@@ -1,15 +1,16 @@
 (function() {
-    var shortAscii = "   hello   ";
-    var longAscii = "   " + "a".repeat(100) + "   ";
-    var noTrim = "hello";
-    var allSpaces = "          ";
-    var unicode = "   \u65e5\u672c\u8a9e   ";
+    var strings = [
+        "   hello   ",
+        "   " + "a".repeat(100) + "   ",
+        "hello",
+        "          ",
+        "   \u65e5\u672c\u8a9e   ",
+    ];
 
-    for (var i = 0; i < 1e6; i++) {
-        shortAscii.trimEnd();
-        longAscii.trimEnd();
-        noTrim.trimEnd();
-        allSpaces.trimEnd();
-        unicode.trimEnd();
-    }
+    var sum = 0;
+    for (var i = 0; i < 5e6; i++)
+        sum += strings[i % 5].trimEnd().length;
+
+    if (sum < 0)
+        throw new Error("bad result: " + sum);
 })();

--- a/JSTests/microbenchmarks/string-trim-no-whitespace.js
+++ b/JSTests/microbenchmarks/string-trim-no-whitespace.js
@@ -1,0 +1,15 @@
+function test(string) {
+    return string.trim().length + string.trimStart().length + string.trimEnd().length;
+}
+noInline(test);
+
+const strings = [];
+for (let i = 0; i < 16; ++i)
+    strings.push('field-' + i + '-value-' + (i * 7));
+
+let result = 0;
+for (let i = 0; i < 2e6; ++i)
+    result += test(strings[i & 15]);
+
+if (result < 0)
+    throw new Error('bad result: ' + result);

--- a/JSTests/microbenchmarks/string-trim-start-unicode-whitespace.js
+++ b/JSTests/microbenchmarks/string-trim-start-unicode-whitespace.js
@@ -2,21 +2,20 @@
     // Non-Latin1 whitespace characters (Zs category + BOM)
     // These test the optimized isWhiteSpace path that avoids ICU calls
     // Longer whitespace sequences to better measure isWhiteSpace performance
-    var ideographicSpace = "\u3000".repeat(20) + "hello" + "\u3000".repeat(20);
-    var enQuad = "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5) + "hello" + "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5);
-    var thinSpaces = "\u2009\u200A".repeat(20) + "hello" + "\u2009\u200A".repeat(20);
-    var narrowNoBreak = "\u202F\u205F".repeat(20) + "hello" + "\u202F\u205F".repeat(20);
-    var ogham = "\u1680".repeat(20) + "hello" + "\u1680".repeat(20);
-    var bom = "\uFEFF".repeat(20) + "hello" + "\uFEFF".repeat(20);
-    var mixed = "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10) + "hello" + "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10);
+    var strings = [
+        "\u3000".repeat(20) + "hello" + "\u3000".repeat(20),
+        "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5) + "hello" + "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5),
+        "\u2009\u200A".repeat(20) + "hello" + "\u2009\u200A".repeat(20),
+        "\u202F\u205F".repeat(20) + "hello" + "\u202F\u205F".repeat(20),
+        "\u1680".repeat(20) + "hello" + "\u1680".repeat(20),
+        "\uFEFF".repeat(20) + "hello" + "\uFEFF".repeat(20),
+        "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10) + "hello" + "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10),
+    ];
 
-    for (var i = 0; i < 1e5; i++) {
-        ideographicSpace.trimStart();
-        enQuad.trimStart();
-        thinSpaces.trimStart();
-        narrowNoBreak.trimStart();
-        ogham.trimStart();
-        bom.trimStart();
-        mixed.trimStart();
-    }
+    var sum = 0;
+    for (var i = 0; i < 7e5; i++)
+        sum += strings[i % 7].trimStart().length;
+
+    if (sum < 0)
+        throw new Error("bad result: " + sum);
 })();

--- a/JSTests/microbenchmarks/string-trim-start.js
+++ b/JSTests/microbenchmarks/string-trim-start.js
@@ -1,15 +1,16 @@
 (function() {
-    var shortAscii = "   hello   ";
-    var longAscii = "   " + "a".repeat(100) + "   ";
-    var noTrim = "hello";
-    var allSpaces = "          ";
-    var unicode = "   \u65e5\u672c\u8a9e   ";
+    var strings = [
+        "   hello   ",
+        "   " + "a".repeat(100) + "   ",
+        "hello",
+        "          ",
+        "   \u65e5\u672c\u8a9e   ",
+    ];
 
-    for (var i = 0; i < 1e6; i++) {
-        shortAscii.trimStart();
-        longAscii.trimStart();
-        noTrim.trimStart();
-        allSpaces.trimStart();
-        unicode.trimStart();
-    }
+    var sum = 0;
+    for (var i = 0; i < 5e6; i++)
+        sum += strings[i % 5].trimStart().length;
+
+    if (sum < 0)
+        throw new Error("bad result: " + sum);
 })();

--- a/JSTests/microbenchmarks/string-trim-unicode-whitespace.js
+++ b/JSTests/microbenchmarks/string-trim-unicode-whitespace.js
@@ -2,21 +2,20 @@
     // Non-Latin1 whitespace characters (Zs category + BOM)
     // These test the optimized isWhiteSpace path that avoids ICU calls
     // Longer whitespace sequences to better measure isWhiteSpace performance
-    var ideographicSpace = "\u3000".repeat(20) + "hello" + "\u3000".repeat(20);
-    var enQuad = "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5) + "hello" + "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5);
-    var thinSpaces = "\u2009\u200A".repeat(20) + "hello" + "\u2009\u200A".repeat(20);
-    var narrowNoBreak = "\u202F\u205F".repeat(20) + "hello" + "\u202F\u205F".repeat(20);
-    var ogham = "\u1680".repeat(20) + "hello" + "\u1680".repeat(20);
-    var bom = "\uFEFF".repeat(20) + "hello" + "\uFEFF".repeat(20);
-    var mixed = "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10) + "hello" + "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10);
+    var strings = [
+        "\u3000".repeat(20) + "hello" + "\u3000".repeat(20),
+        "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5) + "hello" + "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A".repeat(5),
+        "\u2009\u200A".repeat(20) + "hello" + "\u2009\u200A".repeat(20),
+        "\u202F\u205F".repeat(20) + "hello" + "\u202F\u205F".repeat(20),
+        "\u1680".repeat(20) + "hello" + "\u1680".repeat(20),
+        "\uFEFF".repeat(20) + "hello" + "\uFEFF".repeat(20),
+        "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10) + "hello" + "\u3000\u2000\u202F\u1680\u2009\u205F\uFEFF".repeat(10),
+    ];
 
-    for (var i = 0; i < 1e5; i++) {
-        ideographicSpace.trim();
-        enQuad.trim();
-        thinSpaces.trim();
-        narrowNoBreak.trim();
-        ogham.trim();
-        bom.trim();
-        mixed.trim();
-    }
+    var sum = 0;
+    for (var i = 0; i < 7e5; i++)
+        sum += strings[i % 7].trim().length;
+
+    if (sum < 0)
+        throw new Error("bad result: " + sum);
 })();

--- a/JSTests/microbenchmarks/string-trim-whitespace.js
+++ b/JSTests/microbenchmarks/string-trim-whitespace.js
@@ -1,0 +1,15 @@
+function test(string) {
+    return string.trim().length + string.trimStart().length + string.trimEnd().length;
+}
+noInline(test);
+
+const strings = [];
+for (let i = 0; i < 16; ++i)
+    strings.push('   field-' + i + '-value-' + (i * 7) + '  \t ');
+
+let result = 0;
+for (let i = 0; i < 2e6; ++i)
+    result += test(strings[i & 15]);
+
+if (result < 0)
+    throw new Error('bad result: ' + result);

--- a/JSTests/microbenchmarks/string-trim.js
+++ b/JSTests/microbenchmarks/string-trim.js
@@ -1,15 +1,16 @@
 (function() {
-    var shortAscii = "   hello   ";
-    var longAscii = "   " + "a".repeat(100) + "   ";
-    var noTrim = "hello";
-    var allSpaces = "          ";
-    var unicode = "   \u65e5\u672c\u8a9e   ";
+    var strings = [
+        "   hello   ",
+        "   " + "a".repeat(100) + "   ",
+        "hello",
+        "          ",
+        "   \u65e5\u672c\u8a9e   ",
+    ];
 
-    for (var i = 0; i < 1e6; i++) {
-        shortAscii.trim();
-        longAscii.trim();
-        noTrim.trim();
-        allSpaces.trim();
-        unicode.trim();
-    }
+    var sum = 0;
+    for (var i = 0; i < 5e6; i++)
+        sum += strings[i % 5].trim().length;
+
+    if (sum < 0)
+        throw new Error("bad result: " + sum);
 })();

--- a/JSTests/stress/string-trim-intrinsic.js
+++ b/JSTests/stress/string-trim-intrinsic.js
@@ -1,0 +1,127 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + JSON.stringify(actual) + ' expected: ' + JSON.stringify(expected));
+}
+
+function testTrim(string) {
+    return string.trim();
+}
+noInline(testTrim);
+
+function testTrimStart(string) {
+    return string.trimStart();
+}
+noInline(testTrimStart);
+
+function testTrimEnd(string) {
+    return string.trimEnd();
+}
+noInline(testTrimEnd);
+
+const whitespaces = [
+    '\u0009', '\u000A', '\u000B', '\u000C', '\u000D', '\u0020', '\u00A0',
+    '\u1680', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005',
+    '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', '\u2028', '\u2029',
+    '\u202F', '\u205F', '\u3000', '\uFEFF'
+];
+
+const latin1NonWhitespaces = [
+    '\u0008', '\u000E', '\u001F', '\u0021', '\u007F', '\u009F', '\u00A1',
+    '\u00FF'
+];
+
+for (let i = 0; i < testLoopCount; ++i) {
+    // No whitespace: returns the same string.
+    shouldBe(testTrim('hello'), 'hello');
+    shouldBe(testTrimStart('hello'), 'hello');
+    shouldBe(testTrimEnd('hello'), 'hello');
+
+    // Empty string.
+    shouldBe(testTrim(''), '');
+    shouldBe(testTrimStart(''), '');
+    shouldBe(testTrimEnd(''), '');
+
+    // Simple whitespace.
+    shouldBe(testTrim('  hello  '), 'hello');
+    shouldBe(testTrimStart('  hello  '), 'hello  ');
+    shouldBe(testTrimEnd('  hello  '), '  hello');
+
+    // All whitespace.
+    shouldBe(testTrim('   \t\r\n  '), '');
+    shouldBe(testTrimStart('   \t\r\n  '), '');
+    shouldBe(testTrimEnd('   \t\r\n  '), '');
+
+    // Single space.
+    shouldBe(testTrim(' '), '');
+    shouldBe(testTrimStart(' '), '');
+    shouldBe(testTrimEnd(' '), '');
+
+    // Short results (single character strings, atom caches).
+    shouldBe(testTrim('  a  '), 'a');
+    shouldBe(testTrim('  ab  '), 'ab');
+    shouldBe(testTrim('  abc  '), 'abc');
+    shouldBe(testTrimStart('  a'), 'a');
+    shouldBe(testTrimEnd('a  '), 'a');
+
+    // All Latin-1 whitespace characters.
+    shouldBe(testTrim('\t\n\v\f\r  X  \r\f\v\n\t'), 'X');
+    shouldBe(testTrimStart('\t\n\v\f\r  X'), 'X');
+    shouldBe(testTrimEnd('X \t\n\v\f\r   '), 'X');
+
+    // Latin-1 boundary characters that are not whitespace.
+    for (const ch of latin1NonWhitespaces)
+        shouldBe(testTrim(ch + 'x' + ch), ch + 'x' + ch);
+
+    // 16-bit strings with all JS whitespace characters.
+    for (const ws of whitespaces) {
+        shouldBe(testTrim(ws + 'abc' + ws), 'abc');
+        shouldBe(testTrimStart(ws + 'abc' + ws), 'abc' + ws);
+        shouldBe(testTrimEnd(ws + 'abc' + ws), ws + 'abc');
+    }
+    shouldBe(testTrim('　あ　'), 'あ');
+    shouldBe(testTrim('x'), 'x'); // U+0085 NEL is not JS whitespace.
+    shouldBe(testTrim('​x​'), '​x​'); // U+200B ZWSP is not JS whitespace.
+
+    // Rope strings.
+    let left = '   pad';
+    let right = 'ding   ';
+    let rope = left + right;
+    shouldBe(testTrim(rope), 'padding');
+    shouldBe(testTrimStart(rope), 'padding   ');
+    shouldBe(testTrimEnd(rope), '   padding');
+
+    // Substring (substring rope base).
+    let base = 'xxx   middle   yyy';
+    let sub = base.substring(3, 15);
+    shouldBe(testTrim(sub), 'middle');
+    shouldBe(testTrimStart(sub), 'middle   ');
+    shouldBe(testTrimEnd(sub), '   middle');
+
+    // Trim result of trim result (substring of substring).
+    let once = testTrim('  \t nested \t  ');
+    shouldBe(testTrim(' ' + once + ' '), 'nested');
+
+    // Long strings.
+    let long = ' '.repeat(100) + 'core-' + i % 7 + '-value' + ' '.repeat(100);
+    shouldBe(testTrim(long), 'core-' + i % 7 + '-value');
+    shouldBe(testTrimStart(long), 'core-' + i % 7 + '-value' + ' '.repeat(100));
+    shouldBe(testTrimEnd(long), ' '.repeat(100) + 'core-' + i % 7 + '-value');
+}
+
+// Non-string this values fall back to the generic path via OSR exit.
+shouldBe(String.prototype.trim.call(42), '42');
+shouldBe(String.prototype.trimStart.call(42), '42');
+shouldBe(String.prototype.trimEnd.call(42), '42');
+shouldBe(String.prototype.trim.call({ toString() { return '  obj  '; } }), 'obj');
+
+function testTrimPolymorphic(value) {
+    return String.prototype.trim.call(value);
+}
+noInline(testTrimPolymorphic);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(testTrimPolymorphic('  poly  '), 'poly');
+for (let i = 0; i < 1e3; ++i) {
+    shouldBe(testTrimPolymorphic(123.5), '123.5');
+    shouldBe(testTrimPolymorphic('  poly  '), 'poly');
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1640,7 +1640,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case StringSubstring:
     case StringSlice:
-    case StringSubstr: {
+    case StringSubstr:
+    case StringTrim: {
         setTypeForNode(node, SpecString);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -5145,6 +5145,19 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeTrimIntrinsic:
+        case StringPrototypeTrimStartIntrinsic:
+        case StringPrototypeTrimEndIntrinsic: {
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* thisString = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* resultNode = addToGraph(StringTrim, OpInfo(intrinsic), thisString);
+            setResult(resultNode);
+            return CallOptimizationResult::Inlined;
+        }
+
         case NumberPrototypeToStringIntrinsic: {
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2635,6 +2635,10 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         def(PureValue(node));
         return;
 
+    case StringTrim:
+        def(PureValue(node, static_cast<uint64_t>(node->intrinsic())));
+        return;
+
     case NumberToStringWithValidRadixConstant:
         def(PureValue(node, node->validRadixConstant()));
         return;

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -362,6 +362,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringSearch, Common) \
     CLONE_STATUS(StringSubstring, Common) \
     CLONE_STATUS(StringSubstr, Common) \
+    CLONE_STATUS(StringTrim, Common) \
     CLONE_STATUS(StrCat, Common) \
     CLONE_STATUS(Switch, Special) \
     CLONE_STATUS(TailCallForwardVarargsInlinedCaller, Special) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -475,6 +475,7 @@ bool doesGC(Graph& graph, Node* node)
     case CreateRest:
     case ToUpperCase:
     case ToLowerCase:
+    case StringTrim:
     case CallDOMGetter:
     case CallDOM:
     case ArraySlice:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3421,7 +3421,8 @@ private:
         }
 
         case ToUpperCase:
-        case ToLowerCase: {
+        case ToLowerCase:
+        case StringTrim: {
             // We currently only support StringUse since that will ensure that
             // ToLowerCase is a pure operation. If we decide to update this with
             // more types in the future, we need to ensure that the clobberize rules

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1966,6 +1966,7 @@ public:
         case CPUIntrinsic:
         case DateGetTime:
         case DateGetInt32OrNaN:
+        case StringTrim:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -638,6 +638,7 @@ namespace JSC { namespace DFG {
     macro(StringLocaleCompare, NodeMustGenerate | NodeResultInt32) \
     macro(ToLowerCase, NodeResultJS) \
     macro(ToUpperCase, NodeResultJS) \
+    macro(StringTrim, NodeResultJS) \
     /* Nodes for DOM JIT */\
     macro(CallDOMGetter, NodeResultJS | NodeMustGenerate) \
     macro(CallDOM, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3748,6 +3748,52 @@ JSC_DEFINE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject* globa
     OPERATION_RETURN(scope, jsString(vm, WTF::move(lowercasedString)));
 }
 
+template<TrimKind trimKind>
+static ALWAYS_INLINE JSString* stringTrimImpl(JSGlobalObject* globalObject, JSString* string)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto view = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    auto [left, right] = extractTrimOffsets<trimKind>(view);
+
+    if (!left && right == view->length())
+        return string;
+    RELEASE_AND_RETURN(scope, jsSubstring(globalObject, vm, string, left, right - left));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringTrim, JSString*, (JSGlobalObject* globalObject, JSString* string))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, stringTrimImpl<TrimKind::TrimBoth>(globalObject, string));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringTrimStart, JSString*, (JSGlobalObject* globalObject, JSString* string))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, stringTrimImpl<TrimKind::TrimStart>(globalObject, string));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringTrimEnd, JSString*, (JSGlobalObject* globalObject, JSString* string))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, stringTrimImpl<TrimKind::TrimEnd>(globalObject, string));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringLocaleCompare, UCPUStrictInt32, (JSGlobalObject* globalObject, JSString* base, JSString* argument))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -312,6 +312,9 @@ JSC_DECLARE_JIT_OPERATION(operationStringSubstring, JSString*, (JSGlobalObject*,
 JSC_DECLARE_JIT_OPERATION(operationStringSubstringWithEnd, JSString*, (JSGlobalObject*, JSString*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationToUpperCase, JSString*, (JSGlobalObject*, JSString*, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject*, JSString*, uint32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringTrim, JSString*, (JSGlobalObject*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringTrimStart, JSString*, (JSGlobalObject*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringTrimEnd, JSString*, (JSGlobalObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringLocaleCompare, UCPUStrictInt32, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1249,6 +1249,7 @@ private:
         case StringSubstr:
         case ToUpperCase:
         case ToLowerCase:
+        case StringTrim:
         case ArrayJoin:
             setPrediction(SpecString);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -324,6 +324,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StringSubstr:
     case ToUpperCase:
     case ToLowerCase:
+    case StringTrim:
     case MapGet:
     case LoadMapValue:
     case MapOrSetSize:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2013,6 +2013,35 @@ void SpeculativeJIT::compileToLowerCase(Node* node)
     cellResult(lengthGPR, node);
 }
 
+void SpeculativeJIT::compileStringTrim(Node* node)
+{
+    ASSERT(node->op() == StringTrim);
+
+    SpeculateCellOperand string(this, node->child1());
+    GPRReg stringGPR = string.gpr();
+
+    speculateString(node->child1(), stringGPR);
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    switch (node->intrinsic()) {
+    case StringPrototypeTrimIntrinsic:
+        callOperation(operationStringTrim, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR);
+        break;
+    case StringPrototypeTrimStartIntrinsic:
+        callOperation(operationStringTrimStart, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR);
+        break;
+    case StringPrototypeTrimEndIntrinsic:
+        callOperation(operationStringTrimEnd, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR);
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileStringCodePointAt(Node* node)
 {
     // And CheckArray also ensures that this String is not a rope.

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1777,6 +1777,7 @@ public:
     void compileStringSubstr(Node*);
     void compileToUpperCase(Node*);
     void compileToLowerCase(Node*);
+    void compileStringTrim(Node*);
     void compileThrow(Node*);
     void compileThrowStaticError(Node*);
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2726,6 +2726,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringTrim: {
+        compileStringTrim(node);
+        break;
+    }
+
     case NumberToStringWithRadix: {
         compileNumberToStringWithRadix(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5847,6 +5847,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringTrim: {
+        compileStringTrim(node);
+        break;
+    }
+
     case NumberToStringWithRadix: {
         compileNumberToStringWithRadix(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -450,6 +450,7 @@ inline CapabilityLevel canCompile(DFG::Node* node)
     case StringSubstr:
     case ToUpperCase:
     case ToLowerCase:
+    case StringTrim:
     case NumberToStringWithRadix:
     case NumberToStringWithValidRadixConstant:
     case CheckJSCast:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1936,6 +1936,9 @@ private:
         case ToLowerCase:
             compileToLowerCase();
             break;
+        case StringTrim:
+            compileStringTrim();
+            break;
         case NumberToStringWithRadix:
             compileNumberToStringWithRadix();
             break;
@@ -20872,6 +20875,26 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(continuation, lastNext);
         setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
+    }
+
+    void compileStringTrim()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue string = lowString(m_node->child1());
+        switch (m_node->intrinsic()) {
+        case StringPrototypeTrimIntrinsic:
+            setJSValue(vmCall(pointerType(), operationStringTrim, weakPointer(globalObject), string));
+            break;
+        case StringPrototypeTrimStartIntrinsic:
+            setJSValue(vmCall(pointerType(), operationStringTrimStart, weakPointer(globalObject), string));
+            break;
+        case StringPrototypeTrimEndIntrinsic:
+            setJSValue(vmCall(pointerType(), operationStringTrimEnd, weakPointer(globalObject), string));
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
     }
 
     void compileNumberToStringWithRadix()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -147,6 +147,9 @@ namespace JSC {
     macro(StringPrototypeSubstrIntrinsic) \
     macro(StringPrototypeToLowerCaseIntrinsic) \
     macro(StringPrototypeToUpperCaseIntrinsic) \
+    macro(StringPrototypeTrimIntrinsic) \
+    macro(StringPrototypeTrimStartIntrinsic) \
+    macro(StringPrototypeTrimEndIntrinsic) \
     macro(SymbolPrototypeToStringIntrinsic) \
     macro(NumberPrototypeToStringIntrinsic) \
     macro(NumberIsFiniteIntrinsic) \

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -163,7 +163,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("localeCompare"_s, stringProtoFuncLocaleCompare, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeLocaleCompareIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toLocaleLowerCase"_s, stringProtoFuncToLocaleLowerCase, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toLocaleUpperCase"_s, stringProtoFuncToLocaleUpperCase, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("trim"_s, stringProtoFuncTrim, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("trim"_s, stringProtoFuncTrim, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, StringPrototypeTrimIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("startsWith"_s, stringProtoFuncStartsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeStartsWithIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeEndsWithIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIncludesIntrinsic);
@@ -174,8 +174,8 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("normalize"_s, stringProtoFuncNormalize, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().charCodeAtPrivateName(), stringProtoFuncCharCodeAt, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, CharCodeAtIntrinsic);
 
-    JSFunction* trimStartFunction = JSFunction::create(vm, globalObject, 0, "trimStart"_s, stringProtoFuncTrimStart, ImplementationVisibility::Public);
-    JSFunction* trimEndFunction = JSFunction::create(vm, globalObject, 0, "trimEnd"_s, stringProtoFuncTrimEnd, ImplementationVisibility::Public);
+    JSFunction* trimStartFunction = JSFunction::create(vm, globalObject, 0, "trimStart"_s, stringProtoFuncTrimStart, ImplementationVisibility::Public, StringPrototypeTrimStartIntrinsic);
+    JSFunction* trimEndFunction = JSFunction::create(vm, globalObject, 0, "trimEnd"_s, stringProtoFuncTrimEnd, ImplementationVisibility::Public, StringPrototypeTrimEndIntrinsic);
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "trimStart"_s), trimStartFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "trimLeft"_s), trimStartFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, Identifier::fromString(vm, "trimEnd"_s), trimEndFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -1908,12 +1908,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToLocaleUpperCase, (JSGlobalObject* glob
     return toLocaleCase<CaseConversionMode::Upper>(globalObject, callFrame);
 }
 
-enum class TrimKind : uint8_t {
-    TrimStart = 1,
-    TrimEnd = 2,
-    TrimBoth = TrimStart | TrimEnd
-};
-
 template<TrimKind trimKind>
 static inline JSValue trimString(JSGlobalObject* globalObject, JSValue thisValue)
 {
@@ -1933,30 +1927,7 @@ static inline JSValue trimString(JSGlobalObject* globalObject, JSValue thisValue
         RELEASE_AND_RETURN(scope, jsEmptyString(vm));
     }
 
-    unsigned left = 0;
-    unsigned right = length;
-
-    if (str.is8Bit()) {
-        auto characters = str.span8();
-        if constexpr (static_cast<uint8_t>(trimKind) & static_cast<uint8_t>(TrimKind::TrimStart)) {
-            while (left < length && isStrWhiteSpace(characters[left]))
-                left++;
-        }
-        if constexpr (static_cast<uint8_t>(trimKind) & static_cast<uint8_t>(TrimKind::TrimEnd)) {
-            while (right > left && isStrWhiteSpace(characters[right - 1]))
-                right--;
-        }
-    } else {
-        auto characters = str.span16();
-        if constexpr (static_cast<uint8_t>(trimKind) & static_cast<uint8_t>(TrimKind::TrimStart)) {
-            while (left < length && isStrWhiteSpace(characters[left]))
-                left++;
-        }
-        if constexpr (static_cast<uint8_t>(trimKind) & static_cast<uint8_t>(TrimKind::TrimEnd)) {
-            while (right > left && isStrWhiteSpace(characters[right - 1]))
-                right--;
-        }
-    }
+    auto [left, right] = extractTrimOffsets<trimKind>(StringView { str });
 
     // Don't gc allocate a new string if we don't have to.
     if (!left && right == length && thisValue.isString())

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -68,6 +68,34 @@ ALWAYS_INLINE std::tuple<int32_t, int32_t> extractSliceOffsets(int32_t length, i
     return { from, to };
 }
 
+enum class TrimKind : uint8_t {
+    TrimStart = 1,
+    TrimEnd = 2,
+    TrimBoth = TrimStart | TrimEnd
+};
+
+template<TrimKind trimKind>
+ALWAYS_INLINE std::tuple<unsigned, unsigned> extractTrimOffsets(StringView view)
+{
+    unsigned left = 0;
+    unsigned right = view.length();
+    auto scan = [&](auto characters) ALWAYS_INLINE_LAMBDA {
+        if constexpr (static_cast<uint8_t>(trimKind) & static_cast<uint8_t>(TrimKind::TrimStart)) {
+            while (left < right && isStrWhiteSpace(characters[left]))
+                left++;
+        }
+        if constexpr (static_cast<uint8_t>(trimKind) & static_cast<uint8_t>(TrimKind::TrimEnd)) {
+            while (right > left && isStrWhiteSpace(characters[right - 1]))
+                right--;
+        }
+    };
+    if (view.is8Bit())
+        scan(view.span8());
+    else
+        scan(view.span16());
+    return { left, right };
+}
+
 template<typename T> concept Arithmetic = std::is_arithmetic_v<T>;
 
 template<Arithmetic NumberType>


### PR DESCRIPTION
#### 082efc20347d20d555bc7c5fb2c349e791495859
<pre>
[JSC] Handle `String#trim`, `String#trimStart` and `String#trimEnd` in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=318185">https://bugs.webkit.org/show_bug.cgi?id=318185</a>

Reviewed by Yusuke Suzuki.

This patch adds StringPrototypeTrimIntrinsic, StringPrototypeTrimStartIntrinsic, and
StringPrototypeTrimEndIntrinsic, and handles them in DFG and FTL via a new StringTrim
node. For now, the DFG / FTL implementation simply speculates StringUse on the receiver
and calls a JIT operation. We can optimize this further in future patches, e.g. by
emitting the whitespace scan as inline JIT code and allocating the substring rope inline.

This patch also updates the existing string-trim* microbenchmarks so that they consume
the trim results and rotate the input strings: since StringTrim is a pure node, the
previous result-discarding loop bodies were eliminated by DCE / LICM and no longer
measured trim itself.

                                                 ToT                     Patched

string-trim-start-unicode-whitespace       45.2619+-0.9021     ^     39.7963+-0.8249        ^ definitely 1.1373x faster
string-trim-end-unicode-whitespace         47.1853+-1.1061     ^     42.3641+-1.0792        ^ definitely 1.1138x faster
string-trim-whitespace                    112.0596+-1.8629     ^     49.2140+-0.8692        ^ definitely 2.2770x faster
string-trim-no-whitespace                  41.4868+-0.6042     ^     17.3533+-0.3159        ^ definitely 2.3907x faster
string-trim                                82.4187+-0.9117     ^     40.3063+-1.9017        ^ definitely 2.0448x faster
string-trim-unicode-whitespace             81.8615+-2.1368     ^     75.6034+-1.9905        ^ definitely 1.0828x faster
string-trim-end                            76.7737+-1.0939     ^     36.0213+-0.4923        ^ definitely 2.1313x faster
string-trim-start                          76.8228+-0.7388     ^     32.7010+-1.0362        ^ definitely 2.3492x faster

Tests: JSTests/microbenchmarks/string-trim-no-whitespace.js
       JSTests/microbenchmarks/string-trim-whitespace.js
       JSTests/stress/string-trim-intrinsic.js

* JSTests/microbenchmarks/string-trim-end-unicode-whitespace.js:
* JSTests/microbenchmarks/string-trim-end.js:
* JSTests/microbenchmarks/string-trim-no-whitespace.js: Added.
(test):
* JSTests/microbenchmarks/string-trim-start-unicode-whitespace.js:
* JSTests/microbenchmarks/string-trim-start.js:
* JSTests/microbenchmarks/string-trim-unicode-whitespace.js:
* JSTests/microbenchmarks/string-trim-whitespace.js: Added.
(test):
* JSTests/microbenchmarks/string-trim.js:
* JSTests/stress/string-trim-intrinsic.js: Added.
(shouldBe):
(testTrim):
(testTrimStart):
(testTrimEnd):
(shouldBe.String.prototype.trim.call.toString):
(testTrimPolymorphic):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasIntrinsic):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::stringTrimImpl):
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringTrim):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::trimString):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::extractTrimOffsets):

Canonical link: <a href="https://commits.webkit.org/316254@main">https://commits.webkit.org/316254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d68eae811d82ebb35e6c08d5d8dfec6580e20e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38575 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180610 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128947 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133512 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35345 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33610 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29290 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2342 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183195 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32487 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141975 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44812 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38367 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30263 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110206 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37028 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117344 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44012 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8359 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54549 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->