### PR TITLE
[GTK][WPE] Do not auto-enable Swift when cross-building

### DIFF
--- a/Source/cmake/WebKitFeatures.cmake
+++ b/Source/cmake/WebKitFeatures.cmake
@@ -148,13 +148,30 @@ macro(WEBKIT_OPTION_BEGIN)
     # Default the Swift prototype features on for GTK/WPE, but only when the toolchain
     # can build it: Clang (not GCC) with a new-enough Swift. Otherwise they stay off;
     # an explicit -D against such a toolchain is rejected in WEBKIT_OPTION_END.
-    set(ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT OFF)
-    set(ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT OFF)
-    if (COMPILER_IS_CLANG)
-        _WEBKIT_DETECT_SWIFT_CXX_INTEROP_SUPPORT(_swift_interop_ok)
-        if (_swift_interop_ok)
-            set(ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT ON)
-            set(ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT ON)
+    #
+    # If either value was already set before this point (e.g. by a platform config),
+    # keep whatever is already defined and only fill in the one(s) still unset.
+    # When cross-building default to off, because the auto-detection here would pick
+    # up the host swiftc instead of a cross-aware one and break the target build.
+    if (NOT DEFINED ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT OR NOT DEFINED ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT)
+        if (CMAKE_CROSSCOMPILING)
+            set(_swift_features_default OFF)
+        elseif (COMPILER_IS_CLANG)
+            _WEBKIT_DETECT_SWIFT_CXX_INTEROP_SUPPORT(_swift_interop_ok)
+            if (_swift_interop_ok)
+                set(_swift_features_default ON)
+            else ()
+                set(_swift_features_default OFF)
+            endif ()
+        else ()
+            set(_swift_features_default OFF)
+        endif ()
+
+        if (NOT DEFINED ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT)
+            set(ENABLE_SWIFT_DEMO_URI_SCHEME_DEFAULT ${_swift_features_default})
+        endif ()
+        if (NOT DEFINED ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT)
+            set(ENABLE_BACK_FORWARD_LIST_SWIFT_DEFAULT ${_swift_features_default})
         endif ()
     endif ()
 


### PR DESCRIPTION
#### 7248cd80025616412b7f4f78ebb737fca98ee2b9
<pre>
[GTK][WPE] Do not auto-enable Swift when cross-building
<a href="https://bugs.webkit.org/show_bug.cgi?id=318187">https://bugs.webkit.org/show_bug.cgi?id=318187</a>

Reviewed by Carlos Alberto Lopez Perez.

WebKit auto-enables ENABLE_SWIFT_DEMO_URI_SCHEME and
ENABLE_BACK_FORWARD_LIST_SWIFT for WPE/GTK whenever it finds a capable
swiftc on PATH. In a cross build that picks up a host toolchain (e.g.
/opt/swift), which cannot target the SDK, so the build fails while
trying to process a host header like bits/wordsize.h.

Skip the Swift auto-detection when CMAKE_CROSSCOMPILING is set, so the
features default off for any cross build instead of guessing from a host
swiftc. Any default explicitly set beforehand (by the user, the
environment or a platform config) is respected, so a cross target that
does ship a Swift runtime can opt back in by setting the *_DEFAULT
variables to ON.

* Source/cmake/WebKitFeatures.cmake:

Canonical link: <a href="https://commits.webkit.org/316335@main">https://commits.webkit.org/316335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af3cf1d792a5642d75c5c85ae725d7b69452ba2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128994 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133545 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114006 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35387 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33650 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29384 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2412 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183293 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32581 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142041 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44906 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141858 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45596 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110300 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26112 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37094 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204003 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44106 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8395 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54563 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->