### PR TITLE
[Coordinated Graphics][Async Scrolling] the scrolling thread shouldn't block the compositor thread to flush compositing state

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -40,6 +40,7 @@
 #include "ScrollingTreePositionedNodeCoordinated.h"
 #include "ScrollingTreeStickyNodeCoordinated.h"
 #include <ranges>
+#include <wtf/CompletionHandler.h>
 
 namespace WebCore {
 
@@ -85,12 +86,20 @@ void ScrollingTreeCoordinated::applyLayerPositionsInternal()
     if (!rootScrollingNode)
         return;
 
+    if (m_didRequestComposition.exchange(true)) {
+        setNeedsApplyLayerPositions();
+        return;
+    }
+
     ThreadedScrollingTree::applyLayerPositionsInternal();
 
-    if (ScrollingThread::isCurrentThread()) {
-        auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
-        rootContentsLayer->requestComposition(CompositionReason::AsyncScrolling);
-    }
+    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
+    rootContentsLayer->requestCompositionForScrolling(CompletionHandler<void()>([this, protectedThis = protect(this)] {
+        m_didRequestComposition = false;
+        ScrollingThread::dispatch([this, protectedThis] {
+            applyLayerPositions();
+        });
+    }, CompletionHandlerCallThread::AnyThread), ScrollingThread::isCurrentThread());
 }
 
 void ScrollingTreeCoordinated::didCompleteRenderingUpdate()

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.h
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.h
@@ -55,6 +55,9 @@ private:
 #endif
 
     RefPtr<ScrollingTreeNode> scrollingNodeForPoint(FloatPoint) final;
+
+    std::atomic<bool> m_didRequestComposition { false };
+
 #if ENABLE(WHEEL_EVENT_REGIONS)
     OptionSet<EventListenerRegionType> eventListenerRegionTypesForPoint(FloatPoint) const final;
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -176,13 +176,17 @@ void CoordinatedPlatformLayer::notifyCompositionRequired()
 void CoordinatedPlatformLayer::setPosition(FloatPoint&& position)
 {
     ASSERT(m_lock.isHeld());
-    m_pendingState.position = WTF::move(position);
+    m_position = WTF::move(position);
+    m_pendingChanges.add(Change::Position);
+    notifyCompositionRequired();
 }
 
 void CoordinatedPlatformLayer::setPositionForScrolling(const FloatPoint& position)
 {
     Locker locker { m_lock };
-    m_pendingState.positionForScrolling = position;
+    m_positionForScrolling = position;
+    m_pendingChanges.add(Change::PositionForScrolling);
+    notifyCompositionRequired();
 }
 
 const FloatPoint& CoordinatedPlatformLayer::position() const
@@ -210,13 +214,17 @@ FloatPoint CoordinatedPlatformLayer::topLeftPositionForScrolling()
 void CoordinatedPlatformLayer::setBoundsOrigin(const FloatPoint& origin)
 {
     ASSERT(m_lock.isHeld());
-    m_pendingState.boundsOrigin = origin;
+    m_boundsOrigin = origin;
+    m_pendingChanges.add(Change::BoundsOrigin);
+    notifyCompositionRequired();
 }
 
 void CoordinatedPlatformLayer::setBoundsOriginForScrolling(const FloatPoint& origin)
 {
     Locker locker { m_lock };
-    m_pendingState.boundsOriginForScrolling = origin;
+    m_boundsOriginForScrolling = origin;
+    m_pendingChanges.add(Change::BoundsOriginForScrolling);
+    notifyCompositionRequired();
 }
 
 const FloatPoint& CoordinatedPlatformLayer::boundsOrigin() const
@@ -882,6 +890,14 @@ void CoordinatedPlatformLayer::requestComposition(CompositionReason reason)
         m_client->requestComposition(reason);
 }
 
+void CoordinatedPlatformLayer::requestCompositionForScrolling(CompletionHandler<void()>&& completionHandler, bool scheduleUpdate)
+{
+    if (m_client)
+        m_client->requestCompositionForScrolling(WTF::move(completionHandler), scheduleUpdate);
+    else
+        completionHandler();
+}
+
 RunLoop* CoordinatedPlatformLayer::compositingRunLoop() const
 {
     return m_client ? m_client->compositingRunLoop() : nullptr;
@@ -962,43 +978,6 @@ void CoordinatedPlatformLayer::waitUntilPaintingComplete()
         m_backingStoreProxy->waitUntilPaintingComplete();
 }
 
-void CoordinatedPlatformLayer::flushPendingState()
-{
-    Locker locker { m_lock };
-    if (!m_pendingState.position && !m_pendingState.boundsOrigin && !m_pendingState.positionForScrolling && !m_pendingState.boundsOriginForScrolling)
-        return;
-
-    std::optional<FloatPoint> position;
-    if (m_pendingState.positionForScrolling) {
-        m_pendingState.position = std::nullopt;
-        position = *std::exchange(m_pendingState.positionForScrolling, std::nullopt);
-    } else if (m_pendingState.position)
-        position = *std::exchange(m_pendingState.position, std::nullopt);
-
-    std::optional<FloatPoint> boundsOrigin;
-    if (m_pendingState.boundsOriginForScrolling) {
-        m_pendingState.boundsOrigin = std::nullopt;
-        boundsOrigin = *std::exchange(m_pendingState.boundsOriginForScrolling, std::nullopt);
-    } else if (m_pendingState.boundsOrigin)
-        boundsOrigin = *std::exchange(m_pendingState.boundsOrigin, std::nullopt);
-
-    bool requireComposition = false;
-    if (position && m_position != *position) {
-        m_position = *position;
-        m_pendingChanges.add(Change::Position);
-        requireComposition = true;
-    }
-
-    if (boundsOrigin && m_boundsOrigin != boundsOrigin) {
-        m_boundsOrigin = *boundsOrigin;
-        m_pendingChanges.add(Change::BoundsOrigin);
-        requireComposition = true;
-    }
-
-    if (requireComposition)
-        notifyCompositionRequired();
-}
-
 void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<CompositionReason>& reasons, bool useSkiaTarget)
 {
     ASSERT(!isMainThread());
@@ -1020,17 +999,19 @@ void CoordinatedPlatformLayer::flushCompositingState(const OptionSet<Composition
 
 void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<CompositionReason>& reasons, TextureMapperLayer& layer)
 {
+    if (reasons.containsAny({ CompositionReason::AsyncScrolling })) {
+        if (m_pendingChanges.contains(Change::PositionForScrolling)) {
+            layer.setPosition(m_positionForScrolling);
+            m_pendingChanges.remove(Change::PositionForScrolling);
+        }
+
+        if (m_pendingChanges.contains(Change::BoundsOriginForScrolling)) {
+            layer.setBoundsOrigin(m_boundsOriginForScrolling);
+            m_pendingChanges.remove(Change::BoundsOriginForScrolling);
+        }
+    }
+
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
-        if (m_pendingChanges.contains(Change::Position)) {
-            layer.setPosition(m_position);
-            m_pendingChanges.remove(Change::Position);
-        }
-
-        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
-            layer.setBoundsOrigin(m_boundsOrigin);
-            m_pendingChanges.remove(Change::BoundsOrigin);
-        }
-
         if (m_pendingChanges.contains(Change::ContentsRect)) {
             layer.setContentsRect(m_contentsRect);
             m_pendingChanges.remove(Change::ContentsRect);
@@ -1043,6 +1024,16 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
     }
 
     if (reasons.contains(CompositionReason::RenderingUpdate)) {
+        if (m_pendingChanges.contains(Change::Position)) {
+            layer.setPosition(m_position);
+            m_pendingChanges.remove(Change::Position);
+        }
+
+        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
+            layer.setBoundsOrigin(m_boundsOrigin);
+            m_pendingChanges.remove(Change::BoundsOrigin);
+        }
+
         if (m_pendingChanges.contains(Change::AnchorPoint)) {
             layer.setAnchorPoint(m_anchorPoint);
             m_pendingChanges.remove(Change::AnchorPoint);
@@ -1217,17 +1208,19 @@ void CoordinatedPlatformLayer::flushCompositingStateOnTarget(const OptionSet<Com
 #if USE(SKIA)
 void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet<CompositionReason>& reasons, SkiaCompositingLayer& layer)
 {
+    if (reasons.contains(CompositionReason::AsyncScrolling)) {
+        if (m_pendingChanges.contains(Change::PositionForScrolling)) {
+            layer.setPosition(m_positionForScrolling);
+            m_pendingChanges.remove(Change::PositionForScrolling);
+        }
+
+        if (m_pendingChanges.contains(Change::BoundsOriginForScrolling)) {
+            layer.setBoundsOrigin(m_boundsOriginForScrolling);
+            m_pendingChanges.remove(Change::BoundsOriginForScrolling);
+        }
+    }
+
     if (reasons.containsAny({ CompositionReason::RenderingUpdate, CompositionReason::AsyncScrolling })) {
-        if (m_pendingChanges.contains(Change::Position)) {
-            layer.setPosition(m_position);
-            m_pendingChanges.remove(Change::Position);
-        }
-
-        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
-            layer.setBoundsOrigin(m_boundsOrigin);
-            m_pendingChanges.remove(Change::BoundsOrigin);
-        }
-
         if (m_pendingChanges.contains(Change::ContentsRect)) {
             layer.setContentsRect(m_contentsRect);
             m_pendingChanges.remove(Change::ContentsRect);
@@ -1245,6 +1238,16 @@ void CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget(const OptionSet
     }
 
     if (reasons.contains(CompositionReason::RenderingUpdate)) {
+        if (m_pendingChanges.contains(Change::Position)) {
+            layer.setPosition(m_position);
+            m_pendingChanges.remove(Change::Position);
+        }
+
+        if (m_pendingChanges.contains(Change::BoundsOrigin)) {
+            layer.setBoundsOrigin(m_boundsOrigin);
+            m_pendingChanges.remove(Change::BoundsOrigin);
+        }
+
         if (m_pendingChanges.contains(Change::AnchorPoint)) {
             layer.setAnchorPoint(m_anchorPoint);
             m_pendingChanges.remove(Change::AnchorPoint);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -83,6 +83,7 @@ public:
         virtual void notifyCompositionRequired() = 0;
         virtual bool isCompositionRequiredOrOngoing() const = 0;
         virtual void requestComposition(CompositionReason) = 0;
+        virtual void requestCompositionForScrolling(CompletionHandler<void()>&&, bool scheduleUpdate) = 0;
         virtual RunLoop* compositingRunLoop() const = 0;
         virtual int maxTextureSize() const = 0;
         virtual void willPaintTile() = 0;
@@ -195,7 +196,6 @@ public:
     void updateContents(bool affectedByTransformAnimation);
     void updateBackingStore();
 
-    void flushPendingState();
     void flushCompositingState(const OptionSet<CompositionReason>&, bool = false);
 
     bool hasPendingTilesCreation() const { return m_pendingTilesCreation; }
@@ -203,6 +203,7 @@ public:
     void processPendingBackingStoreTileUpdates();
     bool isCompositionRequiredOrOngoing() const;
     void requestComposition(CompositionReason);
+    void requestCompositionForScrolling(CompletionHandler<void()>&&, bool scheduleUpdate);
     RunLoop* compositingRunLoop() const;
     int maxTextureSize() const;
 
@@ -244,6 +245,7 @@ private:
         BackingStore,
         BlendMode,
         BoundsOrigin,
+        BoundsOriginForScrolling,
         Children,
         ChildrenTransform,
         ClipPath,
@@ -266,6 +268,7 @@ private:
         MasksToBounds,
         Opacity,
         Position,
+        PositionForScrolling,
         Preserves3D,
         Replica,
 #if ENABLE(SCROLLING_THREAD)
@@ -296,9 +299,11 @@ private:
     Lock m_lock;
     EnumSet<Change> m_pendingChanges WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint m_position WTF_GUARDED_BY_LOCK(m_lock);
+    FloatPoint m_positionForScrolling WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint3D m_anchorPoint WTF_GUARDED_BY_LOCK(m_lock) { 0.5f, 0.5f, 0 };
     FloatSize m_size WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint m_boundsOrigin WTF_GUARDED_BY_LOCK(m_lock);
+    FloatPoint m_boundsOriginForScrolling WTF_GUARDED_BY_LOCK(m_lock);
     TransformationMatrix m_transform WTF_GUARDED_BY_LOCK(m_lock);
     TransformationMatrix m_childrenTransform WTF_GUARDED_BY_LOCK(m_lock);
     FloatRect m_visibleRect WTF_GUARDED_BY_LOCK(m_lock);
@@ -353,13 +358,6 @@ private:
 #if ENABLE(SCROLLING_THREAD)
     Markable<ScrollingNodeID> m_scrollingNodeID WTF_GUARDED_BY_LOCK(m_lock);
 #endif
-
-    struct {
-        std::optional<FloatPoint> position;
-        std::optional<FloatPoint> positionForScrolling;
-        std::optional<FloatPoint> boundsOrigin;
-        std::optional<FloatPoint> boundsOriginForScrolling;
-    } m_pendingState WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
@@ -90,16 +90,7 @@ bool CoordinatedSceneState::flush()
             m_pendingLayersToRemove.addAll(std::exchange(m_layersToRemove, { }));
     }
 
-    flushPendingState();
-
     return didChangeLayers;
-}
-
-void CoordinatedSceneState::flushPendingState()
-{
-    Locker stateLock { m_stateLock };
-    for (auto& layer : m_layers)
-        layer->flushPendingState();
 }
 
 void CoordinatedSceneState::commitPendingLayers()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -54,7 +54,6 @@ public:
     void removeLayer(WebCore::CoordinatedPlatformLayer&);
 
     bool flush();
-    void flushPendingState();
     void flushCompositingState(const OptionSet<WebCore::CompositionReason>&, bool useSkia);
     void invalidate();
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -352,7 +352,6 @@ void LayerTreeHost::requestComposition(CompositionReason reason)
 {
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
-        m_sceneState->flushPendingState();
         if (!m_compositionRequiredInScrollingThread)
             return;
         m_compositionRequiredInScrollingThread = false;
@@ -436,6 +435,11 @@ void LayerTreeHost::requestCompositionForRenderingUpdate()
         WTFEndSignpost(this, DidComposite);
     });
     WTFEmitSignpost(this, RequestCompositionForRenderingUpdate);
+}
+
+void LayerTreeHost::requestCompositionForScrolling(CompletionHandler<void()>&& completionHandler, bool scheduleUpdate)
+{
+    m_compositor->requestCompositionForScrolling(WTF::move(completionHandler), scheduleUpdate);
 }
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -95,6 +95,7 @@ private:
     void notifyCompositionRequired() override;
     bool isCompositionRequiredOrOngoing() const override;
     void requestComposition(WebCore::CompositionReason) override;
+    void requestCompositionForScrolling(CompletionHandler<void()>&&, bool scheduleUpdate) override;
     RunLoop* compositingRunLoop() const override;
     int maxTextureSize() const override;
     void willPaintTile() override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -409,7 +409,6 @@ void LayerTreeHost::requestComposition(CompositionReason)
 {
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {
-        m_sceneState->flushPendingState();
         if (!m_compositionRequiredInScrollingThread)
             return;
         m_compositionRequiredInScrollingThread = false;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -151,6 +151,8 @@ void ThreadedCompositor::invalidate()
         Locker locker { m_state.lock };
         stopRenderTimer();
         m_state.didCompositeRenderingUpdateFunction = nullptr;
+        if (m_state.didCompositeForScrollingCompletionHandler)
+            m_state.didCompositeForScrollingCompletionHandler();
         m_state.state = State::Invalidated;
     }
 
@@ -454,6 +456,7 @@ void ThreadedCompositor::renderLayerTree()
 
     OptionSet<CompositionReason> reasons;
     bool shouldNotifiyDidComposite = false;
+    CompletionHandlerCallingScope didCompositeForScrollingCompletionHandlerScope;
     {
         Locker locker { m_state.lock };
 
@@ -476,6 +479,8 @@ void ThreadedCompositor::renderLayerTree()
 
         ASSERT(m_state.state == State::Scheduled);
         m_state.state = State::InProgress;
+
+        didCompositeForScrollingCompletionHandlerScope = std::exchange(m_state.didCompositeForScrollingCompletionHandler, { });
     }
 
     if (!m_useSkia && (!m_context || !m_context->makeContextCurrent()))
@@ -506,6 +511,9 @@ void ThreadedCompositor::renderLayerTree()
     WTFBeginSignpost(this, FlushCompositingState);
     flushCompositingState(reasons);
     WTFEndSignpost(this, FlushCompositingState);
+
+    if (auto completionHandler = didCompositeForScrollingCompletionHandlerScope.release())
+        completionHandler();
 
     WTFBeginSignpost(this, PaintToGLContext);
     paintToCurrentGLContext(viewportTransform, viewportSize, reasons);
@@ -542,6 +550,16 @@ void ThreadedCompositor::requestCompositionForRenderingUpdate(Function<void()>&&
     if (m_sceneState->pendingTiles())
         m_state.isWaitingForTiles = true;
     scheduleUpdateLocked();
+}
+
+void ThreadedCompositor::requestCompositionForScrolling(CompletionHandler<void()>&& didCompositeFunction, bool scheduleUpdate)
+{
+    Locker locker { m_state.lock };
+    m_state.reasons.add(CompositionReason::AsyncScrolling);
+    ASSERT(!m_state.didCompositeForScrollingCompletionHandler);
+    m_state.didCompositeForScrollingCompletionHandler = WTF::move(didCompositeFunction);
+    if (scheduleUpdate)
+        scheduleUpdateLocked();
 }
 
 void ThreadedCompositor::requestComposition(CompositionReason reason)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -41,6 +41,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/Atomics.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
@@ -85,6 +86,7 @@ public:
 
     void setSize(const WebCore::IntSize&, float);
     void requestCompositionForRenderingUpdate(Function<void()>&&);
+    void requestCompositionForScrolling(CompletionHandler<void()>&&, bool scheduleUpdate);
     void requestComposition(WebCore::CompositionReason);
     RunLoop* runLoop();
 
@@ -165,6 +167,7 @@ private:
         bool isWaitingForTiles WTF_GUARDED_BY_LOCK(lock) { false };
         OptionSet<WebCore::CompositionReason> reasons WTF_GUARDED_BY_LOCK(lock);
         Function<void()> didCompositeRenderingUpdateFunction WTF_GUARDED_BY_LOCK(lock);
+        CompletionHandler<void()> didCompositeForScrollingCompletionHandler WTF_GUARDED_BY_LOCK(lock);
     } m_state;
 
     struct {


### PR DESCRIPTION
#### 27b74fc2e9e0eed092c4161ae1df3e7869534eab
<pre>
[Coordinated Graphics][Async Scrolling] the scrolling thread shouldn&apos;t block the compositor thread to flush compositing state
<a href="https://bugs.webkit.org/show_bug.cgi?id=318191">https://bugs.webkit.org/show_bug.cgi?id=318191</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::ScrollingTreeCoordinated::applyLayerPositionsInternal):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setPosition):
(WebCore::CoordinatedPlatformLayer::setPositionForScrolling):
(WebCore::CoordinatedPlatformLayer::setBoundsOrigin):
(WebCore::CoordinatedPlatformLayer::setBoundsOriginForScrolling):
(WebCore::CoordinatedPlatformLayer::requestCompositionForScrolling):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnTarget):
(WebCore::CoordinatedPlatformLayer::flushCompositingStateOnSkiaTarget):
(WebCore::CoordinatedPlatformLayer::flushPendingState): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp:
(WebKit::CoordinatedSceneState::flush):
(WebKit::CoordinatedSceneState::flushPendingState): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::requestComposition):
(WebKit::LayerTreeHost::requestCompositionForScrolling):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::requestComposition):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::invalidate):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::requestCompositionForScrolling):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27b74fc2e9e0eed092c4161ae1df3e7869534eab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133727 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94347 "20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34008 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183860 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142433 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45473 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142324 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46153 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30581 "Too many flaky failures: http/tests/contentextensions/text-track-blocked.html, http/tests/media/media-play-stream-chunked-icy.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/navigation/redirect-preserves-fragment.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/register-bypassing-scheme.html, http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image-UpgradeMixedContent.https.html, http/tests/storageAccess/deny-without-prompt-preserves-gesture.html, http/tests/websocket/tests/hybi/contentextensions/upgrade.html (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110797 "Hash 27b74fc2 for PR 68288 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37421 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117841 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44671 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8676 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->