### PR TITLE
Split the start/end block in FrameSelection::respondToNodeModification onto its own line

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -711,7 +711,9 @@ void FrameSelection::respondToNodeModification(Node& node, bool anchorRemoved, b
             clearDOMTreeSelection = true;
 
         clearRenderTreeSelection = true;
-    } if (startRemoved || endRemoved) {
+    }
+
+    if (startRemoved || endRemoved) {
         Position start = m_selection.start();
         Position end = m_selection.end();
         if (startRemoved)


### PR DESCRIPTION
#### 2826db838ec7c2b5eb8b1447484f6306e3d29c63
<pre>
Split the start/end block in FrameSelection::respondToNodeModification onto its own line
<a href="https://bugs.webkit.org/show_bug.cgi?id=318194">https://bugs.webkit.org/show_bug.cgi?id=318194</a>
<a href="https://rdar.apple.com/181000906">rdar://181000906</a>

Reviewed by Chris Dumez.

This change is just to make code easier to understand true intention as
mentioned below:

respondToNodeModification() adjusts the selection for a node removal. The
start/end block is written as `} if (startRemoved || endRemoved) {`, sharing a
line with the close of the anchor/focus block, which reads like a dropped `else`.
It isn&apos;t one, and the missing separation is what makes it look like a typo.

The two blocks are sequential passes, and both are needed. nodeWillBeRemoved()
runs before the node leaves the tree. The anchor/focus block rewrites
anchor-relative positions into positions in the removed node&apos;s parent via
positionInParentBefore/AfterNode(), and setWithoutValidation() derives the start
and end from them. Those parent offsets still describe the pre-removal tree, so
the start/end block runs afterwards to apply the child-index shift.

For `foo&lt;hr&gt;bar` with the caret after the hr, the first block produces (div, 2),
which lands after &quot;bar&quot; once the hr is gone; the second maps it to (div, 1),
matching the expected result in editing/execCommand/insertHorizontalRule. The
double pass cannot over-decrement, since the first block only runs when the
removed node is an inclusive ancestor of the anchor or focus, so it always emits
an offset equal to the node&apos;s own index or one past it.

Put the second `if` on its own line so the fallthrough is deliberate on its face.
No behavior change.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::respondToNodeModification):

Canonical link: <a href="https://commits.webkit.org/318053@main">https://commits.webkit.org/318053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b89eb4b8bbec6abd1a6482979c50342639c3a90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186512 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140145 "Build is in progress. Recent messages:") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11a16338-abfa-4b3c-bb41-8d7741267528) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137826 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/140145 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d67c0add-ceba-490b-8020-69827885f568) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118300 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9060b896-fa9a-4370-8b54-5420a8613dfe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39992 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38360 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38114 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34980 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188935 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50513 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39543 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51196 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34739 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146703 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41465 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123404 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49701 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13098 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49100 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->