### PR TITLE
[JSC] Some DFG intrinsics should bail out when the callee comes from another realm

### DIFF
--- a/JSTests/stress/dfg-array-concat-cross-realm-species.js
+++ b/JSTests/stress/dfg-array-concat-cross-realm-species.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const other = createGlobalObject();
+
+Array.prototype.concat = other.Array.prototype.concat;
+
+function test(array, array2) {
+    return array.concat(array2);
+}
+noInline(test);
+
+const array = [1, 2, 3];
+const array2 = [4, 5];
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test(array, array2)), other.Array.prototype);

--- a/JSTests/stress/dfg-array-slice-cross-realm-species.js
+++ b/JSTests/stress/dfg-array-slice-cross-realm-species.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const other = createGlobalObject();
+
+Array.prototype.slice = other.Array.prototype.slice;
+
+function test(array) {
+    return array.slice(0);
+}
+noInline(test);
+
+const array = [1, 2, 3];
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test(array)), other.Array.prototype);

--- a/JSTests/stress/dfg-array-splice-cross-realm-species.js
+++ b/JSTests/stress/dfg-array-splice-cross-realm-species.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const other = createGlobalObject();
+
+Array.prototype.splice = other.Array.prototype.splice;
+
+function test(array) {
+    return array.splice(0, 0);
+}
+noInline(test);
+
+const array = [1, 2, 3];
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test(array)), other.Array.prototype);

--- a/JSTests/stress/dfg-map-entries-keys-values-cross-realm-iterator-object.js
+++ b/JSTests/stress/dfg-map-entries-keys-values-cross-realm-iterator-object.js
@@ -1,0 +1,35 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+new Map().values();
+
+const other = createGlobalObject();
+const otherIteratorProto = Object.getPrototypeOf(new other.Map().values());
+
+Map.prototype.entries = other.Map.prototype.entries;
+Map.prototype.keys = other.Map.prototype.keys;
+Map.prototype.values = other.Map.prototype.values;
+
+function testEntries(map) {
+    return map.entries();
+}
+noInline(testEntries);
+
+function testKeys(map) {
+    return map.keys();
+}
+noInline(testKeys);
+
+function testValues(map) {
+    return map.values();
+}
+noInline(testValues);
+
+const map = new Map([[1, 2]]);
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(Object.getPrototypeOf(testEntries(map)), otherIteratorProto);
+    shouldBe(Object.getPrototypeOf(testKeys(map)), otherIteratorProto);
+    shouldBe(Object.getPrototypeOf(testValues(map)), otherIteratorProto);
+}

--- a/JSTests/stress/dfg-map-set-iterator-next-cross-realm-result-object.js
+++ b/JSTests/stress/dfg-map-set-iterator-next-cross-realm-result-object.js
@@ -1,0 +1,35 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+new Map().values().next();
+new Set().values().next();
+
+const other = createGlobalObject();
+const otherMapNext = new other.Map().values().next;
+const otherSetNext = new other.Set().values().next;
+
+Object.getPrototypeOf(new Map().values()).next = otherMapNext;
+Object.getPrototypeOf(new Set().values()).next = otherSetNext;
+
+function testMap(map) {
+    return map.values().next();
+}
+noInline(testMap);
+
+function testSet(set) {
+    return set.values().next();
+}
+noInline(testSet);
+
+const map = new Map([[1, 2]]);
+const set = new Set([1]);
+for (let i = 0; i < testLoopCount; ++i) {
+    const mapResult = testMap(map);
+    shouldBe(Object.getPrototypeOf(mapResult), other.Object.prototype);
+    shouldBe(mapResult.done, false);
+    const setResult = testSet(set);
+    shouldBe(Object.getPrototypeOf(setResult), other.Object.prototype);
+    shouldBe(setResult.done, false);
+}

--- a/JSTests/stress/dfg-object-get-own-property-names-cross-realm.js
+++ b/JSTests/stress/dfg-object-get-own-property-names-cross-realm.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const other = createGlobalObject();
+
+Object.getOwnPropertyNames = other.Object.getOwnPropertyNames;
+
+function test(object) {
+    return Object.getOwnPropertyNames(object);
+}
+noInline(test);
+
+const object = { a: 1, b: 2 };
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test(object)), other.Array.prototype);

--- a/JSTests/stress/dfg-object-get-own-property-symbols-cross-realm.js
+++ b/JSTests/stress/dfg-object-get-own-property-symbols-cross-realm.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const other = createGlobalObject();
+
+Object.getOwnPropertySymbols = other.Object.getOwnPropertySymbols;
+
+function test(object) {
+    return Object.getOwnPropertySymbols(object);
+}
+noInline(test);
+
+const object = { [Symbol("a")]: 1, [Symbol("b")]: 2 };
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test(object)), other.Array.prototype);

--- a/JSTests/stress/dfg-object-keys-cross-realm.js
+++ b/JSTests/stress/dfg-object-keys-cross-realm.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const other = createGlobalObject();
+
+Object.keys = other.Object.keys;
+
+function test(object) {
+    return Object.keys(object);
+}
+noInline(test);
+
+const object = { a: 1, b: 2 };
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test(object)), other.Array.prototype);

--- a/JSTests/stress/dfg-regexp-string-iterator-next-cross-realm-result-object.js
+++ b/JSTests/stress/dfg-regexp-string-iterator-next-cross-realm-result-object.js
@@ -1,0 +1,23 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+new Map().values().next();
+
+const other = createGlobalObject();
+const otherIterator = other.String.prototype.matchAll.call("aa", new other.RegExp("a", "g"));
+const otherNext = otherIterator.next;
+
+Object.getPrototypeOf("aa".matchAll(/a/g)).next = otherNext;
+
+function test(string) {
+    return string.matchAll(/a/g).next();
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    const result = test("aa");
+    shouldBe(Object.getPrototypeOf(result), other.Object.prototype);
+    shouldBe(result.done, false);
+}

--- a/JSTests/stress/dfg-set-entries-values-cross-realm-iterator-object.js
+++ b/JSTests/stress/dfg-set-entries-values-cross-realm-iterator-object.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+new Set().values();
+
+const other = createGlobalObject();
+const otherIteratorProto = Object.getPrototypeOf(new other.Set().values());
+
+Set.prototype.entries = other.Set.prototype.entries;
+Set.prototype.values = other.Set.prototype.values;
+
+function testEntries(set) {
+    return set.entries();
+}
+noInline(testEntries);
+
+function testValues(set) {
+    return set.values();
+}
+noInline(testValues);
+
+const set = new Set([1]);
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(Object.getPrototypeOf(testEntries(set)), otherIteratorProto);
+    shouldBe(Object.getPrototypeOf(testValues(set)), otherIteratorProto);
+}

--- a/JSTests/stress/dfg-string-iterator-cross-realm-iterator-object.js
+++ b/JSTests/stress/dfg-string-iterator-cross-realm-iterator-object.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+"x"[Symbol.iterator]();
+
+const other = createGlobalObject();
+const otherStringIterator = other.String.prototype[Symbol.iterator];
+const otherIteratorProto = Object.getPrototypeOf(otherStringIterator.call("x"));
+
+String.prototype[Symbol.iterator] = otherStringIterator;
+
+function test(string) {
+    return string[Symbol.iterator]();
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(Object.getPrototypeOf(test("abc")), otherIteratorProto);

--- a/JSTests/stress/dfg-string-iterator-next-cross-realm-result-object.js
+++ b/JSTests/stress/dfg-string-iterator-next-cross-realm-result-object.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+"x"[Symbol.iterator]().next();
+
+const other = createGlobalObject();
+const otherNext = other.String.prototype[Symbol.iterator].call("x").next;
+
+Object.getPrototypeOf("x"[Symbol.iterator]()).next = otherNext;
+
+function test(string) {
+    return string[Symbol.iterator]().next();
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    const result = test("ab");
+    shouldBe(Object.getPrototypeOf(result), other.Object.prototype);
+    shouldBe(result.done, false);
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2579,6 +2579,14 @@ void ByteCodeParser::handleMinMax(Operand resultOperand, NodeType op, int regist
         set(resultOperand, resultNode);
 }
 
+static bool calleeMayBeCrossRealm(CallVariant variant, JSGlobalObject* globalObject)
+{
+    JSFunction* function = variant.function();
+    if (!function)
+        return true;
+    return function->realmMayBeNull() != globalObject;
+}
+
 template<typename ChecksFunctor>
 auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, CallVariant variant, Intrinsic intrinsic, int registerOffset, int argumentCountIncludingThis, BytecodeIndex osrExitIndex, NodeType callOp, InlineCallFrame::Kind kind, CodeSpecializationKind specializationKind, SpeculatedType prediction, const ChecksFunctor& insertChecks) -> CallOptimizationResult
 {
@@ -2723,10 +2731,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
         case ArrayKeysIntrinsic:
         case ArrayValuesIntrinsic: {
             JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
-            auto* function = variant.function();
-            if (!function)
-                return CallOptimizationResult::DidNothing;
-            if (function->realmMayBeNull() != globalObject)
+            if (calleeMayBeCrossRealm(variant, globalObject))
                 return CallOptimizationResult::DidNothing;
 
             insertChecks();
@@ -2818,6 +2823,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             case Array::Int32:
             case Array::Contiguous: {
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+                if (calleeMayBeCrossRealm(variant, globalObject))
+                    return CallOptimizationResult::DidNothing;
                 // FIXME: We could easily relax the Array/Object.prototype transition as long as we OSR exitted if we saw a hole.
                 // https://bugs.webkit.org/show_bug.cgi?id=173171
                 if (globalObject->arraySpeciesWatchpointSet().state() == IsWatched
@@ -2891,6 +2898,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (!arrayMode.isJSArray())
                 return CallOptimizationResult::DidNothing;
 
+            if (calleeMayBeCrossRealm(variant, m_graph.globalObjectFor(currentNodeOrigin().semantic)))
+                return CallOptimizationResult::DidNothing;
+
             insertChecks();
 
             for (int i = 0; i < argumentCountIncludingThis; ++i)
@@ -2921,6 +2931,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             case Array::Int32:
             case Array::Contiguous: {
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+                if (calleeMayBeCrossRealm(variant, globalObject))
+                    return CallOptimizationResult::DidNothing;
                 if (globalObject->arraySpeciesWatchpointSet().state() != IsWatched
                     || !globalObject->havingABadTimeWatchpointSet().isStillValid()
                     || globalObject->arrayPrototypeChainIsSaneWatchpointSet().state() != IsWatched
@@ -3893,6 +3905,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
 
             JSGlobalObject* globalObject = m_inlineStackTop->m_codeBlock->globalObject();
+            if (calleeMayBeCrossRealm(variant, globalObject))
+                return CallOptimizationResult::DidNothing;
+
             Structure* iteratorResultStructure = globalObject->iteratorResultObjectStructureConcurrently();
             if (!iteratorResultStructure)
                 return CallOptimizationResult::DidNothing;
@@ -3964,6 +3979,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;
 
+            if (calleeMayBeCrossRealm(variant, m_graph.globalObjectFor(currentNodeOrigin().semantic)))
+                return CallOptimizationResult::DidNothing;
+
             insertChecks();
             setResult(addToGraph(ObjectKeys, get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
             return CallOptimizationResult::Inlined;
@@ -3973,6 +3991,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;
 
+            if (calleeMayBeCrossRealm(variant, m_graph.globalObjectFor(currentNodeOrigin().semantic)))
+                return CallOptimizationResult::DidNothing;
+
             insertChecks();
             setResult(addToGraph(ObjectGetOwnPropertyNames, get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
             return CallOptimizationResult::Inlined;
@@ -3980,6 +4001,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
 
         case ObjectGetOwnPropertySymbolsIntrinsic: {
             if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (calleeMayBeCrossRealm(variant, m_graph.globalObjectFor(currentNodeOrigin().semantic)))
                 return CallOptimizationResult::DidNothing;
 
             insertChecks();
@@ -4316,6 +4340,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue) || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
                 return CallOptimizationResult::DidNothing;
 
+            if (calleeMayBeCrossRealm(variant, m_graph.globalObjectFor(currentNodeOrigin().semantic)))
+                return CallOptimizationResult::DidNothing;
+
             insertChecks();
 
             IterationKind kind = IterationKind::Values;
@@ -4378,12 +4405,14 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
                 return CallOptimizationResult::DidNothing;
 
+            JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+            if (calleeMayBeCrossRealm(variant, globalObject))
+                return CallOptimizationResult::DidNothing;
+
             insertChecks();
 
             Node* base = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             addToGraph(Check, Edge(base, StringUse));
-
-            JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
             Node* iterator = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->stringIteratorStructure())));
             addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSStringIterator::Field::Index)), iterator, jsConstant(jsNumber(0)));
             addToGraph(PutInternalField, OpInfo(static_cast<uint32_t>(JSStringIterator::Field::IteratedString)), iterator, base);
@@ -4400,6 +4429,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
 
             JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+            if (calleeMayBeCrossRealm(variant, globalObject))
+                return CallOptimizationResult::DidNothing;
+
             // The structure is created lazily, but profiling already ran next(), so it exists by
             // the time this call site is hot. Bail if it does not exist for some reason.
             Structure* iteratorResultStructure = globalObject->iteratorResultObjectStructureConcurrently();
@@ -4491,6 +4523,9 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
                 return CallOptimizationResult::DidNothing;
 
             JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
+            if (calleeMayBeCrossRealm(variant, globalObject))
+                return CallOptimizationResult::DidNothing;
+
             Structure* iteratorResultStructure = globalObject->iteratorResultObjectStructureConcurrently();
             if (!iteratorResultStructure)
                 return CallOptimizationResult::DidNothing;


### PR DESCRIPTION
#### c2ccda5823d4f9aee4736a0d7fe326040704deb6
<pre>
[JSC] Some DFG intrinsics should bail out when the callee comes from another realm
<a href="https://bugs.webkit.org/show_bug.cgi?id=318195">https://bugs.webkit.org/show_bug.cgi?id=318195</a>

Reviewed by Yusuke Suzuki.

Some DFG intrinsic inline paths allocate objects (iterator result objects,
iterators, result arrays) with structures from the parsing realm&apos;s global
object. But the spec requires creating them in the callee function&apos;s realm,
and that is what the C++ implementations do. Since native functions from
different realms share NativeExecutables, installing another realm&apos;s method
on the caller realm&apos;s prototype reaches these inline paths, and none of the
watchpoints they rely on cover this. The result prototype then observably
differs between DFG / FTL and lower tiers:

    const other = createGlobalObject();
    Array.prototype.slice = other.Array.prototype.slice;
    // After DFG tier-up, Object.getPrototypeOf([1, 2, 3].slice(0))
    // changes from other.Array.prototype to Array.prototype.

Extract the existing ArrayEntries guard into calleeMayBeCrossRealm and
apply it to all intrinsics that allocate realm-owned objects: Map / Set /
String / RegExpString iterator creation and next, ArraySlice / ArraySplice /
ArrayConcat, and ObjectKeys / ObjectGetOwnPropertyNames /
ObjectGetOwnPropertySymbols.

Tests: JSTests/stress/dfg-array-concat-cross-realm-species.js
       JSTests/stress/dfg-array-slice-cross-realm-species.js
       JSTests/stress/dfg-array-splice-cross-realm-species.js
       JSTests/stress/dfg-map-entries-keys-values-cross-realm-iterator-object.js
       JSTests/stress/dfg-map-set-iterator-next-cross-realm-result-object.js
       JSTests/stress/dfg-object-get-own-property-names-cross-realm.js
       JSTests/stress/dfg-object-get-own-property-symbols-cross-realm.js
       JSTests/stress/dfg-object-keys-cross-realm.js
       JSTests/stress/dfg-regexp-string-iterator-next-cross-realm-result-object.js
       JSTests/stress/dfg-set-entries-values-cross-realm-iterator-object.js
       JSTests/stress/dfg-string-iterator-cross-realm-iterator-object.js
       JSTests/stress/dfg-string-iterator-next-cross-realm-result-object.js

* JSTests/stress/dfg-array-concat-cross-realm-species.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-array-slice-cross-realm-species.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-array-splice-cross-realm-species.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-map-entries-keys-values-cross-realm-iterator-object.js: Added.
(shouldBe):
(testEntries):
(testKeys):
(testValues):
* JSTests/stress/dfg-map-set-iterator-next-cross-realm-result-object.js: Added.
(shouldBe):
(testMap):
* JSTests/stress/dfg-object-get-own-property-names-cross-realm.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-object-get-own-property-symbols-cross-realm.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-object-keys-cross-realm.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-regexp-string-iterator-next-cross-realm-result-object.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-set-entries-values-cross-realm-iterator-object.js: Added.
(shouldBe):
* JSTests/stress/dfg-string-iterator-cross-realm-iterator-object.js: Added.
(shouldBe):
(test):
* JSTests/stress/dfg-string-iterator-next-cross-realm-result-object.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::calleeMayBeCrossRealm):
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):

Canonical link: <a href="https://commits.webkit.org/316359@main">https://commits.webkit.org/316359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fee18424b781085922c904f14cf3ed197bf38a30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133516 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94180 "20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35361 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33625 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29328 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2365 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145785 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183236 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32525 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141997 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44850 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141806 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38462 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45540 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110244 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37044 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117363 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203947 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44050 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8371 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43454 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->