### PR TITLE
[iOS] Quite a few tests time out while awaiting the keyboard

### DIFF
--- a/LayoutTests/editing/caret/ios/caret-in-overflow-area.html
+++ b/LayoutTests/editing/caret/ios/caret-in-overflow-area.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
@@ -31,7 +31,7 @@
         async function runTest()
         {
             let container = document.getElementById('editable');
-            await UIHelper.activateAndWaitForInputSessionAt(25, 25);
+            await UIHelper.activateAndWaitForInputSessionStartAt(25, 25);
 
             await UIHelper.tapAt(25, 400);
             const caretRect = await UIHelper.getUICaretViewRect();

--- a/LayoutTests/editing/input/ios/typing-with-inline-predictions.html
+++ b/LayoutTests/editing/input/ios/typing-with-inline-predictions.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true useHardwareKeyboardMode=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="utf-8">
@@ -27,7 +27,7 @@ addEventListener("load", async () => {
     description("This test verifies that typing with inline predictions does not cause the keyboard to incorrectly autocapitalize words. This test requires WebKitTestRunner.");
 
     input = document.querySelector("input");
-    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.activateElementAndWaitForInputSessionStart(input);
 
     let characterCountBeforeLongPauseForInlinePredictions = 10;
     for (let character of [..."to whom it may concern"]) {

--- a/LayoutTests/editing/selection/ios/extend-selection-with-inline-predictions.html
+++ b/LayoutTests/editing/selection/ios/extend-selection-with-inline-predictions.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true allowsInlinePredictions=true useHardwareKeyboardMode=true ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="utf-8">
@@ -28,7 +28,7 @@ jsTestIsAsync = true;
 addEventListener("load", async () => {
     description("This test verifies that selecting backwards after typing with inline predictions does not cause a crash. This test requires WebKitTestRunner.");
 
-    await UIHelper.activateElementAndWaitForInputSession(document.getElementById("target"));
+    await UIHelper.activateElementAndWaitForInputSessionStart(document.getElementById("target"));
     await UIHelper.typeCharacters("i want to c", "keyup", document.body);
     await UIHelper.setInlinePrediction("elebrate");
     await UIHelper.ensurePresentationUpdate();

--- a/LayoutTests/editing/selection/ios/place-selection-in-overflow-area.html
+++ b/LayoutTests/editing/selection/ios/place-selection-in-overflow-area.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
@@ -38,7 +38,7 @@
         async function runTest()
         {
             let container = document.getElementById('editable');
-            await UIHelper.activateAndWaitForInputSessionAt(25, 25);
+            await UIHelper.activateAndWaitForInputSessionStartAt(25, 25);
             document.querySelector("#selection-before").textContent = selectionToString(container);
 
             await UIHelper.tapAt(25, 400);

--- a/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html
+++ b/LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/LayoutTests/editing/selection/ios/selection-extends-into-overflow-area.html
+++ b/LayoutTests/editing/selection/ios/selection-extends-into-overflow-area.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
@@ -31,7 +31,7 @@
         async function runTest()
         {
             let container = document.getElementById('editable');
-            await UIHelper.activateAndWaitForInputSessionAt(25, 25);
+            await UIHelper.activateAndWaitForInputSessionStartAt(25, 25);
             await UIHelper.callFunctionAndWaitForEvent(() => UIHelper.doubleTapElement(target), document, "selectionchange");
             await UIHelper.ensurePresentationUpdate();
             let rectsString = "";

--- a/LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection.html
+++ b/LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -28,13 +28,13 @@ addEventListener("load", async () => {
     // Set up: focus the input (keyboard up), then long-press outside to pull focus away
     // and create a non-editable selection. After this, the input is blurred and 'Hello' is selected.
     const inputRect = input.getBoundingClientRect();
-    await UIHelper.activateAndWaitForInputSessionAt(inputRect.left + inputRect.width / 2, inputRect.top + inputRect.height / 2);
+    await UIHelper.activateAndWaitForInputSessionStartAt(inputRect.left + inputRect.width / 2, inputRect.top + inputRect.height / 2);
     await UIHelper.longPressElement(document.querySelector(".target"));
     await shouldBecomeEqual("getSelection().toString()", "'Hello'");
 
     // Now tap the (currently blurred) input. UIKit's behavior: the field becomes first responder again,
     // and the standalone selection is discarded.
-    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.activateElementAndWaitForInputSessionStart(input);
 
     window.focusedElementIsInput = document.activeElement === input;
     shouldBeTrue("focusedElementIsInput");

--- a/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
+++ b/LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -47,7 +47,7 @@ addEventListener("load", async () => {
     getSelection().setPosition(document.body, 0);
 
     console.log("1. Focusing editor");
-    await UIHelper.activateElementAndWaitForInputSession(document.getElementById("start"));
+    await UIHelper.activateElementAndWaitForInputSessionStart(document.getElementById("start"));
 
     console.log("2. Typing in editor");
     for (let character of [..."i want to c"]) {

--- a/LayoutTests/editing/text-placeholder/insert-into-content-editable-non-zero-width-and-height.html
+++ b/LayoutTests/editing/text-placeholder/insert-into-content-editable-non-zero-width-and-height.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <meta name="viewport" content="initial-scale=1.0">
@@ -16,7 +16,7 @@ async function runTest()
 {
     let testElement = document.getElementById("test");
     if (window.testRunner)
-        await UIHelper.activateElementAndWaitForInputSession(testElement);
+        await UIHelper.activateElementAndWaitForInputSessionStart(testElement);
     else
         await UIHelper.callFunctionAndWaitForEvent(() => testElement.focus(), testElement, "focus");
 

--- a/LayoutTests/fast/events/ios/contenteditable-autocapitalize.html
+++ b/LayoutTests/fast/events/ios/contenteditable-autocapitalize.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 <html>
 <head>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
@@ -16,7 +16,7 @@
             for (const [autocapitalizeType, expectedTextContent] of [["none", "to"], ["sentences", "To"], ["characters", "TO"]]) {
                 editable.autocapitalize = autocapitalizeType;
 
-                await UIHelper.activateElementAndWaitForInputSession(editable);
+                await UIHelper.activateElementAndWaitForInputSessionStart(editable);
                 await UIHelper.typeCharacters("to");
 
                 if (expectedTextContent === editable.textContent)

--- a/LayoutTests/fast/forms/ios/accessory-bar-navigation.html
+++ b/LayoutTests/fast/forms/ios/accessory-bar-navigation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true useHardwareKeyboardMode=true ] -->
 
 <html>
 <head>
@@ -27,7 +27,7 @@
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
-        await UIHelper.activateElementAndWaitForInputSession(document.getElementById('input'));
+        await UIHelper.activateElementAndWaitForInputSessionStart(document.getElementById('input'));
         await UIHelper.waitForZoomingOrScrollingToEnd();
         await dumpScaleAndVisibleRect('After focus first field');
 

--- a/LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html
+++ b/LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ useHardwareKeyboardMode=true ] -->
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>

--- a/LayoutTests/platform/ios/fast/forms/ios/focus-input-via-button-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/focus-input-via-button-expected.txt
@@ -4,4 +4,4 @@ Click to focus input
 
 tap location	{ x: 18.000, y: 62.000 }
 scale	1.455
-visibleRect	{ left: 0.000, top: 631.559, width: 268.018, height: 547.718 }
+visibleRect	{ left: 0.000, top: 746.670, width: 268.018, height: 547.718 }

--- a/LayoutTests/platform/ios/fast/forms/ios/focus-long-textarea-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/focus-long-textarea-expected.txt
@@ -3,4 +3,4 @@ Tests zooming into a tall textarea on tap.
 
 tap location	{ x: 38.000, y: 664.000 }
 scale	1.455
-visibleRect	{ left: 0.000, top: 414.396, width: 268.018, height: 547.718 }
+visibleRect	{ left: 0.000, top: 399.621, width: 268.018, height: 547.718 }

--- a/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-expected.txt
@@ -3,4 +3,4 @@ Tests zooming into a text input on tap.
 
 tap location	{ x: 38.000, y: 862.000 }
 scale	1.455
-visibleRect	{ left: 0.000, top: 611.630, width: 268.018, height: 547.718 }
+visibleRect	{ left: 0.000, top: 726.740, width: 268.018, height: 547.718 }

--- a/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-wide-input-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-wide-input-expected.txt
@@ -3,4 +3,4 @@ Tests zooming to an offset in a wide text input on tap.
 
 tap location	{ x: 328.000, y: 862.000 }
 scale	1.455
-visibleRect	{ left: 384.502, top: 611.630, width: 268.018, height: 547.718 }
+visibleRect	{ left: 384.502, top: 726.740, width: 268.018, height: 547.718 }

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -711,6 +711,40 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async activateAndWaitForInputSessionStartAt(x, y)
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return this.activateAt(x, y);
+
+        if (testRunner.isKeyboardImmediatelyAvailable) {
+            await new Promise(resolve => {
+                testRunner.runUIScript(`
+                    (function() {
+                        uiController.singleTapAtPoint(${x}, ${y}, function() { });
+                        uiController.uiScriptComplete();
+                    })()`, resolve);
+            });
+            await this.ensureStablePresentationUpdate();
+            return;
+        }
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+                (function() {
+                    function clearCallbacksAndScriptComplete() {
+                        uiController.didShowContextMenuCallback = null;
+                        uiController.didStartInputSessionCallback = null;
+                        uiController.willPresentPopoverCallback = null;
+                        uiController.uiScriptComplete();
+                    }
+                    uiController.didShowContextMenuCallback = clearCallbacksAndScriptComplete;
+                    uiController.didStartInputSessionCallback = clearCallbacksAndScriptComplete;
+                    uiController.willPresentPopoverCallback = clearCallbacksAndScriptComplete;
+                    uiController.singleTapAtPoint(${x}, ${y}, function() { });
+                })()`, resolve);
+        });
+    }
+
     static waitForInputSessionToDismiss()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())
@@ -753,6 +787,13 @@ window.UIHelper = class UIHelper {
         const x = element.offsetLeft + element.offsetWidth / 2;
         const y = element.offsetTop + element.offsetHeight / 2;
         return this.activateAndWaitForInputSessionAt(x, y);
+    }
+
+    static activateElementAndWaitForInputSessionStart(element)
+    {
+        const x = element.offsetLeft + element.offsetWidth / 2;
+        const y = element.offsetTop + element.offsetHeight / 2;
+        return this.activateAndWaitForInputSessionStartAt(x, y);
     }
 
     static activateFormControl(element)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -295,6 +295,7 @@ interface UIScriptController {
     readonly attribute boolean isShowingKeyboard;
     readonly attribute boolean hasInputSession;
     attribute object willStartInputSessionCallback;
+    attribute object didStartInputSessionCallback;
 
     attribute double suppressSoftwareKeyboard;
     attribute boolean windowIsKey;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h
@@ -68,6 +68,7 @@ typedef enum  {
     CallbackTypeDidShowContactPicker,
     CallbackTypeDidHideContactPicker,
     CallbackTypeWillStartInputSession,
+    CallbackTypeDidStartInputSession,
     CallbackTypeDidPresentViewController,
     CallbackTypeNonPersistent = firstNonPersistentCallbackID
 } CallbackType;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -448,6 +448,9 @@ public:
     virtual void setWillStartInputSessionCallback(JSValueRef);
     JSValueRef willStartInputSessionCallback() const;
 
+    virtual void setDidStartInputSessionCallback(JSValueRef);
+    JSValueRef didStartInputSessionCallback() const;
+
     virtual void setDidHideMenuCallback(JSValueRef);
     JSValueRef didHideMenuCallback() const;
     virtual void setDidShowMenuCallback(JSValueRef);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -270,6 +270,16 @@ JSValueRef UIScriptController::willStartInputSessionCallback() const
     return m_context->callbackWithID(CallbackTypeWillStartInputSession);
 }
 
+void UIScriptController::setDidStartInputSessionCallback(JSValueRef callback)
+{
+    m_context->registerCallback(callback, CallbackTypeDidStartInputSession);
+}
+
+JSValueRef UIScriptController::didStartInputSessionCallback() const
+{
+    return m_context->callbackWithID(CallbackTypeDidStartInputSession);
+}
+
 void UIScriptController::setDidShowMenuCallback(JSValueRef callback)
 {
     m_context->registerCallback(callback, CallbackTypeDidShowMenu);

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -44,6 +44,7 @@
 @property (nonatomic, copy) void (^didShowKeyboardCallback)(void);
 @property (nonatomic, copy) void (^didHideKeyboardCallback)(void);
 @property (nonatomic, copy) void (^willStartInputSessionCallback)(void);
+@property (nonatomic, copy) void (^didStartInputSessionCallback)(void);
 @property (nonatomic, copy) void (^willPresentPopoverCallback)(void);
 @property (nonatomic, copy) void (^didDismissPopoverCallback)(void);
 @property (nonatomic, copy) void (^didPresentViewControllerCallback)(void);

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -326,6 +326,7 @@ IGNORE_WARNINGS_END
     self.didShowKeyboardCallback = nil;
     self.didHideKeyboardCallback = nil;
     self.willStartInputSessionCallback = nil;
+    self.didStartInputSessionCallback = nil;
     self.willPresentPopoverCallback = nil;
     self.didDismissPopoverCallback = nil;
     self.didPresentViewControllerCallback = nil;
@@ -714,6 +715,12 @@ static bool isQuickboardViewController(UIViewController *viewController)
     if (self.willStartInputSessionCallback)
         self.willStartInputSessionCallback();
     inputSession.accessoryViewShouldNotShow = self.suppressInputAccessoryView;
+}
+
+- (void)_webView:(WKWebView *)webView didStartInputSession:(id<_WKFormInputSession>)inputSession
+{
+    if (self.didStartInputSessionCallback)
+        self.didStartInputSessionCallback();
 }
 
 - (_WKFocusStartsInputSessionPolicy)_webView:(WKWebView *)webView decidePolicyForFocusedElement:(id<_WKFocusedElementInfo>)info

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -393,7 +393,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
         CFPreferencesSetAppValue((__bridge CFStringRef)dictationKeyboardShortcutPreferenceKey, (__bridge CFNumberRef)dictationKeyboardShortcutValueForTesting, CFSTR("com.apple.Preferences"));
     }
 
-    GSEventSetHardwareKeyboardAttached(true, 0);
+    GSEventSetHardwareKeyboardAttached(options.useHardwareKeyboardMode(), 0);
 
     // Ignore calls to inform the keyboard daemon that we accepted autocorrection candidates.
     // This prevents the device from learning misspelled words in between layout tests.
@@ -402,7 +402,6 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
     // Override the implementation of +[UIKeyboard isInHardwareKeyboardMode] to ensure that test runs are deterministic
     // regardless of whether a hardware keyboard is attached. We intentionally never restore the original implementation.
     // FIXME: Investigate whether we can change the default value for `useHardwareKeyboardMode` to `true`.
-    // The swizzled return value is inconsistent with the default value of GSEventSetHardwareKeyboardAttached above.
     setIsInHardwareKeyboardMode(options.useHardwareKeyboardMode());
 
     if (m_overriddenKeyboardInputMode) {

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -179,6 +179,7 @@ private:
     void setDidShowKeyboardCallback(JSValueRef) override;
     void setDidHideKeyboardCallback(JSValueRef) override;
     void setWillStartInputSessionCallback(JSValueRef) override;
+    void setDidStartInputSessionCallback(JSValueRef) override;
     void setWillPresentPopoverCallback(JSValueRef) override;
     void setDidDismissPopoverCallback(JSValueRef) override;
     void setDidPresentViewControllerCallback(JSValueRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1336,6 +1336,16 @@ void UIScriptControllerIOS::setWillStartInputSessionCallback(JSValueRef callback
     }).get();
 }
 
+void UIScriptControllerIOS::setDidStartInputSessionCallback(JSValueRef callback)
+{
+    UIScriptController::setDidStartInputSessionCallback(callback);
+    webView().didStartInputSessionCallback = makeBlockPtr([this, protectedThis = Ref { *this }] {
+        if (!m_context)
+            return;
+        m_context->fireCallback(CallbackTypeDidStartInputSession);
+    }).get();
+}
+
 void UIScriptControllerIOS::chooseMenuAction(JSStringRef jsAction, JSValueRef callback)
 {
     auto action = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, jsAction));


### PR DESCRIPTION
#### d97068f942ec3f1375bc824131b0d989f7a0c44a
<pre>
[iOS] Quite a few tests time out while awaiting the keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=318190">https://bugs.webkit.org/show_bug.cgi?id=318190</a>
<a href="https://rdar.apple.com/178016084">rdar://178016084</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

WebKit test harness&apos; use of keyboard state manipulation and
overriding UIKit&apos;s implementation may cause unexpected behavior.
It seems matching GSEventSetHardwareKeyboardAttached and
isInHardwareKeyboardMode fixes the failing tests.

Previously where there was a mismatch, GSEventSetHardwareKeyboardAttached
would always be true while isInHardwareKeyboardMode could be false. That
could mean the system believes a hardware keyboard is attached but when
isInHardwareKeyboardMode reports false, the software keyboard doesn&apos;t show up.

Due to this behavior change, some EWS tests were failing. To mimic the old
behavior, some needed to add `useHardwareKeyboardMode=true`.

There was an issue where the keyboard state would be up for the first iteration of
the test, then fail because each iteration of a test would not do the full keyboard
reset. So, when the second iteration waits for the keyboard (which is considered
already up), the test timeouts. Then it fails, the full tear-down happens for the
third iteration, and the test passes again. Thus, there was a pattern of Pass, Fail, Pass,
Fail when running tests in multiple iterations. To fix this, instead of waiting for the
keyboard presentation, have a new helper called `activateAndWaitForInputSessionStartAt`
similar to `activateAndWaitForInputSessionAt`, that instead checks for an active input session.

Other tests (specifically the zoom/scroll tests) failed because the results were
generated under the mismatched behavior. Now that GSEventSetHardwareKeyboardAttached and
isInHardwareKeyboardMode match, both flags agree in the case when the hardware keyboard
isn&apos;t toggled on, the software keyboard should actually appear now which offsets the
previous results. So, regenerate the results according to the new offset.

* LayoutTests/editing/caret/ios/caret-in-overflow-area.html:
* LayoutTests/editing/input/ios/typing-with-inline-predictions.html:
* LayoutTests/editing/selection/ios/extend-selection-with-inline-predictions.html:
* LayoutTests/editing/selection/ios/place-selection-in-overflow-area.html:
* LayoutTests/editing/selection/ios/select-text-by-long-press-with-focused-element.html:
* LayoutTests/editing/selection/ios/selection-extends-into-overflow-area.html:
* LayoutTests/editing/selection/ios/tap-focused-input-clears-outside-selection.html:
* LayoutTests/editing/selection/ios/tap-to-change-selection-after-accepting-inline-prediction.html:
* LayoutTests/editing/text-placeholder/insert-into-content-editable-non-zero-width-and-height.html:
* LayoutTests/fast/events/ios/contenteditable-autocapitalize.html:
* LayoutTests/fast/forms/ios/accessory-bar-navigation.html:
* LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html:
* LayoutTests/platform/ios/fast/forms/ios/focus-input-via-button-expected.txt:
* LayoutTests/platform/ios/fast/forms/ios/focus-long-textarea-expected.txt:
* LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-expected.txt:
* LayoutTests/platform/ios/fast/forms/ios/zoom-after-input-tap-wide-input-expected.txt:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.await.new.Promise.):
(window.UIHelper.await.new.Promise):
(window.UIHelper.return.new.Promise.):
(window.UIHelper.return.new.Promise):
(window.UIHelper.async activateAndWaitForInputSessionStartAt):
(window.UIHelper.activateElementAndWaitForInputSessionStart):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptContext.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::UIScriptController::setDidStartInputSessionCallback):
(WTR::UIScriptController::didStartInputSessionCallback const):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView resetInteractionCallbacks]):
(-[TestRunnerWKWebView _webView:didStartInputSession:]):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setDidStartInputSessionCallback):

Canonical link: <a href="https://commits.webkit.org/316922@main">https://commits.webkit.org/316922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad634efef4aeb1ad30994bcbe0cb396293642c4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183150 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131445 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5595913-daa3-46d3-a003-0ec9f8e5a429) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115450 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3312cee2-e791-4c04-b686-72edd12c2e24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185576 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143850 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143707 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47856 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113030 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26426 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38643 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46362 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10180 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45764 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->