### PR TITLE
[WebVTT] Non-snap-to-lines cue with line outside 0..100 is not clamped to 100

### DIFF
--- a/LayoutTests/media/track/track-cue-computed-line-non-snap-clamp-expected.txt
+++ b/LayoutTests/media/track/track-cue-computed-line-non-snap-clamp-expected.txt
@@ -1,0 +1,15 @@
+
+RUN(video.src = findMediaFile("video", "../content/test"))
+EVENT(canplay)
+RUN(cue = new VTTCue(0, 100, "Lorem"))
+RUN(cue.snapToLines = false)
+RUN(textTrack.addCue(cue))
+EXPECTED (cueBox() != 'null') OK
+RUN(cue.line = 50)
+EXPECTED (observedTop == '50cqh') OK
+RUN(cue.line = 200)
+EXPECTED (observedTop == '100cqh') OK
+RUN(cue.line = -25)
+EXPECTED (observedTop == '100cqh') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-cue-computed-line-non-snap-clamp.html
+++ b/LayoutTests/media/track/track-cue-computed-line-non-snap-clamp.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>track-cue-computed-line-non-snap-clamp</title>
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <script>
+
+    function cueBox() {
+        return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+    }
+
+    // Text track layout happens asynchronously, so wait until the cue box "top"
+    // stops changing before asserting. This converges to whatever value the
+    // engine produces (correct or buggy), so a regression fails with a clean text
+    // diff rather than spinning until the harness times out.
+    async function settledTop() {
+        let previous = null;
+        for (let i = 0; i < 120; ++i) {
+            let box = cueBox();
+            let current = box ? box.style.top : null;
+            if (current && current === previous)
+                return current;
+            previous = current;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+        }
+        let box = cueBox();
+        return box ? box.style.top : null;
+    }
+
+    async function checkLine(line, expectedTop) {
+        run(`cue.line = ${line}`);
+        window.observedTop = await settledTop();
+        testExpected('observedTop', expectedTop);
+    }
+
+    async function runTest() {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "../content/test")');
+        await waitFor(video, 'canplay');
+
+        window.textTrack = video.addTextTrack("captions");
+        textTrack.mode = 'showing';
+
+        run('cue = new VTTCue(0, 100, "Lorem")');
+        run('cue.snapToLines = false');
+        run('textTrack.addCue(cue)');
+
+        if (!window.testRunner) {
+            consoleWrite('Test requires internals.');
+            return;
+        }
+
+        await testExpectedEventually('cueBox()', null, '!=', 4000);
+
+        // A line within 0..100 is used unchanged (control: not clamped either way).
+        await checkLine(50, '50cqh');
+
+        // A line greater than 100 clamps to 100 (this was the dead && branch).
+        await checkLine(200, '100cqh');
+
+        // A negative line also clamps to 100.
+        await checkLine(-25, '100cqh');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -607,7 +607,7 @@ int VTTCue::calculateComputedLinePosition() const
     // (Although the WebVTT parser will not set the line to a number outside the
     // range 0..100 and also set the WebVTT cue snap-to-lines flag to false, this
     // can happen when using the DOM API’s snapToLines and line attributes.)
-    if (m_snapToLines && m_linePosition && (*m_linePosition < 0 && *m_linePosition > 100))
+    if (!m_snapToLines && m_linePosition && (*m_linePosition < 0 || *m_linePosition > 100))
         return 100;
 
     // 2. If the line is numeric, return the value of the WebVTT cue line and abort


### PR DESCRIPTION
#### edf5a4fd9af55d738b0064ef022d80fcc84dfd37
<pre>
[WebVTT] Non-snap-to-lines cue with line outside 0..100 is not clamped to 100
<a href="https://bugs.webkit.org/show_bug.cgi?id=318197">https://bugs.webkit.org/show_bug.cgi?id=318197</a>
<a href="https://rdar.apple.com/181002832">rdar://181002832</a>

Reviewed by NOBODY (OOPS!).

VTTCue::calculateComputedLinePosition() implements the &quot;WebVTT cue computed
line&quot; algorithm, whose first step clamps an out-of-range line to 100 for cues
whose snap-to-lines flag is false:

    &quot;If the line is numeric, the WebVTT cue snap-to-lines flag of the WebVTT
     cue is false, and the line is negative or greater than 100, then return
     100 and abort these steps.

     Although the WebVTT parser will not set the line to a number outside the
     range 0..100 and also set the WebVTT cue snap-to-lines flag to false, this
     can happen when using the DOM API&apos;s snapToLines and line attributes.&quot;

Reference: <a href="https://w3c.github.io/webvtt/#cue-computed-line">https://w3c.github.io/webvtt/#cue-computed-line</a>

The condition was written two ways wrong, so it could never be true and the
clamp never fired:

- It tested `m_snapToLines` (flag true) where the spec requires the flag to
  be false.
- It used `*m_linePosition &lt; 0 &amp;&amp; *m_linePosition &gt; 100`, which is
  unsatisfiable; the spec says &quot;negative or greater than 100&quot;.

As a result a non-snap-to-lines cue with a line outside 0..100 (only reachable
via the DOM snapToLines/line attributes, as the parser will not produce such a
value) fell through to the next step and rendered at the raw, off-screen line
position instead of being clamped to 100.

Fix the condition to match the specification.

Test: media/track/track-cue-computed-line-non-snap-clamp.html

* LayoutTests/media/track/track-cue-computed-line-non-snap-clamp-expected.txt: Added.
* LayoutTests/media/track/track-cue-computed-line-non-snap-clamp.html: Added.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::calculateComputedLinePosition const): Clamp to 100 when the
snap-to-lines flag is false and the line is less than 0 or greater than 100.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edf5a4fd9af55d738b0064ef022d80fcc84dfd37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128968 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca833985-e074-4b3c-abff-d78c6889883c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133585 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94183 "1 flakes 20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4905386-ab3e-4d90-b502-bd6ee2995f9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114058 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e27c220-0e6b-44bc-b103-06adba803e75) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33627 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29332 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183240 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142008 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141811 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45544 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110248 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37049 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117365 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44054 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8372 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->