### PR TITLE
TextTrackList::invalidateTrackIndexesAfterTrack only invalidates the first track's index

### DIFF
--- a/Source/WebCore/html/track/TextTrackList.cpp
+++ b/Source/WebCore/html/track/TextTrackList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -176,8 +176,8 @@ void TextTrackList::invalidateTrackIndexesAfterTrack(TextTrack& track)
     if (index == notFound)
         return;
 
-    for (size_t i = index; i < tracks->size(); ++i)
-        downcast<TextTrack>(tracks->at(index).get()).invalidateTrackIndex();
+    for (auto& trackToInvalidate : tracks->subspan(index))
+        downcast<TextTrack>(trackToInvalidate.get()).invalidateTrackIndex();
 }
 
 void TextTrackList::append(Ref<TextTrack>&& track)


### PR DESCRIPTION
#### 0cfd238e978672f45c8c2070725693aa01a5041f
<pre>
TextTrackList::invalidateTrackIndexesAfterTrack only invalidates the first track&apos;s index
<a href="https://bugs.webkit.org/show_bug.cgi?id=318198">https://bugs.webkit.org/show_bug.cgi?id=318198</a>
<a href="https://rdar.apple.com/181003146">rdar://181003146</a>

Reviewed by Brent Fulgham.

invalidateTrackIndexesAfterTrack() is meant to clear the cached index of
the given track and every track following it, since inserting or removing
a track shifts all subsequent positions. The loop advanced its counter
from the found index to the end of the vector, but the body indexed with
the loop-invariant `index` instead of the loop variable, so it repeatedly
invalidated only the first track and left every following track with a
stale cached index.

Fix the indexing, and while here rewrite the loop as a range-for over
Vector::subspan(index) to remove the manual counter.

* Source/WebCore/html/track/TextTrackList.cpp:
(WebCore::TextTrackList::invalidateTrackIndexesAfterTrack):

Canonical link: <a href="https://commits.webkit.org/316577@main">https://commits.webkit.org/316577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bd0f628663f39c31ec5e3da41d4739b5cb4a2de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128970 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d90d7018-a61c-41d1-927b-c856090bab0a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133522 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94185 "5 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6517e9d5-a166-4642-a8e4-29a285e87d25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174235 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113971 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b8d7165-2085-4c19-94d2-b035b168b0a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35365 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33629 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183244 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142012 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44858 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141815 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38631 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45548 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110252 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37052 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117367 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44058 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43462 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43593 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->