### PR TITLE
HTMLFrameSetElement does not correctly update frameborder/noresize state on dynamic attribute changes

### DIFF
--- a/LayoutTests/fast/frames/frameset-frameborder-dynamic-update-expected.txt
+++ b/LayoutTests/fast/frames/frameset-frameborder-dynamic-update-expected.txt
@@ -1,0 +1,21 @@
+Tests that the frameset frameborder state updates correctly on dynamic changes: changing frameborder="no" to a true value restores the border, and removing the attribute restores the default (true) rather than forcing it off.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Changing frameborder="no" to frameborder="yes" restores the border:
+PASS frames[0].offsetWidth is 150
+PASS frames[0].offsetWidth is 145
+PASS frames[1].offsetWidth is 145
+
+
+Removing the frameborder attribute restores the default (true), not false:
+PASS frames[0].offsetWidth is 150
+PASS frames[0].offsetWidth is 145
+PASS frames[1].offsetWidth is 145
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/frames/frameset-frameborder-dynamic-update.html
+++ b/LayoutTests/fast/frames/frameset-frameborder-dynamic-update.html
@@ -1,0 +1,60 @@
+<!doctype html>
+
+<script src="../../resources/js-test.js"></script>
+
+<!--
+    Each frameset starts with frameborder="no" (border off, so the two columns
+    fill the 300px-wide iframe at 150px each). With border="10" turned back on
+    the single vertical border between the columns leaves 290px to split, so the
+    frames become 145px each. We use that 150<->145 difference to observe the
+    m_frameborder state after a dynamic change.
+-->
+<iframe id="restored-by-yes" data-assert-off-width="150" data-assert-on-width="145">
+    <!doctype html>
+    <frameset rows="*" cols="50,50" frameborder="no" border="10">
+        <frame src="data:text/html,<body bgcolor=red>">
+        <frame src="data:text/html,<body bgcolor=blue>">
+    </frameset>
+</iframe>
+
+<iframe id="restored-by-removal" data-assert-off-width="150" data-assert-on-width="145">
+    <!doctype html>
+    <frameset rows="*" cols="50,50" frameborder="no" border="10">
+        <frame src="data:text/html,<body bgcolor=red>">
+        <frame src="data:text/html,<body bgcolor=blue>">
+    </frameset>
+</iframe>
+
+<script>
+    description('Tests that the frameset frameborder state updates correctly on dynamic changes: ' +
+        'changing frameborder="no" to a true value restores the border, and removing the attribute ' +
+        'restores the default (true) rather than forcing it off.');
+
+    function framesetIn(iframe) {
+        // Can't use srcdoc since that wouldn't synchronously load the content.
+        iframe.contentDocument.write(iframe.textContent);
+        iframe.contentDocument.close();
+        return iframe.contentDocument.querySelector('frameset');
+    }
+
+    var offWidth = '150';
+    var onWidth = '145';
+
+    debug('Changing frameborder="no" to frameborder="yes" restores the border:');
+    var frameset = framesetIn(document.getElementById('restored-by-yes'));
+    var frames = frameset.querySelectorAll('frame');
+    shouldBe('frames[0].offsetWidth', offWidth);
+    frameset.setAttribute('frameborder', 'yes');
+    shouldBe('frames[0].offsetWidth', onWidth);
+    shouldBe('frames[1].offsetWidth', onWidth);
+    debug('<br>');
+
+    debug('Removing the frameborder attribute restores the default (true), not false:');
+    frameset = framesetIn(document.getElementById('restored-by-removal'));
+    frames = frameset.querySelectorAll('frame');
+    shouldBe('frames[0].offsetWidth', offWidth);
+    frameset.removeAttribute('frameborder');
+    shouldBe('frames[0].offsetWidth', onWidth);
+    shouldBe('frames[1].offsetWidth', onWidth);
+    debug('<br>');
+</script>

--- a/LayoutTests/fast/frames/frameset-noresize-removal-allows-resize-expected.txt
+++ b/LayoutTests/fast/frames/frameset-noresize-removal-allows-resize-expected.txt
@@ -1,0 +1,14 @@
+
+
+--------
+Frame: 'testFrame'
+--------
+
+
+--------
+Frame: 'results'
+--------
+This tests that frames in a frameset with a noresize attribute can be resized after programmatically removing the frameset's noresize attribute. HTMLFrameSetElement::attributeChanged must clear m_noresize when the attribute is removed.
+
+PASS document.getElementById("testFrame").getBoundingClientRect().width is 210
+

--- a/LayoutTests/fast/frames/frameset-noresize-removal-allows-resize.html
+++ b/LayoutTests/fast/frames/frameset-noresize-removal-allows-resize.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="resources/frame-programmatic-resize.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpChildFramesAsText();
+}
+
+window.onload = runTests;
+
+function runTests()
+{
+    if (!window.eventSender)
+        return; // Cannot run this test without DRT.
+
+    description("This tests that frames in a frameset with a noresize attribute can be resized after programmatically removing the frameset's noresize attribute. HTMLFrameSetElement::attributeChanged must clear m_noresize when the attribute is removed.");
+    setTestFrameById("testFrame");
+    shouldAllowFrameResizeAfterProcessingFrame(function(frame) { frame.parentNode.removeAttribute("noresize") });
+}
+</script>
+</head>
+<frameset cols="200,*" border="10" noresize>
+    <frame id="testFrame" name="testFrame" src="about:blank">
+    <frame id="results" name="results" src="data:text/html,<p id='description'>This test can only be run using DRT.</p><pre id='console'></pre>">
+</frameset>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1388,6 +1388,7 @@ fast/css/resize-textarea-align-content.html [ Skip ]
 fast/events/mouse-events-on-textarea-resize.html [ Skip ]
 fast/events/mouse_resizer_mousedown.html [ Skip ]
 fast/css/resize-corner-over-child-layer.html [ Skip ]
+fast/frames/frameset-noresize-removal-allows-resize.html [ Skip ]
 
 # The file-wrapper part of <attachment> is not yet working on iOS
 fast/attachment/attachment-type-attribute.html [ Skip ]

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Simon Hausmann (hausmann@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * This library is free software; you can redistribute it and/or
@@ -116,17 +116,18 @@ void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const Atom
                 m_frameborder = false;
                 m_frameborderSet = true;
             } else if (equalLettersIgnoringASCIICase(newValue, "yes"_s) || newValue == "1"_s) {
+                m_frameborder = true;
                 m_frameborderSet = true;
             }
         } else {
-            m_frameborder = false;
+            m_frameborder = true;
             m_frameborderSet = false;
         }
-        // FIXME: Do we need to trigger repainting?
+        invalidateStyleForSubtree();
         break;
     case AttributeNames::noresizeAttr:
-        // FIXME: This should set m_noresize to false if the value is null.
-        m_noresize = true;
+        m_noresize = !newValue.isNull();
+        invalidateStyleForSubtree();
         break;
     case AttributeNames::borderAttr:
         if (!newValue.isNull()) {


### PR DESCRIPTION
#### dc6b015add557d1588de0ee477c8ea011871ce51
<pre>
HTMLFrameSetElement does not correctly update frameborder/noresize state on dynamic attribute changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318203">https://bugs.webkit.org/show_bug.cgi?id=318203</a>
<a href="https://rdar.apple.com/181006923">rdar://181006923</a>

Reviewed by Chris Dumez.

HTMLFrameSetElement::attributeChanged() mishandled state-clearing for three cases:

- frameborder=&quot;yes&quot;/&quot;1&quot; set m_frameborderSet but never set m_frameborder back to
  true, so toggling frameborder from &quot;no&quot; to &quot;yes&quot; left the border disabled.
- Removing the frameborder attribute forced m_frameborder to false instead of
  restoring the constructor default (true), so removal was not equivalent to
  never having set the attribute.
- The noresize case unconditionally set m_noresize to true, so removing the
  attribute never cleared it (this had an explicit FIXME).

Additionally, neither the frameborder nor noresize cases invalidated style, so
even corrected state was not reflected until an unrelated relayout. Invalidate
the subtree on these changes (matching the existing rows/cols handling), which
also resolves the &quot;Do we need to trigger repainting?&quot; FIXME for frameborder.

Tests: fast/frames/frameset-frameborder-dynamic-update.html
       fast/frames/frameset-noresize-removal-allows-resize.html

* LayoutTests/fast/frames/frameset-frameborder-dynamic-update-expected.txt: Added.
* LayoutTests/fast/frames/frameset-frameborder-dynamic-update.html: Added.
* LayoutTests/fast/frames/frameset-noresize-removal-allows-resize-expected.txt: Added.
* LayoutTests/fast/frames/frameset-noresize-removal-allows-resize.html: Added.
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::attributeChanged):

&gt; Platform Specific Expectation:
* LayoutTests/platform/ios/TestExpectations: no resize on iOS

Canonical link: <a href="https://commits.webkit.org/317022@main">https://commits.webkit.org/317022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9928a94509a29f87124d141cb537d055d9b17c5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131803 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135266 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95370 "4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115744 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37336 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185935 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144167 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144025 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48214 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113552 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120098 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46720 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10506 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->