### PR TITLE
MediaUsageInfo::outsideOfFullscreen is inverted, reporting media inside fullscreen as outside (and vice versa)

### DIFF
--- a/LayoutTests/media/media-usage-outside-fullscreen-expected.txt
+++ b/LayoutTests/media/media-usage-outside-fullscreen-expected.txt
@@ -1,0 +1,22 @@
+Sibling element that does not contain the video.
+
+Test that MediaUsageInfo::outsideOfFullscreen reflects whether the media element is outside the fullscreen element.
+
+EVENT(canplaythrough)
+
+** No element is fullscreen: video is not 'outside of fullscreen'.
+EXPECTED (usage.outsideOfFullscreen == 'false') OK
+
+** A sibling element is fullscreen: video is outside of fullscreen.
+EVENT(webkitfullscreenchange)
+EXPECTED (usage.outsideOfFullscreen == 'true') OK
+RUN(document.webkitExitFullscreen())
+EVENT(webkitfullscreenchange)
+
+** The video's container is fullscreen: video is inside fullscreen.
+EVENT(webkitfullscreenchange)
+EXPECTED (usage.outsideOfFullscreen == 'false') OK
+RUN(document.webkitExitFullscreen())
+EVENT(webkitfullscreenchange)
+END OF TEST
+

--- a/LayoutTests/media/media-usage-outside-fullscreen.html
+++ b/LayoutTests/media/media-usage-outside-fullscreen.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src='media-file.js'></script>
+        <script src='video-test.js'></script>
+        <script>
+
+            let usage;
+
+            function enterFullscreen(element)
+            {
+                let changed = waitFor(document, 'webkitfullscreenchange');
+                runWithKeyDown(() => { element.webkitRequestFullscreen(); });
+                return changed;
+            }
+
+            function exitFullscreen()
+            {
+                let changed = waitFor(document, 'webkitfullscreenchange');
+                run('document.webkitExitFullscreen()');
+                return changed;
+            }
+
+            window.addEventListener('load', async event => {
+
+                if (!window.internals) {
+                    failTest(`<br>This test requires internals!`);
+                    return;
+                }
+
+                findMediaElement();
+                video.src = findMediaFile("video", "content/test");
+                await waitFor(video, 'canplaythrough');
+
+                consoleWrite("<br>** No element is fullscreen: video is not 'outside of fullscreen'.")
+                usage = internals.mediaUsageState(video);
+                testExpected('usage.outsideOfFullscreen', false);
+
+                consoleWrite("<br>** A sibling element is fullscreen: video is outside of fullscreen.")
+                await enterFullscreen(document.getElementById('sibling'));
+                usage = internals.mediaUsageState(video);
+                testExpected('usage.outsideOfFullscreen', true);
+                await exitFullscreen();
+
+                consoleWrite("<br>** The video's container is fullscreen: video is inside fullscreen.")
+                await enterFullscreen(document.getElementById('container'));
+                usage = internals.mediaUsageState(video);
+                testExpected('usage.outsideOfFullscreen', false);
+                await exitFullscreen();
+
+                endTest();
+            });
+
+        </script>
+    </head>
+    <body>
+        <div id="sibling">Sibling element that does not contain the video.</div>
+        <div id="container"><video controls></video></div>
+        <p>Test that MediaUsageInfo::outsideOfFullscreen reflects whether the media element is outside the fullscreen element.</p>
+    </body>
+</html>

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1586,7 +1586,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr documentFullscreen = document->fullscreenIfExists()) {
         if (RefPtr fullscreenElement = protect(document->fullscreen())->fullscreenElement())
-            isOutsideOfFullscreen = element->isDescendantOf(*fullscreenElement);
+            isOutsideOfFullscreen = !element->isDescendantOf(*fullscreenElement);
     }
 #endif
     bool isAudio = client().presentationType() == MediaType::Audio;


### PR DESCRIPTION
#### 7e532f6ae20014b45fc62f2c3b246878236d9e3f
<pre>
MediaUsageInfo::outsideOfFullscreen is inverted, reporting media inside fullscreen as outside (and vice versa)
<a href="https://bugs.webkit.org/show_bug.cgi?id=318204">https://bugs.webkit.org/show_bug.cgi?id=318204</a>
<a href="https://rdar.apple.com/181007466">rdar://181007466</a>

Reviewed by Brent Fulgham.

MediaElementSession::updateMediaUsageIfChanged() computes the
outsideOfFullscreen flag as `element-&gt;isDescendantOf(*fullscreenElement)`,
which is true when the media element is *inside* the fullscreen element --
the opposite of what the flag name and its consumer mean. The value flows
through MediaUsageInfo::outsideOfFullscreen to the USVideoMetadataKeyOutsideOfFullscreen
key consumed by the UsageTracking (ScreenTime) framework, so ScreenTime was
fed inverted fullscreen metadata.

The negation was present when the flag was introduced (210518) and matches
the sibling idiom in canShowControlsManager() (&quot;Elements which are not
descendants of the current fullscreen element cannot be main content&quot;), but
the `!` was dropped in 273330@main during the mechanical refactor that
wrapped the access in fullscreenManagerIfExists().

Restore the negation so the flag is true exactly when the media element is
not nested within the current fullscreen element. Added test case so we don&apos;t
regress this in future.

Test: media/media-usage-outside-fullscreen.html

* LayoutTests/media/media-usage-outside-fullscreen-expected.txt: Added.
* LayoutTests/media/media-usage-outside-fullscreen.html: Added.
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::updateMediaUsageIfChanged):

Canonical link: <a href="https://commits.webkit.org/316569@main">https://commits.webkit.org/316569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73087d9d4b165277c414e697c6b9bcda27e04aca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180678 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128981 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a4a07e3-b1d6-4187-9d71-ad3248da79c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133536 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94194 "20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22783899-c8bb-459e-b683-ca2d4cdd77d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113989 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52ce3f11-a89f-407f-a461-231dfd4824b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35377 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33640 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183267 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142031 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141838 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38627 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45570 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110274 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37072 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117378 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44080 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8384 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43484 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->