### PR TITLE
Misnamed local static voiceAttr in WebVTTElement::langAttributeName()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt
@@ -12,4 +12,5 @@ PASS VTTCue.getCueAsHTML(), <v a b>
 PASS VTTCue.getCueAsHTML(), <v Foo&amp;Bar>
 PASS VTTCue.getCueAsHTML(), <1:00:00.500>
 PASS VTTCue.getCueAsHTML(), x\0
+PASS VTTCue.getCueAsHTML(), <lang en-US>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html
@@ -9,10 +9,10 @@ test(function(){
     var video = document.createElement('video');
     var t1 = video.addTextTrack('subtitles');
     document.body.appendChild(video);
-    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><v Foo&amp;Bar>text</v><1:00:00.500>x\0');
+    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><v Foo&amp;Bar>text</v><1:00:00.500>x\0<lang en-US>text</lang>');
     t1.addCue(c1);
     window.frag = c1.getCueAsHTML();
-    assert_equals(frag.childNodes.length, 11, 'childNodes.length');
+    assert_equals(frag.childNodes.length, 12, 'childNodes.length');
     assert_true(frag instanceof DocumentFragment, 'getCueAsHTML() should return DocumentFragment');
 }, document.title+', creating the cue');
 test(function(){
@@ -99,4 +99,14 @@ test(function(){
     assert_equals(frag.childNodes[10].data, 'x\0', 'data');
     assert_true(frag.childNodes[10] instanceof Text, 'instanceof');
 }, document.title+', x\\0');
+test(function(){
+    assert_equals(frag.childNodes[11].namespaceURI, 'http://www.w3.org/1999/xhtml', 'namespaceURI');
+    assert_equals(frag.childNodes[11].localName, 'span', 'localName');
+    assert_equals(frag.childNodes[11].attributes.length, 1, 'attributes');
+    assert_equals(frag.childNodes[11].getAttributeNS('', 'lang'), 'en-US', 'lang attribute');
+    assert_equals(frag.childNodes[11].getAttributeNS('', 'title'), null, 'no title attribute');
+    assert_true(frag.childNodes[11].hasChildNodes(), 'hasChildNodes()');
+    assert_equals(frag.childNodes[11].firstChild.data, 'text', 'child text');
+    assert_true(frag.childNodes[11] instanceof HTMLElement, 'instanceof');
+}, document.title+', <lang en-US>');
 </script>

--- a/Source/WebCore/html/track/WebVTTElement.h
+++ b/Source/WebCore/html/track/WebVTTElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,8 +70,8 @@ public:
 
     static const QualifiedName& langAttributeName()
     {
-        static NeverDestroyed<QualifiedName> voiceAttr(nullAtom(), "lang"_s, nullAtom());
-        return voiceAttr;
+        static NeverDestroyed<QualifiedName> langAttr(nullAtom(), "lang"_s, nullAtom());
+        return langAttr;
     }
 
 protected:


### PR DESCRIPTION
#### 87042c9e527f0ba62006d1ac84347743bb0bc079
<pre>
Misnamed local static voiceAttr in WebVTTElement::langAttributeName()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318206">https://bugs.webkit.org/show_bug.cgi?id=318206</a>
<a href="https://rdar.apple.com/181007995">rdar://181007995</a>

Reviewed by Chris Dumez.

The local NeverDestroyed&lt;QualifiedName&gt; in langAttributeName() was
copy-pasted from voiceAttributeName() and left named voiceAttr, even
though it holds the &quot;lang&quot; attribute name. Rename it to langAttr to
match its purpose.

* Source/WebCore/html/track/WebVTTElement.h:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/api/VTTCue/getCueAsHTML.html:
Extend the existing getCueAsHTML() test with &lt;lang&gt; coverage (lang-&gt;lang attribute)
alongside the existing &lt;v&gt; (voice-&gt;title) cases, exercising langAttributeName()&apos;s observable output.

Canonical link: <a href="https://commits.webkit.org/316239@main">https://commits.webkit.org/316239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c7b68f3f921877e8ac50b3ef74c226a17dea25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dad3373-ba7f-4a1b-9fa4-d49a8393e9e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45413 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6a3c873-ba9a-45db-ae76-8ec944d0584e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174814 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114168 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aabe9b6a-257a-48cc-ad8a-880da8ec1767) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29909 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183827 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45440 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38353 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46120 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37392 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44638 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44038 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->