### PR TITLE
Reduce PreloadRequest size by 8 bytes via field reordering

### DIFF
--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -41,8 +41,8 @@ public:
         : m_initiatorType(initiatorType)
         , m_resourceURL(resourceURL)
         , m_baseURL(baseURL.isolatedCopy())
-        , m_resourceType(resourceType)
         , m_mediaAttribute(mediaAttribute)
+        , m_resourceType(resourceType)
         , m_scriptType(scriptType)
         , m_referrerPolicy(referrerPolicy)
         , m_fetchPriority(fetchPriority)
@@ -67,12 +67,12 @@ private:
     String m_resourceURL;
     URL m_baseURL;
     String m_charset;
-    CachedResource::Type m_resourceType;
     String m_mediaAttribute;
     String m_crossOriginMode;
     String m_nonceAttribute;
     String m_integrityAttribute;
     bool m_scriptIsAsync { false };
+    CachedResource::Type m_resourceType;
     ScriptType m_scriptType;
     ReferrerPolicy m_referrerPolicy;
     RequestPriority m_fetchPriority;


### PR DESCRIPTION
#### 8a023d3464fa200520aaf8d97eb5ffc0476ae7c9
<pre>
Reduce PreloadRequest size by 8 bytes via field reordering
<a href="https://bugs.webkit.org/show_bug.cgi?id=318207">https://bugs.webkit.org/show_bug.cgi?id=318207</a>
<a href="https://rdar.apple.com/181008611">rdar://181008611</a>

Reviewed by Chris Dumez.

m_resourceType (CachedResource::Type, a uint8_t enum) sat between
m_charset and m_mediaAttribute, both pointer-sized String members,
forcing 7 bytes of padding into its own 8-byte slot. The class already
has a cluster of sub-word members at the tail (m_scriptIsAsync,
m_scriptType, m_referrerPolicy, m_fetchPriority) sharing a single
8-byte slot with room to spare.

Move m_resourceType down into that cluster so all five small members
pack into one slot, shrinking PreloadRequest by 8 bytes. The
constructor initializer list is reordered to match the new member
declaration order. No behavior change.

* Source/WebCore/html/parser/HTMLResourcePreloader.h:
(WebCore::PreloadRequest::PreloadRequest):

Canonical link: <a href="https://commits.webkit.org/316228@main">https://commits.webkit.org/316228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5350387ade71c7b0d9cb74fa2b7263213c071d3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128984 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41c6ac3f-cabe-428c-a904-ba7ccdb484ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6edf1fe-2297-405d-b408-fc12c6f8a88c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113993 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/225113aa-aa40-4ec0-8a7a-b8b82ff9461d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35379 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33642 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29364 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183273 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142033 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44886 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141842 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38345 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45576 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110280 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37078 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117381 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44086 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8386 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->