### PR TITLE
REGRESSION(315610@main): [LBSE] Event regions missing for non-layer SVG children

### DIFF
--- a/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
+++ b/Source/WebCore/rendering/RenderLayerSVGAdditions.cpp
@@ -409,8 +409,11 @@ void RenderLayer::paintNonLayerChildForFragmentsForSVG(RenderElement& childRende
     if (isSVGRoot)
         svgRootScrollAdjustment = LayoutPoint(-downcast<RenderSVGRoot>(renderer()).scrollPosition());
 
+    // Like collectEventRegionForFragments(), event-region collection runs even for fragments
+    // with no visible content (shouldPaintContent false, empty foreground rect).
+    bool collectingEventRegion = phase == PaintPhase::EventRegion;
     for (const auto& fragment : layerFragments) {
-        if (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty())
+        if (!collectingEventRegion && (!fragment.shouldPaintContent || fragment.dirtyForegroundRect().isEmpty()))
             continue;
 
         GraphicsContextStateSaver stateSaver(context, false);
@@ -421,6 +424,8 @@ void RenderLayer::paintNonLayerChildForFragmentsForSVG(RenderElement& childRende
             phase, paintBehavior, subtreePaintRootForRenderer,
             nullptr, nullptr, &paintingInfo.rootLayer->renderer(), this,
             paintingInfo.requireSecurityOriginAccessForWidgets);
+        if (collectingEventRegion)
+            paintInfo.regionContext = paintingInfo.regionContext;
         if (phase == PaintPhase::Foreground)
             paintInfo.overlapTestRequests = paintingInfo.overlapTestRequests;
         paintInfo.updateSubtreePaintRootForChildren(&renderer());
@@ -522,6 +527,14 @@ void RenderLayer::paintChildrenInDOMOrderForSVG(GraphicsContext& context, const 
                     childToPaint.accumulatedAncestorOffset, paintingInfo, paintFlags,
                     paintBehavior, subtreePaintRootForRenderer, nominalCorrection);
             }
+            continue;
+        }
+
+        // phasesToPaint only covers normal painting (Foreground/Outline), so drive the
+        // EventRegion phase separately for non-layer children when collecting the event region.
+        if (paintFlags.contains(PaintLayerFlag::CollectingEventRegion)) {
+            paintNonLayerChildForFragmentsForSVG(childRenderer.get(), childToPaint.accumulatedAncestorOffset,
+                PaintPhase::EventRegion, layerFragments, context, paintingInfo, paintBehavior, subtreePaintRootForRenderer, containerBaseOffset, isSVGRoot);
             continue;
         }
 


### PR DESCRIPTION
#### 2f69cc47eabe5863ac261d38c2d99fab28dcd528
<pre>
REGRESSION(<a href="https://commits.webkit.org/315610@main">315610@main</a>): [LBSE] Event regions missing for non-layer SVG children
<a href="https://bugs.webkit.org/show_bug.cgi?id=308565">https://bugs.webkit.org/show_bug.cgi?id=308565</a>

Reviewed by NOBODY (OOPS!).

Since SVG renderers no longer unconditionally own a RenderLayer, leaf renderers
(path/image/text) are no longer reached by collectEventRegionForFragments() and
must collect their event region through the layered ancestor&apos;s DOM-order child
walk (paintChildrenInDOMOrderForSVG). That walk only paints non-layer children
in their precomputed phasesToPaint ({ Foreground, Outline }), never in the
EventRegion phase, so touch/wheel/pointer regions for non-layer SVG content were
dropped -- e.g. an ontouchstart handler on a &lt;path&gt; registered no region. (The
&lt;svg&gt; root still contributed via RenderSVGRoot::paintObject().)

Collect the event region for non-layer children through the same DOM-order walk.
Fixes regressions on iOS in fast/events/touch/ios/touch-event-regions-layer-tree.

* Source/WebCore/rendering/RenderLayerSVGAdditions.cpp:
(WebCore::RenderLayer::paintNonLayerChildForFragmentsForSVG): In the EventRegion
phase, mirror collectEventRegionForFragments(): run even when shouldPaintContent
is false, and propagate regionContext into the child PaintInfo.
(WebCore::RenderLayer::paintChildrenInDOMOrderForSVG): When collecting the event
region, paint non-layer children in the EventRegion phase.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f69cc47eabe5863ac261d38c2d99fab28dcd528

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133542 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35384 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29376 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183285 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36022 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142037 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44898 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141852 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38346 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45588 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110292 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37084 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117387 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44098 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->