### PR TITLE
[Tools][WPE][browserperfdash-benchmark] browser-binary-size plan plugin should report the sizes of the stripped binaries and libs.

### DIFF
--- a/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py
@@ -22,6 +22,8 @@
 
 import json
 import os
+import subprocess
+import tempfile
 from webkitpy.common.host import Host
 from webkitpy.port import configuration_options, platform_options, factory
 from webkitpy.binary_bundling.ldd import SharedObjectResolver
@@ -38,20 +40,35 @@ def generate_json_for_benchmark(basename_sizes):
     return benchmark_json
 
 
+def get_stripped_object_size(object_path):
+    fd, tmp_path = tempfile.mkstemp(prefix=f'{PLUGIN_NAME}_', suffix='.stripped')
+    os.close(fd)
+    try:
+        result = subprocess.run(['strip', '--strip-all', '-o', tmp_path, object_path], capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"'strip --strip-all' failed for '{object_path}' (exit {result.returncode}): {result.stderr.strip()}")
+        return os.path.getsize(tmp_path)
+    finally:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+
+
 def get_basenames_and_sizes(path_list):
     basename_sizes = {}
     for object_path in path_list:
         object_base = os.path.basename(object_path)
         if object_base in basename_sizes:
             raise RuntimeError(f'There are repeated objects on the list. Object {object_path} is at least twice')
-        basename_sizes[object_base] = os.path.getsize(object_path)
+        basename_sizes[object_base] = get_stripped_object_size(object_path)
     return basename_sizes
 
 
 def get_browser_relevant_objects_glib(browser_driver):
     required_binary = 'Tools/Scripts/run-minibrowser'
     if not browser_driver.process_name.endswith(required_binary):
-        raise NotImplementedError(f'Getting the browser size data for browser "{browser_name}" is only supported when running the browser via "{required_binary}" and the driver was going to run "{browser_driver.process_name}"')
+        raise NotImplementedError(f'Getting the browser size data for browser "{browser_driver.browser_name}" is only supported when running the browser via "{required_binary}" and the driver was going to run "{browser_driver.process_name}"')
     browser_relevant_objects = []
     port_name = 'gtk' if browser_driver.browser_name == 'minibrowser-gtk' else 'wpe'
     port_driver = factory.PortFactory(Host()).get(port_name)


### PR DESCRIPTION
#### 3ccfb3e02a8d5ab9539efb2a4c214ef48f247a71
<pre>
[Tools][WPE][browserperfdash-benchmark] browser-binary-size plan plugin should report the sizes of the stripped binaries and libs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318205">https://bugs.webkit.org/show_bug.cgi?id=318205</a>

Reviewed by Nikolas Zimmermann.

Ensure to strip the binary and libraries before reporting the size.
That is done in a temporal file to not affect the original ones because
the user may want to keep those with debug symbols to use gdb or similar.

* Tools/Scripts/webkitpy/browserperfdash/plans/browser_binary_size.py:
(get_stripped_object_size):
(get_basenames_and_sizes):
(get_browser_relevant_objects_glib):

Canonical link: <a href="https://commits.webkit.org/316119@main">https://commits.webkit.org/316119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/499e40be6489d01c5c3c03b41117be64b4695f52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38665 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/128992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44882 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/128992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174279 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170641 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183289 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/44902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/141854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45592 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/26051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37090 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/43748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->