### PR TITLE
CanvasNoiseInjection lowerAndUpperBound mishandles neighbor ordering when component1 > component3

### DIFF
--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2023-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -220,7 +220,7 @@ static std::pair<int, int> NODELETE lowerAndUpperBound(int component1, int compo
         if (component1 <= component2 && component2 >= component3)
             return { component3, component2 };
     } else if (component1 > component3) {
-        if (component1 < component2 && component2 > component3)
+        if (component1 >= component2 && component2 >= component3)
             return { component3, component1 };
         if (component1 > component2 && component2 < component3)
             return { component2, component3 };


### PR DESCRIPTION
#### 5f231156f34b99b4d1fae961ba492960414b04b4
<pre>
CanvasNoiseInjection lowerAndUpperBound mishandles neighbor ordering when component1 &gt; component3
<a href="https://bugs.webkit.org/show_bug.cgi?id=318209">https://bugs.webkit.org/show_bug.cgi?id=318209</a>
<a href="https://rdar.apple.com/181010844">rdar://181010844</a>

Reviewed by Kimmo Kinnunen.

In lowerAndUpperBound(component1, component2, component3) the second
branch (component1 &gt; component3) had a duplicated condition. Line 223
used the &quot;component2 above both neighbors&quot; test
(component1 &lt; component2 &amp;&amp; component2 &gt; component3) but returned the
middle-case interval { component3, component1 }, and a later branch
repeated that identical condition with the correct above-both return
value { component1, component2 }, leaving it permanently dead.

As a result, when component2 was above both neighbors it received the
middle-case bounds, and the genuine middle case
(component3 &lt;= component2 &lt;= component1) fell through every condition to
the degenerate { component2, component2 } default, collapsing the noise
interval to zero width for those pixels.

Give the first branch the middle-case condition
(component1 &gt;= component2 &amp;&amp; component2 &gt;= component3) so all three
orderings mirror the component1 &lt;= component3 branch:

    - middle      -&gt; { component3, component1 }
    - below both  -&gt; { component2, component3 }
    - above both  -&gt; { component1, component2 }

* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::lowerAndUpperBound):

Canonical link: <a href="https://commits.webkit.org/319896@main">https://commits.webkit.org/319896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c232a319195a4e754ac6d850d1e2f933c983f4e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/147025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f426d41a-4afb-4f09-b4bb-330ef36a4c5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/58001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142615 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/99025 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c98d8773-bff2-4db0-ae95-0577de906a72) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46338 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163377 "Found 1 new API test failure: TestWebKitAPI.IsolatedSiteStore.EvictsLoadedSitesOverTheCap (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/123050 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7ef08d6-4ccf-4b8e-81c2-4da70c3f3b58) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/45021 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43276 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42906 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/4126 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/49300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56330 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/152068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40835 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/57034 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151768 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46339 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129302 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/125335 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55542 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54914 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/55152 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54980 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->