### PR TITLE
IPC: AsyncWithReply completion handlers are not cancelled if the receiver is missing

### DIFF
--- a/Source/WebKit/Platform/IPC/AsyncReplyID.h
+++ b/Source/WebKit/Platform/IPC/AsyncReplyID.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+namespace IPC {
+
+struct AsyncReplyIDType;
+using AsyncReplyID = AtomicObjectIdentifier<AsyncReplyIDType>;
+
+}

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -451,8 +451,11 @@ void Connection::dispatchMessageReceiverMessage(MessageReceiverType& messageRece
         std::unique_ptr remainingReplyEncoder = replyEncoder.moveToUniquePtr();
         if (remainingReplyEncoder)
             sendMessageImpl(makeUniqueRef<Encoder>(MessageName::CancelSyncMessageReply, decoder->syncRequestID().toUInt64()), { });
-    } else
+    } else {
         messageReceiver.didReceiveMessage(*this, decoder.get());
+        if (decoder->isAsyncWithReplyMessage() && !decoder->wasHandled())
+            sendAsyncReplyCancel(decoder->asyncReplyID());
+    }
 
 #if ASSERT_ENABLED
     --m_inDispatchMessageCount;
@@ -691,7 +694,6 @@ Error Connection::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncR
     ASSERT(replyHandler.replyID);
     ASSERT(replyHandler.completionHandler);
     auto replyID = *replyHandler.replyID;
-    encoder.get() << replyID;
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     if (signpostsEnabled()) [[unlikely]] {
@@ -727,7 +729,6 @@ Error Connection::sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&& e
     ASSERT(replyHandler.replyID);
     ASSERT(replyHandler.completionHandler);
     auto replyID = *replyHandler.replyID;
-    encoder.get() << replyID;
     addAsyncReplyHandlerWithDispatcher(WTF::move(replyHandler));
     auto error = sendMessage(WTF::move(encoder), sendOptions, qos);
     if (error == Error::NoError)
@@ -741,6 +742,11 @@ Error Connection::sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&& e
 Error Connection::sendSyncReply(UniqueRef<Encoder>&& encoder)
 {
     return sendMessageImpl(WTF::move(encoder), { });
+}
+
+void Connection::sendAsyncReplyCancel(AsyncReplyID replyID)
+{
+    sendMessageImpl(makeUniqueRef<Encoder>(MessageName::CancelAsyncReply, replyID.toUInt64()), { });
 }
 
 Timeout Connection::timeoutRespectingIgnoreTimeoutsForTesting(Timeout timeout) const
@@ -1095,6 +1101,19 @@ void Connection::processIncomingMessage(UniqueRef<Decoder> message)
         // Fallback to default case, error handling will be performed in sendMessage().
     }
 
+    // A CancelAsyncReply for a dispatcher-registered reply handler must be handled here so the
+    // cancellation runs on the registered dispatcher. Handlers registered without a dispatcher are
+    // cancelled later in dispatchMessage(). Invoking with a null connection/decoder runs the
+    // handler with the default ("cancelled") reply arguments.
+    if (message->messageName() == MessageName::CancelAsyncReply
+        && AtomicObjectIdentifier<AsyncReplyIDType>::isValidIdentifier(message->destinationID())) {
+        if (auto replyHandlerWithDispatcher = takeAsyncReplyHandlerWithDispatcherWithLockHeld(AtomicObjectIdentifier<AsyncReplyIDType>(message->destinationID()))) {
+            replyHandlerWithDispatcher(nullptr, nullptr);
+            return;
+        }
+        // Not a dispatcher-registered reply; fall through so the message reaches dispatchMessage().
+    }
+
     if (message->isSyncMessage()) {
         Locker locker { m_incomingSyncMessageCallbackLock };
 
@@ -1405,6 +1424,12 @@ void Connection::dispatchMessage(Decoder& decoder)
         return;
     }
 
+    if (decoder.messageName() == MessageName::CancelAsyncReply) {
+        if (auto handler = takeAsyncReplyHandler(AtomicObjectIdentifier<AsyncReplyIDType>(decoder.destinationID())))
+            handler(nullptr, nullptr);
+        return;
+    }
+
 #if ENABLE(IPC_TESTING_API)
     if (isMainRunLoop()) {
         bool hasDeadObservers = false;
@@ -1420,6 +1445,9 @@ void Connection::dispatchMessage(Decoder& decoder)
 #endif
 
     client->didReceiveMessage(*this, decoder);
+
+    if (decoder.isAsyncWithReplyMessage() && !decoder.wasHandled())
+        sendAsyncReplyCancel(decoder.asyncReplyID());
 
 #if ENABLE(IPC_TESTING_API)
     // If we haven't registered an error yet, check whether we found one

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include "AsyncReplyID.h"
 #include "ConnectionHandle.h"
 #include "Decoder.h"
 #include "MessageNames.h"
@@ -220,9 +221,6 @@ class Decoder;
 class MachMessage;
 class UnixMessage;
 class WorkQueueMessageReceiverBase;
-
-struct AsyncReplyIDType;
-using AsyncReplyID = AtomicObjectIdentifier<AsyncReplyIDType>;
 
 // Sync message sender is expected to hold this instance alive as long as the reply() is being
 // accessed. View type data types in replies, such as std::span, refer to data stored in
@@ -503,6 +501,9 @@ public:
     Error sendSyncReply(UniqueRef<Encoder>&&);
     template<typename T, typename... Arguments>
     void sendAsyncReply(AsyncReplyID, Arguments&&...);
+    // Sends a CancelAsyncReply control message so the peer's pending async reply handler for
+    // replyID is invoked with the default ("cancelled") reply arguments instead of being orphaned.
+    void sendAsyncReplyCancel(AsyncReplyID);
 
     void wakeUpRunLoop();
 
@@ -879,6 +880,7 @@ std::optional<Connection::AsyncReplyID> Connection::sendWithAsyncReply(T&& messa
     auto handler = makeAsyncReplyHandler<T>(std::forward<C>(completionHandler));
     auto replyID = handler.replyID;
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID);
+    encoder.get() << *replyID;
     message.encode(encoder.get());
     if (sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(handler), sendOptions) == Error::NoError)
         return replyID;
@@ -893,6 +895,7 @@ std::optional<Connection::AsyncReplyID> Connection::sendWithAsyncReplyOnDispatch
     auto handler = makeAsyncReplyHandlerWithDispatcher<T>(std::forward<C>(completionHandler), dispatcher);
     auto replyID = handler.replyID;
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID);
+    encoder.get() << *replyID;
     message.encode(encoder.get());
     if (sendMessageWithAsyncReplyWithDispatcher(WTF::move(encoder), WTF::move(handler), sendOptions) == Error::NoError)
         return replyID;
@@ -908,6 +911,7 @@ Ref<Promise> Connection::sendWithPromisedReply(T&& message, uint64_t destination
     auto promise = producer.promise();
     auto handler = makeAsyncReplyHandlerWithDispatcher<PC, T, Promise>(WTF::move(producer));
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID);
+    encoder.get() << *handler.replyID;
     message.encode(encoder.get());
     sendMessageWithAsyncReplyWithDispatcher(WTF::move(encoder), WTF::move(handler), sendOptions);
     // The promise will be rejected in the handler should an error occur.

--- a/Source/WebKit/Platform/IPC/Decoder.cpp
+++ b/Source/WebKit/Platform/IPC/Decoder.cpp
@@ -101,11 +101,16 @@ Decoder::Decoder(std::span<const uint8_t> buffer, BufferDeallocator&& bufferDeal
         return;
     }
     m_destinationID = WTF::move(*destinationID);
-    if (messageIsSync(m_messageName)) {
+    if (messageIsAsyncWithReply(m_messageName)) {
+        auto asyncReplyID = decode<AsyncReplyID>();
+        if (!asyncReplyID) [[unlikely]]
+            return;
+        m_replyID = asyncReplyID->toUInt64();
+    } else if (messageIsSync(m_messageName)) {
         auto syncRequestID = decode<SyncRequestID>();
         if (!syncRequestID) [[unlikely]]
             return;
-        m_syncRequestID = syncRequestID;
+        m_replyID = syncRequestID->toUInt64();
     }
 }
 
@@ -125,11 +130,16 @@ Decoder::Decoder(std::span<const uint8_t> stream, uint64_t destinationID)
     if (!messageName) [[unlikely]]
         return;
     m_messageName = WTF::move(*messageName);
-    if (messageIsSync(m_messageName)) {
+    if (messageIsAsyncWithReply(m_messageName)) {
+        auto asyncReplyID = decode<AsyncReplyID>();
+        if (!asyncReplyID) [[unlikely]]
+            return;
+        m_replyID = asyncReplyID->toUInt64();
+    } else if (messageIsSync(m_messageName)) {
         auto syncRequestID = decode<SyncRequestID>();
         if (!syncRequestID) [[unlikely]]
             return;
-        m_syncRequestID = syncRequestID;
+        m_replyID = syncRequestID->toUInt64();
     }
 }
 

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "AsyncReplyID.h"
 #include "Attachment.h"
 #include "MessageNames.h"
 #include "ReceiverMatcher.h"
@@ -91,17 +92,23 @@ public:
     ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
     uint64_t destinationID() const { return m_destinationID; }
-    SyncRequestID syncRequestID() const { ASSERT(m_syncRequestID); return *m_syncRequestID; }
+    SyncRequestID syncRequestID() const { ASSERT(m_replyID); return SyncRequestID(m_replyID); }
+    AsyncReplyID asyncReplyID() const { ASSERT(m_replyID); return AsyncReplyID(m_replyID); }
     bool matches(const ReceiverMatcher& matcher) const { return matcher.matches(messageReceiverName(), destinationID()); }
 
     bool isSyncMessage() const { return messageIsSync(messageName()); }
+    bool isAsyncWithReplyMessage() const { return messageIsAsyncWithReply(messageName()); }
+    bool isAsyncReplyMessage() const { return messageIsReplyToAsyncWithReply(messageName()); }
+
     ShouldDispatchWhenWaitingForSyncReply NODELETE shouldDispatchMessageWhenWaitingForSyncReply() const;
     bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || m_isAllowedWhenWaitingForSyncReplyOverride; }
     bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
     bool NODELETE shouldUseFullySynchronousModeForTesting() const;
     bool NODELETE shouldMaintainOrderingWithAsyncMessages() const;
     void setIsAllowedWhenWaitingForSyncReplyOverride(bool value) { m_isAllowedWhenWaitingForSyncReplyOverride = value; }
-    bool isAsyncReplyMessage() const { return isAsyncReply(messageName()); }
+
+    bool wasHandled() const { return m_wasHandled; }
+    void markHandled() { m_wasHandled = true; }
 
 #if PLATFORM(MAC)
     void NODELETE setImportanceAssertion(ImportanceAssertion&&);
@@ -207,13 +214,16 @@ private:
 #endif
 
     uint64_t m_destinationID;
-    Markable<SyncRequestID> m_syncRequestID;
+    // Holds the SyncRequestID (sync messages) or the AsyncReplyID (async messages with a reply),
+    // both decoded from the message header. 0 means neither is present.
+    uint64_t m_replyID { 0 };
 
     Vector<uint32_t> m_indicesOfObjectsFailingDecoding;
 
 #if ENABLE(IPC_TESTING_API)
     ASCIILiteral m_errorString;
 #endif
+    bool m_wasHandled { false };
 };
 
 template<>

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -530,9 +530,6 @@ void handleMessageAsync(C& connection, Decoder& decoder, T* object, MF U::* func
     auto arguments = decoder.decode<typename MessageType::Arguments>();
     if (!arguments) [[unlikely]]
         return;
-    auto replyID = decoder.decode<IPC::AsyncReplyID>();
-    if (!replyID) [[unlikely]]
-        return;
 
     if constexpr (ValidationType::returnsVoid)
         static_assert(std::is_same_v<typename ValidationType::CompletionHandlerArguments, typename MessageType::ReplyArguments>);
@@ -542,8 +539,10 @@ void handleMessageAsync(C& connection, Decoder& decoder, T* object, MF U::* func
     using CompletionHandlerType = std::conditional_t<ValidationType::returnsVoid, typename ValidationType::CompletionHandlerType, typename MessageType::Reply>;
 
     logMessage(connection, MessageType::name(), object, *arguments);
+    auto replyID = decoder.asyncReplyID();
+    decoder.markHandled();
     auto completionHandler = ValidationType::wrapCompletionHandler(CompletionHandlerType(
-        [replyID = *replyID, connection = protect(connection)] (auto&&... args) mutable {
+        [replyID, connection = protect(connection)] (auto&&... args) mutable {
             connection->template sendAsyncReply<MessageType>(replyID, std::forward<decltype(args)>(args)...);
         }, MessageType::callbackThread));
     if constexpr (ValidationType::returnsVoid) {
@@ -601,13 +600,12 @@ void handleMessageAsyncWithReplyID(Connection& connection, Decoder& decoder, T* 
     using ValidationType = MethodSignatureValidation<MF>;
     static_assert(std::is_same_v<typename ValidationType::MessageArguments, std::tuple<IPC::AsyncReplyID>>);
 
-    auto replyID = decoder.decode<Connection::AsyncReplyID>();
-    if (!replyID) [[unlikely]]
-        return;
 
     logMessage(connection, MessageType::name(), object, std::tuple<>());
     static_assert(!ValidationType::expectsConnectionArgument);
-    callMemberFunction(object, function, std::tuple<IPC::AsyncReplyID>(*replyID));
+    auto replyID = decoder.asyncReplyID();
+    decoder.markHandled();
+    callMemberFunction(object, function, std::tuple<IPC::AsyncReplyID>(replyID));
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -51,9 +51,10 @@ template<typename MessageType, typename C> inline std::optional<AsyncReplyID> Me
 {
     static_assert(!MessageType::isSync);
     auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), destinationID);
-    message.encode(encoder.get());
     auto asyncHandler = Connection::makeAsyncReplyHandler<MessageType>(std::forward<C>(completionHandler));
     auto replyID = asyncHandler.replyID;
+    encoder.get() << *replyID;
+    message.encode(encoder.get());
     if (sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(asyncHandler), options))
         return replyID;
     return std::nullopt;

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -121,8 +121,10 @@ public:
 private:
     StreamClientConnection(Ref<Connection>, StreamClientConnectionBuffer&&, Seconds defaultTimeoutDuration);
 
-    template<typename T, typename... AdditionalData>
-    bool trySendStream(std::span<uint8_t>, T& message, AdditionalData&&...);
+    template<typename T>
+    bool trySendStream(std::span<uint8_t>, T& message);
+    template<typename T>
+    bool trySendAsyncWithReplyStream(std::span<uint8_t>, T& message, AsyncReplyID);
     template<typename T>
     std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, std::span<uint8_t>);
     Error trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
@@ -225,14 +227,14 @@ std::optional<StreamClientConnection::AsyncReplyID> StreamClientConnection::send
     connection->addAsyncReplyHandler(WTF::move(handler));
 
     if constexpr (T::isStreamEncodable) {
-        if (trySendStream(*span, message, replyID))
+        if (trySendAsyncWithReplyStream(*span, message, replyID))
             return replyID;
     }
 
     sendProcessOutOfStreamMessage(WTF::move(*span));
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID.toUInt64());
-    message.encode(encoder.get());
     encoder.get() << replyID;
+    message.encode(encoder.get());
     if (connection->sendMessage(WTF::move(encoder), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply, { }) == Error::NoError)
         return replyID;
 
@@ -285,14 +287,14 @@ std::optional<StreamClientConnection::AsyncReplyID> StreamClientConnection::send
     connection->addAsyncReplyHandlerWithDispatcher(WTF::move(handler));
 
     if constexpr(T::isStreamEncodable) {
-        if (trySendStream(*span, message, replyID))
+        if (trySendAsyncWithReplyStream(*span, message, replyID))
             return replyID;
     }
 
     sendProcessOutOfStreamMessage(WTF::move(*span));
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID.toUInt64());
-    message.encode(encoder.get());
     encoder.get() << replyID;
+    message.encode(encoder.get());
     if (connection->sendMessage(WTF::move(encoder), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply, { }) == Error::NoError)
         return replyID;
 
@@ -305,12 +307,31 @@ std::optional<StreamClientConnection::AsyncReplyID> StreamClientConnection::send
     return { };
 }
 
-template<typename T, typename... AdditionalData>
-bool StreamClientConnection::trySendStream(std::span<uint8_t> span, T& message, AdditionalData&&... args)
+template<typename T>
+bool StreamClientConnection::trySendStream(std::span<uint8_t> span, T& message)
 {
     StreamConnectionEncoder messageEncoder { T::name(), span };
     message.encode(messageEncoder);
-    if ((messageEncoder << ... << std::forward<decltype(args)>(args))) {
+    if (messageEncoder) {
+        auto wakeUpResult = m_buffer.release(messageEncoder.size());
+        if constexpr (T::isStreamBatched)
+            wakeUpServerBatched(wakeUpResult);
+        else
+            wakeUpServer(wakeUpResult);
+        return true;
+    }
+    return false;
+}
+
+template<typename T>
+bool StreamClientConnection::trySendAsyncWithReplyStream(std::span<uint8_t> span, T& message, AsyncReplyID replyID)
+{
+    StreamConnectionEncoder messageEncoder { T::name(), span };
+    // Encode the reply ID as a header field (right after the message name) so the receiver can
+    // recover it without decoding the message arguments (see Decoder and messageIsAsyncWithReply).
+    messageEncoder << replyID;
+    message.encode(messageEncoder);
+    if (messageEncoder) {
         auto wakeUpResult = m_buffer.release(messageEncoder.size());
         if constexpr (T::isStreamBatched)
             wakeUpServerBatched(wakeUpResult);

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -180,6 +180,7 @@ StreamServerConnection::DispatchResult StreamServerConnection::dispatchStreamMes
             // This means we must timeout every receiver in the stream connection.
             // Currently we assert that the receivers are empty, as we only have up to one receiver in
             // a stream connection until possibility of skipping is implemented properly.
+            sendAsyncReplyCancelIfNeeded(decoder);
             Locker locker { m_receiversLock };
             ASSERT(m_receivers.isEmpty());
             return DispatchResult::HasNoMessages;
@@ -220,11 +221,20 @@ bool StreamServerConnection::processStreamMessage(Decoder& decoder, StreamMessag
         result = m_buffer.releaseAll();
         if (m_syncReplyToDispatch)
             protect(connection())->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTF::move(m_syncReplyToDispatch)));
-    } else
+    } else {
+        sendAsyncReplyCancelIfNeeded(decoder);
         result = m_buffer.release(decoder.currentBufferOffset());
+    }
     if (result == WakeUpClient::Yes)
         m_clientWaitSemaphore.signal();
     return true;
+}
+
+void StreamServerConnection::sendAsyncReplyCancelIfNeeded(const Decoder& decoder)
+{
+    if (!decoder.isAsyncWithReplyMessage() || decoder.wasHandled())
+        return;
+    protect(connection())->sendAsyncReplyCancel(decoder.asyncReplyID());
 }
 
 bool StreamServerConnection::processOutOfStreamMessage(Decoder& decoder)
@@ -242,6 +252,7 @@ bool StreamServerConnection::processOutOfStreamMessage(Decoder& decoder)
     if (!message->isValid() || !m_receivers.isValidKey(key)) {
         // The ignoreInvalidMessageForTesting() path for sync messages that dispatchStreamMessage() has
         //  is not supported here because it is likely we don't have a id to reply to. No clients for this.
+        sendAsyncReplyCancelIfNeeded(*message);
         dispatchDidReceiveInvalidMessage(*message);
         return false;
     }
@@ -256,9 +267,10 @@ bool StreamServerConnection::processOutOfStreamMessage(Decoder& decoder)
             return false;
     }
 
-    // If receiver does not exist if it has been removed but messages are still pending to be
-    // processed. It's ok to skip such messages.
-    // FIXME: Note, corresponding skip is not possible at the moment for stream messages.
+    // If the receiver does not exist it has been removed but messages are still pending to be
+    // processed; it's ok to skip such messages. Either way, if the async reply was not handled,
+    // tell the sender to cancel its pending reply handler so it is not orphaned.
+    sendAsyncReplyCancelIfNeeded(*message);
     auto result = m_buffer.release(decoder.currentBufferOffset());
     if (result == WakeUpClient::Yes)
         m_clientWaitSemaphore.signal();

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -139,6 +139,10 @@ private:
     bool processOutOfStreamMessage(Decoder&);
     bool dispatchStreamMessage(Decoder&, StreamMessageReceiver&);
     void dispatchDidReceiveInvalidMessage(Decoder&);
+    // If an async-reply message was not handled (no receiver, or the receiver did not take ownership
+    // of the reply handler), tell the sender to cancel its pending reply handler over the underlying
+    // connection so it is not orphaned.
+    void sendAsyncReplyCancelIfNeeded(const Decoder&);
 
     using WakeUpClient = StreamServerConnectionBuffer::WakeUpClient;
     const Ref<IPC::Connection> m_connection;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -98,9 +98,16 @@ class MessageEnumerator(object):
         assert(all([message.has_attribute(SYNCHRONOUS_ATTRIBUTE) == is_synchronous for message in self.messages]))
         return is_synchronous
 
+    def has_async_reply(self):
+        message = self.messages[0]
+        return (not message.is_async_reply
+                and message.reply_parameters is not None
+                and not message.has_attribute(SYNCHRONOUS_ATTRIBUTE)
+                and not self.receiver.has_attribute(NOT_USING_IPC_CONNECTION_ATTRIBUTE))
+
     @classmethod
     def sort_key(cls, obj):
-        return obj.synchronous(), receiver_enumerator_order_key(obj.receiver.name), str(obj)
+        return obj.synchronous(), obj.has_async_reply(), receiver_enumerator_order_key(obj.receiver.name), str(obj)
 
 
 def get_message_enumerators(receivers):
@@ -1945,34 +1952,6 @@ def generate_message_handler(receiver):
             result.append('    decoder.markInvalid();\n')
         result.append('}\n')
 
-    if receiver.wants_send_cancel_reply:
-        result.append('\n')
-        result.append('void %s::sendCancelReply(IPC::Connection& connection, IPC::Decoder& decoder)\n' % (receiver.name))
-        result.append('{\n')
-        result.append('    ASSERT(decoder.messageReceiverName() == IPC::ReceiverName::%s);\n' % (receiver.name))
-        result.append('    switch (decoder.messageName()) {\n')
-        for message in receiver.messages:
-            if message.reply_parameters is None or message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
-                continue
-            result.append('    case IPC::MessageName::%s_%s: {\n' % (receiver.name, message.name))
-            result.append('        auto arguments = decoder.decode<typename Messages::%s::%s::Arguments>();\n' % (receiver.name, message.name))
-            result.append('        if (!arguments) [[unlikely]]\n')
-            result.append('            return;\n')
-            result.append('        auto replyID = decoder.decode<IPC::AsyncReplyID>();\n')
-            result.append('        if (!replyID) [[unlikely]]\n')
-            result.append('            return;\n')
-            result.append('        connection.sendAsyncReply<Messages::%s::%s>(*replyID\n' % (receiver.name, message.name))
-            for parameter in message.reply_parameters:
-                result.append('            , IPC::AsyncReplyError<%s>::create()\n' % (parameter.type))
-            result.append('        );\n')
-            result.append('        return;\n')
-            result.append('    }\n')
-        result.append('    default:\n')
-        result.append('        // No reply to send.\n')
-        result.append('        return;\n')
-        result.append('    }\n')
-        result.append('}\n')
-
     def append_swift_message_forwarder_methods(result):
         class_name = receiver.name
         weak_ref_class = class_name + 'WeakRef'
@@ -2162,8 +2141,14 @@ def generate_message_names_header(receivers):
 
     result.append('enum class MessageName : uint16_t {\n')
     message_enumerators = get_message_enumerators(receivers)
+    has_any_async_reply = any(e.has_async_reply() for e in message_enumerators)
     seen_synchronous = False
-    for (condition, synchronous), enumerators in itertools.groupby(message_enumerators, lambda e: (e.condition(), e.synchronous())):
+    seen_async_reply = False
+    for (condition, synchronous, has_async_reply), enumerators in itertools.groupby(message_enumerators, lambda e: (e.condition(), e.synchronous(), e.has_async_reply())):
+        if not synchronous and has_async_reply and not seen_async_reply:
+            result.append('    FirstAsyncWithReply,\n')
+            result.append('    LastAsyncWithoutReply = FirstAsyncWithReply - 1,\n')
+            seen_async_reply = True
         if synchronous and not seen_synchronous:
             result.append('    FirstSynchronous,\n')
             result.append('    LastAsynchronous = FirstSynchronous - 1,\n')
@@ -2203,7 +2188,7 @@ def generate_message_names_header(receivers):
         result.append('    return Detail::messageDescriptions[static_cast<size_t>(messageName)].%s;\n' % fname)
         result.append('}\n')
         result.append('\n')
-    result.append('inline bool isAsyncReply(MessageName messageName)\n')
+    result.append('inline bool messageIsReplyToAsyncWithReply(MessageName messageName)\n')
     result.append('{\n')
     result.append('    messageName = std::min(messageName, MessageName::Last);\n')
     result.append('    return Detail::messageDescriptions[static_cast<size_t>(messageName)].isAsyncReply;\n')
@@ -2216,6 +2201,17 @@ def generate_message_names_header(receivers):
     else:
         result.append('    UNUSED_PARAM(name);\n')
         result.append('    return false;\n')
+    result.append('}\n')
+    result.append('\n')
+    result.append('constexpr bool messageIsAsyncWithReply(MessageName name)\n')
+    result.append('{\n')
+    if not has_any_async_reply:
+        result.append('    UNUSED_PARAM(name);\n')
+        result.append('    return false;\n')
+    elif seen_synchronous:
+        result.append('    return name >= MessageName::FirstAsyncWithReply && name < MessageName::FirstSynchronous;\n')
+    else:
+        result.append('    return name >= MessageName::FirstAsyncWithReply && name <= MessageName::Last;\n')
     result.append('}\n')
     result.append('\n')
     result.append('ASCIILiteral processLiteral(ProcessName);\n')

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -34,7 +34,7 @@ SYNCHRONOUS_ATTRIBUTE = 'Synchronous'
 STREAM_ATTRIBUTE = "Stream"
 
 class MessageReceiver(object):
-    def __init__(self, name, superclass, attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, condition, namespace, wants_send_cancel_reply, swift_receiver, swift_receiver_build_enabled_by):
+    def __init__(self, name, superclass, attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, condition, namespace, swift_receiver, swift_receiver_build_enabled_by):
         self.name = name
         self.superclass = superclass
         self.attributes = frozenset(attributes or [])
@@ -49,7 +49,6 @@ class MessageReceiver(object):
         self.messages = messages
         self.condition = condition
         self.namespace = namespace
-        self.wants_send_cancel_reply = wants_send_cancel_reply
         self.swift_receiver = swift_receiver
         self.swift_receiver_build_enabled_by = swift_receiver_build_enabled_by
 
@@ -110,14 +109,15 @@ class Parameter(object):
 
 
 ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_ATTRIBUTE], receiver_enabled_by=None, receiver_enabled_by_exception=False, receiver_enabled_by_conjunction=None, receiver_dispatched_from=None, receiver_dispatched_from_exception=None, receiver_dispatched_to=None, receiver_dispatched_to_exception=None, shared_preferences_needs_connection=False, swift_receiver=False, swift_receiver_build_enabled_by=None, messages=[
-    Message('WrappedAsyncMessageForTesting', [], [], attributes=[BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE], condition=None),
-    Message('SyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-    Message('CancelSyncMessageReply', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-    Message('InitializeConnection', [], [], attributes=[BUILTIN_ATTRIBUTE], condition="PLATFORM(COCOA)"),
-    Message('LegacySessionState', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-    Message('SetStreamDestinationID', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-    Message('ProcessOutOfStreamMessage', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-], condition=None, namespace="WebKit", wants_send_cancel_reply=False)
+    Message('WrappedAsyncMessageForTesting', [], None, attributes=[BUILTIN_ATTRIBUTE, SYNCHRONOUS_ATTRIBUTE, ALLOWEDWHENWAITINGFORSYNCREPLY_ATTRIBUTE], condition=None),
+    Message('SyncMessageReply', [], None, attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('CancelSyncMessageReply', [], None, attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('CancelAsyncReply', [], None, attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('InitializeConnection', [], None, attributes=[BUILTIN_ATTRIBUTE], condition="PLATFORM(COCOA)"),
+    Message('LegacySessionState', [], None, attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('SetStreamDestinationID', [], None, attributes=[BUILTIN_ATTRIBUTE], condition=None),
+    Message('ProcessOutOfStreamMessage', [], None, attributes=[BUILTIN_ATTRIBUTE], condition=None),
+], condition=None, namespace="WebKit")
 
 
 def check_global_model_inputs(receivers):

--- a/Source/WebKit/Scripts/webkit/parser.py
+++ b/Source/WebKit/Scripts/webkit/parser.py
@@ -52,7 +52,6 @@ def parse(file):
     receiver_dispatched_to_exception = False
     receiver_attributes = None
     shared_preferences_needs_connection = False
-    wants_send_cancel_reply = False
     swift_receiver = False
     swift_receiver_build_enabled_by = None
     destination = None
@@ -92,9 +91,6 @@ def parse(file):
                 continue
             elif attribute == 'ExceptionForDispatchedTo':
                 receiver_dispatched_to_exception = True
-                continue
-            elif attribute == 'WantsSendCancelReply':
-                wants_send_cancel_reply = True
                 continue
             elif attribute == 'SwiftReceiver':
                 swift_receiver = True
@@ -202,7 +198,7 @@ def parse(file):
     if receiver_dispatched_to and receiver_dispatched_to_exception:
         raise Exception("ERROR: 'ExceptionForDispatchedTo' cannot be used together with 'DispatchedTo=%s'" % receiver_dispatched_to)
 
-    return model.MessageReceiver(destination, superclass, receiver_attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, combine_condition(master_condition), namespace, wants_send_cancel_reply, swift_receiver, swift_receiver_build_enabled_by)
+    return model.MessageReceiver(destination, superclass, receiver_attributes, receiver_enabled_by, receiver_enabled_by_exception, receiver_enabled_by_conjunction, receiver_dispatched_from, receiver_dispatched_from_exception, receiver_dispatched_to, receiver_dispatched_to_exception, shared_preferences_needs_connection, messages, combine_condition(master_condition), namespace, swift_receiver, swift_receiver_build_enabled_by)
 
 
 def parse_attributes_string(attributes_string):

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -81,6 +81,8 @@
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
 
+#include "GeneratedSerializersExtra.h"
+
 template<uint64_t...> struct BitsInIncreasingOrder;
 template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {
     static constexpr bool value = true;
@@ -103,16 +105,6 @@ IGNORE_WARNINGS_BEGIN("invalid-offsetof")
 
 namespace IPC {
 
-
-template<> struct ArgumentCoder<Namespace::OtherClass> {
-    static void encode(Encoder&, const Namespace::OtherClass&);
-    static std::optional<Namespace::OtherClass> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<Namespace::ClassWithMemberPrecondition> {
-    static void encode(Encoder&, const Namespace::ClassWithMemberPrecondition&);
-    static std::optional<Namespace::ClassWithMemberPrecondition> decode(Decoder&);
-};
 
 #if ENABLE(TEST_FEATURE)
 void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder, const Namespace::Subnamespace::StructName& instance)

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializersExtra.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializersExtra.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GeneratedSerializers.h"
+
+namespace IPC {
+
+class Decoder;
+class Encoder;
+class StreamConnectionEncoder;
+
+template<> struct ArgumentCoder<Namespace::OtherClass> {
+    static void encode(Encoder&, const Namespace::OtherClass&);
+    static std::optional<Namespace::OtherClass> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Namespace::ClassWithMemberPrecondition> {
+    static void encode(Encoder&, const Namespace::ClassWithMemberPrecondition&);
+    static std::optional<Namespace::ClassWithMemberPrecondition> decode(Decoder&);
+};
+
+} // namespace IPC
+
+namespace WTF {
+
+template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<EnumNamespace2::OptionSetEnumType>);
+
+} // namespace WTF

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -29,7 +29,6 @@ namespace IPC::Detail {
 
 const MessageDescriptionsArray messageDescriptions {
 #if USE(AVFOUNDATION)
-    MessageDescription { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply"_s, ReceiverName::TestWithCVPixelBuffer, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithCVPixelBuffer_SendCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
@@ -47,14 +46,12 @@ const MessageDescriptionsArray messageDescriptions {
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     MessageDescription { "TestWithIfMessage_LoadURL"_s, ReceiverName::TestWithIfMessage, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
-    MessageDescription { "TestWithImageData_ReceiveImageData"_s, ReceiverName::TestWithImageData, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithImageData_ReceiveImageDataReply"_s, ReceiverName::TestWithImageData, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithImageData_SendImageData"_s, ReceiverName::TestWithImageData, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     MessageDescription { "TestWithLegacyReceiver_AddEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithLegacyReceiver_Close"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithLegacyReceiver_CreatePlugin"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_CreatePluginReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #if ENABLE(DEPRECATED_FEATURE)
     MessageDescription { "TestWithLegacyReceiver_DeprecatedOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -66,10 +63,8 @@ const MessageDescriptionsArray messageDescriptions {
 #if ENABLE(FEATURE_FOR_TESTING)
     MessageDescription { "TestWithLegacyReceiver_ExperimentalOperation"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
-    MessageDescription { "TestWithLegacyReceiver_GetPlugins"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_GetPluginsReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(MAC)
-    MessageDescription { "TestWithLegacyReceiver_InterpretKeyEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_InterpretKeyEventReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #endif
 #if ENABLE(TOUCH_EVENTS)
@@ -77,10 +72,8 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithLegacyReceiver_LoadSomethingElse"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithLegacyReceiver_LoadURL"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithLegacyReceiver_OpaqueTypeSecurityAssertion"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_PreferencesDidChange"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlert"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlertReply"_s, ReceiverName::TestWithLegacyReceiver, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_SendDoubleAndFloat"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_SendInts"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -91,7 +84,6 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithLegacyReceiver_TouchEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithMultiLineExtendedAttributes_AlwaysEnabled"_s, ReceiverName::TestWithMultiLineExtendedAttributes, false, false, false, ProcessName::GPU, ProcessName::WebContent },
-    MessageDescription { "TestWithSemaphore_ReceiveSemaphore"_s, ReceiverName::TestWithSemaphore, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSemaphore_ReceiveSemaphoreReply"_s, ReceiverName::TestWithSemaphore, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSemaphore_SendSemaphore"_s, ReceiverName::TestWithSemaphore, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSpanOfConst_TestSpanOfConstFloat"_s, ReceiverName::TestWithSpanOfConst, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -99,35 +91,26 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithStreamBatched_SendString"_s, ReceiverName::TestWithStreamBatched, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStreamBuffer_SendStreamBuffer"_s, ReceiverName::TestWithStreamBuffer, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStreamServerConnectionHandle_SendStreamServerConnection"_s, ReceiverName::TestWithStreamServerConnectionHandle, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithStream_CallWithIdentifier"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStream_CallWithIdentifierReply"_s, ReceiverName::TestWithStream, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(COCOA)
     MessageDescription { "TestWithStream_SendMachSendRight"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithStream_SendString"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithStream_SendStringAsync"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithStream_SendStringAsyncReply"_s, ReceiverName::TestWithStream, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclassAndWantsAsyncDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsAsyncDispatch, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclassAndWantsDispatch_LoadURL"_s, ReceiverName::TestWithSuperclassAndWantsDispatch, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_LoadURL"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #if ENABLE(TEST_FEATURE)
-    MessageDescription { "TestWithSuperclass_TestAsyncMessage"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestAsyncMessageReply"_s, ReceiverName::TestWithSuperclass, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithConnection"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithConnectionReply"_s, ReceiverName::TestWithSuperclass, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply"_s, ReceiverName::TestWithSuperclass, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply"_s, ReceiverName::TestWithSuperclass, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #endif
-    MessageDescription { "TestWithSwiftConditionally_TestAsyncMessage"_s, ReceiverName::TestWithSwiftConditionally, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwiftConditionally_TestAsyncMessageReply"_s, ReceiverName::TestWithSwiftConditionally, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithSwift_TestAsyncMessage"_s, ReceiverName::TestWithSwift, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithSwift_TestAsyncMessageReply"_s, ReceiverName::TestWithSwift, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithValidator_AlwaysEnabled"_s, ReceiverName::TestWithValidator, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithValidator_EnabledIfPassValidation"_s, ReceiverName::TestWithValidator, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithValidator_EnabledIfSomeFeatureEnabledAndPassValidation"_s, ReceiverName::TestWithValidator, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithValidator_MessageWithReply"_s, ReceiverName::TestWithValidator, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithValidator_MessageWithReplyReply"_s, ReceiverName::TestWithValidator, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithWantsAsyncDispatch_TestMessage"_s, ReceiverName::TestWithWantsAsyncDispatch, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithWantsDispatchNoSyncMessages_TestMessage"_s, ReceiverName::TestWithWantsDispatchNoSyncMessages, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -136,7 +119,6 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithoutAttributes_AddEvent"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithoutAttributes_Close"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithoutAttributes_CreatePlugin"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_CreatePluginReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #if ENABLE(DEPRECATED_FEATURE)
     MessageDescription { "TestWithoutAttributes_DeprecatedOperation"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -148,10 +130,8 @@ const MessageDescriptionsArray messageDescriptions {
 #if ENABLE(FEATURE_FOR_TESTING)
     MessageDescription { "TestWithoutAttributes_ExperimentalOperation"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
-    MessageDescription { "TestWithoutAttributes_GetPlugins"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_GetPluginsReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(MAC)
-    MessageDescription { "TestWithoutAttributes_InterpretKeyEvent"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_InterpretKeyEventReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
 #endif
 #if ENABLE(TOUCH_EVENTS)
@@ -159,10 +139,8 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithoutAttributes_LoadSomethingElse"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #endif
     MessageDescription { "TestWithoutAttributes_LoadURL"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithoutAttributes_OpaqueTypeSecurityAssertion"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_OpaqueTypeSecurityAssertionReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_PreferencesDidChange"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
-    MessageDescription { "TestWithoutAttributes_RunJavaScriptAlert"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_RunJavaScriptAlertReply"_s, ReceiverName::TestWithoutAttributes, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_SendDoubleAndFloat"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutAttributes_SendInts"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -182,6 +160,7 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply"_s, ReceiverName::TestWithoutUsingIPCConnection, false, false, true, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "CancelAsyncReply"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "CancelSyncMessageReply"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(COCOA)
     MessageDescription { "InitializeConnection"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
@@ -190,6 +169,36 @@ const MessageDescriptionsArray messageDescriptions {
     MessageDescription { "ProcessOutOfStreamMessage"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "SetStreamDestinationID"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "SyncMessageReply"_s, ReceiverName::IPC, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#if USE(AVFOUNDATION)
+    MessageDescription { "TestWithCVPixelBuffer_ReceiveCVPixelBuffer"_s, ReceiverName::TestWithCVPixelBuffer, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#endif
+    MessageDescription { "TestWithImageData_ReceiveImageData"_s, ReceiverName::TestWithImageData, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithLegacyReceiver_CreatePlugin"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithLegacyReceiver_GetPlugins"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#if PLATFORM(MAC)
+    MessageDescription { "TestWithLegacyReceiver_InterpretKeyEvent"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#endif
+    MessageDescription { "TestWithLegacyReceiver_OpaqueTypeSecurityAssertion"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithLegacyReceiver_RunJavaScriptAlert"_s, ReceiverName::TestWithLegacyReceiver, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSemaphore_ReceiveSemaphore"_s, ReceiverName::TestWithSemaphore, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithStream_CallWithIdentifier"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithStream_SendStringAsync"_s, ReceiverName::TestWithStream, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#if ENABLE(TEST_FEATURE)
+    MessageDescription { "TestWithSuperclass_TestAsyncMessage"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithConnection"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithMultipleArguments"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSuperclass_TestAsyncMessageWithNoArguments"_s, ReceiverName::TestWithSuperclass, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#endif
+    MessageDescription { "TestWithSwiftConditionally_TestAsyncMessage"_s, ReceiverName::TestWithSwiftConditionally, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithSwift_TestAsyncMessage"_s, ReceiverName::TestWithSwift, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithValidator_MessageWithReply"_s, ReceiverName::TestWithValidator, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithoutAttributes_CreatePlugin"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithoutAttributes_GetPlugins"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#if PLATFORM(MAC)
+    MessageDescription { "TestWithoutAttributes_InterpretKeyEvent"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+#endif
+    MessageDescription { "TestWithoutAttributes_OpaqueTypeSecurityAssertion"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
+    MessageDescription { "TestWithoutAttributes_RunJavaScriptAlert"_s, ReceiverName::TestWithoutAttributes, false, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_GetPluginProcessConnection"_s, ReceiverName::TestWithLegacyReceiver, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
     MessageDescription { "TestWithLegacyReceiver_TestMultipleAttributes"_s, ReceiverName::TestWithLegacyReceiver, true, false, false, ProcessName::Unknown, ProcessName::Unknown },
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -75,7 +75,6 @@ enum class ReceiverName : uint8_t {
 
 enum class MessageName : uint16_t {
 #if USE(AVFOUNDATION)
-    TestWithCVPixelBuffer_ReceiveCVPixelBuffer,
     TestWithCVPixelBuffer_ReceiveCVPixelBufferReply,
     TestWithCVPixelBuffer_SendCVPixelBuffer,
 #endif
@@ -93,14 +92,12 @@ enum class MessageName : uint16_t {
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     TestWithIfMessage_LoadURL,
 #endif
-    TestWithImageData_ReceiveImageData,
     TestWithImageData_ReceiveImageDataReply,
     TestWithImageData_SendImageData,
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     TestWithLegacyReceiver_AddEvent,
 #endif
     TestWithLegacyReceiver_Close,
-    TestWithLegacyReceiver_CreatePlugin,
     TestWithLegacyReceiver_CreatePluginReply,
 #if ENABLE(DEPRECATED_FEATURE)
     TestWithLegacyReceiver_DeprecatedOperation,
@@ -112,10 +109,8 @@ enum class MessageName : uint16_t {
 #if ENABLE(FEATURE_FOR_TESTING)
     TestWithLegacyReceiver_ExperimentalOperation,
 #endif
-    TestWithLegacyReceiver_GetPlugins,
     TestWithLegacyReceiver_GetPluginsReply,
 #if PLATFORM(MAC)
-    TestWithLegacyReceiver_InterpretKeyEvent,
     TestWithLegacyReceiver_InterpretKeyEventReply,
 #endif
 #if ENABLE(TOUCH_EVENTS)
@@ -123,10 +118,8 @@ enum class MessageName : uint16_t {
     TestWithLegacyReceiver_LoadSomethingElse,
 #endif
     TestWithLegacyReceiver_LoadURL,
-    TestWithLegacyReceiver_OpaqueTypeSecurityAssertion,
     TestWithLegacyReceiver_OpaqueTypeSecurityAssertionReply,
     TestWithLegacyReceiver_PreferencesDidChange,
-    TestWithLegacyReceiver_RunJavaScriptAlert,
     TestWithLegacyReceiver_RunJavaScriptAlertReply,
     TestWithLegacyReceiver_SendDoubleAndFloat,
     TestWithLegacyReceiver_SendInts,
@@ -137,7 +130,6 @@ enum class MessageName : uint16_t {
     TestWithLegacyReceiver_TouchEvent,
 #endif
     TestWithMultiLineExtendedAttributes_AlwaysEnabled,
-    TestWithSemaphore_ReceiveSemaphore,
     TestWithSemaphore_ReceiveSemaphoreReply,
     TestWithSemaphore_SendSemaphore,
     TestWithSpanOfConst_TestSpanOfConstFloat,
@@ -145,35 +137,26 @@ enum class MessageName : uint16_t {
     TestWithStreamBatched_SendString,
     TestWithStreamBuffer_SendStreamBuffer,
     TestWithStreamServerConnectionHandle_SendStreamServerConnection,
-    TestWithStream_CallWithIdentifier,
     TestWithStream_CallWithIdentifierReply,
 #if PLATFORM(COCOA)
     TestWithStream_SendMachSendRight,
 #endif
     TestWithStream_SendString,
-    TestWithStream_SendStringAsync,
     TestWithStream_SendStringAsyncReply,
     TestWithSuperclassAndWantsAsyncDispatch_LoadURL,
     TestWithSuperclassAndWantsDispatch_LoadURL,
     TestWithSuperclass_LoadURL,
 #if ENABLE(TEST_FEATURE)
-    TestWithSuperclass_TestAsyncMessage,
     TestWithSuperclass_TestAsyncMessageReply,
-    TestWithSuperclass_TestAsyncMessageWithConnection,
     TestWithSuperclass_TestAsyncMessageWithConnectionReply,
-    TestWithSuperclass_TestAsyncMessageWithMultipleArguments,
     TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply,
-    TestWithSuperclass_TestAsyncMessageWithNoArguments,
     TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply,
 #endif
-    TestWithSwiftConditionally_TestAsyncMessage,
     TestWithSwiftConditionally_TestAsyncMessageReply,
-    TestWithSwift_TestAsyncMessage,
     TestWithSwift_TestAsyncMessageReply,
     TestWithValidator_AlwaysEnabled,
     TestWithValidator_EnabledIfPassValidation,
     TestWithValidator_EnabledIfSomeFeatureEnabledAndPassValidation,
-    TestWithValidator_MessageWithReply,
     TestWithValidator_MessageWithReplyReply,
     TestWithWantsAsyncDispatch_TestMessage,
     TestWithWantsDispatchNoSyncMessages_TestMessage,
@@ -182,7 +165,6 @@ enum class MessageName : uint16_t {
     TestWithoutAttributes_AddEvent,
 #endif
     TestWithoutAttributes_Close,
-    TestWithoutAttributes_CreatePlugin,
     TestWithoutAttributes_CreatePluginReply,
 #if ENABLE(DEPRECATED_FEATURE)
     TestWithoutAttributes_DeprecatedOperation,
@@ -194,10 +176,8 @@ enum class MessageName : uint16_t {
 #if ENABLE(FEATURE_FOR_TESTING)
     TestWithoutAttributes_ExperimentalOperation,
 #endif
-    TestWithoutAttributes_GetPlugins,
     TestWithoutAttributes_GetPluginsReply,
 #if PLATFORM(MAC)
-    TestWithoutAttributes_InterpretKeyEvent,
     TestWithoutAttributes_InterpretKeyEventReply,
 #endif
 #if ENABLE(TOUCH_EVENTS)
@@ -205,10 +185,8 @@ enum class MessageName : uint16_t {
     TestWithoutAttributes_LoadSomethingElse,
 #endif
     TestWithoutAttributes_LoadURL,
-    TestWithoutAttributes_OpaqueTypeSecurityAssertion,
     TestWithoutAttributes_OpaqueTypeSecurityAssertionReply,
     TestWithoutAttributes_PreferencesDidChange,
-    TestWithoutAttributes_RunJavaScriptAlert,
     TestWithoutAttributes_RunJavaScriptAlertReply,
     TestWithoutAttributes_SendDoubleAndFloat,
     TestWithoutAttributes_SendInts,
@@ -228,6 +206,7 @@ enum class MessageName : uint16_t {
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReplyReply,
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument,
     TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgumentReply,
+    CancelAsyncReply,
     CancelSyncMessageReply,
 #if PLATFORM(COCOA)
     InitializeConnection,
@@ -236,6 +215,38 @@ enum class MessageName : uint16_t {
     ProcessOutOfStreamMessage,
     SetStreamDestinationID,
     SyncMessageReply,
+    FirstAsyncWithReply,
+    LastAsyncWithoutReply = FirstAsyncWithReply - 1,
+#if USE(AVFOUNDATION)
+    TestWithCVPixelBuffer_ReceiveCVPixelBuffer,
+#endif
+    TestWithImageData_ReceiveImageData,
+    TestWithLegacyReceiver_CreatePlugin,
+    TestWithLegacyReceiver_GetPlugins,
+#if PLATFORM(MAC)
+    TestWithLegacyReceiver_InterpretKeyEvent,
+#endif
+    TestWithLegacyReceiver_OpaqueTypeSecurityAssertion,
+    TestWithLegacyReceiver_RunJavaScriptAlert,
+    TestWithSemaphore_ReceiveSemaphore,
+    TestWithStream_CallWithIdentifier,
+    TestWithStream_SendStringAsync,
+#if ENABLE(TEST_FEATURE)
+    TestWithSuperclass_TestAsyncMessage,
+    TestWithSuperclass_TestAsyncMessageWithConnection,
+    TestWithSuperclass_TestAsyncMessageWithMultipleArguments,
+    TestWithSuperclass_TestAsyncMessageWithNoArguments,
+#endif
+    TestWithSwiftConditionally_TestAsyncMessage,
+    TestWithSwift_TestAsyncMessage,
+    TestWithValidator_MessageWithReply,
+    TestWithoutAttributes_CreatePlugin,
+    TestWithoutAttributes_GetPlugins,
+#if PLATFORM(MAC)
+    TestWithoutAttributes_InterpretKeyEvent,
+#endif
+    TestWithoutAttributes_OpaqueTypeSecurityAssertion,
+    TestWithoutAttributes_RunJavaScriptAlert,
     FirstSynchronous,
     LastAsynchronous = FirstSynchronous - 1,
     TestWithLegacyReceiver_GetPluginProcessConnection,
@@ -301,7 +312,7 @@ inline bool messageAllowedWhenWaitingForUnboundedSyncReply(MessageName messageNa
     return Detail::messageDescriptions[static_cast<size_t>(messageName)].messageAllowedWhenWaitingForUnboundedSyncReply;
 }
 
-inline bool isAsyncReply(MessageName messageName)
+inline bool messageIsReplyToAsyncWithReply(MessageName messageName)
 {
     messageName = std::min(messageName, MessageName::Last);
     return Detail::messageDescriptions[static_cast<size_t>(messageName)].isAsyncReply;
@@ -310,6 +321,11 @@ inline bool isAsyncReply(MessageName messageName)
 constexpr bool messageIsSync(MessageName name)
 {
     return name >= MessageName::FirstSynchronous;
+}
+
+constexpr bool messageIsAsyncWithReply(MessageName name)
+{
+    return name >= MessageName::FirstAsyncWithReply && name < MessageName::FirstSynchronous;
 }
 
 ASCIILiteral processLiteral(ProcessName);

--- a/Source/WebKit/Scripts/webkit/tests/TestWithValidator.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithValidator.messages.in
@@ -23,7 +23,6 @@
 [
     ExceptionForDispatchedFrom,
     ExceptionForDispatchedTo,
-    WantsSendCancelReply,
     EnabledBy=SomeOtherFeature
 ]
 messages -> TestWithValidator {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithValidatorMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithValidatorMessageReceiver.cpp
@@ -83,29 +83,6 @@ void TestWithValidator::didReceiveMessage(IPC::Connection& connection, IPC::Deco
     decoder.markInvalid();
 }
 
-void TestWithValidator::sendCancelReply(IPC::Connection& connection, IPC::Decoder& decoder)
-{
-    ASSERT(decoder.messageReceiverName() == IPC::ReceiverName::TestWithValidator);
-    switch (decoder.messageName()) {
-    case IPC::MessageName::TestWithValidator_MessageWithReply: {
-        auto arguments = decoder.decode<typename Messages::TestWithValidator::MessageWithReply::Arguments>();
-        if (!arguments) [[unlikely]]
-            return;
-        auto replyID = decoder.decode<IPC::AsyncReplyID>();
-        if (!replyID) [[unlikely]]
-            return;
-        connection.sendAsyncReply<Messages::TestWithValidator::MessageWithReply>(*replyID
-            , IPC::AsyncReplyError<String>::create()
-            , IPC::AsyncReplyError<double>::create()
-        );
-        return;
-    }
-    default:
-        // No reply to send.
-        return;
-    }
-}
-
 } // namespace WebKit
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -394,9 +394,10 @@ std::optional<AuxiliaryProcessProxy::AsyncReplyID> AuxiliaryProcessProxy::sendWi
     static_assert(!T::isSync, "Async message expected");
 
     auto encoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
-    message.encode(encoder.get());
     auto handler = IPC::Connection::makeAsyncReplyHandler<T>(std::forward<C>(completionHandler));
     auto replyID = handler.replyID;
+    encoder.get() << *replyID;
+    message.encode(encoder.get());
     if (sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler), shouldStartProcessThrottlerActivity))
         return replyID;
     return std::nullopt;
@@ -408,9 +409,10 @@ std::optional<AuxiliaryProcessProxy::AsyncReplyID> AuxiliaryProcessProxy::sendWi
     static_assert(!T::isSync, "Async message expected");
 
     auto encoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
-    message.encode(encoder.get());
     auto handler = IPC::Connection::makeAsyncReplyHandlerWithDispatcher<T>(std::forward<C>(completionHandler), dispatcher);
     auto replyID = handler.replyID;
+    encoder.get() << *replyID;
+    message.encode(encoder.get());
     if (sendMessageWithDispatcher(WTF::move(encoder), sendOptions, WTF::move(handler), shouldStartProcessThrottlerActivity))
         return replyID;
     return std::nullopt;

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -311,7 +311,6 @@ public:
     void takeSnapshotOfNode(WebCore::JSHandleIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
-    static void sendCancelReply(IPC::Connection&, IPC::Decoder&);
     template<typename M, typename C> void sendWithAsyncReply(M&&, C&&);
     template<typename M> void send(M&&);
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFrameProxy.messages.in
@@ -21,7 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    WantsSendCancelReply,
     DispatchedTo=UI,
     DispatchedFrom=WebContent
 ]

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1350,8 +1350,6 @@ bool WebProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::Decoder&
     if (decoder.messageReceiverName() == Messages::WebFrameProxy::messageReceiverName()) {
         if (RefPtr frame = FrameIdentifier::isValidIdentifier(decoder.destinationID()) ? WebFrameProxy::webFrame(FrameIdentifier(decoder.destinationID())) : nullptr)
             frame->didReceiveMessage(connection, decoder);
-        else
-            WebFrameProxy::sendCancelReply(connection, decoder);
         return true;
     }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -7044,6 +7044,7 @@
 		7B22007129B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.h; sourceTree = "<group>"; };
 		7B2DDD5E27CCD9710060ABAB /* IPCStreamTesterProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTesterProxy.h; sourceTree = "<group>"; };
 		7B2E73472CA2C611002C1A84 /* SyncRequestID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyncRequestID.h; sourceTree = "<group>"; };
+		0AC0DE112CA2C611002C1A84 /* AsyncReplyID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AsyncReplyID.h; sourceTree = "<group>"; };
 		7B43C1292D79B0EA00B119F7 /* RemoteGraphicsContextIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextIdentifier.h; sourceTree = "<group>"; };
 		7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueueMap.h; sourceTree = "<group>"; };
 		7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueue.h; sourceTree = "<group>"; };
@@ -10965,6 +10966,7 @@
 				1A3D610413A7F03A00F95D4E /* ArgumentCoders.cpp */,
 				1AEFD2F611D1807B008219D3 /* ArgumentCoders.h */,
 				4955A6E528076D4C00BB91C4 /* ArrayReferenceTuple.h */,
+				0AC0DE112CA2C611002C1A84 /* AsyncReplyID.h */,
 				BCEE966B112FAF57006BCC24 /* Attachment.h */,
 				BC032DA210F437D10058C15A /* Connection.cpp */,
 				BC032DA310F437D10058C15A /* Connection.h */,

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -557,9 +557,6 @@ static JSValueRef jsSend(IPC::Connection& connection, uint64_t destinationID, IP
 
 static JSValueRef jsSendWithAsyncReply(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, JSContextRef context, const JSObjectRef callback, const JSValueRef messageArguments, JSValueRef* exception)
 {
-    auto encoder = makeUniqueRef<IPC::Encoder>(messageName, destinationID);
-    if (messageArguments && !encodeArgument(encoder.get(), context, messageArguments, exception))
-        return JSValueMakeUndefined(context);
     JSGlobalContextRetain(JSContextGetGlobalContext(context));
     JSValueProtect(context, callback);
     IPC::Connection::AsyncReplyHandler handler = {
@@ -586,6 +583,10 @@ static JSValueRef jsSendWithAsyncReply(IPC::Connection& connection, uint64_t des
         IPC::Connection::AsyncReplyID::generate()
     };
     auto asyncReplyID = *handler.replyID;
+    auto encoder = makeUniqueRef<IPC::Encoder>(messageName, destinationID);
+    encoder.get() << asyncReplyID;
+    if (messageArguments && !encodeArgument(encoder.get(), context, messageArguments, exception))
+        return JSValueMakeUndefined(context);
     auto result = connection.sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(handler), IPC::SendOption::IPCTestingMessage);
     if (result != IPC::Error::NoError) {
         *exception = createErrorFromIPCError(context, result);
@@ -3035,7 +3036,7 @@ JSValueRef JSIPC::messages(JSContextRef context, JSObjectRef thisObject, JSStrin
         dictionary->putDirect(vm, dispatchedToIdent, JSC::jsString(vm, String(dispatchedTo(name))));
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
-        dictionary->putDirect(vm, isAsyncReplyIdent, JSC::jsBoolean(isAsyncReply(name)));
+        dictionary->putDirect(vm, isAsyncReplyIdent, JSC::jsBoolean(messageIsReplyToAsyncWithReply(name)));
         RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
         messagesObject->putDirect(vm, JSC::Identifier::fromString(vm, description(name)), dictionary);
@@ -3172,11 +3173,10 @@ JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* 
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
 
-    if (!decoder.isSyncMessage() && messageReplyArgumentDescriptions(decoder.messageName())) {
-        if (auto asyncReplyID = decoder.decode<IPC::Connection::AsyncReplyID>()) {
-            jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "listenerID"_s), JSC::JSValue(asyncReplyID->toUInt64()));
-            RETURN_IF_EXCEPTION(scope, nullptr);
-        }
+    if (decoder.isAsyncWithReplyMessage()) {
+        // The reply ID is a header field (see Decoder and messageIsAsyncWithReply), already decoded.
+        jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "listenerID"_s), JSC::JSValue(decoder.asyncReplyID().toUInt64()));
+        RETURN_IF_EXCEPTION(scope, nullptr);
     }
     return jsResult;
 }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -277,7 +277,6 @@ public:
     bool wasRemovedInAnotherProcess() const { return m_wasRemovedInAnotherProcess; }
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
-    static void sendCancelReply(IPC::Connection&, IPC::Decoder&);
 
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -21,7 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    WantsSendCancelReply,
     DispatchedTo=WebContent,
     DispatchedFrom=UI
 ]

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1121,8 +1121,8 @@ bool WebProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& deco
     if (decoder.messageReceiverName() == Messages::WebFrame::messageReceiverName()) {
         if (RefPtr frame = FrameIdentifier::isValidIdentifier(decoder.destinationID()) ? webFrame(FrameIdentifier(decoder.destinationID())) : nullptr)
             frame->didReceiveMessage(connection, decoder);
-        else
-            WebFrame::sendCancelReply(connection, decoder);
+        // If the frame is gone, the message is left unhandled; Connection::dispatchMessage() sends a
+        // CancelAsyncReply for any unhandled async-reply message so the sender is not left waiting.
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -553,8 +553,9 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
 {
     ASSERT_TRUE(openA());
     aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-        auto listenerID = decoder.decode<uint64_t>();
-        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        auto listenerID = decoder.asyncReplyID().toUInt64();
+        decoder.markHandled();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
         encoder.get() << decoder.destinationID();
         a()->sendSyncReply(WTF::move(encoder));
         return true;
@@ -774,8 +775,9 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsyncOnTarget)
 
         ASSERT_TRUE(openA());
         aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-            auto listenerID = decoder.decode<uint64_t>();
-            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+            auto listenerID = decoder.asyncReplyID().toUInt64();
+            decoder.markHandled();
+            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
             encoder.get() << decoder.destinationID();
             a()->sendSyncReply(WTF::move(encoder));
             return true;
@@ -808,8 +810,9 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
 {
     ASSERT_TRUE(openA());
     aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-        auto listenerID = decoder.decode<uint64_t>();
-        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        auto listenerID = decoder.asyncReplyID().toUInt64();
+        decoder.markHandled();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
         encoder.get() << decoder.destinationID();
         a()->sendSyncReply(WTF::move(encoder));
         return true;
@@ -853,8 +856,9 @@ TEST_P(ConnectionRunLoopTest, SendWithConvertedPromisedReply)
 {
     ASSERT_TRUE(openA());
     aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-        auto listenerID = decoder.decode<uint64_t>();
-        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        auto listenerID = decoder.asyncReplyID().toUInt64();
+        decoder.markHandled();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
         encoder.get() << decoder.destinationID();
         a()->sendSyncReply(WTF::move(encoder));
         return true;
@@ -887,8 +891,9 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnMixAndMatchDispatche
         AutoWorkQueue awq;
         ASSERT_TRUE(openA());
         aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-            auto listenerID = decoder.decode<uint64_t>();
-            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+            auto listenerID = decoder.asyncReplyID().toUInt64();
+            decoder.markHandled();
+            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
             encoder.get() << decoder.destinationID();
             a()->sendSyncReply(WTF::move(encoder));
             return true;
@@ -935,8 +940,9 @@ TEST_P(ConnectionRunLoopTest, SendAsyncAndInvalidateOnDispatcher)
         BinarySemaphore semaphore;
         runLoop->dispatch([&] {
             bClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-                auto listenerID = decoder.decode<uint64_t>();
-                auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+                auto listenerID = decoder.asyncReplyID().toUInt64();
+                decoder.markHandled();
+                auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
                 encoder.get() << decoder.destinationID();
                 b()->sendSyncReply(WTF::move(encoder));
                 messages.add(decoder.destinationID());
@@ -1025,8 +1031,9 @@ TEST_P(ConnectionRunLoopTest, SendAsyncAndInvalidate)
     BinarySemaphore semaphore;
     runLoop->dispatch([&] {
         bClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-            auto listenerID = decoder.decode<uint64_t>();
-            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+            auto listenerID = decoder.asyncReplyID().toUInt64();
+            decoder.markHandled();
+            auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
             encoder.get() << decoder.destinationID();
             b()->sendSyncReply(WTF::move(encoder));
             messages.add(decoder.destinationID());
@@ -1067,8 +1074,9 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOrder)
     ASSERT_TRUE(openA());
     uint64_t replyID = 0;
     aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-        auto listenerID = decoder.decode<uint64_t>();
-        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        auto listenerID = decoder.asyncReplyID().toUInt64();
+        decoder.markHandled();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
         encoder.get() << replyID++;
         a()->sendSyncReply(WTF::move(encoder));
         return true;
@@ -1115,8 +1123,9 @@ TEST_P(ConnectionRunLoopTest, DISABLED_RunLoopSendAsyncOnAnotherRunLoopDispatche
 {
     ASSERT_TRUE(openA());
     aClient().setAsyncMessageHandler([&] (IPC::Connection&, IPC::Decoder& decoder) -> bool {
-        auto listenerID = decoder.decode<uint64_t>();
-        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        auto listenerID = decoder.asyncReplyID().toUInt64();
+        decoder.markHandled();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), listenerID);
         encoder.get() << decoder.destinationID();
         a()->sendSyncReply(WTF::move(encoder));
         return true;

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -705,8 +705,9 @@ public:
     using Arguments = std::tuple<ObjCHolderForTesting>;
     using ReplyArguments = std::tuple<ObjCHolderForTesting>;
 
-    // We can use any MessageName here
-    static IPC::MessageName name() { return IPC::MessageName::IPCTester_AsyncPing; }
+    // We can use any MessageName here that is not classified as async-with-reply (the
+    // WithoutUsingIPCConnection path does not encode an async reply ID header field).
+    static IPC::MessageName name() { return IPC::MessageName::IPCTester_AsyncPingReply; }
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::IPCTester_AsyncPingReply; }
 
     static constexpr bool isSync = false;
@@ -730,8 +731,9 @@ public:
     using Arguments = std::tuple<CFHolderForTesting>;
     using ReplyArguments = std::tuple<CFHolderForTesting>;
 
-    // We can use any MessageName here
-    static IPC::MessageName name() { return IPC::MessageName::IPCTester_AsyncPing; }
+    // We can use any MessageName here that is not classified as async-with-reply (the
+    // WithoutUsingIPCConnection path does not encode an async reply ID header field).
+    static IPC::MessageName name() { return IPC::MessageName::IPCTester_AsyncPingReply; }
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::IPCTester_AsyncPingReply; }
 
     static constexpr bool isSync = false;
@@ -2092,7 +2094,7 @@ TEST(IPCSerialization, NSURLCredentialKerberosFlags)
         @"flags": @{ @"name": @"value" },
     }]);
 
-    IPC::Encoder encoder(IPC::MessageName::IPCTester_AsyncPing, 0);
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
     encoder << WebKit::CoreIPCNSURLCredential { credential.get() };
     auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
     auto decoded = decoder->decode<WebKit::CoreIPCNSURLCredentialData>();
@@ -2107,7 +2109,7 @@ TEST(IPCSerialization, NSURLCredentialAttributes)
         @"attributes": @{ @"name": @"value" },
     }]);
 
-    IPC::Encoder encoder(IPC::MessageName::IPCTester_AsyncPing, 0);
+    IPC::Encoder encoder(IPC::MessageName::IPCTester_EmptyMessage, 0);
     encoder << WebKit::CoreIPCNSURLCredential { credential.get() };
     auto decoder = IPC::Decoder::create(encoder.span(), encoder.releaseAttachments());
     auto decoded = decoder->decode<WebKit::CoreIPCNSURLCredentialData>();

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp
@@ -43,7 +43,7 @@ struct MockTestMessage2 {
     static constexpr bool isSync = false;
     static constexpr bool canDispatchOutOfOrder = false;
     static constexpr bool replyCanDispatchOutOfOrder = false;
-    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_EmptyMessageWithReply; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_StartMessageTesting; }
     template<typename Encoder> void encode(Encoder&) { }
 };
 
@@ -62,7 +62,7 @@ struct MockTestMessage4 {
     static constexpr bool isSync = false;
     static constexpr bool canDispatchOutOfOrder = false;
     static constexpr bool replyCanDispatchOutOfOrder = false;
-    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_AsyncPing; }
+    static constexpr IPC::MessageName name() { return IPC::MessageName::IPCTester_SendSameSemaphoreBack; }
     template<typename Encoder> void encode(Encoder&) { }
 };
 
@@ -330,8 +330,8 @@ TEST_F(MessageLogEndToEndTest, AsyncReplyMessagesLogged)
 
     // Set up A to respond to async reply messages
     aClient().setAsyncMessageHandler([this](IPC::Connection&, IPC::Decoder& decoder) -> bool {
-        auto listenerID = decoder.decode<uint64_t>();
-        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        decoder.markHandled();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), decoder.asyncReplyID().toUInt64());
         encoder.get() << decoder.destinationID();
         a()->sendSyncReply(WTF::move(encoder));
         return true;

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -329,13 +329,13 @@ public:
         m_mockServerReceiver->setAsyncMessageHandler([] (IPC::StreamServerConnection& connection, IPC::Decoder& decoder) {
             if (decoder.messageName() != MockStreamTestMessageWithAsyncReply1::name())
                 return false;
-            using AsyncReplyID = IPC::StreamServerConnection::AsyncReplyID;
             auto contents = decoder.decode<uint64_t>();
             ASSERT(contents);
-            auto asyncReplyID = decoder.decode<AsyncReplyID>();
-            ASSERT(asyncReplyID);
             ASSERT(decoder.isValid());
-            connection.sendAsyncReply<MockStreamTestMessageWithAsyncReply1>(*asyncReplyID, *contents);
+            ASSERT(decoder.isAsyncWithReplyMessage());
+            auto asyncReplyID = decoder.asyncReplyID();
+            decoder.markHandled();
+            connection.sendAsyncReply<MockStreamTestMessageWithAsyncReply1>(asyncReplyID, *contents);
             return true;
         });
         serverQueue().dispatch([this, serverConnection = WTF::move(serverConnection)] () mutable {


### PR DESCRIPTION
#### 47a8bd6b019f65995ac452e5f95b62d1677a0e04
<pre>
IPC: AsyncWithReply completion handlers are not cancelled if the receiver is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=318210">https://bugs.webkit.org/show_bug.cgi?id=318210</a>
<a href="https://rdar.apple.com/181011782">rdar://181011782</a>

Reviewed by NOBODY (OOPS!).

Message handler definitions had WantsSendCancelReply for interfaces
which needed to send a cancel message for unhandled asynchronous with
reply messages. Implement this feature generically, so that all
async-with-reply messages are cancelled if not replied to. This follows
the synchronous message logic.

The cancel is detected as the MessageReceiver::didReceiveMessage not
calling Decoder::wasHandled(). The cancel is implemented as new IPC
protocol message CancelAsyncReply.

This makes it possible to robustly use asynchronous with reply messages
for initialization responses and resource management. This will be used
in VideoFrame offers, currently implementing this manually. This also
enables future code re-use when sync message and async message with
replies can be handled in more uniform way.

Reorders message names so that the Decoder knows if the message
is async-with-reply by checking the message name value. This is the same
logic as with synchronous messages. Order: async-no-reply,
async-with-reply, sync.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::sendMessageWithAsyncReplyWithDispatcher):
(IPC::Connection::sendAsyncReplyCancel):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::sendWithAsyncReplyOnDispatcher):
(IPC::Connection::sendWithPromisedReply):
* Source/WebKit/Platform/IPC/Decoder.cpp:
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::syncRequestID const):
(IPC::Decoder::asyncReplyID const):
(IPC::Decoder::isAsyncWithReplyMessage const):
(IPC::Decoder::isAsyncReplyMessage const):
(IPC::Decoder::wasHandled const):
(IPC::Decoder::markHandled):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWithReplyID):
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithAsyncReply):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendWithAsyncReplyOnDispatcher):
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::trySendAsyncWithReplyStream):
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessages):
(IPC::StreamServerConnection::processStreamMessage):
(IPC::StreamServerConnection::sendAsyncReplyCancelIfNeeded):
(IPC::StreamServerConnection::processOutOfStreamMessage):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Scripts/webkit/messages.py:
(MessageEnumerator.has_async_reply):
(MessageEnumerator.sort_key):
(generate_message_handler):
(generate_message_names_header):
* Source/WebKit/Scripts/webkit/model.py:
(MessageReceiver.__init__):
* Source/WebKit/Scripts/webkit/parser.py:
(parse):
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
(IPC::messageIsReplyToAsyncWithReply):
(IPC::messageIsAsyncWithReply):
(IPC::isAsyncReply): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithValidator.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithValidatorMessageReceiver.cpp:
(WebKit::TestWithValidator::sendCancelReply): Deleted.
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReplyOnDispatcher):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::dispatchMessage):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::jsSendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPC::messages):
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::dispatchMessage):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(ObjCPingBackMessage::name):
(CFPingBackMessage::name):
(TEST(IPCSerialization, NSURLCredentialKerberosFlags)):
(TEST(IPCSerialization, NSURLCredentialAttributes)):
* Tools/TestWebKitAPI/Tests/IPC/MessageLogEndToEndTests.cpp:
(TestWebKitAPI::MockTestMessage2::name):
(TestWebKitAPI::MockTestMessage4::name):
(TestWebKitAPI::TEST_F(MessageLogEndToEndTest, AsyncReplyMessagesLogged)):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47a8bd6b019f65995ac452e5f95b62d1677a0e04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171330 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128997 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/420ba894-ce9a-4d69-ad81-d0f0b87491ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133546 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94205 "1 flakes 20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24938e2c-331c-4985-8dee-0db14afa1383) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6eb4ea2-ef99-4b74-8e4f-9bc8cd7ee7ef) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170651 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35390 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33653 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29390 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183299 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37847 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142044 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 17 flakes 2 failures; Uploaded test results; layout-tests; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44912 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110306 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37100 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117394 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44112 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8398 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43516 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43647 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->