### PR TITLE
[css-mixins-1] Implement argument parsing in terms of first-valid()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
@@ -20,8 +20,8 @@ PASS Cycle through global, self
 PASS Cycle through local, other function
 PASS Cycle through local, other function, fallback in function
 PASS Cycle through various variables and other functions
-FAIL Function in a cycle with its own default assert_equals: expected "PASS" but got "10px"
-FAIL Cyclic defaults assert_equals: expected "42px PASS-y PASS-z" but got "42px var(--z) var(--y)"
-FAIL Cyclic outer --b shadows custom property assert_equals: expected "PASS" but got "var(--b)"
+PASS Function in a cycle with its own default
+PASS Cyclic defaults
+PASS Cyclic outer --b shadows custom property
 PASS Locals are function specific
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
@@ -19,19 +19,19 @@ PASS Parameter with complex type (px)
 PASS Passing argument to inner function
 PASS var() in argument resolved before call
 PASS var() in argument resolved before call, typed
-FAIL Argument captures IACVT due to invalid var() assert_equals: expected "PASS" but got ""
-FAIL Argument captures IACVT due to invalid var(), typed assert_equals: expected "PASS" but got ""
+PASS Argument captures IACVT due to invalid var()
+PASS Argument captures IACVT due to invalid var(), typed
 PASS Argument captures IACVT due to type mismatch
 PASS Single parameter with default value
 PASS Multiple parameters with defaults
 PASS Multiple parameters with defaults, typed
-FAIL Default referencing another parameter assert_equals: expected "5px 5px" but got "5px var(--x)"
-FAIL Default referencing another parameter, local interference assert_equals: expected "17px 5px" but got "17px var(--x)"
-FAIL Default referencing another defaulted parameter assert_equals: expected "5px 5px" but got "5px var(--x)"
+PASS Default referencing another parameter
+PASS Default referencing another parameter, local interference
+PASS Default referencing another defaulted parameter
 FAIL Typed default with reference assert_equals: expected "5px 6px" but got ""
-FAIL IACVT arguments are defaulted assert_equals: expected "1 2 3" but got ""
-FAIL IACVT arguments are defaulted, typed assert_equals: expected "1 2 3" but got ""
-FAIL Arguments are defaulted on type mismatch assert_equals: expected "1 2 3" but got ""
+PASS IACVT arguments are defaulted
+PASS IACVT arguments are defaulted, typed
+PASS Arguments are defaulted on type mismatch
 PASS Unused local
 PASS Local does not affect outer scope
 PASS Substituting local in result
@@ -55,9 +55,9 @@ PASS Inner function call should see resolved outer locals
 PASS Inner function call should see resolved outer locals (reverse)
 PASS Parameter shadows custom property
 PASS Local shadows parameter
-FAIL IACVT argument shadows outer scope assert_equals: expected "PASS" but got ""
-FAIL IACVT argument shadows outer scope, typed assert_equals: expected "PASS" but got ""
-FAIL IACVT argument shadows outer scope, type mismatch assert_equals: expected "PASS" but got "FAIL"
+PASS IACVT argument shadows outer scope
+PASS IACVT argument shadows outer scope, typed
+PASS IACVT argument shadows outer scope, type mismatch
 PASS Missing only argument
 PASS Missing one argument of several
 FAIL Passing list as only argument assert_equals: expected "1px,2px" but got "{1px,2px}"
@@ -68,7 +68,7 @@ FAIL Passing {} as argument assert_equals: expected "{}" but got "{{}}"
 FAIL Passing non-whole-value {} as argument assert_equals: expected "foo{}" but got "{foo{}}"
 PASS Local variable with initial keyword
 PASS Local variable with initial keyword, defaulted
-FAIL Local variable with initial keyword, no value via IACVT-capture assert_equals: expected "PASS" but got ""
+PASS Local variable with initial keyword, no value via IACVT-capture
 PASS Default with initial keyword
 FAIL initial appearing via fallback assert_equals: expected "PASS" but got ""
 PASS Local variable with inherit keyword

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
@@ -7,7 +7,7 @@ PASS Return attr(type(<length>)) from untyped function
 PASS Return attr(type(<length>)) from typed function
 PASS Return attr(type(*)) from typed function
 PASS Return attr(type(*)) from untyped function
-FAIL attr() in default parameter value assert_equals: expected "42px" but got "784px"
+PASS attr() in default parameter value
 PASS attr() in local variable
 PASS Returned url() is attr-tainted
 PASS Returned url() is attr-tainted, typed attr()

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -226,21 +226,31 @@ void Builder::applyCustomProperty(const AtomString& name)
 
     auto iterator = m_cascade.customProperties().find(name);
     if (iterator == m_cascade.customProperties().end()) {
-        // The property is not in this cascade, but a custom function body inherits the calling
-        // context's custom properties, which are resolved lazily. Resolve it there and copy in the
-        // computed value so var() references can find it.
-        if (auto* callingContextBuilder = m_state->callingContextBuilder()) {
-            callingContextBuilder->applyCustomProperty(name);
-            if (RefPtr value = callingContextBuilder->state().style().customPropertyValue(name)) {
-                bool isInherited = isInheritedCustomProperty(m_state->registeredProperty(name));
-                m_state->style().setCustomPropertyValue(value.releaseNonNull(), isInherited);
-            }
-            m_state->m_appliedCustomProperties.add(name);
-        }
+        // A property missing from this cascade is resolved against the function evaluation context, if any.
+        if (m_state->callingContextBuilder())
+            applyCustomPropertyFromCallingContext(name);
         return;
     }
 
     applyCustomPropertyImpl(name, iterator->value);
+}
+
+// A custom property absent from a function's cascade is either a parameter (locally registered: it
+// shadows inheritance and resolves to its registered value) or one inherited from the calling context
+// (resolved lazily). https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+void Builder::applyCustomPropertyFromCallingContext(const AtomString& name)
+{
+    auto* callingContextBuilder = m_state->callingContextBuilder();
+    ASSERT(callingContextBuilder);
+
+    if (m_state->registeredProperty(name))
+        applyCustomProperty(name, CSSWideKeyword::Initial);
+    else {
+        callingContextBuilder->applyCustomProperty(name);
+        if (RefPtr value = callingContextBuilder->state().style().customPropertyValue(name))
+            m_state->style().setCustomPropertyValue(value.releaseNonNull(), isInheritedCustomProperty(m_state->registeredProperty(name)));
+    }
+    m_state->m_appliedCustomProperties.add(name);
 }
 
 void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCascade::Property& property)
@@ -263,6 +273,11 @@ void Builder::applyCustomPropertyImpl(const AtomString& name, const PropertyCasc
         // The property is a registered custom property with universal syntax:
         // The computed value is the guaranteed-invalid value.
         if (!registered || registered->syntax.isUniversal())
+            return CustomProperty::createForGuaranteedInvalid(name);
+        // For a custom function's hypothetical element, an invalid value resolves to the guaranteed-invalid
+        // value (the parameter overrides inheritance), not unset.
+        // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+        if (m_state->callingContextBuilder())
             return CustomProperty::createForGuaranteedInvalid(name);
         // Otherwise:
         // ...as if the property’s value had been specified as the unset keyword.
@@ -692,7 +707,7 @@ std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyVa
 
     auto resolvedData = switchOn(value.value(),
         [&](const Ref<CSSSubstitutionValue>& substitutionValue) -> RefPtr<CSSVariableData> {
-            SubstitutionResolver substitutionResolver(*this);
+            SubstitutionResolver substitutionResolver(*this, registered);
             return substitutionResolver.substitute(substitutionValue.get());
         },
         [&](const Ref<CSSVariableData>& data) -> RefPtr<CSSVariableData> {

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -69,6 +69,7 @@ private:
     void applyLogicalGroupProperties();
     void applyCustomProperties();
     void applyCustomPropertyImpl(const AtomString&, const PropertyCascade::Property&);
+    void applyCustomPropertyFromCallingContext(const AtomString&);
 
     enum CustomPropertyCycleTracking { Enabled = 0, Disabled };
     template<CustomPropertyCycleTracking trackCycles>

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -60,6 +60,7 @@
 #include "StyleLocalPropertyRegistry.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include <wtf/IndexedRange.h>
 
 namespace WebCore {
 namespace Style {
@@ -75,6 +76,24 @@ static bool containsURLTokens(std::span<const CSSParserToken> tokens)
     return false;
 }
 
+static Ref<CSSVariableData> createFirstValidVariableData(std::span<const std::span<const CSSParserToken>> candidates, const CSSParserContext& context)
+{
+    // Uses the internal -internal-first-valid name rather than the public first-valid(). The public
+    // function must validate against any property's grammar, which is not implemented yet. See the
+    // FIXME on substituteFirstValid().
+    Vector<CSSParserToken> tokens;
+    tokens.append(CSSParserToken(FunctionToken, "-internal-first-valid"_s, CSSParserToken::BlockStart));
+    bool isFirst = true;
+    for (auto& candidate : candidates) {
+        if (!isFirst)
+            tokens.append(CSSParserToken(CommaToken));
+        isFirst = false;
+        tokens.append(candidate);
+    }
+    tokens.append(CSSParserToken(RightParenthesisToken, CSSParserToken::BlockEnd));
+    return CSSVariableData::create(CSSParserTokenRange { tokens }, context);
+}
+
 void SubstitutionResolver::propagateAttrTaint(IsAttrTainted isAttrTainted, std::span<const CSSParserToken> tokens)
 {
     if (isAttrTainted != IsAttrTainted::Yes)
@@ -84,8 +103,9 @@ void SubstitutionResolver::propagateAttrTaint(IsAttrTainted isAttrTainted, std::
         m_hasTaintedURL = true;
 }
 
-SubstitutionResolver::SubstitutionResolver(Builder& builder)
+SubstitutionResolver::SubstitutionResolver(Builder& builder, const CSSRegisteredCustomProperty* registration)
     : m_styleBuilder(builder)
+    , m_registration(registration)
 {
 }
 
@@ -173,12 +193,44 @@ bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range,
     return true;
 }
 
+// https://drafts.csswg.org/css-values-5/#first-valid
+// FIXME: This only validates against a custom property's registered syntax. The real, author-exposed
+// first-valid() is a <whole-value> usable on any property, so candidates must be validated against the
+// target property's grammar (e.g. by feeding them to the property parser) rather than only a registration.
+bool SubstitutionResolver::substituteFirstValid(CSSParserTokenRange range, Vector<CSSParserToken>& tokens, const CSSParserContext& context)
+{
+    for (unsigned i = 0; !range.atEnd(); ++i) {
+        auto candidateRange = CSSPropertyParserHelpers::consumeArgument(range, i);
+        if (!candidateRange)
+            break;
+
+        auto substituted = substituteTokenRange(*candidateRange, context);
+        if (!substituted || substituted->isEmpty())
+            continue;
+
+        if (m_registration && !m_registration->syntax.isUniversal()
+            && !CSSPropertyParser::isValidCustomPropertyValueForSyntax(m_registration->syntax, CSSParserTokenRange { *substituted }, context))
+            continue;
+
+        tokens.appendVector(*substituted);
+        return true;
+    }
+    return false;
+}
+
 // https://drafts.csswg.org/css-mixins/#evaluate-a-custom-function
 // Registers each parameter with its type, resolves argument styles, then updates registrations
 // to universal syntax with resolved values as initial values.
 // Returns resolved argument properties to prepend to the body rule, or nullptr on failure.
 RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>& parameters, const Vector<Vector<CSSParserToken>>& arguments, LocalPropertyRegistry& registrations)
 {
+    // A parameter without a default requires a corresponding argument. A missing one makes the whole
+    // invocation guaranteed-invalid (unlike a supplied-but-invalid argument, which defaults below).
+    for (auto [i, parameter] : indexedRange(parameters)) {
+        if (!parameter.defaultValue && i >= arguments.size())
+            return nullptr;
+    }
+
     // "For each function parameter, create a custom property registration with the parameter's type."
     auto argumentRegistrations = LocalPropertyRegistry { };
     for (auto& parameter : parameters) {
@@ -191,26 +243,42 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
 
     // "Let argument rule be an initially empty style rule" with first-valid(arg value, default value) for each parameter.
     auto argumentRule = MutableStyleProperties::create();
-    for (unsigned i = 0; i < parameters.size(); ++i) {
-        auto& parameter = parameters[i];
-        auto argumentData = [&] -> RefPtr<CSSVariableData> {
-            if (i < arguments.size() && !arguments[i].isEmpty())
-                return CSSVariableData::create(CSSParserTokenRange { arguments[i] }, m_substitutionValue->context());
-            return parameter.defaultValue;
-        }();
-        if (!argumentData)
-            return nullptr;
+    for (auto [i, parameter] : indexedRange(parameters)) {
+        bool hasArgument = i < arguments.size() && !arguments[i].isEmpty();
 
-        // A bare CSS-wide keyword argument/default (e.g. a parameter defaulting to `inherit`) must keep
-        // its keyword semantics so it resolves against the calling context, rather than being treated as
-        // a literal universal value. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
-        auto value = [&] -> Ref<CSSCustomPropertyValue> {
-            auto tokens = argumentData->tokenRange();
-            tokens.consumeWhitespace();
-            if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(tokens); keyword && tokens.atEnd())
-                return CSSCustomPropertyValue::createWithCSSWideKeyword(parameter.name, *keyword);
-            return CSSCustomPropertyValue::createSyntaxAll(parameter.name, argumentData.releaseNonNull());
+        // first-valid(arg value, default value). A parameter with neither is omitted from the rule,
+        // resolving to the guaranteed-invalid value via its (valueless) registration.
+        auto candidates = [&] {
+            Vector<std::span<const CSSParserToken>, 2> candidates;
+            if (hasArgument)
+                candidates.append(arguments[i].span());
+            if (parameter.defaultValue)
+                candidates.append(parameter.defaultValue->tokens().span());
+            return candidates;
         }();
+        if (candidates.isEmpty())
+            continue;
+
+        // A bare CSS-wide keyword (e.g. a parameter defaulting to `inherit`) keeps its keyword semantics
+        // rather than becoming a literal value. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+        auto primaryTokens = CSSParserTokenRange { candidates.first() };
+        primaryTokens.consumeWhitespace();
+        if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(primaryTokens); keyword && primaryTokens.atEnd()) {
+            argumentRule->addParsedProperty({ CSSPropertyCustom, CSSCustomPropertyValue::createWithCSSWideKeyword(parameter.name, *keyword) });
+            continue;
+        }
+
+        // Fast path: an untyped parameter with an argument needs no first-valid(). The argument is
+        // already substituted and, being non-empty, is always valid for the universal syntax, so it
+        // wins outright and the default is irrelevant.
+        if (hasArgument && parameter.type.isUniversal()) {
+            auto value = CSSCustomPropertyValue::createSyntaxAll(parameter.name, CSSVariableData::create(arguments[i], m_substitutionValue->context()));
+            argumentRule->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
+            continue;
+        }
+
+        auto firstValidData = createFirstValidVariableData(candidates.span(), m_substitutionValue->context());
+        auto value = CSSCustomPropertyValue::createUnresolved(parameter.name, CSSSubstitutionValue::create(WTF::move(firstValidData)));
         argumentRule->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
     }
 
@@ -247,7 +315,7 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
         });
 
         if (resolvedValue && !resolvedValue->isGuaranteedInvalid()) {
-            auto tokenData = CSSVariableData::create(CSSParserTokenRange { resolvedValue->tokens() });
+            auto tokenData = CSSVariableData::create(CSSParserTokenRange { resolvedValue->tokens() }, resolvedValue->isAttrTainted(), m_substitutionValue->context());
             auto value = CSSCustomPropertyValue::createSyntaxAll(parameter.name, WTF::move(tokenData));
             resolvedArgumentProperties->addParsedProperty({ CSSPropertyCustom, WTF::move(value) });
         }
@@ -290,9 +358,9 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
             if (!argumentRange)
                 break;
             auto substituted = substituteTokenRange(*argumentRange, m_substitutionValue->context());
-            if (!substituted)
-                return { };
-            result.append(WTF::move(*substituted));
+            // A failed substitution leaves the argument guaranteed-invalid (empty) so it defaults via
+            // first-valid(), rather than aborting. https://drafts.csswg.org/css-mixins/#replace-a-dashed-function
+            result.append(substituted.value_or(Vector<CSSParserToken> { }));
         }
         if (result.size() > parameters.size())
             return { };
@@ -698,6 +766,11 @@ std::optional<Vector<CSSParserToken>> SubstitutionResolver::substituteTokenRange
             }
             if (functionId == CSSValueInternalAutoBase) {
                 if (!substituteInternalAutoBaseFunction(range.consumeBlock(), tokens, context))
+                    success = false;
+                continue;
+            }
+            if (token.value() == "-internal-first-valid"_s) {
+                if (!substituteFirstValid(range.consumeBlock(), tokens, context))
                     success = false;
                 continue;
             }

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -36,6 +36,7 @@ class CSSValue;
 class CSSVariableData;
 class CSSSubstitutionValue;
 struct CSSParserContext;
+struct CSSRegisteredCustomProperty;
 enum CSSPropertyID : uint16_t;
 enum CSSValueID : uint16_t;
 
@@ -51,7 +52,9 @@ class LocalPropertyRegistry;
 // https://drafts.csswg.org/css-values-5/#arbitrary-substitution
 class SubstitutionResolver {
 public:
-    explicit SubstitutionResolver(Builder&);
+    // The registration is that of the custom property whose value is being resolved, if any. It is
+    // used to validate first-valid() candidates against the target syntax.
+    explicit SubstitutionResolver(Builder&, const CSSRegisteredCustomProperty* = nullptr);
 
     RefPtr<CSSValue> substituteAndParse(const CSSSubstitutionValue&, CSSPropertyID);
     RefPtr<CSSValue> substituteAndParseShorthand(const CSSShorthandSubstitutionValue&, CSSPropertyID);
@@ -61,6 +64,7 @@ private:
     std::optional<Vector<CSSParserToken>> substituteTokenRange(CSSParserTokenRange, const CSSParserContext&);
 
     bool substituteVariableFunction(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&);
+    bool substituteFirstValid(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&);
     RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&);
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
@@ -83,6 +87,7 @@ private:
     void propagateAttrTaint(IsAttrTainted, std::span<const CSSParserToken>);
 
     Builder& m_styleBuilder;
+    const CSSRegisteredCustomProperty* m_registration { nullptr };
     RefPtr<const CSSSubstitutionValue> m_substitutionValue;
     Vector<String> m_intermediateTokenStrings;
     Vector<RefPtr<const CustomProperty>> m_intermediateCustomProperties;


### PR DESCRIPTION
#### 6c94926886b44e8b5d50d95ba23c2cce00a32c16
<pre>
[css-mixins-1] Implement argument parsing in terms of first-valid()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318212">https://bugs.webkit.org/show_bug.cgi?id=318212</a>
<a href="https://rdar.apple.com/181014309">rdar://181014309</a>

Reviewed by Alan Baradlay and Sam Weinig.

<a href="https://drafts.csswg.org/css-mixins-1/#evaluate-a-custom-function">https://drafts.csswg.org/css-mixins-1/#evaluate-a-custom-function</a>

    3. Add a custom property to argument rule with a name of the parameter’s name, and a value
       of first-valid(arg value, default value).

This patch implements first-valid() internally for @function use but does not yet expose
it externally.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt:

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyCustomPropertyFromCallingContext):

A parameter shadows inherited custom properties; other properties are inherited lazily from
the calling context.

(WebCore::Style::Builder::applyCustomPropertyImpl):

In a function context an invalid value resolves to guaranteed-invalid, not unset.

(WebCore::Style::Builder::resolveCustomPropertyValue):

Pass the registration so first-valid() can validate candidates against the target syntax.

* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteFirstValid):

Substitute to the first candidate valid for the target syntax, else guaranteed-invalid.

(WebCore::Style::SubstitutionResolver::resolveAndRegisterDashedFunctionArguments):

Build each parameter value as first-valid(arg, default). A missing positional argument for a
parameter without a default makes the invocation guaranteed-invalid.

(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Leave a failed argument substitution guaranteed-invalid rather than aborting the function.

* Source/WebCore/style/StyleSubstitutionResolver.h:

Canonical link: <a href="https://commits.webkit.org/316169@main">https://commits.webkit.org/316169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44660059f19ef0510903e09cb0ef7f73b5eed960

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38847 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0957d3f7-fc74-4806-ba75-372282cd04e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45056 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42fc82ee-605f-419b-a88d-01d2c8d30709) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174453 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d20f9a1a-b808-440f-acd1-29c080d51bae) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29559 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183463 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45080 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38284 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45775 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37245 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44277 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43683 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43928 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->