### PR TITLE
GeneratedSerializers should include soft link headers last

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1413,8 +1413,16 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     result.append('#include "GeneratedWebKitSecureCoding.h"')
     result.append('#include <wtf/IsIncreasing.h>')
     result.append('')
+    # *SoftLink.h headers must be included after every other header (WebKit's
+    # build/include_order style rule). Emit them last — after the bundle's own
+    # headers and the GeneratedSerializersExtra.h include below — by holding
+    # them aside while iterating the sorted header list.
+    soft_link_headers = []
     for header in headers:
         if header.webkit_platform != generating_webkit_platform_impl:
+            continue
+        if header.header[:-1].endswith('SoftLink.h'):
+            soft_link_headers.append(header)
             continue
         if header.condition is not None:
             result.append(f'#if {header.condition}')
@@ -1429,7 +1437,15 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
         # can emit zero header includes — every type it references is already
         # in scope from the includes above. This avoids redundant header parsing
         # across all the GeneratedSerializers*.mm files.
-        result.append('#include "GeneratedSerializersExtra.h"')
+        result.append('#include "GeneratedSerializersExtra.h" // NOLINT')
+        result.append('')
+    if soft_link_headers:
+        for header in soft_link_headers:
+            if header.condition is not None:
+                result.append(f'#if {header.condition}')
+            result.append(f'#include {header.header}')
+            if header.condition is not None:
+                result.append('#endif')
         result.append('')
     result.append('template<uint64_t...> struct BitsInIncreasingOrder;')
     result.append('template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -72,14 +72,17 @@
 #include <WebCore/ScrollingStateFrameHostingNode.h>
 #include <WebCore/ScrollingStateFrameHostingNodeWithStuffAfterTuple.h>
 #include <WebCore/TimingFunction.h>
+#include <wtf/CreateUsingClass.h>
+#include <wtf/Seconds.h>
+
+#include "GeneratedSerializersExtra.h" // NOLINT
+
 #if USE(AVFOUNDATION)
 #include <pal/cocoa/AVFoundationSoftLink.h>
 #endif
 #if ENABLE(DATA_DETECTION)
 #include <pal/cocoa/DataDetectorsCoreSoftLink.h>
 #endif
-#include <wtf/CreateUsingClass.h>
-#include <wtf/Seconds.h>
 
 template<uint64_t...> struct BitsInIncreasingOrder;
 template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {
@@ -103,16 +106,6 @@ IGNORE_WARNINGS_BEGIN("invalid-offsetof")
 
 namespace IPC {
 
-
-template<> struct ArgumentCoder<Namespace::OtherClass> {
-    static void encode(Encoder&, const Namespace::OtherClass&);
-    static std::optional<Namespace::OtherClass> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<Namespace::ClassWithMemberPrecondition> {
-    static void encode(Encoder&, const Namespace::ClassWithMemberPrecondition&);
-    static std::optional<Namespace::ClassWithMemberPrecondition> decode(Decoder&);
-};
 
 #if ENABLE(TEST_FEATURE)
 void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder, const Namespace::Subnamespace::StructName& instance)

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializersExtra.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializersExtra.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GeneratedSerializers.h"
+
+namespace IPC {
+
+class Decoder;
+class Encoder;
+class StreamConnectionEncoder;
+
+template<> struct ArgumentCoder<Namespace::OtherClass> {
+    static void encode(Encoder&, const Namespace::OtherClass&);
+    static std::optional<Namespace::OtherClass> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<Namespace::ClassWithMemberPrecondition> {
+    static void encode(Encoder&, const Namespace::ClassWithMemberPrecondition&);
+    static std::optional<Namespace::ClassWithMemberPrecondition> decode(Decoder&);
+};
+
+} // namespace IPC
+
+namespace WTF {
+
+template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<EnumNamespace2::OptionSetEnumType>);
+
+} // namespace WTF


### PR DESCRIPTION
#### cc6164615e73692de385a93b985a7c243ceb0b03
<pre>
GeneratedSerializers should include soft link headers last
<a href="https://bugs.webkit.org/show_bug.cgi?id=318215">https://bugs.webkit.org/show_bug.cgi?id=318215</a>
<a href="https://rdar.apple.com/181017732">rdar://181017732</a>

Reviewed by Brent Fulgham.

Add SoftLink.h includes as last includes to avoid style checker
errors.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializersExtra.h: Added.

Canonical link: <a href="https://commits.webkit.org/316247@main">https://commits.webkit.org/316247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b83e135d1ca539209c55877f044ec5c5af1d0f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180737 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129008 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9489a916-aaaf-4bbf-a640-f3e3186f34b8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/745f45e6-4616-46c6-b26e-03a575a7d540) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114026 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f717343b-1f74-4734-846e-b69630ef1aca) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/170673 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35399 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29412 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183321 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142053 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44934 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38362 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45623 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110331 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37123 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117405 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44134 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8409 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43538 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43781 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43669 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->