### PR TITLE
[cleanup] Remove the DOM-flavored client* API from RenderBox

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1612,7 +1612,7 @@ int Element::clientLeft()
     protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Left, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
 
     if (CheckedPtr renderer = renderBox()) {
-        auto clientLeft = LayoutUnit { roundToInt(renderer->clientLeft()) };
+        auto clientLeft = LayoutUnit { roundToInt(renderer->borderLeft()) };
         return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(clientLeft, *renderer).toDouble());
     }
     return 0;
@@ -1623,7 +1623,7 @@ int Element::clientTop()
     protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Top, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
 
     if (CheckedPtr renderer = renderBox()) {
-        auto clientTop = LayoutUnit { roundToInt(renderer->clientTop()) };
+        auto clientTop = LayoutUnit { roundToInt(renderer->borderTop()) };
         return convertToNonSubpixelValue(Style::adjustLayoutUnitForAbsoluteZoom(clientTop, *renderer).toDouble());
     }
     return 0;
@@ -1646,7 +1646,7 @@ int Element::clientWidth()
         return Style::adjustForAbsoluteZoom(protect(renderView->frameView())->layoutWidth(), renderView);
     
     if (CheckedPtr renderer = renderBox()) {
-        auto clientWidth = LayoutUnit { roundToInt(renderer->clientWidth()) };
+        auto clientWidth = LayoutUnit { roundToInt(renderer->paddingBoxWidth()) };
         // clientWidth/Height is the visual portion of the box content, not including
         // borders or scroll bars, but includes padding. And per
         // https://www.w3.org/TR/CSS2/tables.html#model,
@@ -1683,7 +1683,7 @@ int Element::clientHeight()
         return Style::adjustForAbsoluteZoom(protect(renderView->frameView())->layoutHeight(), renderView);
 
     if (CheckedPtr renderer = renderBox()) {
-        auto clientHeight = LayoutUnit { roundToInt(renderer->clientHeight()) };
+        auto clientHeight = LayoutUnit { roundToInt(renderer->paddingBoxHeight()) };
         // clientWidth/Height is the visual portion of the box content, not including
         // borders or scroll bars, but includes padding. And per
         // https://www.w3.org/TR/CSS2/tables.html#model,

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -60,6 +60,7 @@
 #include "Pasteboard.h"
 #include "Range.h"
 #include "RenderBox.h"
+#include "RenderBoxInlines.h"
 #include "ReplaceSelectionCommand.h"
 #include "Scrollbar.h"
 #include "Settings.h"
@@ -232,7 +233,7 @@ static unsigned verticalScrollDistance(LocalFrame& frame)
     CheckedRef style = renderBox->style();
     if (!(style->overflowY() == Overflow::Scroll || style->overflowY() == Overflow::Auto || focusedElement->hasEditableStyle()))
         return 0;
-    int height = std::min<int>(renderBox->clientHeight(), frame.view()->visibleHeight());
+    int height = std::min<int>(renderBox->paddingBoxHeight(), frame.view()->visibleHeight());
     return static_cast<unsigned>(Scrollbar::pageStep(height));
 }
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -51,6 +51,7 @@
 #include "NowPlayingInfo.h"
 #include "Page.h"
 #include "PlatformMediaSessionManager.h"
+#include "RenderBoxInlines.h"
 #include "RenderMediaInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
@@ -1266,8 +1267,8 @@ static bool isElementLargeRelativeToMainFrame(const HTMLMediaElement& element)
     if (!mainFrameView)
         return false;
 
-    auto maxVisibleClientWidth = std::min(renderer->clientWidth().toInt(), mainFrameView->visibleWidth());
-    auto maxVisibleClientHeight = std::min(renderer->clientHeight().toInt(), mainFrameView->visibleHeight());
+    auto maxVisibleClientWidth = std::min(renderer->paddingBoxWidth().toInt(), mainFrameView->visibleWidth());
+    auto maxVisibleClientHeight = std::min(renderer->paddingBoxHeight().toInt(), mainFrameView->visibleHeight());
 
     return maxVisibleClientWidth * maxVisibleClientHeight > minimumPercentageOfMainFrameAreaForMainContent * mainFrameView->visibleWidth() * mainFrameView->visibleHeight();
 }
@@ -1283,8 +1284,8 @@ static bool isElementLargeEnoughForMainContent(const HTMLMediaElement& element, 
     if (!renderer)
         return false;
 
-    double width = renderer->clientWidth();
-    double height = renderer->clientHeight();
+    double width = renderer->paddingBoxWidth();
+    double height = renderer->paddingBoxHeight();
     double area = width * height;
     double aspectRatio = width / height;
 

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -174,7 +174,7 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
             auto& renderBox = downcast<RenderBox>(*renderer);
 
             LayoutBoxExtent margins(renderBox.marginTop(), renderBox.marginRight(), renderBox.marginBottom(), renderBox.marginLeft());
-            paddingBox = renderBox.clientBoxRect();
+            paddingBox = LayoutRect(renderBox.borderLeft(), renderBox.borderTop(), renderBox.paddingBoxWidth(), renderBox.paddingBoxHeight());
             contentBox = LayoutRect(paddingBox.x() + renderBox.paddingLeft(), paddingBox.y() + renderBox.paddingTop(),
                 paddingBox.width() - renderBox.paddingLeft() - renderBox.paddingRight(), paddingBox.height() - renderBox.paddingTop() - renderBox.paddingBottom());
             borderBox = LayoutRect(paddingBox.x() - renderBox.borderLeft(), paddingBox.y() - renderBox.borderTop(),

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -42,6 +42,7 @@
 #include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
 #include "Page.h"
+#include "RenderBoxInlines.h"
 #include "RenderInline.h"
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
@@ -374,15 +375,15 @@ bool scrollInDirection(const ContainerNode& container, FocusDirection direction)
             dx = - std::min<LayoutUnit>(Scrollbar::pixelsPerLineStep(), renderBox->scrollLeft());
             break;
         case FocusDirection::Right:
-            ASSERT(renderBox->scrollWidth() > (renderBox->scrollLeft() + renderBox->clientWidth()));
-            dx = std::min<LayoutUnit>(Scrollbar::pixelsPerLineStep(), renderBox->scrollWidth() - (renderBox->scrollLeft() + renderBox->clientWidth()));
+            ASSERT(renderBox->scrollWidth() > (renderBox->scrollLeft() + renderBox->paddingBoxWidth()));
+            dx = std::min<LayoutUnit>(Scrollbar::pixelsPerLineStep(), renderBox->scrollWidth() - (renderBox->scrollLeft() + renderBox->paddingBoxWidth()));
             break;
         case FocusDirection::Up:
             dy = - std::min<LayoutUnit>(Scrollbar::pixelsPerLineStep(), renderBox->scrollTop());
             break;
         case FocusDirection::Down:
-            ASSERT(renderBox->scrollHeight() - (renderBox->scrollTop() + renderBox->clientHeight()));
-            dy = std::min<LayoutUnit>(Scrollbar::pixelsPerLineStep(), renderBox->scrollHeight() - (renderBox->scrollTop() + renderBox->clientHeight()));
+            ASSERT(renderBox->scrollHeight() - (renderBox->scrollTop() + renderBox->paddingBoxHeight()));
+            dy = std::min<LayoutUnit>(Scrollbar::pixelsPerLineStep(), renderBox->scrollHeight() - (renderBox->scrollTop() + renderBox->paddingBoxHeight()));
             break;
         default:
             ASSERT_NOT_REACHED();
@@ -453,9 +454,9 @@ bool canScrollInDirection(const ContainerNode& container, FocusDirection directi
         case FocusDirection::Up:
             return renderBox->style().overflowY() != Overflow::Hidden && renderBox->scrollTop() > 0;
         case FocusDirection::Right:
-            return renderBox->style().overflowX() != Overflow::Hidden && renderBox->scrollLeft() + renderBox->clientWidth() < renderBox->scrollWidth();
+            return renderBox->style().overflowX() != Overflow::Hidden && renderBox->scrollLeft() + renderBox->paddingBoxWidth() < renderBox->scrollWidth();
         case FocusDirection::Down:
-            return renderBox->style().overflowY() != Overflow::Hidden && renderBox->scrollTop() + renderBox->clientHeight() < renderBox->scrollHeight();
+            return renderBox->style().overflowY() != Overflow::Hidden && renderBox->scrollTop() + renderBox->paddingBoxHeight() < renderBox->scrollHeight();
         default:
             ASSERT_NOT_REACHED();
             return false;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -799,7 +799,7 @@ bool RenderBlock::simplifiedLayout()
     // Make sure a forced break is applied after the content if we are a flow thread in a simplified layout.
     // This ensures the size information is correctly computed for the last auto-height fragment receiving content.
     if (CheckedPtr fragmentedFlow = dynamicDowncast<RenderFragmentedFlow>(*this))
-        fragmentedFlow->applyBreakAfterContent(clientLogicalBottom());
+        fragmentedFlow->applyBreakAfterContent(paddingBoxLogicalBottom());
 
     // Recompute our overflow information.
     // FIXME: Skip recalculation if we didn't actually relayout our in-flow boxes and don't have cached overflow.
@@ -3544,7 +3544,7 @@ LayoutUnit RenderBlock::layoutOverflowLogicalBottom(const RenderBlock& renderer)
         auto childLogicalBottom = renderer.logicalTopForChild(child) + renderer.logicalHeightForChild(child) + renderer.marginAfterForChild(child);
         maxChildLogicalBottom = std::max(maxChildLogicalBottom, childLogicalBottom);
     }
-    return std::max(renderer.clientLogicalBottom(), maxChildLogicalBottom + renderer.paddingAfter());
+    return std::max(renderer.paddingBoxLogicalBottom(), maxChildLogicalBottom + renderer.paddingAfter());
 }
 
 void RenderBlock::updateInFlowDescendantTransformsAfterLayout()

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -642,7 +642,7 @@ void RenderBlockFlow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit 
 
     // Calculate our new height.
     LayoutUnit oldHeight = logicalHeight();
-    auto afterPaddingEdge = clientLogicalBottom();
+    auto afterPaddingEdge = paddingBoxLogicalBottom();
 
     // Before updating the final size of the flow thread make sure a forced break is applied after the content.
     // This ensures the size information is correctly computed for the last auto-height fragment receiving content.

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -590,18 +590,6 @@ void RenderBox::layout()
     clearNeedsLayout();
 }
 
-// More IE extensions.  clientWidth and clientHeight represent the interior of an object
-// excluding border and scrollbar.
-LayoutUnit RenderBox::clientWidth() const
-{
-    return paddingBoxWidth();
-}
-
-LayoutUnit RenderBox::clientHeight() const
-{
-    return paddingBoxHeight();
-}
-
 int RenderBox::scrollWidth() const
 {
     if (hasPotentiallyScrollableOverflow() && layer())
@@ -609,9 +597,9 @@ int RenderBox::scrollWidth() const
     // For objects with visible overflow, this matches IE.
     if (writingMode().isLogicalLeftInlineStart()) {
         // FIXME: This should use snappedIntSize() instead with absolute coordinates.
-        return roundToInt(std::max(clientWidth(), layoutOverflowRect().maxX() - borderLeft()));
+        return roundToInt(std::max(paddingBoxWidth(), layoutOverflowRect().maxX() - borderLeft()));
     }
-    return roundToInt(clientWidth() - std::min<LayoutUnit>(0, layoutOverflowRect().x() - borderLeft()));
+    return roundToInt(paddingBoxWidth() - std::min<LayoutUnit>(0, layoutOverflowRect().x() - borderLeft()));
 }
 
 int RenderBox::scrollHeight() const
@@ -621,7 +609,7 @@ int RenderBox::scrollHeight() const
     // For objects with visible overflow, this matches IE.
     // FIXME: Need to work right with writing modes.
     // FIXME: This should use snappedIntSize() instead with absolute coordinates.
-    return roundToInt(std::max(clientHeight(), layoutOverflowRect().maxY() - borderTop()));
+    return roundToInt(std::max(paddingBoxHeight(), layoutOverflowRect().maxY() - borderTop()));
 }
 
 int RenderBox::scrollLeft() const
@@ -895,7 +883,7 @@ IntRect absoluteInteractionBounds(const RenderObject& renderer)
         if (box->style().isOverflowVisible())
             rect = box->layoutOverflowRect();
         else
-            rect = box->clientBoxRect();
+            rect = LayoutRect(box->borderLeft(), box->borderTop(), box->paddingBoxWidth(), box->paddingBoxHeight());
         return box->localToAbsoluteQuad(rect).enclosingBoundingBox();
     }
 
@@ -4248,9 +4236,9 @@ LayoutRange RenderBox::containingBlockRangeForPositioned(const RenderBoxModelObj
             if (auto boxInfo = containingBlock->renderBoxFragmentInfo(fragment)) {
                 auto size = boxInfo->logicalWidth();
                 if (BoxAxis::Horizontal == physicalAxis)
-                    size -= containingBlock->borderBoxWidth() - containingBlock->clientWidth();
+                    size -= containingBlock->borderBoxWidth() - containingBlock->paddingBoxWidth();
                 else
-                    size -= containingBlock->borderBoxHeight() - containingBlock->clientHeight();
+                    size -= containingBlock->borderBoxHeight() - containingBlock->paddingBoxHeight();
                 return LayoutRange(startEdge, std::max<LayoutUnit>(0, size));
             }
         }
@@ -4260,8 +4248,8 @@ LayoutRange RenderBox::containingBlockRangeForPositioned(const RenderBoxModelObj
         return getScrollableContainingBlockRange(*containingBlock, physicalAxis);
 
     return BoxAxis::Horizontal == physicalAxis
-        ? LayoutRange(startEdge, containingBlock->clientWidth())
-        : LayoutRange(startEdge, containingBlock->clientHeight());
+        ? LayoutRange(startEdge, containingBlock->paddingBoxWidth())
+        : LayoutRange(startEdge, containingBlock->paddingBoxHeight());
 }
 
 void RenderBox::computeOutOfFlowPositionedLogicalWidth(LogicalExtentComputedValues& computedValues) const
@@ -4846,7 +4834,7 @@ bool RenderBox::hasLayoutOverflow() const
     if (!m_overflow)
         return false;
 
-    return !flippedClientBoxRect().contains(m_overflow->layoutOverflowRect());
+    return !flippedPaddingBoxRect().contains(m_overflow->layoutOverflowRect());
 }
 
 LayoutOptionalOutsets RenderBox::allowedLayoutOverflow() const
@@ -4874,25 +4862,25 @@ LayoutOptionalOutsets RenderBox::allowedLayoutOverflow() const
     return allowance;
 }
 
-LayoutRect RenderBox::clampToAllowedLayoutOverflow(const LayoutRect& rect, const LayoutRect& flippedClientBoxRect)
+LayoutRect RenderBox::clampToAllowedLayoutOverflow(const LayoutRect& rect, const LayoutRect& flippedPaddingBoxRect)
 {
     LayoutOptionalOutsets allowance = allowedLayoutOverflow();
     LayoutRect clippedRect(rect);
     // Non-negative values indicate a limit, let's apply them.
     if (allowance.top())
-        clippedRect.shiftYEdgeTo(std::max(rect.y(), flippedClientBoxRect.y() - *allowance.top()));
+        clippedRect.shiftYEdgeTo(std::max(rect.y(), flippedPaddingBoxRect.y() - *allowance.top()));
     if (allowance.bottom())
-        clippedRect.shiftMaxYEdgeTo(std::min(rect.maxY(), flippedClientBoxRect.maxY() + *allowance.bottom()));
+        clippedRect.shiftMaxYEdgeTo(std::min(rect.maxY(), flippedPaddingBoxRect.maxY() + *allowance.bottom()));
     if (allowance.left())
-        clippedRect.shiftXEdgeTo(std::max(rect.x(), flippedClientBoxRect.x() - *allowance.left()));
+        clippedRect.shiftXEdgeTo(std::max(rect.x(), flippedPaddingBoxRect.x() - *allowance.left()));
     if (allowance.right())
-        clippedRect.shiftMaxXEdgeTo(std::min(rect.maxX(), flippedClientBoxRect.maxX() + *allowance.right()));
+        clippedRect.shiftMaxXEdgeTo(std::min(rect.maxX(), flippedPaddingBoxRect.maxX() + *allowance.right()));
     return clippedRect;
 }
 
 void RenderBox::addLayoutOverflow(const LayoutRect& rect)
 {
-    auto clientBox = flippedClientBoxRect();
+    auto clientBox = flippedPaddingBoxRect();
     if (clientBox.contains(rect) || rect.isEmpty())
         return;
 
@@ -4930,7 +4918,7 @@ void RenderBox::addMarginBoxOverflow(const RenderBox& renderer, LayoutSize offse
 
     // Some in-flow boxes (e.g. grid items) only extend the layout overflow edge.
     if (options.contains(ComputeOverflowOptions::MarginsExtendLayoutOverflow)) {
-        auto clippedChildMarginRect = clampToAllowedLayoutOverflow(childMarginRect, flippedClientBoxRect());
+        auto clippedChildMarginRect = clampToAllowedLayoutOverflow(childMarginRect, flippedPaddingBoxRect());
         if (!layoutOverflowRect().contains(clippedChildMarginRect))
             ensureOverflow().addLayoutOverflow(clippedChildMarginRect);
         ASSERT(!options.containsAny({ ComputeOverflowOptions::MarginsExtendContentAreaX, ComputeOverflowOptions::MarginsExtendContentAreaY })); // If you need this to work, remove the return statement.
@@ -4954,7 +4942,7 @@ void RenderBox::clearOverflow()
 RenderOverflow& RenderBox::ensureOverflow()
 {
     if (!m_overflow)
-        m_overflow = makeUnique<RenderOverflow>(flippedClientBoxRect(), borderBoxRect(), flippedContentBoxRect());
+        m_overflow = makeUnique<RenderOverflow>(flippedPaddingBoxRect(), borderBoxRect(), flippedContentBoxRect());
 
     return *m_overflow;
 }
@@ -5121,12 +5109,11 @@ LayoutRect RenderBox::layoutOverflowRectForPropagation(const WritingMode parentW
     return convertRectToParentWritingMode(rect, parentWritingMode);
 }
 
-LayoutRect RenderBox::flippedClientBoxRect() const
+LayoutRect RenderBox::flippedPaddingBoxRect() const
 {
     // Because of the special coordinate system used for overflow rectangles (not quite logical, not
     // quite physical), we need to flip the block progression coordinate in vertical-rl and
-    // horizontal-bt writing modes. Apart from that, this method does the same as clientBoxRect().
-
+    // horizontal-bt writing modes. Apart from that, this method does the same as paddingBoxRect().
     auto rect = paddingBoxRectIncludingScrollbar();
     // Flip block progression axis if writing mode is vertical-rl or horizontal-bt.
     flipForWritingMode(rect);

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -154,10 +154,10 @@ public:
     // For horizontal-tb and vertical-lr they will match physical directions, but for horizontal-bt and vertical-rl, the top/bottom and left/right
     // respectively are flipped when compared to their physical counterparts.  For example minX is on the left in vertical-lr,
     // but it is on the right in vertical-rl.
-    WEBCORE_EXPORT LayoutRect flippedClientBoxRect() const;
+    WEBCORE_EXPORT LayoutRect flippedPaddingBoxRect() const;
     inline const LayoutRect scrollableContentAreaOverflowRect() const;
     inline const LayoutRect scrollablePaddingAreaOverflowRect() const;
-    LayoutRect layoutOverflowRect() const { return m_overflow ? m_overflow->layoutOverflowRect() : flippedClientBoxRect(); }
+    LayoutRect layoutOverflowRect() const { return m_overflow ? m_overflow->layoutOverflowRect() : flippedPaddingBoxRect(); }
     bool hasLayoutOverflow() const;
     inline LayoutUnit logicalLeftLayoutOverflow() const;
     inline LayoutUnit logicalRightLayoutOverflow() const;
@@ -167,7 +167,7 @@ public:
 
     // RenderBox's basic allowedLayoutOverflow() accounts for the writing mode (only).
     virtual LayoutOptionalOutsets allowedLayoutOverflow() const;
-    LayoutRect clampToAllowedLayoutOverflow(const LayoutRect&, const LayoutRect& flippedClientBoxRect);
+    LayoutRect clampToAllowedLayoutOverflow(const LayoutRect&, const LayoutRect& flippedPaddingBoxRect);
     void addLayoutOverflow(const LayoutRect&);
     void addVisualOverflow(const LayoutRect&);
     void clearOverflow();
@@ -207,6 +207,9 @@ public:
 
     inline LayoutUnit paddingBoxWidth() const;
     inline LayoutUnit paddingBoxHeight() const;
+    inline LayoutUnit paddingBoxLogicalWidth() const;
+    inline LayoutUnit paddingBoxLogicalHeight() const;
+    inline LayoutUnit paddingBoxLogicalBottom() const;
     LayoutRect paddingBoxRect() const;
     inline LayoutRect paddingBoxRectIncludingScrollbar() const;
 
@@ -215,18 +218,7 @@ public:
     LayoutUnit offsetWidth() const override { return borderBoxWidth(); }
     LayoutUnit offsetHeight() const override { return borderBoxHeight(); }
 
-    // More IE extensions.  clientWidth and clientHeight represent the interior of an object
-    // excluding border and scrollbar.  clientLeft/Top are just the borderLeftWidth and borderTopWidth.
-    inline LayoutUnit clientLeft() const;
-    inline LayoutUnit clientTop() const;
-    WEBCORE_EXPORT LayoutUnit clientWidth() const;
-    WEBCORE_EXPORT LayoutUnit clientHeight() const;
-    inline LayoutUnit clientLogicalWidth() const;
-    inline LayoutUnit clientLogicalHeight() const;
-    inline LayoutUnit clientLogicalBottom() const;
-    inline LayoutRect clientBoxRect() const;
-
-    // scrollWidth/scrollHeight will be the same as clientWidth/clientHeight unless the
+    // scrollWidth/scrollHeight will be the same as paddingBoxWidth/paddingBoxHeight unless the
     // object has overflow:hidden/scroll/auto specified and also has overflow.
     // scrollLeft/Top return the current scroll position.  These methods are virtual so that objects like
     // textareas can scroll shadow content (but pretend that they are the objects that are
@@ -574,7 +566,7 @@ public:
             return false;
 
         auto layoutOverflowRect = m_overflow->layoutOverflowRect();
-        auto paddingBoxRect = flippedClientBoxRect();
+        auto paddingBoxRect = flippedPaddingBoxRect();
         return layoutOverflowRect.x() < paddingBoxRect.x() || layoutOverflowRect.maxX() > paddingBoxRect.maxX();
     }
 
@@ -584,7 +576,7 @@ public:
             return false;
 
         auto layoutOverflowRect = m_overflow->layoutOverflowRect();
-        auto paddingBoxRect = flippedClientBoxRect();
+        auto paddingBoxRect = flippedPaddingBoxRect();
         return layoutOverflowRect.y() < paddingBoxRect.y() || layoutOverflowRect.maxY() > paddingBoxRect.maxY();
     }
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -29,12 +29,6 @@
 namespace WebCore {
 
 inline LayoutUnit RenderBox::marginBoxLogicalHeight(WritingMode writingMode) const { return writingMode.isHorizontal() ? m_marginBox.top() + borderBoxHeight() + m_marginBox.bottom() : m_marginBox.right() + borderBoxWidth() + m_marginBox.left(); }
-inline LayoutRect RenderBox::clientBoxRect() const { return LayoutRect(clientLeft(), clientTop(), clientWidth(), clientHeight()); }
-inline LayoutUnit RenderBox::clientLeft() const { return borderLeft(); }
-inline LayoutUnit RenderBox::clientLogicalBottom() const { return borderBefore() + clientLogicalHeight(); }
-inline LayoutUnit RenderBox::clientLogicalHeight() const { return writingMode().isHorizontal() ? clientHeight() : clientWidth(); }
-inline LayoutUnit RenderBox::clientLogicalWidth() const { return writingMode().isHorizontal() ? clientWidth() : clientHeight(); }
-inline LayoutUnit RenderBox::clientTop() const { return borderTop(); }
 inline LayoutRect RenderBox::computedCSSContentBoxRect() const { return LayoutRect(borderLeft() + computedCSSPaddingLeft(), borderTop() + computedCSSPaddingTop(), paddingBoxWidth() - computedCSSPaddingLeft() - computedCSSPaddingRight()  - (style().scrollbarGutter().isStableBothEdges() ? verticalScrollbarWidth() : 0), paddingBoxHeight() - computedCSSPaddingTop() - computedCSSPaddingBottom() - (style().scrollbarGutter().isStableBothEdges() ? horizontalScrollbarHeight() : 0)); }
 inline LayoutUnit RenderBox::contentBoxHeight() const { return std::max(0_lu, paddingBoxHeight() - paddingTop() - paddingBottom() - (style().scrollbarGutter().isStableBothEdges() ? horizontalScrollbarHeight() : 0)); }
 inline LayoutUnit RenderBox::contentBoxLogicalHeight() const { return writingMode().isHorizontal() ? contentBoxHeight() : contentBoxWidth(); }
@@ -72,6 +66,9 @@ inline LayoutSize RenderBox::logicalSize() const { return writingMode().isHorizo
 inline LayoutUnit RenderBox::logicalTop() const { return writingMode().isHorizontal() ? y() : x(); }
 inline LayoutUnit RenderBox::logicalWidth() const { return writingMode().isHorizontal() ? borderBoxWidth() : borderBoxHeight(); }
 inline LayoutUnit RenderBox::paddingBoxHeight() const { return std::max(0_lu, borderBoxHeight() - borderTop() - borderBottom() - horizontalScrollbarHeight()); }
+inline LayoutUnit RenderBox::paddingBoxLogicalBottom() const { return borderBefore() + paddingBoxLogicalHeight(); }
+inline LayoutUnit RenderBox::paddingBoxLogicalHeight() const { return writingMode().isHorizontal() ? paddingBoxHeight() : paddingBoxWidth(); }
+inline LayoutUnit RenderBox::paddingBoxLogicalWidth() const { return writingMode().isHorizontal() ? paddingBoxWidth() : paddingBoxHeight(); }
 inline LayoutUnit RenderBox::paddingBoxWidth() const { return std::max(0_lu, borderBoxWidth() - borderLeft() - borderRight() - verticalScrollbarWidth()); }
 inline int RenderBox::scrollbarLogicalHeight() const { return writingMode().isHorizontal() ? horizontalScrollbarHeight() : verticalScrollbarWidth(); }
 inline int RenderBox::scrollbarLogicalWidth() const { return writingMode().isHorizontal() ? verticalScrollbarWidth() : horizontalScrollbarHeight(); }
@@ -165,7 +162,7 @@ inline LayoutRect RenderBox::contentBoxRect() const
 
 inline LayoutRect RenderBox::flippedContentBoxRect() const
 {
-    auto rect = flippedClientBoxRect();
+    auto rect = flippedPaddingBoxRect();
     auto padding = this->padding();
     if (!padding.isZero()) {
         if (writingMode().isBlockFlipped())
@@ -198,7 +195,7 @@ inline const LayoutRect RenderBox::scrollableContentAreaOverflowRect() const
 inline const LayoutRect RenderBox::scrollablePaddingAreaOverflowRect() const
 {
     if (!m_overflow)
-        return flippedClientBoxRect();
+        return flippedPaddingBoxRect();
 
     auto overflowRect = m_overflow->contentArea();
     flipForWritingMode(overflowRect);

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -425,7 +425,7 @@ LayoutRect RenderFragmentContainer::computedVisualOverflowRectForBox(const Rende
 LayoutRect RenderFragmentContainer::computedLayoutOverflowRectForBox(const RenderBox& box) const
 {
     ASSERT(m_fragmentedFlow->objectShouldFragmentInFlowFragment(&box, this));
-    auto clientBox = box.clientBoxRect();
+    auto clientBox = LayoutRect(box.borderLeft(), box.borderTop(), box.paddingBoxWidth(), box.paddingBoxHeight());
     if (clientBox.isEmpty())
         return { };
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2234,7 +2234,7 @@ LayoutRange RenderGrid::gridAreaRangeForOutOfFlow(const RenderBox& gridItem, Sty
         return borderBefore();
     }();
 
-    LayoutRange defaultRange(borderEdge, isRowAxis ? clientLogicalWidth() : clientLogicalHeight());
+    LayoutRange defaultRange(borderEdge, isRowAxis ? paddingBoxLogicalWidth() : paddingBoxLogicalHeight());
     if (!gridItem.style().positionArea().isNone() && hasRenderOverflow() && hasPotentiallyScrollableOverflow()) {
         // position-area uses the scrollable containing block
         defaultRange = isRowAxis == writingMode().isHorizontal()
@@ -2260,7 +2260,7 @@ LayoutRange RenderGrid::gridAreaRangeForOutOfFlow(const RenderBox& gridItem, Sty
     auto& positions = this->positions(direction);
     if (positions.isEmpty()) {
         ASSERT_WITH_SECURITY_IMPLICATION(!positions.isEmpty());
-        return LayoutRange(borderEdge, isRowAxis ? clientLogicalWidth() : clientLogicalHeight());
+        return LayoutRange(borderEdge, isRowAxis ? paddingBoxLogicalWidth() : paddingBoxLogicalHeight());
     }
 
     if (startIsAuto)
@@ -2449,7 +2449,7 @@ LayoutOptionalOutsets RenderGrid::allowedLayoutOverflow() const
 
 LayoutUnit RenderGrid::translateRTLCoordinate(LayoutUnit coordinate) const
 {
-    LayoutUnit width = borderLogicalLeft() + borderLogicalRight() + clientLogicalWidth();
+    LayoutUnit width = borderLogicalLeft() + borderLogicalRight() + paddingBoxLogicalWidth();
 
     // If we are in horizontal writing mode and RTL direction the scrollbar is painted on the left,
     // so we need to take into account when computing the position of the columns.

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3078,7 +3078,7 @@ IntSize RenderLayer::visibleSize() const
     if (!box)
         return IntSize();
 
-    return IntSize(roundToInt(box->clientWidth()), roundToInt(box->clientHeight()));
+    return IntSize(roundToInt(box->paddingBoxWidth()), roundToInt(box->paddingBoxHeight()));
 }
 
 RenderLayer::OverflowControlRects RenderLayer::overflowControlsRects() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1213,14 +1213,14 @@ bool RenderLayerScrollableArea::hasHorizontalOverflow() const
 {
     ASSERT(!m_scrollDimensionsDirty);
 
-    return scrollWidth() > roundToInt(m_layer.renderBox()->clientWidth());
+    return scrollWidth() > roundToInt(m_layer.renderBox()->paddingBoxWidth());
 }
 
 bool RenderLayerScrollableArea::hasVerticalOverflow() const
 {
     ASSERT(!m_scrollDimensionsDirty);
 
-    return scrollHeight() > roundToInt(m_layer.renderBox()->clientHeight());
+    return scrollHeight() > roundToInt(m_layer.renderBox()->paddingBoxHeight());
 }
 
 void RenderLayerScrollableArea::updateScrollbarPresenceAndState(std::optional<bool> hasHorizontalOverflow, std::optional<bool> hasVerticalOverflow)
@@ -1363,7 +1363,7 @@ void RenderLayerScrollableArea::updateScrollbarSteps()
     CheckedPtr box = m_layer.renderBox();
     ASSERT(box);
 
-    LayoutRect paddedLayerBounds(0_lu, 0_lu, box->clientWidth(), box->clientHeight());
+    LayoutRect paddedLayerBounds(0_lu, 0_lu, box->paddingBoxWidth(), box->paddingBoxHeight());
     paddedLayerBounds.contract(box->scrollPaddingForViewportRect(paddedLayerBounds));
 
     // Set up the  page step/line step.

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -886,17 +886,17 @@ ScrollbarOrientation RenderListBox::scrollbarOrientationForWritingMode() const
 int RenderListBox::scrollWidth() const
 {
     if (writingMode().isHorizontal())
-        return roundToInt(clientWidth());
+        return roundToInt(paddingBoxWidth());
 
-    return roundToInt(std::max(clientWidth(), listLogicalHeight()));
+    return roundToInt(std::max(paddingBoxWidth(), listLogicalHeight()));
 }
 
 int RenderListBox::scrollHeight() const
 {
     if (writingMode().isHorizontal())
-        return roundToInt(std::max(clientHeight(), listLogicalHeight()));
+        return roundToInt(std::max(paddingBoxHeight(), listLogicalHeight()));
 
-    return roundToInt(clientHeight());
+    return roundToInt(paddingBoxHeight());
 }
 
 int RenderListBox::scrollLeft() const

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -49,6 +49,7 @@
 #include "HTMLMarqueeElement.h"
 #include "HTMLNames.h"
 #include "LocalFrameView.h"
+#include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderElementInlines.h"
 #include "RenderLayer.h"
@@ -141,7 +142,7 @@ int RenderMarquee::computePosition(MarqueeDirection dir, bool stopAtContentEdge)
     CheckedRef boxStyle = box->style();
     if (isHorizontal()) {
         bool ltr = boxStyle->writingMode().deprecatedIsLeftToRightDirection();
-        LayoutUnit clientWidth = box->clientWidth();
+        LayoutUnit paddingBoxWidth = box->paddingBoxWidth();
         LayoutUnit contentWidth = ltr ? box->maxContentLogicalWidthContribution() : box->minContentLogicalWidthContribution();
         if (ltr)
             contentWidth += (box->paddingRight() - box->borderLeft());
@@ -151,29 +152,29 @@ int RenderMarquee::computePosition(MarqueeDirection dir, bool stopAtContentEdge)
         }
         if (dir == MarqueeDirection::Right) {
             if (stopAtContentEdge)
-                return std::max<LayoutUnit>(0, ltr ? (contentWidth - clientWidth) : (clientWidth - contentWidth));
+                return std::max<LayoutUnit>(0, ltr ? (contentWidth - paddingBoxWidth) : (paddingBoxWidth - contentWidth));
 
-            return ltr ? contentWidth : clientWidth;
+            return ltr ? contentWidth : paddingBoxWidth;
         }
 
         if (stopAtContentEdge)
-            return std::min<LayoutUnit>(0, ltr ? (contentWidth - clientWidth) : (clientWidth - contentWidth));
+            return std::min<LayoutUnit>(0, ltr ? (contentWidth - paddingBoxWidth) : (paddingBoxWidth - contentWidth));
 
-        return ltr ? -clientWidth : -contentWidth;
+        return ltr ? -paddingBoxWidth : -contentWidth;
     }
 
     // Vertical
     int contentHeight = box->layoutOverflowRect().maxY() - box->borderTop() + box->paddingBottom();
-    int clientHeight = roundToInt(box->clientHeight());
+    int paddingBoxHeight = roundToInt(box->paddingBoxHeight());
     if (dir == MarqueeDirection::Up) {
         if (stopAtContentEdge)
-            return std::min(contentHeight - clientHeight, 0);
+            return std::min(contentHeight - paddingBoxHeight, 0);
 
-        return -clientHeight;
+        return -paddingBoxHeight;
     }
 
     if (stopAtContentEdge)
-        return std::max(contentHeight - clientHeight, 0);
+        return std::max(contentHeight - paddingBoxHeight, 0);
 
     return contentHeight;
 }
@@ -303,7 +304,7 @@ void RenderMarquee::timerFired()
             addIncrement = !addIncrement;
         }
         bool positive = range > 0;
-        int clientSize = (isHorizontal() ? roundToInt(renderBox->clientWidth()) : roundToInt(renderBox->clientHeight()));
+        int clientSize = (isHorizontal() ? roundToInt(renderBox->paddingBoxWidth()) : roundToInt(renderBox->paddingBoxHeight()));
         int increment = std::abs(Style::evaluate<float>(layer->renderer().style().marqueeIncrement(), clientSize, Style::ZoomNeeded { }));
         int currentPos = (isHorizontal() ? scrollableArea->scrollOffset().x() : scrollableArea->scrollOffset().y());
         newPos =  currentPos + (addIncrement ? increment : -increment);

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -655,7 +655,7 @@ LayoutUnit RenderReplaced::computeConstrainedLogicalWidth() const
         // the available width is constrained by those values.
         auto& logicalLeft = style().logicalLeft();
         auto& logicalRight = style().logicalRight();
-        auto containerWidth = containingBlock()->clientLogicalWidth();
+        auto containerWidth = containingBlock()->paddingBoxLogicalWidth();
 
         if (!logicalLeft.isAuto() && !logicalRight.isAuto()) {
             auto left = Style::evaluate<LayoutUnit>(logicalLeft, containerWidth, style().usedZoomForLength());

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -437,7 +437,7 @@ int RenderTextControlSingleLine::scrollWidth() const
 {
     if (CheckedPtr innerTextRenderer = this->innerTextRenderer()) {
         // Adjust scrollWidth to inculde input element horizontal paddings and decoration width.
-        auto adjustment = clientWidth() - innerTextRenderer->clientWidth();
+        auto adjustment = paddingBoxWidth() - innerTextRenderer->paddingBoxWidth();
         return innerTextRenderer->scrollWidth() + adjustment;
     }
     return RenderBlockFlow::scrollWidth();
@@ -447,7 +447,7 @@ int RenderTextControlSingleLine::scrollHeight() const
 {
     if (CheckedPtr innerTextRenderer = this->innerTextRenderer()) {
         // Adjust scrollHeight to inculde input element vertical paddings and decoration height.
-        auto adjustment = clientHeight() - innerTextRenderer->clientHeight();
+        auto adjustment = paddingBoxHeight() - innerTextRenderer->paddingBoxHeight();
         return innerTextRenderer->scrollHeight() + adjustment;
     }
     return RenderBlockFlow::scrollHeight();

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -52,6 +52,7 @@
 #include "RemoteFrame.h"
 #include "RemoteFrameView.h"
 #include "RenderBlockFlow.h"
+#include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderCounter.h"
 #include "RenderElementInlines.h"
@@ -594,9 +595,9 @@ inline void writeLayerUsingGeometryType(TextStream& ts, const RenderLayer& layer
                 ts << " scrollX "_s << scrollableArea->scrollOffset().x();
             if (scrollableArea->scrollOffset().y())
                 ts << " scrollY "_s << scrollableArea->scrollOffset().y();
-            if (layer.renderBox() && roundToInt(layer.renderBox()->clientWidth()) != scrollableArea->scrollWidth())
+            if (layer.renderBox() && roundToInt(layer.renderBox()->paddingBoxWidth()) != scrollableArea->scrollWidth())
                 ts << " scrollWidth "_s << scrollableArea->scrollWidth();
-            if (layer.renderBox() && roundToInt(layer.renderBox()->clientHeight()) != scrollableArea->scrollHeight())
+            if (layer.renderBox() && roundToInt(layer.renderBox()->paddingBoxHeight()) != scrollableArea->scrollHeight())
                 ts << " scrollHeight "_s << scrollableArea->scrollHeight();
         }
 #if PLATFORM(MAC)

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -255,7 +255,7 @@ LayoutUnit RenderView::clientLogicalWidthForFixedPosition() const
     if (settings().visualViewportEnabled())
         return isHorizontalWritingMode() ? frameView->layoutViewportRect().width() : frameView->layoutViewportRect().height();
 
-    return clientLogicalWidth();
+    return paddingBoxLogicalWidth();
 }
 
 LayoutUnit RenderView::clientLogicalHeightForFixedPosition() const
@@ -272,7 +272,7 @@ LayoutUnit RenderView::clientLogicalHeightForFixedPosition() const
     if (settings().visualViewportEnabled())
         return isHorizontalWritingMode() ? frameView->layoutViewportRect().height() : frameView->layoutViewportRect().width();
 
-    return clientLogicalHeight();
+    return paddingBoxLogicalHeight();
 }
 
 void RenderView::mapLocalToContainer(const RenderLayerModelObject* ancestorContainer, TransformState& transformState, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const

--- a/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
+++ b/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
@@ -51,9 +51,9 @@ ScrollbarUpdateScope::~ScrollbarUpdateScope()
 
     // Set up the range.
     if (RefPtr hBar = m_renderLayerScrollableArea->m_hBar)
-        hBar->setProportion(roundToInt(box->clientWidth()), m_renderLayerScrollableArea->m_scrollWidth);
+        hBar->setProportion(roundToInt(box->paddingBoxWidth()), m_renderLayerScrollableArea->m_scrollWidth);
     if (RefPtr vBar = m_renderLayerScrollableArea->m_vBar)
-        vBar->setProportion(roundToInt(box->clientHeight()), m_renderLayerScrollableArea->m_scrollHeight);
+        vBar->setProportion(roundToInt(box->paddingBoxHeight()), m_renderLayerScrollableArea->m_scrollHeight);
 
     m_renderLayerScrollableArea->updateScrollbarSteps();
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -134,7 +134,7 @@ bool WebContextMenuClient::clientFloatRectForNode(WebCore::Node& node, WebCore::
         return false;
     auto& renderBox = downcast<WebCore::RenderBox>(*renderer);
 
-    WebCore::LayoutRect layoutRect = renderBox.clientBoxRect();
+    WebCore::LayoutRect layoutRect = WebCore::LayoutRect(renderBox.borderLeft(), renderBox.borderTop(), renderBox.paddingBoxWidth(), renderBox.paddingBoxHeight());
     WebCore::FloatQuad floatQuad = renderBox.localToAbsoluteQuad(WebCore::FloatQuad(layoutRect));
     rect = floatQuad.boundingBox();
 


### PR DESCRIPTION
#### 6a6bb4258c586afe702c77cda962322792dc5e86
<pre>
[cleanup] Remove the DOM-flavored client* API from RenderBox
<a href="https://bugs.webkit.org/show_bug.cgi?id=318042">https://bugs.webkit.org/show_bug.cgi?id=318042</a>
&lt;<a href="https://rdar.apple.com/problem/181017761">rdar://problem/181017761</a>&gt;

Reviewed by Antti Koivisto.

clientWidth/clientHeight/clientLeft/clientTop and clientBoxRect are DOM concepts
(Element.clientWidth and friends) that on RenderBox were just thin aliases over
layout geometry: clientWidth is paddingBoxWidth, clientLeft is borderLeft, and
clientBoxRect is a padding-box-sized rect placed at the border-box origin.

Remove them and point every caller, including the DOM Element::client*
implementations, straight at paddingBox*/border*. Add
paddingBoxLogicalWidth/Height/Bottom to mirror contentBoxLogical* for the former
clientLogical* callers, and rename flippedClientBoxRect to flippedPaddingBoxRect
since it returns the flipped padding box used for overflow rectangles, not a DOM
rect.

No behavior change.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::clientLeft):
(WebCore::Element::clientTop):
(WebCore::Element::clientWidth):
(WebCore::Element::clientHeight):
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::verticalScrollDistance):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isElementLargeRelativeToMainFrame):
(WebCore::isElementLargeEnoughForMainContent):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::buildRendererHighlight):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::scrollInDirection):
(WebCore::canScrollInDirection):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::simplifiedLayout):
(WebCore::RenderBlock::layoutOverflowLogicalBottom):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::scrollWidth const):
(WebCore::RenderBox::scrollHeight const):
(WebCore::absoluteInteractionBounds):
(WebCore::RenderBox::containingBlockRangeForPositioned const):
(WebCore::RenderBox::hasLayoutOverflow const):
(WebCore::RenderBox::clampToAllowedLayoutOverflow):
(WebCore::RenderBox::addLayoutOverflow):
(WebCore::RenderBox::addMarginBoxOverflow):
(WebCore::RenderBox::ensureOverflow):
(WebCore::RenderBox::flippedPaddingBoxRect const):
(WebCore::RenderBox::clientWidth const): Deleted.
(WebCore::RenderBox::clientHeight const): Deleted.
(WebCore::RenderBox::flippedClientBoxRect const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::layoutOverflowRect const):
(WebCore::RenderBox::hasHorizontalLayoutOverflow const):
(WebCore::RenderBox::hasVerticalLayoutOverflow const):
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::marginBoxLogicalHeight const):
(WebCore::RenderBox::paddingBoxLogicalBottom const):
(WebCore::RenderBox::paddingBoxLogicalHeight const):
(WebCore::RenderBox::paddingBoxLogicalWidth const):
(WebCore::RenderBox::flippedContentBoxRect const):
(WebCore::RenderBox::scrollablePaddingAreaOverflowRect const):
(WebCore::RenderBox::clientBoxRect const): Deleted.
(WebCore::RenderBox::clientLeft const): Deleted.
(WebCore::RenderBox::clientLogicalBottom const): Deleted.
(WebCore::RenderBox::clientLogicalHeight const): Deleted.
(WebCore::RenderBox::clientLogicalWidth const): Deleted.
(WebCore::RenderBox::clientTop const): Deleted.
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::computedLayoutOverflowRectForBox const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaRangeForOutOfFlow const):
(WebCore::RenderGrid::translateRTLCoordinate const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::visibleSize const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::hasHorizontalOverflow const):
(WebCore::RenderLayerScrollableArea::hasVerticalOverflow const):
(WebCore::RenderLayerScrollableArea::updateScrollbarSteps):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::scrollWidth const):
(WebCore::RenderListBox::scrollHeight const):
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::computePosition):
(WebCore::RenderMarquee::timerFired):
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeConstrainedLogicalWidth const):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::scrollWidth const):
(WebCore::RenderTextControlSingleLine::scrollHeight const):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::writeLayerUsingGeometryType):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::clientLogicalWidthForFixedPosition const):
(WebCore::RenderView::clientLogicalHeightForFixedPosition const):
* Source/WebCore/rendering/ScrollbarUpdateScope.cpp:
(WebCore::ScrollbarUpdateScope::~ScrollbarUpdateScope):
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::clientFloatRectForNode const):

Canonical link: <a href="https://commits.webkit.org/316255@main">https://commits.webkit.org/316255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58c21113e68d51fdd1876c770a32c6e982eaf474

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180775 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129028 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133562 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114037 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33682 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29451 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145844 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183360 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32648 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142071 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44973 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141915 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38368 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45663 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30329 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110370 "Build was cancelled. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37158 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117425 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44173 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8425 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43577 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->