### PR TITLE
Treat table cell boundary as a word delimiter for inline/inline-block cells

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells-expected.txt
@@ -1,0 +1,12 @@
+head1head2head3
+onetwothree
+alpha beta gamma deltasibling
+alpha beta gamma delta	sibling
+iotakappalambda
+
+PASS Double click on inline-block table cell selects only until cell boundary
+PASS Double click on inline table cell selects only until cell boundary
+PASS Double click in a multi-word inline table cell selects one word, not the whole cell
+PASS Double click in a multi-word normal table cell still selects one word
+PASS Double click in an editable region inside an inline table cell stops at the editable region
+

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>
+  This test is for testing that double click does not select beyond a table
+  cell boundary when the cell uses display:inline or display:inline-block,
+  while still selecting a single word within a cell.
+</title>
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=286666" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  table.inline th { display: inline-block; }
+  table.inline td { display: inline; }
+</style>
+<table class="inline">
+  <tr>
+    <th>head1</th>
+    <th id="title">head2</th>
+    <th>head3</th>
+  </tr>
+  <tr>
+    <td>one</td>
+    <td id="value">two</td>
+    <td>three</td>
+  </tr>
+</table>
+<table class="inline">
+  <tr>
+    <td>alpha beta <span id="inlineWord">gamma</span> delta</td>
+    <td>sibling</td>
+  </tr>
+</table>
+<table>
+  <tr>
+    <td>alpha beta <span id="blockWord">gamma</span> delta</td>
+    <td>sibling</td>
+  </tr>
+</table>
+<table class="inline">
+  <tr>
+    <td>iota<span contenteditable id="editableInCell">kappa</span></td>
+    <td>lambda</td>
+  </tr>
+</table>
+<script>
+  async function doubleClickOnTargetAndCheckSelection(target, expectedSelection, assertionMessage) {
+    target.focus();
+    let actions = new test_driver.Actions()
+      .pointerMove(0, 0, { origin: target })
+      .pointerDown()
+      .pointerUp()
+      .pointerDown()
+      .pointerUp();
+    await actions.send();
+    const selection = window.getSelection();
+    let selectedText = selection.toString();
+    assert_equals(selectedText, expectedSelection, assertionMessage);
+  }
+
+  function runTests() {
+    promise_test(async () => {
+      await doubleClickOnTargetAndCheckSelection(
+        document.getElementById("title"),
+        "head2",
+        "Selected text should be equal to value in header col 2"
+      );
+    }, "Double click on inline-block table cell selects only until cell boundary");
+
+    promise_test(async () => {
+      await doubleClickOnTargetAndCheckSelection(
+        document.getElementById("value"),
+        "two",
+        "Selected text should be equal to value in col 2"
+      );
+    }, "Double click on inline table cell selects only until cell boundary");
+
+    promise_test(async () => {
+      await doubleClickOnTargetAndCheckSelection(
+        document.getElementById("inlineWord"),
+        "gamma",
+        "Selected text should be a single word within the inline cell"
+      );
+    }, "Double click in a multi-word inline table cell selects one word, not the whole cell");
+
+    promise_test(async () => {
+      await doubleClickOnTargetAndCheckSelection(
+        document.getElementById("blockWord"),
+        "gamma",
+        "Selected text should be a single word within the normal cell"
+      );
+    }, "Double click in a multi-word normal table cell still selects one word");
+
+    promise_test(async () => {
+      await doubleClickOnTargetAndCheckSelection(
+        document.getElementById("editableInCell"),
+        "kappa",
+        "Selected text should stop at the editable region, not run to the cell edge"
+      );
+    }, "Double click in an editable region inside an inline table cell stops at the editable region");
+  }
+
+  window.addEventListener("load", runTests, { once: true });
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -632,6 +632,8 @@ editing/selection/editable-links.html [ Skip ]
 editing/selection/empty-cell-right-click.html [ Skip ]
 editing/selection/extend-after-mouse-selection.html [ Skip ]
 editing/selection/extend-selection-after-double-click.html [ Skip ]
+# webkit.org/b/286666 Double-click (double-tap) does not select a word on iOS; word selection uses long-press/loupe, so this desktop-gesture test yields an empty selection.
+imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells.html [ Skip ]
 editing/selection/fake-drag.html [ Skip ]
 editing/selection/focus-and-display-none.html [ Skip ]
 editing/selection/focus-crash.html [ Skip ]

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -37,6 +37,7 @@
 #include "HTMLBodyElement.h"
 #include "HTMLHtmlElement.h"
 #include "HTMLNames.h"
+#include "HTMLTableCellElement.h"
 #include "HTMLTableElement.h"
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorLogicalOrderTraversal.h"
@@ -515,7 +516,7 @@ bool Position::atEditingBoundary() const
         && prevPosition.isNotNull() && !protect(prevPosition.deprecatedNode())->hasEditableStyle();
 }
 
-RefPtr<Node> Position::parentEditingBoundary() const
+RefPtr<Node> Position::parentEditingBoundary(StopAtEnclosingTableCell stopAtEnclosingTableCell) const
 {
     if (!m_anchorNode)
         return nullptr;
@@ -525,9 +526,12 @@ RefPtr<Node> Position::parentEditingBoundary() const
         return nullptr;
 
     RefPtr boundary = m_anchorNode;
-    while (boundary != documentElement && boundary->nonShadowBoundaryParentNode() && protect(m_anchorNode)->hasEditableStyle() == protect(boundary->parentNode())->hasEditableStyle())
+    while (boundary != documentElement && boundary->nonShadowBoundaryParentNode() && protect(m_anchorNode)->hasEditableStyle() == protect(boundary->parentNode())->hasEditableStyle()) {
+        if (stopAtEnclosingTableCell == StopAtEnclosingTableCell::Yes && is<HTMLTableCellElement>(*boundary))
+            break;
         boundary = boundary->nonShadowBoundaryParentNode();
-    
+    }
+
     return boundary;
 }
 

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -162,7 +162,10 @@ public:
 
     // Returns true if the visually equivalent positions around have different editability
     bool atEditingBoundary() const;
-    RefPtr<Node> parentEditingBoundary() const;
+    // Returns the outermost ancestor that has the same editability as the anchor node. When asked
+    // to stop at an enclosing table cell, the walk also stops at a <td> or <th>, so the innermost
+    // of the two boundaries wins.
+    RefPtr<Node> parentEditingBoundary(StopAtEnclosingTableCell = StopAtEnclosingTableCell::No) const;
     
     bool atStartOfTree() const;
     bool atEndOfTree() const;

--- a/Source/WebCore/editing/EditingBoundary.h
+++ b/Source/WebCore/editing/EditingBoundary.h
@@ -38,4 +38,6 @@ enum EditableType {
     HasEditableAXRole
 };
 
+enum class StopAtEnclosingTableCell : bool { No, Yes };
+
 } // namespace WebCore

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -543,9 +543,10 @@ unsigned forwardSearchForBoundaryWithTextIterator(TextIterator& it, Vector<char1
 
 enum class NeedsContextAtParagraphStart : bool { No, Yes };
 static VisiblePosition previousBoundary(const VisiblePosition& position, BoundarySearchFunction searchFunction,
-    NeedsContextAtParagraphStart needsContextAtParagraphStart = NeedsContextAtParagraphStart::No)
+    NeedsContextAtParagraphStart needsContextAtParagraphStart = NeedsContextAtParagraphStart::No,
+    StopAtEnclosingTableCell stopAtEnclosingTableCell = StopAtEnclosingTableCell::No)
 {
-    auto boundary = position.deepEquivalent().parentEditingBoundary();
+    auto boundary = position.deepEquivalent().parentEditingBoundary(stopAtEnclosingTableCell);
     if (!boundary)
         return { };
 
@@ -589,10 +590,11 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     return VisiblePosition(makeDeprecatedLegacyPosition(charIt.range().end), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
 }
 
-static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunction searchFunction)
+static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunction searchFunction,
+    StopAtEnclosingTableCell stopAtEnclosingTableCell = StopAtEnclosingTableCell::No)
 {
     Position pos = c.deepEquivalent();
-    RefPtr boundary = pos.parentEditingBoundary();
+    RefPtr boundary = pos.parentEditingBoundary(stopAtEnclosingTableCell);
     if (!boundary)
         return VisiblePosition();
 
@@ -669,7 +671,7 @@ VisiblePosition startOfWord(const VisiblePosition& c, WordSide side)
         if (p.isNull())
             return c;
     }
-    return previousBoundary(p, startWordBoundary);
+    return previousBoundary(p, startWordBoundary, NeedsContextAtParagraphStart::No, StopAtEnclosingTableCell::Yes);
 }
 
 unsigned endWordBoundary(StringView text, unsigned offset, BoundarySearchContextAvailability mayHaveMoreContext, bool& needMoreContext)
@@ -698,7 +700,7 @@ VisiblePosition endOfWord(const VisiblePosition& c, WordSide side)
     } else if (isEndOfParagraph(c))
         return c;
     
-    return nextBoundary(p, endWordBoundary);
+    return nextBoundary(p, endWordBoundary, StopAtEnclosingTableCell::Yes);
 }
 
 static unsigned previousWordPositionBoundary(StringView text, unsigned offset, BoundarySearchContextAvailability mayHaveMoreContext, bool& needMoreContext)


### PR DESCRIPTION
#### d369f0210c254d186a99684f20675fc85adb61cb
<pre>
Treat table cell boundary as a word delimiter for inline/inline-block cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=286666">https://bugs.webkit.org/show_bug.cgi?id=286666</a>
<a href="https://rdar.apple.com/144213216">rdar://144213216</a>

Reviewed by NOBODY (OOPS!).

Double-clicking a word inside a table cell styled with display:inline or
display:inline-block selected text across the entire row instead of stopping at
the cell boundary. Such cells are not laid out as RenderTableCell, so
TextIterator emits no tab separator between them.

Clamp the word boundary search in startOfWord()/endOfWord() to the enclosing
&lt;td&gt;/&lt;th&gt; element. The cell is found by tag name rather than by renderer type,
because the renderer for an inline/inline-block cell is a RenderBlock, not a
RenderTableCell.

This matches Firefox.
Blink has a proposed but not-yet-landed fix in TextOffsetMapping
(<a href="https://crrev.com/c/6148931).">https://crrev.com/c/6148931).</a>

Test: imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells.html

* LayoutTests/imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/editing/other/double-click-range-selection-in-inline-table-cells.html: Added.
* LayoutTests/platform/ios/TestExpectations:
  skipping on iOS because double-click doesn&apos;t make in this context.
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::isTableCellByTag):
(WebCore::previousBoundary):
(WebCore::nextBoundary):
(WebCore::startOfWord):
(WebCore::endOfWord):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d369f0210c254d186a99684f20675fc85adb61cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145563 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a3d89de6-c5c7-4a85-a754-0d5f686a4770) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141431 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98114 "5 flakes 15 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121882 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8a0cf3e-e652-49b1-ae8d-adde4f0e55cc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42058 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41716 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2617 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193389 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/161704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150825 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55539 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38343 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150542 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45134 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127807 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123372 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54056 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16714 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53438 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53675 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53503 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->