### PR TITLE
`configurationchange` event is dropped when MediaStream track configuration changes while track is muted

### DIFF
--- a/LayoutTests/fast/mediastream/configurationchange-defer-and-abort-expected.txt
+++ b/LayoutTests/fast/mediastream/configurationchange-defer-and-abort-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL configurationchange task is deferred until track is no longer muted promise_test: Unhandled rejection with value: object "Error: timeout waiting for configurationchange after deferred unmute"
+PASS configurationchange task is deferred until track is no longer muted
 PASS configurationchange task aborts if track readyState is 'ended'
 

--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-while-muted-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-while-muted-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS configurationchange is deferred while muted and fires after unmute
+PASS multiple configurationchange notifications while muted coalesce into one event on unmute
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-while-muted.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-while-muted.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>configurationchange is deferred while muted and fires on unmute.</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <video id=video playsInline autoplay></video>
+    <script>
+    promise_test(async (t) => {
+        if (!window.testRunner || !window.internals)
+            return;
+
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+        const track = stream.getVideoTracks()[0];
+
+        video.srcObject = stream;
+        await video.play();
+
+        assert_false(track.muted);
+        assert_false(track.getSettings().backgroundBlur);
+
+        let configChangeCount = 0;
+        track.onconfigurationchange = () => { ++configChangeCount; };
+
+        const mutePromise = new Promise(resolve => track.onmute = resolve);
+        internals.setMediaStreamSourceInterrupted(track, true);
+        await mutePromise;
+        assert_true(track.muted);
+
+        testRunner.triggerMockCaptureConfigurationChange(true, false, false);
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        assert_equals(configChangeCount, 0, "configurationchange must not fire while muted");
+
+        const unmutePromise = new Promise(resolve => track.onunmute = resolve);
+        internals.setMediaStreamSourceInterrupted(track, false);
+        await unmutePromise;
+        assert_false(track.muted);
+
+        await new Promise(resolve => setTimeout(resolve, 200));
+        assert_equals(configChangeCount, 1, "configurationchange must fire exactly once after unmute");
+        assert_true(track.getSettings().backgroundBlur);
+    }, "configurationchange is deferred while muted and fires after unmute");
+
+    promise_test(async (t) => {
+        if (!window.testRunner || !window.internals)
+            return;
+
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+        const track = stream.getVideoTracks()[0];
+
+        video.srcObject = stream;
+        await video.play();
+
+        let configChangeCount = 0;
+        track.onconfigurationchange = () => { ++configChangeCount; };
+
+        const mutePromise = new Promise(resolve => track.onmute = resolve);
+        internals.setMediaStreamSourceInterrupted(track, true);
+        await mutePromise;
+
+        testRunner.triggerMockCaptureConfigurationChange(true, false, false);
+        testRunner.triggerMockCaptureConfigurationChange(true, false, false);
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        assert_equals(configChangeCount, 0, "configurationchange must not fire while muted");
+
+        const unmutePromise = new Promise(resolve => track.onunmute = resolve);
+        internals.setMediaStreamSourceInterrupted(track, false);
+        await unmutePromise;
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+        assert_equals(configChangeCount, 1, "multiple deferred changes coalesce into a single event on unmute");
+    }, "multiple configurationchange notifications while muted coalesce into one event on unmute");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -562,6 +562,11 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
                 manager->audioCaptureSourceStateChanged(muted ? MediaSessionManagerInterface::IsCaptureStarting::No : MediaSessionManagerInterface::IsCaptureStarting::Yes);
 
         dispatchEvent(Event::create(muted ? eventNames().muteEvent : eventNames().unmuteEvent, Event::CanBubble::No, Event::IsCancelable::No));
+
+        if (!muted && m_isConfigurationChangePending) {
+            m_isConfigurationChangePending = false;
+            dispatchEvent(Event::create(eventNames().configurationchangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        }
     };
 
     if (m_shouldFireMuteEventImmediately)
@@ -588,8 +593,13 @@ void MediaStreamTrack::trackSettingsChanged(MediaStreamTrackPrivate&)
 void MediaStreamTrack::trackConfigurationChanged(MediaStreamTrackPrivate&)
 {
     queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& track) {
-        if (!track.scriptExecutionContext() || track.scriptExecutionContext()->activeDOMObjectsAreStopped() || track.m_private->muted() || track.ended())
+        if (!track.scriptExecutionContext() || track.scriptExecutionContext()->activeDOMObjectsAreStopped() || track.ended())
             return;
+
+        if (track.m_private->muted()) {
+            track.m_isConfigurationChangePending = true;
+            return;
+        }
 
         track.dispatchEvent(Event::create(eventNames().configurationchangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -259,6 +259,7 @@ private:
     const bool m_isCaptureTrack { false };
     bool m_isInterrupted { false };
     bool m_shouldFireMuteEventImmediately { false };
+    bool m_isConfigurationChangePending { false };
     bool m_isDetached { false };
     mutable AtomString m_kind;
     mutable AtomString m_contentHint;


### PR DESCRIPTION
#### 7c9125971d94c50643fee08e076840fc700806f7
<pre>
`configurationchange` event is dropped when MediaStream track configuration changes while track is muted
<a href="https://bugs.webkit.org/show_bug.cgi?id=318222">https://bugs.webkit.org/show_bug.cgi?id=318222</a>
<a href="https://rdar.apple.com/180728609">rdar://180728609</a>

Reviewed by Youenn Fablet.

Per the MediaCapture Extensions specification, when a source-side
configuration change occurs while a MediaStreamTrack is muted, the
configurationchange event must be deferred until the track is no longer
muted (or the track ends). WebKit instead queued the task immediately
and aborted it on dispatch when the track was still muted, dropping the
event entirely. After unmute, no event ever fired for the missed change.

Record that a configurationchange was suppressed while muted, and flush
it from the unmute path after the unmute event is dispatched. Multiple
notifications while muted coalesce into a single event on unmute.

Test: fast/mediastream/mediastreamtrack-configurationchange-while-muted.html

* LayoutTests/fast/mediastream/configurationchange-defer-and-abort-expected.txt:
* LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-while-muted-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-configurationchange-while-muted.html: Added.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::trackMutedChanged):
(WebCore::MediaStreamTrack::trackConfigurationChanged):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:

Canonical link: <a href="https://commits.webkit.org/316301@main">https://commits.webkit.org/316301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/727ee593d606a9e26181c42b47f061514e2c3f26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129266 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/599ad3c7-87c7-4af0-ba85-3a74b064436d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133623 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94259 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af1f4ff7-fbd4-45ba-8240-eee4908bd5b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114095 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b669a730-942a-4f40-aa33-a24061fb1252) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35601 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33865 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29765 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183683 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142284 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142175 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38413 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45976 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110610 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37307 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117664 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44494 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8554 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43894 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44126 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43953 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->