### PR TITLE
[JSC] Make SparseArrayValueMap 33% compact by using HashSet

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -866,9 +866,9 @@ ALWAYS_INLINE EncodedJSValue getByValArrayStorageInt(JSGlobalObject* globalObjec
             } else if (map) {
                 SparseArrayValueMap::iterator it = map->find(i);
                 if (it != map->notFound()) {
-                    if (it->value.attributes()) [[unlikely]] // accessor / special: needs the full slot path.
+                    if (it->attributes()) [[unlikely]] // accessor / special: needs the full slot path.
                         return JSValue::encode(JSValue(base).get(globalObject, i));
-                    return JSValue::encode(it->value.getNonSparseMode());
+                    return JSValue::encode(it->getNonSparseMode());
                 }
             }
 

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -494,7 +494,7 @@ bool JSArray::setLengthWithArrayStorage(JSGlobalObject* globalObject, unsigned n
             keys.reserveInitialCapacity(std::min(map->size(), static_cast<size_t>(length - newLength)));
             SparseArrayValueMap::const_iterator end = map->end();
             for (SparseArrayValueMap::const_iterator it = map->begin(); it != end; ++it) {
-                unsigned index = static_cast<unsigned>(it->key);
+                unsigned index = it->index();
                 if (index < length && index >= newLength)
                     keys.append(index);
             }
@@ -509,7 +509,7 @@ bool JSArray::setLengthWithArrayStorage(JSGlobalObject* globalObject, unsigned n
                     unsigned index = keys[--i];
                     SparseArrayValueMap::iterator it = map->find(index);
                     ASSERT(it != map->notFound());
-                    if (it->value.attributes() & PropertyAttribute::DontDelete) {
+                    if (it->attributes() & PropertyAttribute::DontDelete) {
                         storage->setLength(index + 1);
                         return typeError(globalObject, scope, throwException, UnableToDeletePropertyError);
                     }

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -643,7 +643,7 @@ bool JSObject::getOwnPropertySlotByIndex(JSObject* thisObject, JSGlobalObject* g
         } else if (SparseArrayValueMap* map = storage->m_sparseMap.get()) {
             SparseArrayValueMap::iterator it = map->find(i);
             if (it != map->notFound()) {
-                it->value.get(thisObject, slot);
+                it->get(thisObject, slot);
                 return true;
             }
         }
@@ -1175,7 +1175,7 @@ ArrayStorage* JSObject::enterDictionaryIndexingModeWhenArrayStorageAlreadyExists
         // This will always be a new entry in the map, so no need to check we can write,
         // and attributes are default so no need to set them.
         if (value)
-            map->add(this, i).iterator->value.forceSet(vm, map, value, 0);
+            map->add(this, i).iterator->forceSet(vm, map, value, 0);
     }
 
     DeferGC deferGC(vm);
@@ -2473,7 +2473,7 @@ bool JSObject::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject,
         } else if (SparseArrayValueMap* map = storage->m_sparseMap.get()) {
             SparseArrayValueMap::iterator it = map->find(i);
             if (it != map->notFound()) {
-                if (it->value.attributes() & PropertyAttribute::DontDelete)
+                if (it->attributes() & PropertyAttribute::DontDelete)
                     return false;
                 map->remove(it);
             }
@@ -2802,8 +2802,8 @@ void JSObject::getOwnIndexedPropertyNames(JSGlobalObject*, PropertyNameArrayBuil
             
             if (SparseArrayValueMap* map = storage->m_sparseMap.get()) {
                 auto keys = WTF::compactMap<0, UnsafeVectorOverflow>(*map, [mode](auto& entry) ->std::optional<unsigned> {
-                    if (mode == DontEnumPropertiesMode::Include || !(entry.value.attributes() & PropertyAttribute::DontEnum))
-                        return static_cast<unsigned>(entry.key);
+                    if (mode == DontEnumPropertiesMode::Include || !(entry.attributes() & PropertyAttribute::DontEnum))
+                        return entry.index();
                     return std::nullopt;
                 });
                 
@@ -3069,14 +3069,14 @@ bool JSObject::defineOwnIndexedProperty(JSGlobalObject* globalObject, unsigned i
     
     // 1. Let current be the result of calling the [[GetOwnProperty]] internal method of O with property name P.
     SparseArrayValueMap::AddResult result = map->add(this, index);
-    SparseArrayEntry* entryInMap = &result.iterator->value;
+    SparseArrayEntry* entryInMap = &*result.iterator;
 
     // 2. Let extensible be the value of the [[Extensible]] internal property of O.
     // 3. If current is undefined and extensible is false, then Reject.
     // 4. If current is undefined and extensible is true, then
     if (result.isNewEntry) {
         if (!isStructureExtensible()) {
-            map->remove(result.iterator);
+            map->remove(static_cast<SparseArrayValueMap::const_iterator>(result.iterator));
             return typeError(globalObject, scope, throwException, NonExtensibleObjectPropertyDefineError);
         }
 
@@ -3195,9 +3195,9 @@ bool JSObject::attemptToInterceptPutByIndexOnHoleForPrototype(JSGlobalObject* gl
         ArrayStorage* storage = current->arrayStorageOrNull();
         if (storage && storage->m_sparseMap) {
             SparseArrayValueMap::iterator iter = storage->m_sparseMap->find(i);
-            if (iter != storage->m_sparseMap->notFound() && (iter->value.attributes() & (PropertyAttribute::Accessor | PropertyAttribute::ReadOnly))) {
+            if (iter != storage->m_sparseMap->notFound() && (iter->attributes() & (PropertyAttribute::Accessor | PropertyAttribute::ReadOnly))) {
                 scope.release();
-                putResult = iter->value.put(globalObject, thisValue, storage->m_sparseMap.get(), value, shouldThrow);
+                putResult = SparseArrayValueMap::entryFor(iter).put(globalObject, thisValue, storage->m_sparseMap.get(), value, shouldThrow);
                 return true;
             }
         }
@@ -3365,7 +3365,7 @@ bool JSObject::putByIndexBeyondVectorLengthWithArrayStorage(JSGlobalObject* glob
     WriteBarrier<Unknown>* vector = storage->m_vector;
     SparseArrayValueMap::const_iterator end = map->end();
     for (SparseArrayValueMap::const_iterator it = map->begin(); it != end; ++it)
-        vector[it->key].set(vm, this, it->value.getNonSparseMode());
+        vector[it->index()].set(vm, this, it->getNonSparseMode());
     deallocateSparseIndexMap();
 
     // Store the new property into the vector.
@@ -3517,7 +3517,7 @@ bool JSObject::putDirectIndexBeyondVectorLengthWithArrayStorage(JSGlobalObject* 
     WriteBarrier<Unknown>* vector = storage->m_vector;
     SparseArrayValueMap::const_iterator end = map->end();
     for (SparseArrayValueMap::const_iterator it = map->begin(); it != end; ++it)
-        vector[it->key].set(vm, this, it->value.getNonSparseMode());
+        vector[it->index()].set(vm, this, it->getNonSparseMode());
     deallocateSparseIndexMap();
 
     // Store the new property into the vector.

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -1076,10 +1076,10 @@ void JSObject::forEachOwnIndexedProperty(JSGlobalObject* globalObject, const Fun
             MarkedArgumentBuffer values;
             if constexpr (mode == JSObject::SortMode::Default) {
                 Vector<unsigned, 8> properties;
-                for (auto& [key, value] : *map) {
-                    if (!(value.attributes() & PropertyAttribute::DontEnum)) {
-                        properties.append(key);
-                        values.appendWithCrashOnOverflow(value.get());
+                for (auto& entry : *map) {
+                    if (!(entry.attributes() & PropertyAttribute::DontEnum)) {
+                        properties.append(entry.index());
+                        values.appendWithCrashOnOverflow(entry.get());
                     }
                 }
 
@@ -1090,10 +1090,10 @@ void JSObject::forEachOwnIndexedProperty(JSGlobalObject* globalObject, const Fun
             } else {
                 Vector<std::tuple<unsigned, unsigned>, 8> propertyAndValueIndexTuples;
                 unsigned valueIndex = 0;
-                for (auto& [key, value] : *map) {
-                    if (!(value.attributes() & PropertyAttribute::DontEnum)) {
-                        propertyAndValueIndexTuples.append({ key, valueIndex++ });
-                        values.appendWithCrashOnOverflow(value.get());
+                for (auto& entry : *map) {
+                    if (!(entry.attributes() & PropertyAttribute::DontEnum)) {
+                        propertyAndValueIndexTuples.append({ entry.index(), valueIndex++ });
+                        values.appendWithCrashOnOverflow(entry.get());
                     }
                 }
 

--- a/Source/JavaScriptCore/runtime/PropertySlot.h
+++ b/Source/JavaScriptCore/runtime/PropertySlot.h
@@ -65,10 +65,14 @@ enum class PropertyAttribute : unsigned {
     DOMAttribute      = 1 << 14, // property is a simple DOM attribute - only used by static hashtables
     DOMJITAttribute   = 1 << 15, // property is a DOM JIT attribute - only used by static hashtables
     DOMJITFunction    = 1 << 16, // property is a DOM JIT function - only used by static hashtables
+
+    LastAttribute = DOMJITFunction,
+
     BuiltinOrFunction = Builtin | Function, // helper only used by static hashtables
     BuiltinOrFunctionOrLazyProperty = Builtin | Function | CellProperty | ClassStructure | PropertyCallback, // helper only used by static hashtables
     BuiltinOrFunctionOrAccessorOrLazyProperty = Builtin | Function | Accessor | CellProperty | ClassStructure | PropertyCallback, // helper only used by static hashtables
     BuiltinOrFunctionOrAccessorOrLazyPropertyOrConstant = Builtin | Function | Accessor | CellProperty | ClassStructure | PropertyCallback | ConstantInteger // helper only used by static hashtables
+
 };
 
 static constexpr unsigned operator| (PropertyAttribute a, PropertyAttribute b) { return static_cast<unsigned>(a) | static_cast<unsigned>(b); }

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp
@@ -61,32 +61,36 @@ Structure* SparseArrayValueMap::createStructure(VM& vm, JSGlobalObject* globalOb
 
 SparseArrayValueMap::AddResult SparseArrayValueMap::add(JSObject* array, unsigned i)
 {
-    AddResult result;
+    AddResult addResult;
     size_t increasedCapacity = 0;
     {
         Locker locker { cellLock() };
-        result = m_map.add(i, SparseArrayEntry());
-        size_t capacity = m_map.capacity();
+        addResult = m_set.ensure<SparseArrayEntryTranslator>(i, [&] {
+            return SparseArrayEntry(i);
+        });
+        size_t capacity = m_set.capacity();
         if (capacity > m_reportedCapacity) {
             increasedCapacity = capacity - m_reportedCapacity;
             m_reportedCapacity = capacity;
         }
     }
     if (increasedCapacity)
-        Heap::heap(array)->reportExtraMemoryAllocated(array, increasedCapacity * sizeof(Map::KeyValuePairType));
-    return result;
+        Heap::heap(array)->reportExtraMemoryAllocated(array, increasedCapacity * sizeof(SparseArrayEntry));
+    return addResult;
 }
 
 void SparseArrayValueMap::remove(iterator it)
 {
     Locker locker { cellLock() };
-    m_map.remove(it);
+    m_set.remove(it);
 }
 
 void SparseArrayValueMap::remove(unsigned i)
 {
     Locker locker { cellLock() };
-    m_map.remove(i);
+    auto it = m_set.find<SparseArrayEntryTranslator>(i);
+    if (it != m_set.end())
+        m_set.remove(it);
 }
 
 bool SparseArrayValueMap::putEntry(JSGlobalObject* globalObject, JSObject* array, unsigned i, JSValue value, bool shouldThrow)
@@ -94,18 +98,18 @@ bool SparseArrayValueMap::putEntry(JSGlobalObject* globalObject, JSObject* array
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     ASSERT(value);
-    
+
     AddResult result = add(array, i);
-    SparseArrayEntry& entry = result.iterator->value;
+    SparseArrayEntry& entry = *result.iterator;
 
     // To save a separate find & add, we first always add to the sparse map.
     // In the uncommon case that this is a new property, and the array is not
     // extensible, this is not the right thing to have done - so remove again.
     if (result.isNewEntry && !array->isStructureExtensible()) {
-        remove(result.iterator);
+        remove(static_cast<const_iterator>(result.iterator));
         return typeError(globalObject, scope, shouldThrow, ReadonlyPropertyWriteError);
     }
-    
+
     RELEASE_AND_RETURN(scope, entry.put(globalObject, array, this, value, shouldThrow));
 }
 
@@ -118,13 +122,13 @@ bool SparseArrayValueMap::putDirect(JSGlobalObject* globalObject, JSObject* arra
     bool shouldThrow = (mode == PutDirectIndexShouldThrow);
 
     AddResult result = add(array, i);
-    SparseArrayEntry& entry = result.iterator->value;
+    SparseArrayEntry& entry = *result.iterator;
 
     // To save a separate find & add, we first always add to the sparse map.
     // In the uncommon case that this is a new property, and the array is not
     // extensible, this is not the right thing to have done - so remove again.
     if (mode != PutDirectIndexLikePutDirect && result.isNewEntry && !array->isStructureExtensible()) {
-        remove(result.iterator);
+        remove(static_cast<const_iterator>(result.iterator));
         return typeError(globalObject, scope, shouldThrow, NonExtensibleObjectPropertyDefineError);
     }
 
@@ -138,15 +142,34 @@ bool SparseArrayValueMap::putDirect(JSGlobalObject* globalObject, JSObject* arra
 JSValue SparseArrayValueMap::getConcurrently(unsigned i)
 {
     Locker locker { cellLock() };
-    auto iterator = m_map.find(i);
-    if (iterator == m_map.end())
+    auto iterator = m_set.find<SparseArrayEntryTranslator>(i);
+    if (iterator == m_set.end())
         return JSValue();
-    return iterator->value.getConcurrently();
+    return iterator->getConcurrently();
+}
+
+void SparseArrayEntry::forceSet(SparseArrayValueMap* map, unsigned attributes)
+{
+    // FIXME: We can expand this for non x86 environments. Currently, loading ReadOnly | DontDelete property
+    // from compiler thread is only supported in X86 architecture because of its TSO nature.
+    // https://bugs.webkit.org/show_bug.cgi?id=134641
+    if (isX86())
+        WTF::storeStoreFence();
+
+    if (attributes & PropertyAttribute::Accessor)
+        map->setHasAnyKindOfGetterSetterProperties();
+    m_attributes = attributes;
+}
+
+void SparseArrayEntry::forceSet(VM& vm, SparseArrayValueMap* map, JSValue value, unsigned attributes)
+{
+    m_value.set(vm, map, value);
+    forceSet(map, attributes);
 }
 
 void SparseArrayEntry::get(JSObject* thisObject, PropertySlot& slot) const
 {
-    JSValue value = Base::get();
+    JSValue value = m_value.get();
     ASSERT(value);
 
     if (!value.isGetterSetter()) [[likely]] {
@@ -159,7 +182,7 @@ void SparseArrayEntry::get(JSObject* thisObject, PropertySlot& slot) const
 
 void SparseArrayEntry::get(PropertyDescriptor& descriptor) const
 {
-    descriptor.setDescriptor(Base::get(), m_attributes);
+    descriptor.setDescriptor(m_value.get(), m_attributes);
 }
 
 JSValue SparseArrayEntry::getConcurrently() const
@@ -180,7 +203,7 @@ JSValue SparseArrayEntry::getConcurrently() const
     if (!(attributes & PropertyAttribute::DontDelete))
         return JSValue();
 
-    return attributesDependency.consume(this)->Base::get();
+    return attributesDependency.consume(this)->m_value.get();
 }
 
 bool SparseArrayEntry::put(JSGlobalObject* globalObject, JSValue thisValue, SparseArrayValueMap* map, JSValue value, bool shouldThrow)
@@ -192,22 +215,22 @@ bool SparseArrayEntry::put(JSGlobalObject* globalObject, JSValue thisValue, Spar
         if (m_attributes & PropertyAttribute::ReadOnly)
             return typeError(globalObject, scope, shouldThrow, ReadonlyPropertyWriteError);
 
-        set(vm, map, value);
+        m_value.set(vm, map, value);
         return true;
     }
 
-    RELEASE_AND_RETURN(scope, uncheckedDowncast<GetterSetter>(Base::get())->callSetter(globalObject, thisValue, value, shouldThrow));
+    RELEASE_AND_RETURN(scope, uncheckedDowncast<GetterSetter>(m_value.get())->callSetter(globalObject, thisValue, value, shouldThrow));
 }
 
 JSValue SparseArrayEntry::getNonSparseMode() const
 {
     ASSERT(!m_attributes);
-    return Base::get();
+    return m_value.get();
 }
 
 JSValue SparseArrayEntry::get() const
 {
-    return Base::get();
+    return m_value.get();
 }
 
 template<typename Visitor>
@@ -218,10 +241,10 @@ void SparseArrayValueMap::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(cell, visitor);
     {
         Locker locker { thisObject->cellLock() };
-        for (auto& entry : thisObject->m_map)
-            visitor.append(entry.value.asValue());
+        for (auto& entry : thisObject->m_set)
+            visitor.append(entry.asValue());
     }
-    visitor.reportExtraMemoryVisited(thisObject->m_reportedCapacity * sizeof(Map::KeyValuePairType));
+    visitor.reportExtraMemoryVisited(thisObject->m_reportedCapacity * sizeof(SparseArrayEntry));
 }
 
 DEFINE_VISIT_CHILDREN(SparseArrayValueMap);

--- a/Source/JavaScriptCore/runtime/SparseArrayValueMap.h
+++ b/Source/JavaScriptCore/runtime/SparseArrayValueMap.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -31,20 +31,94 @@
 #include <JavaScriptCore/PutDirectIndexMode.h>
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/WriteBarrier.h>
-#include <wtf/HashMap.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashSet.h>
+#include <wtf/HashTraits.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC {
 
-class SparseArrayEntry;
+class SparseArrayValueMap;
+
+class SparseArrayEntry {
+    WTF_MAKE_TZONE_ALLOCATED(SparseArrayEntry);
+public:
+    static constexpr unsigned isEmptyBucketFlag = 1u << 31;
+    static constexpr unsigned isDeletedBucketFlag = 1u << 30;
+    static_assert(PropertyAttribute::LastAttribute < isDeletedBucketFlag);
+
+    enum EmptyBucketTag { EmptyBucket };
+    enum DeletedBucketTag { DeletedBucket };
+
+    SparseArrayEntry() = default;
+
+    explicit SparseArrayEntry(unsigned index)
+        : m_index(index)
+    {
+    }
+
+    explicit SparseArrayEntry(EmptyBucketTag)
+        : m_attributes(isEmptyBucketFlag)
+    {
+    }
+
+    explicit SparseArrayEntry(DeletedBucketTag)
+        : m_attributes(isDeletedBucketFlag)
+    {
+    }
+
+    void NODELETE get(JSObject*, PropertySlot&) const;
+    void get(PropertyDescriptor&) const;
+    bool put(JSGlobalObject*, JSValue thisValue, SparseArrayValueMap*, JSValue, bool shouldThrow);
+    JSValue NODELETE getNonSparseMode() const;
+    JSValue getConcurrently() const;
+    JSValue get() const;
+
+    unsigned index() const { return m_index; }
+    unsigned attributes() const { return m_attributes; }
+
+    bool isEmptyBucket() const { return m_attributes & isEmptyBucketFlag; }
+    bool isDeletedBucket() const { return m_attributes & isDeletedBucketFlag; }
+
+    void forceSet(SparseArrayValueMap*, unsigned attributes);
+    void forceSet(VM&, SparseArrayValueMap*, JSValue, unsigned attributes);
+
+    WriteBarrier<Unknown>& asValue() { return m_value; }
+    const WriteBarrier<Unknown>& asValue() const { return m_value; }
+
+private:
+    unsigned m_attributes { 0 };
+    unsigned m_index { 0 };
+    WriteBarrier<Unknown> m_value { UndefinedWriteBarrierTag };
+};
+
+struct SparseArrayEntryHash {
+    static unsigned hash(const SparseArrayEntry& entry) { return WTF::IntHash<uint32_t>::hash(entry.index()); }
+    static bool equal(const SparseArrayEntry& a, const SparseArrayEntry& b) { return a.index() == b.index(); }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+struct SparseArrayEntryHashTraits : WTF::GenericHashTraits<SparseArrayEntry> {
+    static constexpr bool emptyValueIsZero = false;
+    static constexpr bool hasIsEmptyValueFunction = true;
+    static SparseArrayEntry emptyValue() { return SparseArrayEntry(SparseArrayEntry::EmptyBucket); }
+    static bool isEmptyValue(const SparseArrayEntry& entry) { return entry.isEmptyBucket(); }
+    static void constructDeletedValue(SparseArrayEntry& slot) { new (NotNull, std::addressof(slot)) SparseArrayEntry(SparseArrayEntry::DeletedBucket); }
+    static bool isDeletedValue(const SparseArrayEntry& entry) { return entry.isDeletedBucket(); }
+};
+
+struct SparseArrayEntryTranslator {
+    static unsigned hash(uint32_t key) { return WTF::IntHash<uint32_t>::hash(key); }
+    static bool equal(const SparseArrayEntry& entry, uint32_t key) { return entry.index() == key; }
+};
 
 class SparseArrayValueMap final : public JSCell {
 public:
-    typedef JSCell Base;
+    using Base = JSCell;
     static constexpr unsigned StructureFlags = Base::StructureFlags | StructureIsImmortal;
-    
+
 private:
-    typedef UncheckedKeyHashMap<uint64_t, SparseArrayEntry, WTF::IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> Map;
+    using Set = UncheckedKeyHashSet<SparseArrayEntry, SparseArrayEntryHash, SparseArrayEntryHashTraits>;
 
     enum Flags {
         Normal                             = 0,
@@ -54,18 +128,18 @@ private:
     };
 
     SparseArrayValueMap(VM&);
-    
+
     DECLARE_DEFAULT_FINISH_CREATION;
 
 public:
     DECLARE_EXPORT_INFO;
-    
-    typedef Map::iterator iterator;
-    typedef Map::const_iterator const_iterator;
-    typedef Map::AddResult AddResult;
+
+    using iterator = Set::iterator;
+    using const_iterator = Set::const_iterator;
+    using AddResult = Set::AddResult;
 
     static SparseArrayValueMap* create(VM&);
-    
+
     static constexpr DestructionMode needsDestruction = NeedsDestruction;
     static void destroy(JSCell*);
 
@@ -74,7 +148,7 @@ public:
     {
         return &vm.sparseArrayValueMapSpace();
     }
-    
+
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
 
     DECLARE_VISIT_CHILDREN;
@@ -109,74 +183,32 @@ public:
         m_flags = static_cast<Flags>(m_flags | HasAnyKindOfGetterSetterProperties);
     }
 
+    static SparseArrayEntry& entryFor(const_iterator it) { return const_cast<SparseArrayEntry&>(*it); }
+
     // These methods may mutate the contents of the map
     bool putEntry(JSGlobalObject*, JSObject*, unsigned, JSValue, bool shouldThrow);
     bool putDirect(JSGlobalObject*, JSObject*, unsigned, JSValue, unsigned attributes, PutDirectIndexMode);
     AddResult add(JSObject*, unsigned);
-    iterator find(unsigned i) { return m_map.find(i); }
+    iterator find(unsigned i) { return m_set.find<SparseArrayEntryTranslator>(i); }
     // This should ASSERT the remove is valid (check the result of the find).
-    void remove(iterator it);
+    void remove(iterator);
     void remove(unsigned i);
 
     JSValue getConcurrently(unsigned index);
 
     // These methods do not mutate the contents of the map.
-    iterator notFound() { return m_map.end(); }
-    bool isEmpty() const { return m_map.isEmpty(); }
-    bool contains(unsigned i) const { return m_map.contains(i); }
-    size_t size() const { return m_map.size(); }
+    iterator notFound() { return m_set.end(); }
+    bool isEmpty() const { return m_set.isEmpty(); }
+    bool contains(unsigned i) const { return m_set.contains<SparseArrayEntryTranslator>(i); }
+    size_t size() const { return m_set.size(); }
     // Only allow const begin/end iteration.
-    const_iterator begin() const { return m_map.begin(); }
-    const_iterator end() const { return m_map.end(); }
+    const_iterator begin() const { return m_set.begin(); }
+    const_iterator end() const { return m_set.end(); }
 
 private:
-    Map m_map;
+    Set m_set;
     Flags m_flags { Normal };
     size_t m_reportedCapacity { 0 };
-};
-
-class SparseArrayEntry : private WriteBarrier<Unknown> {
-    WTF_MAKE_TZONE_ALLOCATED(SparseArrayEntry);
-public:
-    using Base = WriteBarrier<Unknown>;
-
-    SparseArrayEntry()
-    {
-        Base::setWithoutWriteBarrier(jsUndefined());
-    }
-
-    void NODELETE get(JSObject*, PropertySlot&) const;
-    void get(PropertyDescriptor&) const;
-    bool put(JSGlobalObject*, JSValue thisValue, SparseArrayValueMap*, JSValue, bool shouldThrow);
-    JSValue NODELETE getNonSparseMode() const;
-    JSValue getConcurrently() const;
-    JSValue get() const;
-
-    unsigned attributes() const { return m_attributes; }
-
-    void forceSet(SparseArrayValueMap* map, unsigned attributes)
-    {
-        // FIXME: We can expand this for non x86 environments. Currently, loading ReadOnly | DontDelete property
-        // from compiler thread is only supported in X86 architecture because of its TSO nature.
-        // https://bugs.webkit.org/show_bug.cgi?id=134641
-        if (isX86())
-            WTF::storeStoreFence();
-
-        if (attributes & PropertyAttribute::Accessor)
-            map->setHasAnyKindOfGetterSetterProperties();
-        m_attributes = attributes;
-    }
-
-    void forceSet(VM& vm, SparseArrayValueMap* map, JSValue value, unsigned attributes)
-    {
-        Base::set(vm, map, value);
-        forceSet(map, attributes);
-    }
-
-    WriteBarrier<Unknown>& asValue() { return *this; }
-
-private:
-    unsigned m_attributes { 0 };
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### b80bcf43bdceb9913c30b5aa85a18b41e3547396
<pre>
[JSC] Make SparseArrayValueMap 33% compact by using HashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=318223">https://bugs.webkit.org/show_bug.cgi?id=318223</a>
<a href="https://rdar.apple.com/181023846">rdar://181023846</a>

Reviewed by Dan Hecht and Tadeu Zagallo.

We were using `UncheckedKeyHashMap&lt;uint64_t, SparseArrayEntry, ...&gt;` for
SparseArrayValueMap since its key range is [0, UINT32_MAX]. So we cannot
have a space for &quot;empty&quot; and &quot;deleted&quot;, thus we were using uint64_t as a
key. However, this makes each KeyValuePair sizeof(uint64_t) * 3.
If we look into the value side, it is having `unsigned attributes`, but
it is not using all bits. We can convert this Map to
`UncheckedKeyHashSet&lt;SparseArrayEntry, ...&gt;` and we can store &quot;empty&quot; and
&quot;deleted&quot; as bit flags in attributes side. So we can make KeyValuePair
sizeof(uint64_t) * 2, so 33% reduction in size (and since it becomes
16bytes, it is good for index computation &amp; cache efficacy).

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::getByValArrayStorageInt):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::setLengthWithArrayStorage):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::getOwnPropertySlotByIndex):
(JSC::JSObject::enterDictionaryIndexingModeWhenArrayStorageAlreadyExists):
(JSC::JSObject::deletePropertyByIndex):
(JSC::JSObject::getOwnIndexedPropertyNames):
(JSC::JSObject::defineOwnIndexedProperty):
(JSC::JSObject::attemptToInterceptPutByIndexOnHoleForPrototype):
(JSC::JSObject::putByIndexBeyondVectorLengthWithArrayStorage):
(JSC::JSObject::putDirectIndexBeyondVectorLengthWithArrayStorage):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::forEachOwnIndexedProperty):
* Source/JavaScriptCore/runtime/PropertySlot.h:
* Source/JavaScriptCore/runtime/SparseArrayValueMap.cpp:
(JSC::SparseArrayValueMap::add):
(JSC::SparseArrayValueMap::remove):
(JSC::SparseArrayValueMap::putEntry):
(JSC::SparseArrayValueMap::putDirect):
(JSC::SparseArrayValueMap::getConcurrently):
(JSC::SparseArrayEntry::forceSet):
(JSC::SparseArrayEntry::get const):
(JSC::SparseArrayEntry::getConcurrently const):
(JSC::SparseArrayEntry::put):
(JSC::SparseArrayEntry::getNonSparseMode const):
(JSC::SparseArrayValueMap::visitChildrenImpl):
* Source/JavaScriptCore/runtime/SparseArrayValueMap.h:
(JSC::SparseArrayEntry::SparseArrayEntry):
(JSC::SparseArrayEntry::index const):
(JSC::SparseArrayEntry::attributes const):
(JSC::SparseArrayEntry::isEmptyBucket const):
(JSC::SparseArrayEntry::isDeletedBucket const):
(JSC::SparseArrayEntry::asValue):
(JSC::SparseArrayEntry::asValue const):
(JSC::SparseArrayEntryHash::hash):
(JSC::SparseArrayEntryHash::equal):
(JSC::SparseArrayEntryHashTraits::emptyValue):
(JSC::SparseArrayEntryHashTraits::isEmptyValue):
(JSC::SparseArrayEntryHashTraits::constructDeletedValue):
(JSC::SparseArrayEntryHashTraits::isDeletedValue):
(JSC::SparseArrayEntryTranslator::hash):
(JSC::SparseArrayEntryTranslator::equal):
(JSC::SparseArrayEntry::forceSet): Deleted.

Canonical link: <a href="https://commits.webkit.org/316199@main">https://commits.webkit.org/316199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/528e5bac3074afdc3ad502bd8a797c3c7bf34cbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180841 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b76e13e9-7b77-4977-93e2-9ce2b4870107) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45078 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e29b4fa6-f74c-4c80-8285-400cd253e094) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174479 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72e2041c-d614-4e64-80c3-a2aa97b26055) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29585 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2581 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183495 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32780 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45106 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142026 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45798 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110437 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26072 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37257 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204199 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44303 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54580 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43709 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43780 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->