### PR TITLE
Fix some failures in imported/w3c/web-platform-tests/svg/styling

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media-dynamic-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Changing the media attribute updates the associated stylesheet assert_equals: fill should switch once the second sheet's media matches expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL Removing the media attribute updates the associated stylesheet assert_equals: removing the media attribute should make the rule apply expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
+PASS Changing the media attribute updates the associated stylesheet
+PASS Removing the media attribute updates the associated stylesheet
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type-dynamic-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Initial state: invalid type leaves the sheet unprocessed
-FAIL Changing the type from invalid to valid creates the stylesheet assert_equals: sheet should be created once the type becomes CSS expected 1 but got 0
+PASS Changing the type from invalid to valid creates the stylesheet
 PASS Changing the type from valid to invalid removes the stylesheet
-FAIL Removing the type attribute restores the default CSS handling assert_equals: sheet should be created once the type attribute is removed expected 1 but got 0
+PASS Removing the type attribute restores the default CSS handling
 

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -26,6 +26,7 @@
 #include "CSSStyleSheet.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
+#include "MediaQueryParser.h"
 #include "NodeName.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
@@ -79,9 +80,18 @@ void SVGStyleElement::attributeChanged(const QualifiedName& name, const AtomStri
         break;
     case AttributeNames::typeAttr:
         m_styleSheetOwner.setContentType(newValue);
+        m_styleSheetOwner.childrenChanged(*this);
+        if (CheckedPtr scope = m_styleSheetOwner.styleScope())
+            scope->didChangeStyleSheetContents();
         break;
     case AttributeNames::mediaAttr:
         m_styleSheetOwner.setMedia(newValue);
+        if (RefPtr sheet = this->sheet()) {
+            sheet->setMediaQueries(MQ::MediaQueryParser::parse(newValue, protect(document())->cssParserContext()));
+            if (CheckedPtr scope = m_styleSheetOwner.styleScope())
+                scope->didChangeStyleSheetContents();
+        } else
+            m_styleSheetOwner.childrenChanged(*this);
         break;
     default:
         break;


### PR DESCRIPTION
#### ae0d90b965a8ae1d40a6c2ad9d1bfdad66dffed8
<pre>
Fix some failures in imported/w3c/web-platform-tests/svg/styling
<a href="https://bugs.webkit.org/show_bug.cgi?id=318224">https://bugs.webkit.org/show_bug.cgi?id=318224</a>

Reviewed by Nikolas Zimmermann.

Fix some failures in imported/w3c/web-platform-tests/svg/styling by copying the
HTMLStyleElement code that handles dynamic changes of type and media attributes.

* LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-media-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/attr-style-type-dynamic-expected.txt:
* Source/WebCore/svg/SVGStyleElement.cpp:
(WebCore::SVGStyleElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/316174@main">https://commits.webkit.org/316174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf2d115a1aa719b92e24842fa0865d374b68ce36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38751 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44968 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174365 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/153983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29467 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33487 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183375 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44988 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141934 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38294 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Nikolas Zimmermann; Compiled WebKit (warnings); layout-tests (exception)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45678 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110380 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37177 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44188 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->