### PR TITLE
[CoreIPC][GPUProcess] UserMediaCaptureManagerProxy::startProducingData races prepareAudioDescription() against audioSamplesAvailable() lead to various UAF/write-after-unmap

### DIFF
--- a/LayoutTests/ipc/usermedia-capture-start-producing-data-race-expected.txt
+++ b/LayoutTests/ipc/usermedia-capture-start-producing-data-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/usermedia-capture-start-producing-data-race.html
+++ b/LayoutTests/ipc/usermedia-capture-start-producing-data-race.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.setUserMediaPermission(true);
+}
+
+function done() {
+    document.body.textContent = "This test passes if it does not crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function failTest(error) {
+    document.body.textContent = `Fail: ${error.message}`;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+async function runTest()
+{
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    let stream;
+    try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+        throw error;
+    }
+
+    // Hardcoded ID chosen to be much larger than the WebProcess's
+    // RealtimeMediaSourceIdentifier monotonic counter could ever reach in a
+    // single layout-test session, avoiding collision with the id allocated
+    // for the getUserMedia() source above.
+    //
+    // WARNING: RealtimeMediaSourceIdentifier is a process-global monotonic
+    // counter (ObjectIdentifier::generate()) that is never reset across
+    // tests sharing a WebProcess (e.g. mac-wk2). A small hardcoded value
+    // like 100 will eventually collide with the id auto-allocated for the
+    // getUserMedia() source above once enough prior tests have advanced the
+    // counter, tripping ASSERT(!m_proxies.contains(id)) in
+    // UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints
+    // and crashing the GPU process on debug bots. Any future IPC test that
+    // hardcodes a RealtimeMediaSourceIdentifier must pick a value well above
+    // any plausible counter (and below the UINT64_MAX hash-traits sentinel).
+    const sourceId = 0xFFFFFFFFn;
+
+    const emptyConstraintMap = {
+        m_width: {}, m_height: {}, m_sampleRate: {}, m_sampleSize: {},
+        m_aspectRatio: {}, m_frameRate: {}, m_volume: {},
+        m_echoCancellation: {}, m_displaySurface: {}, m_logicalSurface: {},
+        m_facingMode: {}, m_deviceId: {}, m_groupId: {}, m_whiteBalanceMode: {},
+        m_zoom: {}, m_torch: {}, m_backgroundBlur: {}, m_powerEfficient: {}
+    };
+
+    let timer;
+    await new Promise((resolve, reject) => {
+        CoreIPC.GPU.UserMediaCaptureManagerProxy.CreateMediaSourceForCaptureDeviceWithConstraints(0, {
+            id: sourceId,
+            device: {
+                persistentId: '239c24b0-2b15-11e3-8224-0800200c9a66',
+                type: 2,
+                label: 'Mock audio device 1',
+                groupId: 'microphonegroup',
+                enabled: true,
+                isDefault: true,
+                isMockDevice: true,
+                isEphemeral: false
+            },
+            hashSalts: { persistentDeviceSalt: 'a', ephemeralDeviceSalt: 'b' },
+            constraints: { mandatoryConstraints: emptyConstraintMap, advancedConstraints: [], isValid: true },
+            shouldUseGPUProcessRemoteFrames: false,
+            pageIdentifier: IPC.pageID
+        }, () => { 
+            resolve();
+        });
+
+        timer = setTimeout(() => reject(`Timed out waiting for CreateMediaSourceForCaptureDeviceWithConstraints`), 5000);
+    });
+    clearTimeout(timer);
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.StartProducingData(0, { id: sourceId, pageIdentifier: IPC.pageID });
+
+    let count = 0;
+    const interval = setInterval(() => {
+        for (let i = 0; i < 10; i++)
+            CoreIPC.GPU.UserMediaCaptureManagerProxy.StartProducingData(0, { id: sourceId, pageIdentifier: IPC.pageID });
+        if (++count > 20) {
+            clearInterval(interval);
+            stream.getTracks().forEach(t => t.stop());
+
+            // Tear down the GPU-side proxy we created via raw IPC so layout-test
+            // runs that share this WebProcess don't collide on the hardcoded sourceId.
+            CoreIPC.GPU.UserMediaCaptureManagerProxy.RemoveSource(0, { id: sourceId });
+            done();
+        }
+    }, 10);
+}
+
+window.addEventListener('load', async event => {
+    runTest().catch((error) => {
+        failTest(error);
+    });
+});
+
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3606,6 +3606,7 @@ ipc/pasteboard-write-custom-data.html [ Skip ]
 ipc/remotedisplaylistrecorder-drawcontrolpart-slidertrackpart-crash.html [ Skip ]
 ipc/media-containment-bypass-create-player.html [ Skip ]
 http/tests/ipc/gpu-load-error-empty-user-info-crssh.html [ Skip ]
+ipc/usermedia-capture-start-producing-data-race.html [ Skip ]
 
 # These tests are specific to Cocoa's definition of WebCore::PlatformColorSpace which is different from Skia's.
 ipc/decode-feConvolveMatrix-kernelSize-overflow.html [ Skip ]

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -140,6 +140,11 @@ public:
 
     void start()
     {
+        // A compromised WebContent process may send StartProducingData repeatedly. Once we are
+        // observing, prepareAudioDescription() would race the capture thread's audioSamplesAvailable().
+        if (m_isObservingMedia)
+            return;
+
         m_shouldReset = true;
         m_isStopped = false;
         m_source->start();


### PR DESCRIPTION
#### 866892a3052f6739cffd35175d93b0d238091b29
<pre>
[CoreIPC][GPUProcess] UserMediaCaptureManagerProxy::startProducingData races prepareAudioDescription() against audioSamplesAvailable() lead to various UAF/write-after-unmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=314115">https://bugs.webkit.org/show_bug.cgi?id=314115</a>
<a href="https://rdar.apple.com/174411400">rdar://174411400</a>

Reviewed by Youenn Fablet and Jer Noble.

A compromised WebContent process can send StartProducingData repeatedly
for the same source. After the first call, the source proxy is registered
as an AudioSampleObserver and the capture unit is invoking
audioSamplesAvailable() on a background WorkQueue. On subsequent calls,
prepareAudioDescription() runs on the GPU main thread and reassigns
m_captureSemaphore, m_ringBuffer, m_audioHandle and m_description without
removing the observer or taking any lock, while the capture thread is
concurrently dereferencing them. This leads to heap-use-after-free on the
freed ProducerSharedCARingBuffer / IPC::Semaphore and write-after-unmap
into the old SharedMemory ring buffer.

Make UserMediaCaptureManagerProxySourceProxy::start() a no-op when the
proxy is already observing media. Legitimate stop()/start() sequences are
unaffected since stop() removes the observer.

Test: ipc/usermedia-capture-start-producing-data-race.html

* LayoutTests/ipc/usermedia-capture-start-producing-data-race-expected.txt: Added.
* LayoutTests/ipc/usermedia-capture-start-producing-data-race.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:

Originally-landed-as: 305413.863@safari-7624-branch (651097467a79). <a href="https://rdar.apple.com/180438398">rdar://180438398</a>
Canonical link: <a href="https://commits.webkit.org/316261@main">https://commits.webkit.org/316261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc90ec8f27ee112a0a145610efed7fc8ffbeeeb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37a0ad16-3cec-4632-a2ed-23ede8cadb44) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133564 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/582ac146-7098-40c7-aa22-822ab4b85869) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114039 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9007ef6e-2369-49d1-973e-c85f1abd3c14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29469 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183377 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142081 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38375 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45680 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30339 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110381 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37179 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117434 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44190 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8435 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->