### PR TITLE
[threaded-animations] animation associated with external document timeline crashes under `DocumentTimeline::createAcceleratedRepresentation()`

### DIFF
--- a/LayoutTests/webanimations/animation-associated-with-external-document-timeline-expected.txt
+++ b/LayoutTests/webanimations/animation-associated-with-external-document-timeline-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash

--- a/LayoutTests/webanimations/animation-associated-with-external-document-timeline.html
+++ b/LayoutTests/webanimations/animation-associated-with-external-document-timeline.html
@@ -1,0 +1,21 @@
+<div id="target">PASS if this does not crash</div>
+
+<script>
+
+window.testRunner?.dumpAsText();
+
+// This test needs to make sure there is an existing document timeline
+// for the main document.
+document.timeline;
+
+// We then create an external document and use its timeline to create
+// an animation that will support acceleration.
+const externalDocument = document.implementation.createHTMLDocument("");
+const keyframeEffect = new KeyframeEffect(target, { "transform": "scale(2)" }, 1000);
+const animation = new Animation(keyframeEffect, externalDocument.timeline);
+
+// Set its current time such that the animation is picked up by the
+// accelerated animation scheduler.
+animation.currentTime = 0;
+
+</script>

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -535,6 +535,11 @@ Seconds DocumentTimeline::convertTimelineTimeToOriginRelativeTime(Seconds timeli
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
+bool DocumentTimeline::canBeAccelerated() const
+{
+    return m_document && m_document->window();
+}
+
 Ref<AcceleratedTimeline> DocumentTimeline::createAcceleratedRepresentation() const
 {
     // The origin time of a document timeline is relative to the time origin

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -98,7 +98,7 @@ private:
 
     AnimationTimelinesController* controller() const override;
 #if ENABLE(THREADED_ANIMATIONS)
-    bool canBeAccelerated() const final { return true; }
+    bool canBeAccelerated() const final;
     Ref<AcceleratedTimeline> createAcceleratedRepresentation() const final;
 #endif
 


### PR DESCRIPTION
#### b9dbeb655123e9dc8a5202e71f797c60f37b50be
<pre>
[threaded-animations] animation associated with external document timeline crashes under `DocumentTimeline::createAcceleratedRepresentation()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318226">https://bugs.webkit.org/show_bug.cgi?id=318226</a>
<a href="https://rdar.apple.com/180912517">rdar://180912517</a>

Reviewed by Simon Fraser.

If an animation that targets a property that can be accelerated is associated with a document timeline,
we always allow acceleration by virtue of `DocumentTimeline::canBeAccelerated()` returning `true`. However,
that `DocumentTimeline` may be associated with a document that is not associated with a `LocalDOMWindow`,
which is required to perform time computations in `DocumentTimeline::createAcceleratedRepresentation()`.

So we now check that we have a valid `window()` in `DocumentTimeline::canBeAccelerated()`.

This fix was automatically suggested by an LLM during bug analysis, I validated its approach.

Test: webanimations/animation-associated-with-external-document-timeline.html

* LayoutTests/webanimations/animation-associated-with-external-document-timeline-expected.txt: Added.
* LayoutTests/webanimations/animation-associated-with-external-document-timeline.html: Added.
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::canBeAccelerated const):
* Source/WebCore/animation/DocumentTimeline.h:

Canonical link: <a href="https://commits.webkit.org/316250@main">https://commits.webkit.org/316250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52e6b13341281eff8594f5e861c0e3f1bb4ed14c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45801 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181187 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45441 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174842 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29937 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183855 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45468 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46148 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110787 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26086 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/37416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44666 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44066 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44298 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44125 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->