### PR TITLE
AX: After ACCESSIBILITY_LOCAL_FRAME, VoiceOver can read stale element geometry after a frame scrolls its own content

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/local-frame-content-scroll-geometry-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/local-frame-content-scroll-geometry-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that an element inside a local iframe never exposes stale geometry, even after a scroll of the iframe's contents.
+
+PASS: iframe.contentWindow.scrollX === 500
+PASS: scrolledX < initialX === true
+PASS: delta > 400 && delta < 600 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/local-frame-content-scroll-geometry.html
+++ b/LayoutTests/accessibility/ios-simulator/local-frame-content-scroll-geometry.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+#iframe { position: absolute; left: 50px; top: 50px; width: 300px; height: 300px; border: 0; }
+</style>
+</head>
+<body>
+
+<iframe id="iframe" role="presentation" src="../resources/scrollable-iframe-content.html"></iframe>
+
+<script>
+var output = "This test verifies that an element inside a local iframe never exposes stale geometry, even after a scroll of the iframe's contents.\n\n";
+var initialX, scrolledX, delta;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var frameTarget;
+    setTimeout(async function() {
+        var iframe = document.getElementById("iframe");
+
+        await waitForElementById("frame-target");
+        await waitForFrameGeometryReady();
+        frameTarget = accessibilityController.accessibleElementById("frame-target");
+        initialX = frameTarget.x;
+
+        // Scroll the iframe's own content horizontally (the frame scrolls its own document, like a column
+        // page-turn, as in the case of Books). scrollTo updates the frame's scroll offset synchronously.
+        // We then read the accessibility frame in the same run-loop, which should still yield the correct result.
+        iframe.contentWindow.scrollTo(500, 0);
+        scrolledX = frameTarget.x;
+
+        output += expect("iframe.contentWindow.scrollX", "500");
+        output += expect("scrolledX < initialX", "true");
+        delta = initialX - scrolledX;
+        output += expect("delta > 400 && delta < 600", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/ios-simulator/local-frame-root-scroll-geometry-expected.txt
+++ b/LayoutTests/accessibility/ios-simulator/local-frame-root-scroll-geometry-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that the root scroll view of a local iframe moves with the iframe's own content scroll (the behavior Books relies on), rather than staying pinned at the viewport.
+
+PASS: iframe.contentWindow.scrollX === 500
+PASS: scrolledX < initialX === true
+PASS: delta > 400 && delta < 600 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ios-simulator/local-frame-root-scroll-geometry.html
+++ b/LayoutTests/accessibility/ios-simulator/local-frame-root-scroll-geometry.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+#iframe { position: absolute; left: 50px; top: 50px; width: 300px; height: 300px; border: 0; }
+</style>
+</head>
+<body>
+
+<iframe id="iframe" src="../resources/scrollable-iframe-content.html"></iframe>
+
+<script>
+var output = "This test verifies that the root scroll view of a local iframe moves with the iframe's own content scroll (the behavior Books relies on), rather than staying pinned at the viewport.\n\n";
+// Emphasis on "the behavior Books relies on". If you want to change the behavior being tested here, make sure to test
+// Books (which renders its content with WebKit) still works with VoiceOver and other ATs.
+var initialX, scrolledX, delta;
+var scrollView;
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        var iframe = document.getElementById("iframe");
+
+        await waitForFrameGeometryReady();
+        await waitFor(() => {
+            // Wait until the iframe's own document is loaded scrollable, so scrollTo() below
+            // actually moves it (otherwise it clamps to 0).
+            var doc = iframe.contentDocument;
+            return doc && doc.readyState === "complete" && doc.documentElement.scrollWidth > iframe.clientWidth;
+        });
+
+        await waitFor(() => {
+            var container = accessibilityController.accessibleElementById("iframe");
+            scrollView = container ? container.childAtIndex(0) : null;
+            return scrollView && scrollView.isFrameGeometryInitialized;
+        });
+
+        initialX = scrollView.x;
+        // Scroll the iframe's own content horizontally (the frame scrolls its own document, like a column
+        // page-turn, as in the case of Books). scrollTo updates the frame's scroll offset synchronously. We
+        // read the scroll view's accessibility x in the same run-loop turn, which should track the scroll.
+        iframe.contentWindow.scrollTo(500, 0);
+        scrolledX = scrollView.x;
+
+        output += expect("iframe.contentWindow.scrollX", "500");
+        output += expect("scrolledX < initialX", "true");
+        delta = initialX - scrolledX;
+        output += expect("delta > 400 && delta < 600", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+
+

--- a/LayoutTests/accessibility/resources/scrollable-iframe-content.html
+++ b/LayoutTests/accessibility/resources/scrollable-iframe-content.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+html, body { margin: 0; }
+/* Content wider than the hosting iframe so the iframe's own document scrolls horizontally,
+   mimicking an ePub CSS-column "page-turn" (the frame scrolls its own content). */
+body { width: 3000px; height: 600px; }
+#frame-target { position: absolute; left: 600px; top: 100px; width: 100px; height: 50px; }
+</style>
+</head>
+<body>
+<button id="frame-target">Target</button>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1274,16 +1274,16 @@ void AXObjectCache::setFrameInheritedState(LocalFrame& frame, const InheritedFra
 
 void AXObjectCache::setFrameGeometry(LocalFrame& frame, const AXFrameGeometry& geometry)
 {
-    UNUSED_PARAM(frame);
     m_frameGeometry = geometry;
 
+    // Reset to zero to avoid leaving a stale value in the case of a null frame.view().
+    m_frameViewOriginScrollPosition = { };
+    if (CheckedPtr view = frame.view())
+        m_frameViewOriginScrollPosition = IntPoint(view->documentScrollPositionRelativeToViewOrigin());
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID)) {
-        IntPoint viewOriginScrollPosition;
-        if (CheckedPtr view = frame.view())
-            viewOriginScrollPosition = IntPoint(view->documentScrollPositionRelativeToViewOrigin());
-        tree->setFrameGeometry(AXFrameGeometry { geometry }, viewOriginScrollPosition);
-    }
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+        tree->setFrameGeometry(AXFrameGeometry { geometry }, m_frameViewOriginScrollPosition);
 #endif
 }
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -305,6 +305,8 @@ public:
     WEBCORE_EXPORT void setFrameInheritedState(LocalFrame&, const InheritedFrameState&);
     WEBCORE_EXPORT void setFrameGeometry(LocalFrame&, const AXFrameGeometry&);
     const std::optional<AXFrameGeometry>& frameGeometry() const LIFETIME_BOUND { return m_frameGeometry; }
+    // The scroll value that was implicitly baked into the latest frameGeometry().screenPosition.
+    IntPoint frameViewOriginScrollPosition() const { return m_frameViewOriginScrollPosition; }
     const std::optional<AXFrameGeometry>& getAndUpdateFrameGeometry() LIFETIME_BOUND;
 #endif
 
@@ -984,6 +986,7 @@ private:
     const FrameIdentifier m_frameID; // constant for object's lifetime.
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     std::optional<AXFrameGeometry> m_frameGeometry;
+    IntPoint m_frameViewOriginScrollPosition;
 #endif
     OptionSet<ActivityState> m_pageActivityState;
     HashMap<AXID, Ref<AccessibilityObject>> m_objects;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -594,17 +594,37 @@ FloatRect AccessibilityObject::convertFrameToSpace(const FloatRect& frameRect, A
         auto scaledRect = geometry.screenTransform.mapRect(FloatRect(snappedFrameRect));
 
         auto screenPosition = geometry.screenPosition;
-        // screenPosition tracks the document origin, which moves with scroll.
-        // The viewport is fixed on screen, so subtract the scroll and content
-        // inset offsets that contentsToView baked into screenPosition.
-        if (this == rootScrollView.get()) {
-            if (RefPtr scrollView = rootScrollView->scrollView()) {
-                auto viewOriginScrollPosition = geometry.screenTransform.mapPoint(FloatPoint(scrollView->documentScrollPositionRelativeToViewOrigin()));
-                screenPosition.move(-roundToInt(viewOriginScrollPosition.x()), -roundToInt(viewOriginScrollPosition.y()));
-            }
-        }
+
+        IntPoint currentScrollOffset;
+        if (RefPtr scrollView = rootScrollView->scrollView())
+            currentScrollOffset = scrollView->documentScrollPositionRelativeToViewOrigin();
+        auto currentScroll = geometry.screenTransform.mapPoint(FloatPoint(currentScrollOffset));
+
+        // This was the scroll at the time |geometry.screenPosition| was taken. The scroll
+        // may have changed since then, and we may not have gotten the corresponding AXFrameGeometry
+        // update yet. We can avoid serving stale geometry in this scenario by taking |cachedScroll|
+        // and undo'ing it from the screen position, and then applying the current-scroll offset (which we
+        // can do in this context, being on the main-thread). This prevents ATs from temporarily reading
+        // a stale value.
+        auto cachedScroll = geometry.screenTransform.mapPoint(FloatPoint(rootScrollView->frameViewOriginScrollPosition()));
 
         // macOS uses bottom-left origin, non-macOS assumes top-left origin.
+        // FIXME: It would be cleaner to store screenPosition as one canonical value
+        // and apply the Mac transformations only as a final step.
+#if PLATFORM(MAC)
+        // accessibility/mac/webkit-scrollarea-position.html demands that we don't
+        // apply the current scroll for the root.
+        const bool applyCurrentScroll = this != rootScrollView.get();
+        constexpr int yScale = -1;
+#else
+        const bool applyCurrentScroll = true;
+        constexpr int yScale = 1;
+#endif
+        FloatPoint scrollDelta = cachedScroll;
+        if (applyCurrentScroll)
+            scrollDelta.move(-currentScroll.x(), -currentScroll.y());
+        screenPosition.move(roundToInt(scrollDelta.x()), yScale * roundToInt(scrollDelta.y()));
+
         FloatPoint position = {
             screenPosition.x() + scaledRect.x(),
 #if PLATFORM(MAC)

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -626,6 +626,12 @@ AXFrameGeometry AccessibilityScrollView::frameGeometry() const
     return { };
 }
 
+IntPoint AccessibilityScrollView::frameViewOriginScrollPosition() const
+{
+    CheckedPtr cache = axObjectCache();
+    return cache ? cache->frameViewOriginScrollPosition() : IntPoint();
+}
+
 bool AccessibilityScrollView::isARIAHidden() const
 {
     // This is necessary to implement on root scrollviews so that the base isAXHidden ancestor traversal works as expected.

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -65,6 +65,7 @@ public:
     AXFrameGeometry frameGeometry() const;
     IntPoint frameScreenPosition() const final { return frameGeometry().screenPosition; }
     AffineTransform frameScreenTransform() const final { return frameGeometry().screenTransform; }
+    IntPoint frameViewOriginScrollPosition() const;
 
     bool isFrameGeometryInitialized() const final;
 


### PR DESCRIPTION
#### 79927d64201a2baed8ee1604f9c46cc4aa3c14c2
<pre>
AX: After ACCESSIBILITY_LOCAL_FRAME, VoiceOver can read stale element geometry after a frame scrolls its own content
<a href="https://bugs.webkit.org/show_bug.cgi?id=318158">https://bugs.webkit.org/show_bug.cgi?id=318158</a>
<a href="https://rdar.apple.com/179106823">rdar://179106823</a>

Reviewed by Dominic Mazzoni.

With ENABLE(ACCESSIBILITY_LOCAL_FRAME), local frames compose an element&apos;s screen
position the same way remote frames do: a cached per-frame AXFrameGeometry.screenPosition
(the frame&apos;s content origin on screen, with the frame&apos;s scroll baked in when it was
sampled) plus the element&apos;s content-space rect. That cached geometry is refreshed only
by an asynchronous re-push, so when a frame scrolls its own content, e.g. a horizontal
CSS-column page-turn in Apple Books, the baked-in scroll goes stale until the re-push
lands. An assistive technology reading in that window gets a mispositioned rect, so
paginated content lands off the viewport and VoiceOver cannot reach it.

Stop depending on the re-push for a frame&apos;s own scroll. In convertFrameToSpace, read the
current scroll live (we are on the main thread here), undo the stale sampled scroll baked
into screenPosition, and re-apply the current scroll. In steady state the two are equal
and this is a no-op. During the race it keeps the read correct. To carry the sampled scroll
to the reader, capture it in AXObjectCache::setFrameGeometry and expose it via
frameViewOriginScrollPosition().

Also fix the related first-access case: when accessibility turns on, frameGeometry()
returned the default {0,0} origin while it kicked off the asynchronous request, so an AT
that walks and caches frames immediately would receive mispositioned rects. Compute the
screen position synchronously on that first main-thread access instead, falling back to
the asynchronous request only when it can&apos;t be computed in-process.

* LayoutTests/accessibility/ios-simulator/local-frame-content-scroll-geometry-expected.txt: Added.
* LayoutTests/accessibility/ios-simulator/local-frame-content-scroll-geometry.html: Added.
* LayoutTests/accessibility/resources/scrollable-iframe-content.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::setFrameGeometry):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::convertFrameToSpace const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::frameGeometry const):
(WebCore::AccessibilityScrollView::frameViewOriginScrollPosition const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:

Canonical link: <a href="https://commits.webkit.org/316341@main">https://commits.webkit.org/316341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9ce53985ef80c658f79c264db738a6192c1449f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181415 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8ad9169-0d3e-4b36-b9f7-65581c87555f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133785 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee69b71b-71a5-4ab9-ba58-dca90f8ef614) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37186 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114257 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82ffdc3c-4846-4e29-a500-7d54a245294d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35818 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30029 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183948 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142504 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38442 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46240 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30653 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110903 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37493 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44758 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8747 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44158 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44390 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->