### PR TITLE
Cherry-pick 0a9952c703a7. rdar://176483124

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -31,6 +31,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/URL.h>
 #include <wtf/WorkQueue.h>
 
@@ -41,7 +42,7 @@ namespace WebKit {
 class WebExtensionSQLiteStatement;
 class WebExtensionSQLiteStore;
 
-class WebExtensionSQLiteDatabase final : public RefCounted<WebExtensionSQLiteDatabase> {
+class WebExtensionSQLiteDatabase final : public ThreadSafeRefCounted<WebExtensionSQLiteDatabase> {
     WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteDatabase);
     WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteDatabase);
 


### PR DESCRIPTION
#### 4e721b046f9e0d2445eb476e4d0d56d7306c6add
<pre>
Cherry-pick 0a9952c703a7. <a href="https://rdar.apple.com/176483124">rdar://176483124</a>

    Use-after-free in WebExtensionSQLiteDatabase via cross-thread non-atomic RefCounted race.
    <a href="https://webkit.org/b/314569">https://webkit.org/b/314569</a>
    <a href="https://rdar.apple.com/176483124">rdar://176483124</a>

    Reviewed by Abrar Rahman Protyasha.

    WebExtensionSQLiteDatabase used a non-atomic RefCounted base despite its refcount being accessed
    concurrently from both the WKWebExtensionSQLiteStore WorkQueue and the UI main thread, so
    concurrent ref/deref operations could corrupt the count and cause a premature free.

    * Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h: Use ThreadSafeRefCounted.

    Identifier: 305413.879@safari-7624-branch

Originally-landed-as: 305413.783@safari-7624.4-branch (957a87db434a). <a href="https://rdar.apple.com/180436843">rdar://180436843</a>
Canonical link: <a href="https://commits.webkit.org/316314@main">https://commits.webkit.org/316314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ddae9a911aa3cccf28da6f8377b1fcf126a8eae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181101 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129352 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133653 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37040 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35672 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33934 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183769 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142356 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45382 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142247 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38420 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46062 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110697 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37349 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117750 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44580 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8602 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43980 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->