### PR TITLE
Introduce IsolatedSVGDocumentContext

### DIFF
--- a/LayoutTests/svg/paint-servers/external-paint-server-css-expected.html
+++ b/LayoutTests/svg/paint-servers/external-paint-server-css-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Linear gradient paint server referenced from a CSS rule (external and data: URL), on fill and stroke</title>
+<style>
+  .fill-local { fill: url(#grad); }
+  .stroke-local { stroke: url(#grad); }
+</style>
+<svg width="230" height="230" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+  <rect class="fill-local" x="10" y="10" width="100" height="100" fill="orange"/>
+  <rect class="stroke-local" x="120" y="10" width="100" height="100" fill="none" stroke="orange" stroke-width="20"/>
+  <rect class="fill-local" x="10" y="120" width="100" height="100" fill="orange"/>
+  <rect class="stroke-local" x="120" y="120" width="100" height="100" fill="none" stroke="orange" stroke-width="20"/>
+</svg>

--- a/LayoutTests/svg/paint-servers/external-paint-server-css.html
+++ b/LayoutTests/svg/paint-servers/external-paint-server-css.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Linear gradient paint server referenced from a CSS rule (external and data: URL), on fill and stroke</title>
+<style>
+  /* Author rules override the solid fill/stroke presentation attributes below. */
+  .fill-file { fill: url(resources/paint-servers.svg#grad); }
+  .stroke-file { stroke: url(resources/paint-servers.svg#grad); }
+  .fill-data { fill: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxsaW5lYXJHcmFkaWVudCBpZD0iZ3JhZCI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSJncmVlbiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iYmx1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PHBhdHRlcm4gaWQ9InBhdCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9IiNjZmUiLz48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSI2IiBmaWxsPSJibHVlIi8+PC9wYXR0ZXJuPjwvc3ZnPg==#grad"); }
+  .stroke-data { stroke: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxsaW5lYXJHcmFkaWVudCBpZD0iZ3JhZCI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSJncmVlbiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iYmx1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PHBhdHRlcm4gaWQ9InBhdCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9IiNjZmUiLz48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSI2IiBmaWxsPSJibHVlIi8+PC9wYXR0ZXJuPjwvc3ZnPg==#grad"); }
+</style>
+<svg width="230" height="230" xmlns="http://www.w3.org/2000/svg">
+  <rect class="fill-file" x="10" y="10" width="100" height="100" fill="orange"/>
+  <rect class="stroke-file" x="120" y="10" width="100" height="100" fill="none" stroke="orange" stroke-width="20"/>
+  <rect class="fill-data" x="10" y="120" width="100" height="100" fill="orange"/>
+  <rect class="stroke-data" x="120" y="120" width="100" height="100" fill="none" stroke="orange" stroke-width="20"/>
+</svg>

--- a/LayoutTests/svg/paint-servers/external-paint-server-gradient-expected.html
+++ b/LayoutTests/svg/paint-servers/external-paint-server-gradient-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Linear gradient paint server referenced from an external and a data: URL, on fill and stroke</title>
+<svg width="230" height="230" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad">
+      <stop offset="0" stop-color="green"/>
+      <stop offset="1" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+  <rect x="10" y="10" width="100" height="100" fill="url(#grad)"/>
+  <rect x="120" y="10" width="100" height="100" fill="none" stroke-width="20" stroke="url(#grad)"/>
+  <rect x="10" y="120" width="100" height="100" fill="url(#grad)"/>
+  <rect x="120" y="120" width="100" height="100" fill="none" stroke-width="20" stroke="url(#grad)"/>
+</svg>

--- a/LayoutTests/svg/paint-servers/external-paint-server-gradient.html
+++ b/LayoutTests/svg/paint-servers/external-paint-server-gradient.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>Linear gradient paint server referenced from an external and a data: URL, on fill and stroke</title>
+<svg width="230" height="230" xmlns="http://www.w3.org/2000/svg">
+  <!-- External file. -->
+  <rect x="10" y="10" width="100" height="100" fill="url(resources/paint-servers.svg#grad)"/>
+  <rect x="120" y="10" width="100" height="100" fill="none" stroke-width="20" stroke="url(resources/paint-servers.svg#grad)"/>
+  <!-- data: URL. -->
+  <rect x="10" y="120" width="100" height="100" fill="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxsaW5lYXJHcmFkaWVudCBpZD0iZ3JhZCI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSJncmVlbiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iYmx1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PHBhdHRlcm4gaWQ9InBhdCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9IiNjZmUiLz48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSI2IiBmaWxsPSJibHVlIi8+PC9wYXR0ZXJuPjwvc3ZnPg==#grad)"/>
+  <rect x="120" y="120" width="100" height="100" fill="none" stroke-width="20" stroke="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxsaW5lYXJHcmFkaWVudCBpZD0iZ3JhZCI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSJncmVlbiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iYmx1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PHBhdHRlcm4gaWQ9InBhdCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9IiNjZmUiLz48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSI2IiBmaWxsPSJibHVlIi8+PC9wYXR0ZXJuPjwvc3ZnPg==#grad)"/>
+</svg>

--- a/LayoutTests/svg/paint-servers/external-paint-server-pattern-expected.html
+++ b/LayoutTests/svg/paint-servers/external-paint-server-pattern-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Pattern paint server referenced from an external and a data: URL, on fill and stroke</title>
+<svg width="230" height="230" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="pat" width="20" height="20" patternUnits="userSpaceOnUse">
+      <rect width="20" height="20" fill="#cfe"/>
+      <circle cx="10" cy="10" r="6" fill="blue"/>
+    </pattern>
+  </defs>
+  <rect x="10" y="10" width="100" height="100" fill="url(#pat)"/>
+  <rect x="120" y="10" width="100" height="100" fill="none" stroke-width="20" stroke="url(#pat)"/>
+  <rect x="10" y="120" width="100" height="100" fill="url(#pat)"/>
+  <rect x="120" y="120" width="100" height="100" fill="none" stroke-width="20" stroke="url(#pat)"/>
+</svg>

--- a/LayoutTests/svg/paint-servers/external-paint-server-pattern.html
+++ b/LayoutTests/svg/paint-servers/external-paint-server-pattern.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>Pattern paint server referenced from an external and a data: URL, on fill and stroke</title>
+<svg width="230" height="230" xmlns="http://www.w3.org/2000/svg">
+  <!-- External file. -->
+  <rect x="10" y="10" width="100" height="100" fill="url(resources/paint-servers.svg#pat)"/>
+  <rect x="120" y="10" width="100" height="100" fill="none" stroke-width="20" stroke="url(resources/paint-servers.svg#pat)"/>
+  <!-- data: URL. -->
+  <rect x="10" y="120" width="100" height="100" fill="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxsaW5lYXJHcmFkaWVudCBpZD0iZ3JhZCI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSJncmVlbiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iYmx1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PHBhdHRlcm4gaWQ9InBhdCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9IiNjZmUiLz48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSI2IiBmaWxsPSJibHVlIi8+PC9wYXR0ZXJuPjwvc3ZnPg==#pat)"/>
+  <rect x="120" y="120" width="100" height="100" fill="none" stroke-width="20" stroke="url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxsaW5lYXJHcmFkaWVudCBpZD0iZ3JhZCI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSJncmVlbiIvPjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iYmx1ZSIvPjwvbGluZWFyR3JhZGllbnQ+PHBhdHRlcm4gaWQ9InBhdCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9IiNjZmUiLz48Y2lyY2xlIGN4PSIxMCIgY3k9IjEwIiByPSI2IiBmaWxsPSJibHVlIi8+PC9wYXR0ZXJuPjwvc3ZnPg==#pat)"/>
+</svg>

--- a/LayoutTests/svg/paint-servers/resources/paint-servers.svg
+++ b/LayoutTests/svg/paint-servers/resources/paint-servers.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="grad">
+    <stop offset="0" stop-color="green"/>
+    <stop offset="1" stop-color="blue"/>
+  </linearGradient>
+  <pattern id="pat" width="20" height="20" patternUnits="userSpaceOnUse">
+    <rect width="20" height="20" fill="#cfe"/>
+    <circle cx="10" cy="10" r="6" fill="blue"/>
+  </pattern>
+</svg>

--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -129,7 +129,7 @@ class Preference
       @getter
     elsif @name.start_with?("VP")
       @name[0..1].downcase + @name[2..@name.length]
-    elsif @name.start_with?("CSS", "DOM", "DNS", "FTP", "ICE", "IPC", "PDF", "XSS")
+    elsif @name.start_with?("CSS", "DOM", "DNS", "FTP", "ICE", "IPC", "PDF", "SVG", "XSS")
       @name[0..2].downcase + @name[3..@name.length]
     elsif @name.start_with?("HTTP")
       @name[0..3].downcase + @name[4..@name.length]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7110,6 +7110,20 @@ SKAttributionEnabled:
     WebKit:
       default: true
 
+SVGExternalResourcesEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "SVG external resources"
+  humanReadableDescription: "Enable referencing SVG resources (paint servers, etc.) via external or data: URLs"
+  defaultValue:
+    WebCore:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+
 SWVPDecodersAlwaysEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/Scripts/GenerateSettings.rb
+++ b/Source/WebCore/Scripts/GenerateSettings.rb
@@ -113,7 +113,7 @@ class Setting
       name[0..1].downcase + name[2..name.length]
     elsif name.start_with?("CSSOM", "HTTPS")
       name
-    elsif name.start_with?("URL","CSS", "XSS", "FTP", "DOM", "DNS", "PDF", "ICE", "HDR", "RTC")
+    elsif name.start_with?("URL","CSS", "XSS", "FTP", "DOM", "DNS", "PDF", "ICE", "HDR", "RTC", "SVG")
       name[0..2].downcase + name[3..name.length]
     elsif name.start_with?("HTTP", "HTML")
       name[0..3].downcase + name[4..name.length]
@@ -160,7 +160,7 @@ class Setting
   def setterFunctionName
     if @name.start_with?("html")
       "set" + @name[0..3].upcase + @name[4..@name.length]
-    elsif @name.start_with?("url", "css", "xss", "ftp", "dom", "dns", "ice", "hdr", "pdf", "rtc")
+    elsif @name.start_with?("url", "css", "xss", "ftp", "dom", "dns", "ice", "hdr", "pdf", "rtc", "svg")
       "set" + @name[0..2].upcase + @name[3..@name.length]
     elsif @name.start_with?("vp")
       "set" + @name[0..1].upcase + @name[2..@name.length]

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3532,6 +3532,7 @@ style/values/ui/StyleResize.cpp
 style/values/view-transitions/StyleViewTransitionName.cpp
 style/values/will-change/StyleWillChange.cpp
 svg/DocumentSVG.cpp
+svg/IsolatedSVGDocumentContext.cpp
 svg/SVGAElement.cpp @header:RenderStyleGetters
 svg/SVGAltGlyphDefElement.cpp
 svg/SVGAltGlyphElement.cpp @header:RenderStyleGetters

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -14986,6 +14986,8 @@
 		7C017C3D24969F1300DC0C02 /* NavigatorPlugins.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigatorPlugins.idl; sourceTree = "<group>"; };
 		7C023200251A524800BA7BB6 /* DocumentSVG.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DocumentSVG.h; sourceTree = "<group>"; };
 		7C023201251A524800BA7BB6 /* DocumentSVG.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentSVG.cpp; sourceTree = "<group>"; };
+		9E114EAF2FF41ACE007BD399 /* IsolatedSVGDocumentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolatedSVGDocumentContext.h; sourceTree = "<group>"; };
+		9E114EB02FF41AF3007BD399 /* IsolatedSVGDocumentContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsolatedSVGDocumentContext.cpp; sourceTree = "<group>"; };
 		7C029C6D2493C8F800268204 /* ColorTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorTypes.h; sourceTree = "<group>"; };
 		7C0CEF281E4A542C008DEB80 /* JSDOMConstructorBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMConstructorBase.h; sourceTree = "<group>"; };
 		7C0CEF291E4A54D3008DEB80 /* JSDOMConstructorWithDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMConstructorWithDocument.h; sourceTree = "<group>"; };
@@ -36040,6 +36042,8 @@
 				7C023201251A524800BA7BB6 /* DocumentSVG.cpp */,
 				7C023200251A524800BA7BB6 /* DocumentSVG.h */,
 				B22277CD0D00BF1F0071B782 /* GradientAttributes.h */,
+				9E114EB02FF41AF3007BD399 /* IsolatedSVGDocumentContext.cpp */,
+				9E114EAF2FF41ACE007BD399 /* IsolatedSVGDocumentContext.h */,
 				B22277CE0D00BF1F0071B782 /* LinearGradientAttributes.h */,
 				B22277DB0D00BF1F0071B782 /* PatternAttributes.h */,
 				B22277DC0D00BF1F0071B782 /* RadialGradientAttributes.h */,

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -20,7 +20,10 @@
 #include "config.h"
 #include "SVGResources.h"
 
+#include "Document.h"
+#include "DocumentInlines.h"
 #include "FilterOperation.h"
+#include "IsolatedSVGDocumentContext.h"
 #include "LegacyRenderSVGResourceClipperInlines.h"
 #include "LegacyRenderSVGResourceContainerInlines.h"
 #include "LegacyRenderSVGResourceFilterInlines.h"
@@ -29,6 +32,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "PathOperation.h"
 #include "RenderElementInlines.h"
+#include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGFilterElement.h"
 #include "SVGGradientElement.h"
@@ -36,6 +40,7 @@
 #include "SVGNames.h"
 #include "SVGPatternElement.h"
 #include "SVGURIReference.h"
+#include "Settings.h"
 #include "StyleCachedImage.h"
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/SetForScope.h>
@@ -183,16 +188,12 @@ static inline bool NODELETE isChainableResource(const SVGElement& element, const
     return false;
 }
 
-static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
+static CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromTreeScopeAndId(TreeScope& treeScope, const AtomString& id, bool* hasPendingResource)
 {
-    auto paintURL = paint.tryAnyURL();
-    if (!paintURL)
-        return nullptr;
-
-    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, protect(treeScope.documentScope()));
     CheckedPtr container = getRenderSVGResourceContainerById(treeScope, id);
     if (!container) {
-        hasPendingResource = true;
+        if (hasPendingResource)
+            *hasPendingResource = true;
         return nullptr;
     }
 
@@ -201,6 +202,40 @@ static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromS
         return nullptr;
 
     return container;
+}
+
+static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromSVGPaint(TreeScope& treeScope, const Style::SVGPaint& paint, AtomString& id, bool& hasPendingResource)
+{
+    auto paintURL = paint.tryAnyURL();
+    if (!paintURL)
+        return nullptr;
+
+    Ref document = treeScope.documentScope();
+
+    if (document->settings().svgExternalResourcesEnabled()
+        && (paintURL->resolved.protocolIsData() || SVGURIReference::isExternalURIReference(paintURL->resolved.string(), document))) {
+        id = paintURL->resolved.fragmentIdentifier().toAtomString();
+        if (id.isEmpty())
+            return nullptr;
+
+        auto documentURL = *paintURL;
+        documentURL.resolved.removeFragmentIdentifier();
+
+        RefPtr isolatedDocument = document->svgExtensions().isolatedSVGPaintDocument(documentURL.resolved);
+        if (!isolatedDocument)
+            return nullptr;
+
+        RefPtr externalDocument = isolatedDocument->document();
+        if (!externalDocument)
+            return nullptr;
+
+        // The resource lives in the isolated document, which is realized separately and does not use
+        // this document's pending-resource mechanism so no hasPendingResource.
+        return paintingResourceFromTreeScopeAndId(*externalDocument, id, nullptr);
+    }
+
+    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, document);
+    return paintingResourceFromTreeScopeAndId(treeScope, id, &hasPendingResource);
 }
 
 std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderElement& renderer, const Style::ComputedStyle& style)

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -27,9 +27,16 @@
 #include "StylePendingResources.h"
 
 #include "CSSCursorImageValue.h"
+#include "CachedImage.h"
+#include "CachedResourceLoader.h"
+#include "CachedResourceRequest.h"
+#include "CachedResourceRequestInitiatorTypes.h"
+#include "Document.h"
 #include "DocumentResourceLoader.h"
 #include "DocumentView.h"
 #include "NodeInlinesLight.h"
+#include "ResourceRequest.h"
+#include "SVGDocumentExtensions.h"
 #include "SVGURIReference.h"
 #include "Settings.h"
 #include "StyleComputedStyle+GettersInlines.h"
@@ -70,6 +77,39 @@ static void loadPendingImage(Document& document, const Image* image, const Eleme
     const_cast<Image&>(*image).load(protect(document.cachedResourceLoader()), options);
 }
 
+static void loadPendingExternalSVGPaint(Document& document, const Style::SVGPaint& paint)
+{
+    auto url = paint.tryAnyURL();
+    if (!url)
+        return;
+
+    auto& resolved = url->resolved;
+    if (resolved.isNull())
+        return;
+
+    if (!resolved.protocolIsData() && !SVGURIReference::isExternalURIReference(resolved.string(), document))
+        return;
+
+    auto documentURL = *url;
+    documentURL.resolved.removeFragmentIdentifier();
+
+    CheckedRef extensions = document.svgExtensions();
+    auto key = documentURL.resolved;
+    if (extensions->hasExternalSVGPaintResource(key))
+        return;
+
+    auto options = CachedResourceLoader::defaultCachedResourceOptions();
+    options.mode = FetchOptions::Mode::SameOrigin;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+
+    CachedResourceRequest request(ResourceRequest(WTF::URL { documentURL.resolved }), options);
+    request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
+    RefPtr cachedImage = protect(document.cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
+    if (!cachedImage)
+        return;
+    extensions->addExternalSVGPaintResource(key, *cachedImage, document);
+}
+
 void loadPendingResources(Style::ComputedStyle& style, Document& document, const Element* element)
 {
     for (auto& backgroundLayer : style.backgroundLayers().usedValues())
@@ -107,7 +147,12 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
     if (RefPtr shapeValueImage = style.shapeOutside().image())
         loadPendingImage(document, shapeValueImage.get(), element, LoadPolicy::Anonymous);
 
-    // Are there other pseudo-elements that need resource loading? 
+    if (document.settings().svgExternalResourcesEnabled()) {
+        loadPendingExternalSVGPaint(document, style.fill());
+        loadPendingExternalSVGPaint(document, style.stroke());
+    }
+
+    // Are there other pseudo-elements that need resource loading?
     if (CheckedPtr firstLineStyle = style.pseudoElementStyle({ PseudoElementType::FirstLine }))
         loadPendingResources(*firstLineStyle, document, element);
 }

--- a/Source/WebCore/svg/IsolatedSVGDocumentContext.cpp
+++ b/Source/WebCore/svg/IsolatedSVGDocumentContext.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IsolatedSVGDocumentContext.h"
+
+#include "CachedImage.h"
+#include "Document.h"
+#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
+#include "Page.h"
+#include "SVGDocument.h"
+#include "SVGImage.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IsolatedSVGDocumentContext);
+
+Ref<IsolatedSVGDocumentContext> IsolatedSVGDocumentContext::create(CachedImage& cachedImage, Document& document)
+{
+    Ref result = adoptRef(*new IsolatedSVGDocumentContext(cachedImage, document));
+    // Register only after adoptRef(): addClient() may call imageChanged() synchronously (already-loaded
+    // resource), which refs `this`.
+    cachedImage.addClient(result.get());
+    return result;
+}
+
+IsolatedSVGDocumentContext::IsolatedSVGDocumentContext(CachedImage& cachedImage, Document& owningDocument)
+    : m_cachedImage(&cachedImage)
+    , m_owningDocument(owningDocument)
+{
+}
+
+IsolatedSVGDocumentContext::~IsolatedSVGDocumentContext()
+{
+    protect(*m_cachedImage)->removeClient(*this);
+}
+
+SVGDocument* IsolatedSVGDocumentContext::document() const
+{
+    RefPtr svgImage = dynamicDowncast<SVGImage>(protect(*m_cachedImage)->image());
+    if (!svgImage)
+        return nullptr;
+
+    RefPtr page = svgImage->internalPage();
+    if (!page)
+        return nullptr;
+
+    RefPtr localMainFrame = page->localMainFrame();
+    return localMainFrame ? dynamicDowncast<SVGDocument>(localMainFrame->document()) : nullptr;
+}
+
+void IsolatedSVGDocumentContext::imageChanged(CachedImage*, const IntRect*)
+{
+    // The isolated document just finished loading and laying out. Force referencing renderers to
+    // rebuild their SVGResources so paint servers re-resolve.
+    // FIXME: Track referencing elements and invalidate only those (as RenderLayerFilters does).
+    RefPtr owningDocument = m_owningDocument.get();
+    if (RefPtr documentElement = owningDocument ? owningDocument->documentElement() : nullptr)
+        documentElement->invalidateStyleAndRenderersForSubtree();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/svg/IsolatedSVGDocumentContext.h
+++ b/Source/WebCore/svg/IsolatedSVGDocumentContext.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedImageClient.h"
+#include "CachedResourceHandle.h"
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class CachedImage;
+class Document;
+class SVGDocument;
+class WeakPtrImplWithEventTargetData;
+
+// A thin wrapper around the SVGImage infrastructure. Where SVGImage's public
+// contract is pixel output, IsolatedSVGDocumentContext's contract is the laid-out render tree: it exposes
+// an SVG document's resources (paint servers, etc.) so they can be referenced from a host document.
+class IsolatedSVGDocumentContext final : public CachedImageClient, public RefCounted<IsolatedSVGDocumentContext> {
+    WTF_MAKE_TZONE_ALLOCATED(IsolatedSVGDocumentContext);
+public:
+    static Ref<IsolatedSVGDocumentContext> create(CachedImage&, Document&);
+    ~IsolatedSVGDocumentContext();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    SVGDocument* document() const;
+
+private:
+    IsolatedSVGDocumentContext(CachedImage&, Document&);
+
+    void imageChanged(CachedImage*, const IntRect*) final;
+
+    const CachedResourceHandle<CachedImage> m_cachedImage;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_owningDocument;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -22,9 +22,12 @@
 #include "config.h"
 #include "SVGDocumentExtensions.h"
 
+#include "CachedImage.h"
+#include "Document.h"
 #include "DocumentPage.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
+#include "IsolatedSVGDocumentContext.h"
 #include "LocalFrame.h"
 #include "SMILTimeContainer.h"
 #include "SVGElement.h"
@@ -37,6 +40,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringHash.h>
 
 namespace WebCore {
 
@@ -168,6 +172,22 @@ void SVGDocumentExtensions::unregisterSVGFontFaceElement(SVGFontFaceElement& ele
 {
     ASSERT(m_svgFontFaceElements.contains(element));
     m_svgFontFaceElements.remove(element);
+}
+
+bool SVGDocumentExtensions::hasExternalSVGPaintResource(const URL& url) const
+{
+    return m_externalSVGPaintDocuments.contains(url);
+}
+
+void SVGDocumentExtensions::addExternalSVGPaintResource(const URL& url, CachedImage& cachedImage, Document& document)
+{
+    m_externalSVGPaintDocuments.set(url, IsolatedSVGDocumentContext::create(cachedImage, document));
+}
+
+IsolatedSVGDocumentContext* SVGDocumentExtensions::isolatedSVGPaintDocument(const URL& url) const
+{
+    auto it = m_externalSVGPaintDocuments.find(url);
+    return it != m_externalSVGPaintDocuments.end() ? it->value.ptr() : nullptr;
 }
 
 }

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -25,11 +25,14 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/URLHash.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
+class CachedImage;
 class Document;
+class IsolatedSVGDocumentContext;
 class Element;
 class SVGElement;
 class SVGFontFaceElement;
@@ -72,6 +75,10 @@ public:
     void registerSVGFontFaceElement(SVGFontFaceElement&);
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 
+    bool hasExternalSVGPaintResource(const URL&) const;
+    void addExternalSVGPaintResource(const URL&, CachedImage&, Document&);
+    IsolatedSVGDocumentContext* isolatedSVGPaintDocument(const URL&) const;
+
 private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_timeContainers; // For SVG 1.2 support this will need to be made more general.
@@ -81,6 +88,7 @@ private:
     Vector<Ref<SVGElement>> m_rebuildElements;
     bool m_areAnimationsPaused;
 
+    HashMap<URL, Ref<IsolatedSVGDocumentContext>> m_externalSVGPaintDocuments;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c2ced939fa425c189b0427f0acb5061b2627efac
<pre>
Introduce IsolatedSVGDocumentContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=318229">https://bugs.webkit.org/show_bug.cgi?id=318229</a>
<a href="https://rdar.apple.com/181031373">rdar://181031373</a>

Reviewed by Simon Fraser.

SVG paint servers referenced via data: or external URLs need to resolve a
gradient/pattern that lives in a different document. Unlike the frameless
document from CachedSVGDocument (used by &lt;use&gt; and filters, which only read
attributes), such a resource must be laid out before it can be referenced.

Introduce IsolatedSVGDocumentContext, a thin wrapper over the SVGImage infrastructure.
The referenced SVG is fetched as a CachedImage and built into an SVGImage, which
already owns an isolated Page laid out.

Notes and follow-ups:

- Style::loadPendingResources fetches a non-local fill/stroke url() through the
loader layer, so external and data: references are handled uniformly and
CSP-checked. Going through the loader also means these documents are treated
as subresources and participate in the window.onload event.

- An IsolatedSVGDocumentContext&apos;s lifetime is currently scoped to the host document.
Follow-up: move ownership onto the style value (as Style::FilterReference
does) so an unreferenced document is evicted once no element paints with it.

- The API surface is intentionally minimal, enough to serve paint servers in a
static form. Animated (SMIL) paint servers render a single frame: the isolated
timeline runs, but there is no cross-document invalidation to repaint the
host. Extending to animation/mutation is a follow-up.

* LayoutTests/svg/paint-servers/external-paint-server-css-expected.html: Added.
* LayoutTests/svg/paint-servers/external-paint-server-css.html: Added.
* LayoutTests/svg/paint-servers/external-paint-server-gradient-expected.html: Added.
* LayoutTests/svg/paint-servers/external-paint-server-gradient.html: Added.
* LayoutTests/svg/paint-servers/external-paint-server-pattern-expected.html: Added.
* LayoutTests/svg/paint-servers/external-paint-server-pattern.html: Added.
* LayoutTests/svg/paint-servers/resources/paint-servers.svg: Added.

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Scripts/GenerateSettings.rb:

Treat &quot;SVG&quot; as an acronym so the generated accessor is svg...(), not sVG...().

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::paintingResourceFromTreeScopeAndId):
(WebCore::paintingResourceFromSVGPaint):
* Source/WebCore/style/StylePendingResources.cpp:
(WebCore::Style::loadPendingExternalSVGPaint):
(WebCore::Style::loadPendingResources):
* Source/WebCore/svg/IsolatedSVGDocumentContext.cpp: Added.
(WebCore::IsolatedSVGDocumentContext::create):
(WebCore::IsolatedSVGDocumentContext::IsolatedSVGDocumentContext):
(WebCore::IsolatedSVGDocumentContext::~IsolatedSVGDocumentContext):
(WebCore::IsolatedSVGDocumentContext::document const):
(WebCore::IsolatedSVGDocumentContext::imageChanged):
* Source/WebCore/svg/IsolatedSVGDocumentContext.h: Added.
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::hasExternalSVGPaintResource const):
(WebCore::SVGDocumentExtensions::addExternalSVGPaintResource):
(WebCore::SVGDocumentExtensions::isolatedSVGPaintDocument const):
* Source/WebCore/svg/SVGDocumentExtensions.h:

Canonical link: <a href="https://commits.webkit.org/317199@main">https://commits.webkit.org/317199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af97f4003bae5137c37f129ca9c48c9727e590e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132396 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2c0fd14-3eff-4e18-a905-c61e250ea33d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdb29e97-8b33-4bcd-889e-055efebec985) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7502e62-438a-42e7-b186-90f3efcddbb4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37860 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32586 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/5090 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186531 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35790 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/156136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38978 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48807 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/114446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39460 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120789 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/211581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47314 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11038 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/55202 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->