### PR TITLE
[WebCore] Store WaveShaperProcessor curve as Vector<float> to avoid cross-thread RefCounted race

### DIFF
--- a/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash-expected.txt
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash-expected.txt
@@ -1,0 +1,10 @@
+Reading WaveShaperNode.curve on the main thread while offline rendering accesses it on the audio thread should not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Test passed because it did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Reading WaveShaperNode.curve on the main thread while offline rendering accesses it on the audio thread should not crash.");
+
+jsTestIsAsync = true;
+
+let context = new OfflineAudioContext(2, 44100, 48000);
+let node = context.createWaveShaper();
+node.curve = new Float32Array(2);
+node.connect(context.destination);
+context.startRendering().then(() => {
+    testPassed("Test passed because it did not crash.");
+    finishJSTest();
+});
+for (let i = 0; i < 1000; i++)
+    void node.curve;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
@@ -30,7 +30,6 @@
 
 #include "AudioUtilities.h"
 #include "WaveShaperProcessor.h"
-#include <JavaScriptCore/Float32Array.h>
 #include <algorithm>
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
@@ -85,9 +84,7 @@ void WaveShaperDSPKernel::process(std::span<const float> source, std::span<float
 void WaveShaperDSPKernel::processCurve(std::span<const float> source, std::span<float> destination)
 {
     assertIsHeld(waveShaperProcessor()->processLock());
-    RefPtr curve = waveShaperProcessor()->curve();
-    auto curveData = curve ? curve->typedMutableSpan() : std::span<float> { };
-    processCurveWithData(source, destination, curveData);
+    processCurveWithData(source, destination, waveShaperProcessor()->curve().span());
 }
 
 void WaveShaperDSPKernel::processCurveWithData(std::span<const float> source, std::span<float> destination, std::span<const float> curveData)

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
@@ -81,27 +81,22 @@ ExceptionOr<void> WaveShaperNode::setCurveForBindings(RefPtr<Float32Array>&& cur
     if (curve && curve->length() < 2)
         return Exception { ExceptionCode::InvalidStateError, "Length of curve array cannot be less than 2"_s };
 
-    if (curve) {
-        // The specification states that we should maintain an internal copy of the curve so that
-        // subsequent modifications of the contents of the array have no effect.
-        auto clonedCurve = Float32Array::create(curve->data(), curve->length());
-        curve = WTF::move(clonedCurve);
-    }
-
-    waveShaperProcessor()->setCurveForBindings(curve.get());
+    // The specification states that we should maintain an internal copy of the curve so that
+    // subsequent modifications of the contents of the array have no effect.
+    waveShaperProcessor()->setCurveForBindings(curve ? Vector<float>(curve->typedSpan()) : Vector<float>());
     return { };
 }
 
 RefPtr<Float32Array> WaveShaperNode::curveForBindings()
 {
     ASSERT(isMainThread());
-    RefPtr curve = waveShaperProcessor()->curveForBindings();
-    if (!curve)
+    auto& curve = waveShaperProcessor()->curveForBindings();
+    if (curve.isEmpty())
         return nullptr;
 
     // Make a clone of our internal array so that JS cannot modify our internal array
     // on the main thread while the audio thread is using it for rendering.
-    return Float32Array::create(curve->data(), curve->length());
+    return Float32Array::create(curve.span());
 }
 
 static inline WaveShaperProcessor::OverSampleType NODELETE processorType(OverSampleType type)
@@ -149,8 +144,7 @@ bool WaveShaperNode::propagatesSilence() const
         return false;
 
     Locker locker { AdoptLock, waveShaperProcessor()->processLock() };
-    RefPtr curve = waveShaperProcessor()->curve();
-    return !curve || !curve->length();
+    return waveShaperProcessor()->curve().isEmpty();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.h
@@ -30,6 +30,7 @@
 #include "OverSampleType.h"
 #include "WaveShaperOptions.h"
 #include "WaveShaperProcessor.h"
+#include <JavaScriptCore/Forward.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -29,7 +29,6 @@
 #include "WaveShaperProcessor.h"
 
 #include "WaveShaperDSPKernel.h"
-#include <JavaScriptCore/Float32Array.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -52,13 +51,13 @@ std::unique_ptr<AudioDSPKernel> WaveShaperProcessor::createKernel()
     return makeUnique<WaveShaperDSPKernel>(this);
 }
 
-void WaveShaperProcessor::setCurveForBindings(Float32Array* curve)
+void WaveShaperProcessor::setCurveForBindings(Vector<float>&& curve)
 {
     ASSERT(isMainThread());
     // This synchronizes with process().
     Locker locker { m_processLock };
 
-    m_curve = curve;
+    m_curve = WTF::move(curve);
 }
 
 void WaveShaperProcessor::setOversampleForBindings(OverSampleType oversample)

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
@@ -27,11 +27,10 @@
 #include "AudioDSPKernel.h"
 #include "AudioDSPKernelProcessor.h"
 #include "AudioNode.h"
-#include <JavaScriptCore/Forward.h>
 #include <memory>
 #include <wtf/Lock.h>
-#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -55,9 +54,9 @@ public:
 
     void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) final;
 
-    void setCurveForBindings(Float32Array*);
-    Float32Array* curveForBindings() WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_curve.get(); } // Doesn't grab the lock, only safe to call on the main thread.
-    Float32Array* curve() const WTF_REQUIRES_LOCK(m_processLock) { return m_curve.get(); }
+    void setCurveForBindings(Vector<float>&&);
+    const Vector<float>& curveForBindings() const LIFETIME_BOUND WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_curve; } // Doesn't grab the lock, only safe to call on the main thread.
+    const Vector<float>& curve() const LIFETIME_BOUND WTF_REQUIRES_LOCK(m_processLock) { return m_curve; }
 
     void setOversampleForBindings(OverSampleType);
     OverSampleType oversampleForBindings() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_oversample; } // Doesn't grab the lock, only safe to call on the main thread.
@@ -69,7 +68,7 @@ private:
     Type processorType() const final { return Type::WaveShaper; }
 
     // m_curve represents the non-linear shaping curve.
-    RefPtr<Float32Array> m_curve WTF_GUARDED_BY_LOCK(m_processLock);
+    Vector<float> m_curve WTF_GUARDED_BY_LOCK(m_processLock);
 
     OverSampleType m_oversample WTF_GUARDED_BY_LOCK(m_processLock) { OverSampleNone };
 


### PR DESCRIPTION
#### 8912cf5b00c44e5c81ba047c9b3ec32f4135d437
<pre>
[WebCore] Store WaveShaperProcessor curve as Vector&lt;float&gt; to avoid cross-thread RefCounted race
<a href="https://bugs.webkit.org/show_bug.cgi?id=313528">https://bugs.webkit.org/show_bug.cgi?id=313528</a>
<a href="https://rdar.apple.com/175171873">rdar://175171873</a>

Reviewed by Chris Dumez.

WaveShaperProcessor::m_curve was a RefPtr&lt;Float32Array&gt;. Float32Array inherits
RefCounted&lt;ArrayBufferView&gt;, whose refcount is non-atomic. 296577@main changed
the audio-thread readers in WaveShaperDSPKernel::processCurve and
WaveShaperNode::propagatesSilence to wrap waveShaperProcessor()-&gt;curve() in a
local RefPtr; the main-thread getter WaveShaperNode::curveForBindings() already
did the same lockless. The concurrent non-atomic ref/deref races; a lost
increment leaves the count one too low; a subsequent deref frees m_curve out
from under the processor; the next render quantum is a heap-use-after-free in
processCurve.

On builds with ENABLE(SECURITY_ASSERTIONS), RefCountDebugger&apos;s threading
checker traps first; on plain Release the UAF is reachable from web content via
OfflineAudioContext + the WaveShaperNode.curve getter.

Fix by storing the curve as Vector&lt;float&gt; instead of RefPtr&lt;Float32Array&gt;. The
internal curve was already cloned on set and on get, so the Float32Array wrapper
was vestigial. With a Vector there is no RefCounted object on the audio-thread
path; m_processLock continues to guard buffer replacement against audio-thread
reads. This matches AudioParamTimeline::ParamEvent::m_curve and
IIRProcessor::m_feedforward.

Test: webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html
* LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash-expected.txt: Added.
* LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html: Added.
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
(WebCore::WaveShaperDSPKernel::processCurve):
* Source/WebCore/Modules/webaudio/WaveShaperNode.cpp:
(WebCore::WaveShaperNode::setCurveForBindings):
(WebCore::WaveShaperNode::curveForBindings):
(WebCore::WaveShaperNode::propagatesSilence const):
* Source/WebCore/Modules/webaudio/WaveShaperNode.h:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp:
(WebCore::WaveShaperProcessor::setCurveForBindings):
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.h:
(WebCore::WaveShaperProcessor::curveForBindings const):
(WebCore::WaveShaperProcessor::curve const):
(WebCore::WaveShaperProcessor::curveForBindings): Deleted.

Originally-landed-as: 305413.793@safari-7624-branch (0dcea6bac528). <a href="https://rdar.apple.com/181076704">rdar://181076704</a>
Canonical link: <a href="https://commits.webkit.org/316385@main">https://commits.webkit.org/316385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a49d52a33f8bdad55a556e35430452a88438eb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173675 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47012 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133660 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33940 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183781 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142368 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142259 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38486 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110709 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37357 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117762 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44592 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8606 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->