### PR TITLE
AX: AT-SPI implementation computes offsets incorrectly when user-select:none is set

### DIFF
--- a/LayoutTests/accessibility/gtk/text-at-offset-user-select-none-expected.txt
+++ b/LayoutTests/accessibility/gtk/text-at-offset-user-select-none-expected.txt
@@ -1,0 +1,19 @@
+text inside the link
+second line
+Text outside the block
+This tests the ability to get element text inside a link when user-select:none is set.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS link.characterAtOffset(0) is 't, 0, 1'
+PASS link.characterAtOffset(6) is 'n, 6, 7'
+PASS link.wordAtOffset(0) is 'text , 0, 5'
+PASS link.wordAtOffset(6) is 'inside , 5, 12'
+PASS link.lineAtOffset(0) is 'text inside the link\n, 0, 21'
+PASS link.lineAtOffset(23) is 'second line, 21, 32'
+PASS secondLineRuns.includes("Range attributes for 'second line'") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/gtk/text-at-offset-user-select-none.html
+++ b/LayoutTests/accessibility/gtk/text-at-offset-user-select-none.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body id="body">
+<div style='-webkit-user-select:none'>
+<a href='https://www.webkitgtk.org' id='link'>text inside the link<br/>second line</a>
+</div>
+<span>Text outside the block</span>
+<div id="console"></div>
+<script>
+description("This tests the ability to get element text inside a link when user-select:none is set.");
+if (window.accessibilityController) {
+    var link = accessibilityController.accessibleElementById("link");
+
+    shouldBe("link.characterAtOffset(0)", "'t, 0, 1'");
+    shouldBe("link.characterAtOffset(6)", "'n, 6, 7'");
+    shouldBe("link.wordAtOffset(0)", "'text , 0, 5'");
+    shouldBe("link.wordAtOffset(6)", "'inside , 5, 12'");
+    shouldBe("link.lineAtOffset(0)", "'text inside the link\\n, 0, 21'");
+    shouldBe("link.lineAtOffset(23)", "'second line, 21, 32'");
+
+    var secondLineRuns = link.attributedStringForRange(21, 11);
+    shouldBeTrue("secondLineRuns.includes(\"Range attributes for 'second line'\")");
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2022,7 +2022,7 @@ VisiblePosition AccessibilityNodeObject::visiblePositionForIndex(int index) cons
         return { };
 #if USE(ATSPI)
     // We need to consider replaced elements for GTK, as they will be presented with the 'object replacement character' (0xFFFC).
-    return WebCore::visiblePositionForIndex(index, node.get(), TextIteratorBehavior::EmitsObjectReplacementCharacters);
+    return WebCore::visiblePositionForIndex(index, node.get(), TextIteratorBehavior::EmitsObjectReplacementCharacters, AllowUserSelectNone::Yes);
 #else
     return visiblePositionForIndexUsingCharacterIterator(*node, index);
 #endif

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -909,8 +909,8 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         endPosition = lastPositionInOrAfterNode(endRenderer->node());
     }
 
-    auto startOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(startPosition), m_hasListMarkerAtStart);
-    auto endOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(endPosition), m_hasListMarkerAtStart);
+    auto startOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(VisiblePosition(startPosition, VisiblePosition::defaultAffinity, AllowUserSelectNone::Yes)), m_hasListMarkerAtStart);
+    auto endOffset = adjustOutputOffset(m_coreObject->indexForVisiblePosition(VisiblePosition(endPosition, VisiblePosition::defaultAffinity, AllowUserSelectNone::Yes)), m_hasListMarkerAtStart);
     if (!includeDefault)
         return { WTF::move(attributes), startOffset, endOffset };
 

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1001,7 +1001,7 @@ RefPtr<Node> Position::rootUserSelectAllForNode(Node* node)
 }
 
 // This function should be kept in sync with PositionIterator::isCandidate().
-bool Position::isCandidate() const
+bool Position::isCandidate(AllowUserSelectNone allowUserSelectNone) const
 {
     if (isNull())
         return false;
@@ -1021,13 +1021,13 @@ bool Position::isCandidate() const
 
     if (is<RenderText>(*renderer)) {
         auto [resolvedText, resolvedOffset] = resolvedTextRendererAndOffset();
-        return !nodeIsUserSelectNone(node.get()) && resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
+        return (allowUserSelectNone == AllowUserSelectNone::Yes || !nodeIsUserSelectNone(node.get())) && resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
     }
 
     if (positionBeforeOrAfterNodeIsCandidate(*node)) {
         return ((atFirstEditingPositionForNode() && m_anchorType == PositionIsBeforeAnchor)
             || (atLastEditingPositionForNode() && m_anchorType == PositionIsAfterAnchor))
-            && !nodeIsUserSelectNone(node->parentNode());
+            && (allowUserSelectNone == AllowUserSelectNone::Yes || !nodeIsUserSelectNone(node->parentNode()));
     }
 
     if (is<HTMLHtmlElement>(*m_anchorNode))
@@ -1037,14 +1037,14 @@ bool Position::isCandidate() const
         if (isAnyOf<RenderBlockFlow, RenderGrid, RenderFlexibleBox>(*block)) {
             if (block->logicalHeight() || is<HTMLBodyElement>(*m_anchorNode) || protect(m_anchorNode)->isRootEditableElement()) {
                 if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(*block))
-                    return atFirstEditingPositionForNode() && !Position::nodeIsUserSelectNone(node.get());
-                return protect(m_anchorNode)->hasEditableStyle() && !Position::nodeIsUserSelectNone(node.get()) && atEditingBoundary();
+                    return atFirstEditingPositionForNode() && (allowUserSelectNone == AllowUserSelectNone::Yes  || !Position::nodeIsUserSelectNone(node.get()));
+                return protect(m_anchorNode)->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(node.get())) && atEditingBoundary();
             }
             return false;
         }
     }
 
-    return protect(m_anchorNode)->hasEditableStyle() && !Position::nodeIsUserSelectNone(node.get()) && atEditingBoundary();
+    return protect(m_anchorNode)->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(node.get())) && atEditingBoundary();
 }
 
 bool Position::isRenderedCharacter() const

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -51,6 +51,8 @@ enum PositionMoveType {
     BackwardDeletion // Subject to platform conventions.
 };
 
+enum class AllowUserSelectNone : bool { No, Yes };
+
 struct InlineBoxAndOffset;
 
 class Position {
@@ -174,7 +176,7 @@ public:
     WEBCORE_EXPORT Position upstream(EditingBoundaryCrossingRule = CannotCrossEditingBoundary) const;
     WEBCORE_EXPORT Position downstream(EditingBoundaryCrossingRule = CannotCrossEditingBoundary) const;
     
-    bool isCandidate() const;
+    bool isCandidate(AllowUserSelectNone = AllowUserSelectNone::No) const;
     bool isRenderedCharacter() const;
     bool rendersInDifferentPosition(const Position&) const;
 

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -159,7 +159,7 @@ bool PositionIterator::atEndOfNode() const
 }
 
 // This function should be kept in sync with Position::isCandidate().
-bool PositionIterator::isCandidate() const
+bool PositionIterator::isCandidate(AllowUserSelectNone allowUserSelectNone) const
 {
     RefPtr anchorNode = node();
     if (!anchorNode)
@@ -176,14 +176,14 @@ bool PositionIterator::isCandidate() const
         return Position(*this).isCandidate();
 
     if (is<RenderText>(*renderer)) {
-        if (Position::nodeIsUserSelectNone(anchorNode.get()))
+        if (Position::nodeIsUserSelectNone(anchorNode.get()) && allowUserSelectNone == AllowUserSelectNone::No)
             return false;
         auto [resolvedText, resolvedOffset] = Position(*this).resolvedTextRendererAndOffset();
         return resolvedText && resolvedText->containsCaretOffset(resolvedOffset);
     }
 
     if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
-        return (atStartOfNode() || atEndOfNode()) && !Position::nodeIsUserSelectNone(anchorNode->parentNode());
+        return (atStartOfNode() || atEndOfNode()) && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode->parentNode()));
 
     if (is<HTMLHtmlElement>(*anchorNode))
         return false;
@@ -192,14 +192,14 @@ bool PositionIterator::isCandidate() const
         if (isAnyOf<RenderBlockFlow, RenderGrid, RenderFlexibleBox>(*block)) {
             if (block->logicalHeight() || is<HTMLBodyElement>(*anchorNode) || anchorNode->isRootEditableElement()) {
                 if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(*block))
-                    return atStartOfNode() && !Position::nodeIsUserSelectNone(anchorNode.get());
-                return anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(anchorNode.get()) && Position(*this).atEditingBoundary();
+                    return atStartOfNode() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode.get()));
+                return anchorNode->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode.get())) && Position(*this).atEditingBoundary();
             }
             return false;
         }
     }
 
-    return anchorNode->hasEditableStyle() && !Position::nodeIsUserSelectNone(anchorNode.get()) && Position(*this).atEditingBoundary();
+    return anchorNode->hasEditableStyle() && (allowUserSelectNone == AllowUserSelectNone::Yes || !Position::nodeIsUserSelectNone(anchorNode.get())) && Position(*this).atEditingBoundary();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -48,7 +48,7 @@ public:
     bool atEnd() const;
     bool NODELETE atStartOfNode() const;
     bool atEndOfNode() const;
-    bool isCandidate() const;
+    bool isCandidate(AllowUserSelectNone = AllowUserSelectNone::No) const;
 
 private:
     RefPtr<Node> m_anchorNode;

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -209,11 +209,11 @@ RefPtr<Element> unsplittableElementForPosition(const Position& position)
     return editableRootForPosition(position);
 }
 
-Position nextCandidate(const Position& position)
+Position nextCandidate(const Position& position, AllowUserSelectNone allowUserSelectNone)
 {
     for (PositionIterator nextPosition = position; !nextPosition.atEnd(); ) {
         nextPosition.increment();
-        if (nextPosition.isCandidate())
+        if (nextPosition.isCandidate(allowUserSelectNone))
             return nextPosition;
     }
     return { };
@@ -241,12 +241,12 @@ Position nextVisuallyDistinctCandidate(const Position& position, SkipDisplayCont
     return { };
 }
 
-Position previousCandidate(const Position& position)
+Position previousCandidate(const Position& position, AllowUserSelectNone allowUserSelectNone)
 {
     PositionIterator previousPosition = position;
     while (!previousPosition.atStart()) {
         previousPosition.decrement();
-        if (previousPosition.isCandidate())
+        if (previousPosition.isCandidate(allowUserSelectNone))
             return previousPosition;
     }
     return { };
@@ -1026,11 +1026,11 @@ VisiblePosition visiblePositionForPositionWithOffset(const VisiblePosition& posi
     return visiblePositionForIndex(startIndex + offset, root.get());
 }
 
-VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors behaviors)
+VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors behaviors, AllowUserSelectNone allowUserSelectNone)
 {
     if (!scope)
         return { };
-    return { makeDeprecatedLegacyPosition(resolveCharacterLocation(makeRangeSelectingNodeContents(*scope), index, behaviors)) };
+    return { makeDeprecatedLegacyPosition(resolveCharacterLocation(makeRangeSelectingNodeContents(*scope), index, behaviors)), VisiblePosition::defaultAffinity, allowUserSelectNone };
 }
 
 VisiblePosition visiblePositionForIndexUsingCharacterIterator(Node& node, int index)

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -135,8 +135,8 @@ WEBCORE_EXPORT EnclosingLayerInfomation computeEnclosingLayer(const SimpleRange&
 // Position
 // -------------------------------------------------------------------------
 
-Position nextCandidate(const Position&);
-Position previousCandidate(const Position&);
+Position nextCandidate(const Position&, AllowUserSelectNone = AllowUserSelectNone::No);
+Position previousCandidate(const Position&, AllowUserSelectNone = AllowUserSelectNone::No);
 
 enum class SkipDisplayContents : bool { No, Yes };
 Position nextVisuallyDistinctCandidate(const Position&, SkipDisplayContents = SkipDisplayContents::Yes);
@@ -171,7 +171,7 @@ bool lineBreakExistsAtVisiblePosition(const VisiblePosition&);
 WEBCORE_EXPORT int indexForVisiblePosition(const VisiblePosition&, RefPtr<ContainerNode>& scope);
 int indexForVisiblePosition(Node&, const VisiblePosition&, TextIteratorBehaviors);
 WEBCORE_EXPORT VisiblePosition visiblePositionForPositionWithOffset(const VisiblePosition&, int offset);
-WEBCORE_EXPORT VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors = TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions);
+WEBCORE_EXPORT VisiblePosition visiblePositionForIndex(int index, Node* scope, TextIteratorBehaviors = TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions, AllowUserSelectNone = AllowUserSelectNone::No);
 VisiblePosition visiblePositionForIndexUsingCharacterIterator(Node&, int index); // FIXME: Why do we need this version?
 
 WEBCORE_EXPORT VisiblePosition closestEditablePositionInElementForAbsolutePoint(const Element&, const IntPoint&);

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -70,8 +70,9 @@ static RenderTextFragment* remainingTextFragmentForFirstLetter(const RenderObjec
     return { };
 }
 
-VisiblePosition::VisiblePosition(const Position& position, Affinity affinity)
-    : m_deepPosition { canonicalPosition(position) }
+VisiblePosition::VisiblePosition(const Position& position, Affinity affinity, AllowUserSelectNone allowUserSelectNone)
+    : m_deepPosition(canonicalPosition(position, allowUserSelectNone))
+    , m_allowUserSelectNone(allowUserSelectNone)
 {
     if (affinity == Affinity::Upstream && !isNull()) {
         auto upstreamCopy = *this;
@@ -502,7 +503,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrBefore(const VisiblePos
     }
 
     // Return the last position before pos that is in the same editable region as this position
-    return lastEditablePositionBeforePositionInRoot(position.deepEquivalent(), highestRoot.get());
+    return VisiblePosition(lastEditablePositionBeforePositionInRoot(position.deepEquivalent(), highestRoot.get()), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
 }
 
 VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosition& otherPosition, bool* reachedBoundary) const
@@ -539,21 +540,21 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosi
     }
 
     // Return the next position after pos that is in the same editable region as this position
-    return firstEditablePositionAfterPositionInRoot(otherPosition.deepEquivalent(), highestRoot.get());
+    return VisiblePosition(firstEditablePositionAfterPositionInRoot(otherPosition.deepEquivalent(), highestRoot.get()), VisiblePosition::defaultAffinity, otherPosition.allowUserSelectNone());
 }
 
-static Position canonicalizeCandidate(const Position& candidate)
+static Position canonicalizeCandidate(const Position& candidate, AllowUserSelectNone allowUserSelectNone)
 {
     if (candidate.isNull())
         return Position();
-    ASSERT(candidate.isCandidate());
+    ASSERT(candidate.isCandidate(allowUserSelectNone));
     Position upstream = candidate.upstream();
-    if (upstream.isCandidate())
+    if (upstream.isCandidate(allowUserSelectNone))
         return upstream;
     return candidate;
 }
 
-Position VisiblePosition::canonicalPosition(const Position& passedPosition)
+Position VisiblePosition::canonicalPosition(const Position& passedPosition, AllowUserSelectNone allowUserSelectNone)
 {
     // The updateLayout call below can do so much that even the position passed
     // in to us might get changed as a side effect. Specifically, there are code
@@ -574,16 +575,16 @@ Position VisiblePosition::canonicalPosition(const Position& passedPosition)
     RefPtr node = position.containerNode();
 
     Position candidate = position.upstream();
-    if (candidate.isCandidate())
+    if (candidate.isCandidate(allowUserSelectNone))
         return candidate;
     candidate = position.downstream();
-    if (candidate.isCandidate())
+    if (candidate.isCandidate(allowUserSelectNone))
         return candidate;
 
     // When neither upstream or downstream gets us to a candidate (upstream/downstream won't leave 
     // blocks or enter new ones), we search forward and backward until we find one.
-    Position next = canonicalizeCandidate(nextCandidate(position));
-    Position prev = canonicalizeCandidate(previousCandidate(position));
+    Position next = canonicalizeCandidate(nextCandidate(position, allowUserSelectNone), allowUserSelectNone);
+    Position prev = canonicalizeCandidate(previousCandidate(position, allowUserSelectNone), allowUserSelectNone);
     RefPtr nextNode = next.deprecatedNode();
     RefPtr prevNode = prev.deprecatedNode();
 

--- a/Source/WebCore/editing/VisiblePosition.h
+++ b/Source/WebCore/editing/VisiblePosition.h
@@ -40,7 +40,7 @@ public:
     VisiblePosition() = default;
 
     // This constructor will ignore the passed-in affinity if the position is not at the end of a line.
-    WEBCORE_EXPORT VisiblePosition(const Position&, Affinity = defaultAffinity);
+    WEBCORE_EXPORT VisiblePosition(const Position&, Affinity = defaultAffinity, AllowUserSelectNone = AllowUserSelectNone::No);
 
     bool isNull() const { return m_deepPosition.isNull(); }
     bool isNotNull() const { return m_deepPosition.isNotNull(); }
@@ -48,6 +48,7 @@ public:
 
     Position deepEquivalent() const { return m_deepPosition; }
     Affinity affinity() const { return m_affinity; }
+    AllowUserSelectNone allowUserSelectNone() const { return m_allowUserSelectNone; }
 
     void setAffinity(Affinity affinity) { m_affinity = affinity; }
 
@@ -98,13 +99,14 @@ public:
 #endif
 
 private:
-    static Position canonicalPosition(const Position&);
+    static Position canonicalPosition(const Position&, AllowUserSelectNone = AllowUserSelectNone::No);
 
     Position leftVisuallyDistinctCandidate() const;
     Position rightVisuallyDistinctCandidate() const;
 
     Position m_deepPosition;
     Affinity m_affinity { defaultAffinity };
+    AllowUserSelectNone m_allowUserSelectNone;
 };
 
 bool operator==(const VisiblePosition&, const VisiblePosition&);

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -100,7 +100,7 @@ static Position previousLineCandidatePosition(Node* node, const VisiblePosition&
         Position pos = previousNode->hasTagName(HTMLNames::brTag) ? positionBeforeNode(*previousNode) :
             makeDeprecatedLegacyPosition(previousNode.get(), caretMaxOffset(*previousNode));
         
-        if (pos.isCandidate())
+        if (pos.isCandidate(visiblePosition.allowUserSelectNone()))
             return pos;
 
         previousNode = previousLeafWithSameEditability(previousNode.get(), editableType);
@@ -122,7 +122,7 @@ static Position nextLineCandidatePosition(Node* node, const VisiblePosition& vis
         Position pos;
         pos = makeDeprecatedLegacyPosition(nextNode.get(), caretMinOffset(*nextNode));
         
-        if (pos.isCandidate())
+        if (pos.isCandidate(visiblePosition.allowUserSelectNone()))
             return pos;
 
         nextNode = nextLeafWithSameEditability(nextNode.get(), editableType);
@@ -572,13 +572,13 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     unsigned next = backwardSearchForBoundaryWithTextIterator(it, string, suffixLength, searchFunction);
 
     if (!next)
-        return it.atEnd() ? makeDeprecatedLegacyPosition(searchRange->start) : position;
+        return it.atEnd() ? VisiblePosition(makeDeprecatedLegacyPosition(searchRange->start), VisiblePosition::defaultAffinity, position.allowUserSelectNone()) : position;
 
     Ref node = (it.atEnd() ? *searchRange : it.range()).start.container;
     RefPtr textNode = dynamicDowncast<Text>(node);
     if (textNode && !suffixLength && next <= textNode->length()) {
         // The next variable contains a usable index into a text node.
-        return makeDeprecatedLegacyPosition(node.ptr(), next);
+        return VisiblePosition(makeDeprecatedLegacyPosition(node.ptr(), next), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
     }
 
     // Use the character iterator to translate the next value into a DOM position.
@@ -586,7 +586,7 @@ static VisiblePosition previousBoundary(const VisiblePosition& position, Boundar
     if (next < string.size() - suffixLength)
         charIt.advance(string.size() - suffixLength - next);
     // FIXME: charIt can get out of shadow host.
-    return makeDeprecatedLegacyPosition(charIt.range().end);
+    return VisiblePosition(makeDeprecatedLegacyPosition(charIt.range().end), VisiblePosition::defaultAffinity, position.allowUserSelectNone());
 }
 
 static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunction searchFunction)
@@ -636,7 +636,7 @@ static VisiblePosition nextBoundary(const VisiblePosition& c, BoundarySearchFunc
         }
     }
 
-    return VisiblePosition(pos, Affinity::Upstream);
+    return VisiblePosition(pos, Affinity::Upstream, c.allowUserSelectNone());
 }
 
 // ---------
@@ -776,7 +776,7 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
     }
 
     if (RefPtr startTextNode = dynamicDowncast<Text>(*startNode))
-        return Position(startTextNode.releaseNonNull(), downcast<InlineIterator::TextBox>(*startBox).start());
+        return VisiblePosition(Position(startTextNode.releaseNonNull(), downcast<InlineIterator::TextBox>(*startBox).start()), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
     return positionBeforeNode(*startNode);
 }
 
@@ -860,7 +860,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
     } else
         pos = positionAfterNode(*endNode);
 
-    return VisiblePosition(pos, Affinity::Upstream);
+    return VisiblePosition(pos, Affinity::Upstream, c.allowUserSelectNone());
 }
 
 static bool inSameLogicalLine(const VisiblePosition& a, const VisiblePosition& b)
@@ -1052,7 +1052,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
             RenderedPosition renderedPosition(position);
             lineBox = renderedPosition.lineBox();
             if (!lineBox)
-                return position;
+                return VisiblePosition(position, VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
         }
     }
     
@@ -1065,12 +1065,12 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
         CheckedRef renderer = box->renderer();
         RefPtr node = renderer->node();
         if (node && editingIgnoresContent(*node))
-            return positionInParentBeforeNode(*node);
+            return VisiblePosition(positionInParentBeforeNode(*node), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
         // FIXME: The HitTestSource state should be propagated down from calls into JavaScript bindings.
         // For the time being, just err on the side of passing in `Bindings`.
         CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer.get());
         auto localOffset = renderBox ? renderBox->locationOffset() : LayoutSize { };
-        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine - localOffset, HitTestSource::Script);
+        return const_cast<RenderObject&>(renderer.get()).visiblePositionForPoint(pointInLine - localOffset, HitTestSource::Script, visiblePosition.allowUserSelectNone());
     }
 
     // Could not find a next line. This means we must already be on the last line.
@@ -1079,7 +1079,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
     RefPtr rootElement = rootEditableOrDocumentElement(*node, editableType);
     if (!rootElement)
         return VisiblePosition();
-    return lastPositionInNode(*rootElement);
+    return VisiblePosition(lastPositionInNode(*rootElement), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
 }
 
 // ---------
@@ -1266,14 +1266,14 @@ VisiblePosition startOfParagraph(const VisiblePosition& c, EditingBoundaryCrossi
     RefPtr node = findStartOfParagraph(startNode.get(), highestRoot.get(), startBlock.get(), offset, type, boundaryCrossingRule);
 
     if (RefPtr textNode = dynamicDowncast<Text>(node))
-        return Position(WTF::move(textNode), offset);
+        return VisiblePosition(Position(WTF::move(textNode), offset), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 
     if (type == Position::PositionIsOffsetInAnchor) {
         ASSERT(type == Position::PositionIsOffsetInAnchor || !offset);
-        return Position(WTF::move(node), offset, type);
+        return VisiblePosition(Position(WTF::move(node), offset, type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
     }
 
-    return Position(WTF::move(node), type);
+    return VisiblePosition(Position(WTF::move(node), type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 }
 
 VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossingRule boundaryCrossingRule)
@@ -1296,12 +1296,12 @@ VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossing
     RefPtr node = findEndOfParagraph(startNode.get(), highestRoot.get(), stayInsideBlock.get(), offset, type, boundaryCrossingRule);
 
     if (RefPtr textNode = dynamicDowncast<Text>(node))
-        return Position(WTF::move(textNode), offset);
+        return VisiblePosition(Position(WTF::move(textNode), offset), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 
     if (type == Position::PositionIsOffsetInAnchor)
-        return Position(WTF::move(node), offset, type);
+        return VisiblePosition(Position(WTF::move(node), offset, type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 
-    return Position(WTF::move(node), type);
+    return VisiblePosition(Position(WTF::move(node), type), VisiblePosition::defaultAffinity, c.allowUserSelectNone());
 }
 
 // FIXME: isStartOfParagraph(startOfNextParagraph(pos)) is not always true
@@ -1368,7 +1368,7 @@ VisiblePosition startOfBlock(const VisiblePosition& visiblePosition, EditingBoun
     RefPtr<Node> startBlock;
     if (!position.containerNode() || !(startBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
-    return firstPositionInNode(*startBlock);
+    return VisiblePosition(firstPositionInNode(*startBlock), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
 }
 
 VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBoundaryCrossingRule rule)
@@ -1377,7 +1377,7 @@ VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBounda
     RefPtr<Node> endBlock;
     if (!position.containerNode() || !(endBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
-    return lastPositionInNode(*endBlock);
+    return VisiblePosition(lastPositionInNode(*endBlock), VisiblePosition::defaultAffinity, visiblePosition.allowUserSelectNone());
 }
 
 bool inSameBlock(const VisiblePosition& a, const VisiblePosition& b)

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1847,10 +1847,10 @@ PositionWithAffinity RenderObject::positionForPoint(const LayoutPoint&, HitTestS
     return createPositionWithAffinity(caretMinOffset(), Affinity::Downstream);
 }
 
-VisiblePosition RenderObject::visiblePositionForPoint(const LayoutPoint& point, HitTestSource source)
+VisiblePosition RenderObject::visiblePositionForPoint(const LayoutPoint& point, HitTestSource source, AllowUserSelectNone allowUserSelectNone)
 {
     auto positionWithAffinity = positionForPoint(point, source, nullptr);
-    return VisiblePosition(positionWithAffinity.position(), positionWithAffinity.affinity());
+    return VisiblePosition(positionWithAffinity.position(), positionWithAffinity.affinity(), allowUserSelectNone);
 }
 
 bool RenderObject::isComposited() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -28,6 +28,7 @@
 #include <WebCore/CachedImageClient.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/PlatformLayerIdentifier.h>
+#include <WebCore/Position.h>
 #include <WebCore/RenderObjectEnums.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/RepaintRectCalculation.h>
@@ -803,7 +804,7 @@ public:
     PositionWithAffinity createPositionWithAffinity(int offset, Affinity) const;
     PositionWithAffinity createPositionWithAffinity(const Position&) const;
 
-    WEBCORE_EXPORT VisiblePosition visiblePositionForPoint(const LayoutPoint&, HitTestSource);
+    WEBCORE_EXPORT VisiblePosition visiblePositionForPoint(const LayoutPoint&, HitTestSource, AllowUserSelectNone = AllowUserSelectNone::No);
 
     // Returns the containing block level element for this element.
     WEBCORE_EXPORT RenderBlock* containingBlock() const;


### PR DESCRIPTION
#### 291c3ca40cf8068ae4251f350c2f450499595e10
<pre>
AX: AT-SPI implementation computes offsets incorrectly when user-select:none is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=318228">https://bugs.webkit.org/show_bug.cgi?id=318228</a>

Reviewed by Tyler Wilcock.

When GetStringAtOffset is called, the code currently uses VisiblePositions
to calculate text boundaries. The VisiblePosition code skips over text
when user-select:none is set, causing the resulting positions to be
canonicalized to point outside of the node, resulting in offsets that
are out of synch with the text that is being exposed for accessibility
purposes. This later causes a crash when the code tries to convert
the offsets to UTF-8, but the offsets can be larger than the length of
the text.

VisiblePositions now optionally consider positions inside user-select:none
to be valid, and the setting is propagated when new VisiblePositions
are constructed based on existing ones.

* LayoutTests/accessibility/gtk/text-at-offset-user-select-none-expected.txt: Added.
* LayoutTests/accessibility/gtk/text-at-offset-user-select-none.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::visiblePositionForIndex const):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::isCandidate const):
* Source/WebCore/dom/Position.h:
* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::isCandidate const):
* Source/WebCore/dom/PositionIterator.h:
* Source/WebCore/editing/Editing.cpp:
(WebCore::nextCandidate):
(WebCore::previousCandidate):
(WebCore::visiblePositionForIndex):
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::VisiblePosition):
(WebCore::VisiblePosition::honorEditingBoundaryAtOrBefore const):
(WebCore::VisiblePosition::honorEditingBoundaryAtOrAfter const):
(WebCore::canonicalizeCandidate):
(WebCore::VisiblePosition::canonicalPosition):
* Source/WebCore/editing/VisiblePosition.h:
(WebCore::VisiblePosition::allowUserSelectNone const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::previousLineCandidatePosition):
(WebCore::nextLineCandidatePosition):
(WebCore::previousBoundary):
(WebCore::nextBoundary):
(WebCore::startPositionForLine):
(WebCore::endPositionForLine):
(WebCore::nextLinePosition):
(WebCore::startOfParagraph):
(WebCore::endOfParagraph):
(WebCore::startOfBlock):
(WebCore::endOfBlock):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::visiblePositionForPoint):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/318359@main">https://commits.webkit.org/318359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829b5f930eb6f8be49c4793ef79b34db9f6917d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187676 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/141310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/179926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51710 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/138811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/141310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42354 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/159559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41020 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/39369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39057 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36134 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44600 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/43612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159085 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/147949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39728 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52351 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147722 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42432 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124614 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119088 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50869 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14029 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->