### PR TITLE
Use PlatformTimeRanges::span instead of start(index)/end(index) methods

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -621,8 +621,8 @@ void MediaSource::streamEndedWithError(std::optional<EndOfStreamError> error)
         // the buffered attribute across all SourceBuffer objects in sourceBuffers.
         MediaTime maxEndTime;
         for (Ref sourceBuffer : m_sourceBuffers.get()) {
-            if (auto length = sourceBuffer->bufferedInternal().length())
-                maxEndTime = std::max(sourceBuffer->bufferedInternal().end(length - 1), maxEndTime);
+            if (auto span = sourceBuffer->bufferedInternal().span(); !span.empty())
+                maxEndTime = std::max(span.back().end, maxEndTime);
         }
         setDurationInternal(maxEndTime);
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6380,10 +6380,9 @@ Ref<TimeRanges> HTMLMediaElement::buffered() const
 double HTMLMediaElement::maxBufferedTime() const
 {
     auto bufferedRanges = buffered();
-    unsigned numRanges = bufferedRanges->length();
-    if (!numRanges)
-        return 0;
-    return bufferedRanges.get().ranges().end(numRanges - 1).toDouble();
+    if (auto span = bufferedRanges.get().ranges().span(); !span.empty())
+        return span.back().end.toDouble();
+    return 0;
 }
 
 Ref<TimeRanges> HTMLMediaElement::played()

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.cpp
@@ -422,9 +422,8 @@ PlatformTimeRanges MediaSourcePrivate::computeBufferedRanges(const Vector<Platfo
     // 3. Let highest end time be the largest range end time in the active ranges.
     MediaTime highestEndTime = MediaTime::zeroTime();
     for (auto& ranges : activeRanges) {
-        unsigned length = ranges.length();
-        if (length)
-            highestEndTime = std::max(highestEndTime, ranges.end(length - 1));
+        if (auto span = ranges.span(); !span.empty())
+            highestEndTime = std::max(highestEndTime, span.back().end);
     }
 
     // Return an empty range if all ranges are empty.

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -307,8 +307,9 @@ bool PlatformTimeRanges::containWithEpsilon(const PlatformTimeRanges& ranges, NO
         return true;
 
     // Ensure that if we have a gap in the buffered range, it is smaller than the epsilon tolerance at the gap's start;
-    for (unsigned i = 1; i < bufferedRanges.length(); i++) {
-        if (bufferedRanges.start(i) - bufferedRanges.end(i - 1) > epsilonAtTime(bufferedRanges.end(i - 1)))
+    auto rangesSpan = bufferedRanges.span();
+    for (size_t i = 1; i < rangesSpan.size(); i++) {
+        if (rangesSpan[i].start - rangesSpan[i - 1].end > epsilonAtTime(rangesSpan[i - 1].end))
             return false;
     }
 

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -437,9 +437,9 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
     //     allowed by contiguousFrameTolerance).
     PlatformTimeRanges clippedErasedRanges;
     PlatformTimeRanges additionalErasedRanges;
-    for (unsigned i = 0; i < erasedRanges.length(); ++i) {
-        auto erasedStart = erasedRanges.start(i);
-        auto erasedEnd = erasedRanges.end(i);
+    for (auto& range : erasedRanges.span()) {
+        auto erasedStart = range.start;
+        auto erasedEnd = range.end;
 
         auto startIterator = m_samples.presentationOrder().reverseFindSampleBeforePresentationTime(erasedStart);
         if (startIterator == m_samples.presentationOrder().rend())

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -295,8 +295,7 @@ void MockMediaPlayerMediaSource::advanceCurrentTime()
     if (pos == notFound)
         return;
 
-    bool ignoreError;
-    m_currentTime = std::min(m_duration, buffered.end(pos, ignoreError));
+    m_currentTime = std::min(m_duration, buffered.end(pos));
     if (auto player = m_player.get())
         player->timeChanged();
 }

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -326,8 +326,8 @@ void PlaybackSessionInterfaceLMK::rateChanged(OptionSet<WebCore::PlaybackSession
 void PlaybackSessionInterfaceLMK::seekableRangesChanged(const WebCore::PlatformTimeRanges& timeRanges, double, double)
 {
     RetainPtr seekableRanges = adoptNS([[NSMutableArray alloc] initWithCapacity:timeRanges.length()]);
-    for (unsigned i = 0; i < timeRanges.length(); ++i) {
-        RetainPtr timeRange = adoptNS([allocWKSLinearMediaTimeRangeInstance() initWithLowerBound:timeRanges.start(i).toDouble() upperBound:timeRanges.end(i).toDouble()]);
+    for (auto& range : timeRanges.span()) {
+        RetainPtr timeRange = adoptNS([allocWKSLinearMediaTimeRangeInstance() initWithLowerBound:range.start.toDouble() upperBound:range.end.toDouble()]);
         [seekableRanges addObject:timeRange.get()];
     }
 


### PR DESCRIPTION
#### b035c5f53fa51e400c87834e7fb1316d8533aadc
<pre>
Use PlatformTimeRanges::span instead of start(index)/end(index) methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=318154">https://bugs.webkit.org/show_bug.cgi?id=318154</a>
<a href="https://rdar.apple.com/180963394">rdar://180963394</a>

Reviewed by Jer Noble.

Make use of the new PlatformTimeRanges::span() where possible.

No change in behaviour.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::streamEndedWithError):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::maxBufferedTime const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::computeBufferedRanges):
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::containWithEpsilon const):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::removeSamples):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::advanceCurrentTime):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::seekableRangesChanged):

Canonical link: <a href="https://commits.webkit.org/316252@main">https://commits.webkit.org/316252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bea4725d7fc960508c265aa159754f83e315e7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129059 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9071798-7d9a-49ab-831b-926f78d04bb1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1162fff2-3681-4a6c-995d-734618510e8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114044 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec6bae78-25e2-4efc-a236-33d23c52c345) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33709 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29513 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183421 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142099 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45034 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38365 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110403 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37206 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117456 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44234 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8451 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43638 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43746 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->