### PR TITLE
Move use of deprecatedToStyle out of CSS keyframe selector parsing

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1210,6 +1210,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/values/primitives/CSSKeywordList.h
     css/values/primitives/CSSPosition.h
     css/values/primitives/CSSPrimitiveData.h
+    css/values/primitives/CSSPrimitiveNumeric+Forward.h
     css/values/primitives/CSSPrimitiveNumeric.h
     css/values/primitives/CSSPrimitiveNumericCategory.h
     css/values/primitives/CSSPrimitiveNumericConcepts.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5612,6 +5612,7 @@
 		BCC0F3D62D99BDD90065B859 /* CSSURLValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC0F3D52D99BDD90065B859 /* CSSURLValue.h */; };
 		BCC0F3DA2D99D4860065B859 /* StyleURL.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC0F3D92D99D4860065B859 /* StyleURL.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCC5BE010C0E93110011C2DB /* JSCSSStyleSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC5BDFF0C0E93110011C2DB /* JSCSSStyleSheet.h */; };
+		BCC9ECA92FED9AE0006C8BAD /* CSSPrimitiveNumeric+Forward.h in Headers */ = {isa = PBXBuildFile; fileRef = BCC9ECA82FED9A69006C8BAD /* CSSPrimitiveNumeric+Forward.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCCBAD410C18C14200CE890F /* JSHTMLCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCBAD3F0C18C14200CE890F /* JSHTMLCollection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCCE02912E766AA30028EA38 /* StyleSingleTransitionDelay.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCE02902E766A860028EA38 /* StyleSingleTransitionDelay.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCCE02922E766AAA0028EA38 /* StyleSingleTransitionDuration.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCE028F2E7669A40028EA38 /* StyleSingleTransitionDuration.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -20351,6 +20352,7 @@
 		BCC5BDFF0C0E93110011C2DB /* JSCSSStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSCSSStyleSheet.h; sourceTree = "<group>"; };
 		BCC6DEE768FF3CAEF219270B /* Airplay-fullscreen.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Airplay-fullscreen.svg"; sourceTree = "<group>"; };
 		BCC8CFCA0986CD2400140BF2 /* ColorData.gperf */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = ColorData.gperf; sourceTree = "<group>"; };
+		BCC9ECA82FED9A69006C8BAD /* CSSPrimitiveNumeric+Forward.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPrimitiveNumeric+Forward.h"; sourceTree = "<group>"; };
 		BCCBAD3E0C18C14200CE890F /* JSHTMLCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLCollection.cpp; sourceTree = "<group>"; };
 		BCCBAD3F0C18C14200CE890F /* JSHTMLCollection.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSHTMLCollection.h; sourceTree = "<group>"; };
 		BCCCF06B2EF76F720019EA48 /* StyleComputedStyle+ConstructionInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StyleComputedStyle+ConstructionInlines.h"; sourceTree = "<group>"; };
@@ -38947,6 +38949,7 @@
 				BCB271D92CC0142C00265123 /* CSSPosition.cpp */,
 				BCB271D82CC0142C00265123 /* CSSPosition.h */,
 				BC2C0C8E2D32EBCB00FCFBA0 /* CSSPrimitiveData.h */,
+				BCC9ECA82FED9A69006C8BAD /* CSSPrimitiveNumeric+Forward.h */,
 				BC2C0C8F2D32F35000FCFBA0 /* CSSPrimitiveNumeric.h */,
 				BC4630BC2E9D5A5A00EA911F /* CSSPrimitiveNumericCategory.cpp */,
 				BC4630BB2E9D5A5A00EA911F /* CSSPrimitiveNumericCategory.h */,
@@ -44844,6 +44847,7 @@
 				BC3B7A1D2DB55F9B00C7A692 /* CSSPositionValue.h in Headers */,
 				977B3863122883E900B81FF8 /* CSSPreloadScanner.h in Headers */,
 				BC2C0C972D32FCE600FCFBA0 /* CSSPrimitiveData.h in Headers */,
+				BCC9ECA92FED9AE0006C8BAD /* CSSPrimitiveNumeric+Forward.h in Headers */,
 				BC2C0C982D32FCF500FCFBA0 /* CSSPrimitiveNumeric.h in Headers */,
 				BC4630BD2E9D5B7C00EA911F /* CSSPrimitiveNumericCategory.h in Headers */,
 				BCD67C122D1F10BB0079EB9C /* CSSPrimitiveNumericConcepts.h in Headers */,

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -35,6 +35,7 @@
 #include "RenderObject.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleInterpolation.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleProperties.h"
 #include "StyleResolver.h"
 #include "StyleTransform.h"
@@ -132,28 +133,34 @@ void BlendingKeyframes::copyKeyframes(const BlendingKeyframes& other)
 
 static const StyleRuleKeyframe& zeroPercentKeyframe()
 {
+    using namespace CSS::Literals;
+
     static LazyNeverDestroyed<Ref<StyleRuleKeyframe>> rule;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         rule.construct(StyleRuleKeyframe::create(MutableStyleProperties::create()));
-        rule.get()->setKey({ CSSValueNormal, 0 });
+        rule.get()->setKey({ CSSValueNormal, 0_css_percentage });
     });
     return rule.get().get();
 }
 
 static const StyleRuleKeyframe& hundredPercentKeyframe()
 {
+    using namespace CSS::Literals;
+
     static LazyNeverDestroyed<Ref<StyleRuleKeyframe>> rule;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         rule.construct(StyleRuleKeyframe::create(MutableStyleProperties::create()));
-        rule.get()->setKey({ CSSValueNormal, 1 });
+        rule.get()->setKey({ CSSValueNormal, 100_css_percentage });
     });
     return rule.get().get();
 }
 
 void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, const Style::ComputedStyle& underlyingStyle)
 {
+    using namespace CSS::Literals;
+
     if (isEmpty())
         return;
 
@@ -208,7 +215,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
             expectedExplicitProperties.addAll(keyframe.properties());
     }
 
-    auto addImplicitKeyframe = [&](double key, const HashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
+    auto addImplicitKeyframe = [&](Style::Percentage<> percentageOffset, const HashSet<AnimatableCSSProperty>& implicitProperties, const StyleRuleKeyframe& keyframeRule, BlendingKeyframe* existingImplicitBlendingKeyframe) {
         // If we're provided an existing implicit keyframe, we need to add all the styles for the implicit properties.
         if (existingImplicitBlendingKeyframe) {
             ASSERT(existingImplicitBlendingKeyframe->style());
@@ -222,7 +229,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
         }
 
         // Otherwise we create a new keyframe.
-        BlendingKeyframe blendingKeyframe(key, { nullptr });
+        BlendingKeyframe blendingKeyframe(percentageOffset, { nullptr });
         blendingKeyframe.setStyle(styleResolver->styleForKeyframe(element.get(), underlyingStyle, { nullptr }, keyframeRule, blendingKeyframe));
         for (auto property : implicitProperties)
             blendingKeyframe.addProperty(property);
@@ -235,7 +242,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
 
     auto zeroKeyframeImplicitProperties = expectedExplicitProperties.differenceWith(zeroKeyframeExplicitProperties);
     if (!zeroKeyframeImplicitProperties.isEmpty())
-        addImplicitKeyframe(0, zeroKeyframeImplicitProperties, protect(zeroPercentKeyframe()), implicitZeroKeyframe);
+        addImplicitKeyframe(0_css_percentage, zeroKeyframeImplicitProperties, protect(zeroPercentKeyframe()), implicitZeroKeyframe);
 
     HashSet<AnimatableCSSProperty> oneKeyframeExplicitProperties;
     BlendingKeyframe* implicitOneKeyframe = nullptr;
@@ -251,7 +258,7 @@ void BlendingKeyframes::fillImplicitKeyframes(const KeyframeEffect& effect, cons
 
     auto oneKeyframeImplicitProperties = expectedExplicitProperties.differenceWith(oneKeyframeExplicitProperties);
     if (!oneKeyframeImplicitProperties.isEmpty())
-        addImplicitKeyframe(1, oneKeyframeImplicitProperties, protect(hundredPercentKeyframe()), implicitOneKeyframe);
+        addImplicitKeyframe(100_css_percentage, oneKeyframeImplicitProperties, protect(hundredPercentKeyframe()), implicitOneKeyframe);
 }
 
 bool BlendingKeyframes::containsAnimatableCSSProperty() const
@@ -457,7 +464,7 @@ BlendingKeyframe::BlendingKeyframe(Offset&& offset, std::unique_ptr<Style::Compu
     , m_style(WTF::move(style))
 {
     if (!usesRangeOffset())
-        m_computedOffset = m_specifiedOffset.value;
+        m_computedOffset = Style::evaluate<double>(m_specifiedOffset.value);
 }
 
 BlendingKeyframe::BlendingKeyframe(const BlendingKeyframe& source)

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -28,6 +28,7 @@
 #include "KeyframeInterpolation.h"
 #include "StyleComputedStyle.h"
 #include "StyleSingleAnimationRangeName.h"
+#include "StylePrimitiveNumericTypes.h"
 #include "WebAnimationTypes.h"
 #include <wtf/Vector.h>
 #include <wtf/HashSet.h>
@@ -48,17 +49,29 @@ class BlendingKeyframe final : public KeyframeInterpolation::Keyframe {
 public:
     struct Offset {
         Style::SingleAnimationRangeName name;
-        double value;
+        Style::Percentage<> value;
 
-        Offset(double value)
+        Offset(Style::Percentage<> value)
             : name(Style::SingleAnimationRangeName::Omitted)
             , value(value)
         {
         }
 
-        Offset(Style::SingleAnimationRangeName name, double value)
+        Offset(CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal)
+            : name(Style::SingleAnimationRangeName::Omitted)
+            , value(literal)
+        {
+        }
+
+        Offset(Style::SingleAnimationRangeName name, Style::Percentage<> value)
             : name(name)
             , value(value)
+        {
+        }
+
+        Offset(Style::SingleAnimationRangeName name, CSS::ValueLiteral<CSS::PercentageUnit::Percentage> literal)
+            : name(name)
+            , value(literal)
         {
         }
     };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -72,6 +72,9 @@
 #include "StyleExtractor.h"
 #include "StyleInterpolation.h"
 #include "StylePendingResources.h"
+#include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes+DeprecatedConversions.h"
+#include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
@@ -199,12 +202,15 @@ static std::optional<Variant<double, TimelineRangeOffset>> doubleOrTimelineRange
     if (offsets.size() != 1)
         return { };
 
-    auto [rangeCSSValueID, value] = offsets[0];
-    auto rangeName = Style::convertCSSValueIDToSingleAnimationRangeName(rangeCSSValueID);
-    if (rangeName == Style::SingleAnimationRangeName::Normal)
-        return value;
+    auto [rangeCSSValueID, offsetCSSPercentage] = offsets[0];
 
-    return { TimelineRangeOffset { Style::convertSingleAnimationRangeNameToRangeString(rangeName), CSSNumericFactory::percent(value * 100) } };
+    auto resolvedOffsetPercentage = Style::deprecatedToStyle(offsetCSSPercentage).value;
+    auto rangeName = Style::convertCSSValueIDToSingleAnimationRangeName(rangeCSSValueID);
+
+    if (rangeName == Style::SingleAnimationRangeName::Normal)
+        return { CSS::clampToRange<CSS::ClosedPercentageRange, double>(resolvedOffsetPercentage) / 100 };
+
+    return { TimelineRangeOffset { Style::convertSingleAnimationRangeNameToRangeString(rangeName), CSSNumericFactory::percent(resolvedOffsetPercentage) } };
 }
 
 static std::optional<KeyframeEffect::KeyframeOffset> validateKeyframeOffset(const KeyframeEffect::KeyframeOffset& offset, const Document& document)
@@ -231,21 +237,21 @@ static std::optional<KeyframeEffect::KeyframeOffset> validateKeyframeOffset(cons
     return nullptr;
 };
 
-static double computedOffset(Style::SingleAnimationRangeName rangeName, double offset, const ScrollTimeline* scrollTimeline, WebAnimation* animation)
+static double computedOffset(Style::SingleAnimationRangeName rangeName, Style::Percentage<> offset, const ScrollTimeline* scrollTimeline, WebAnimation* animation)
 {
     if ((rangeName == Style::SingleAnimationRangeName::Normal || rangeName == Style::SingleAnimationRangeName::Omitted))
-        return offset;
+        return Style::evaluate<double>(offset);
 
     if (!scrollTimeline)
         return std::numeric_limits<double>::quiet_NaN();
 
     RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(scrollTimeline);
     if (!viewTimeline)
-        return offset;
+        return Style::evaluate<double>(offset);
 
     auto [namedRangeStartOffset, namedRangeEndOffset] = viewTimeline->offsetIntervalForTimelineRangeName(rangeName);
     auto namedRangeOffsetDelta = namedRangeEndOffset - namedRangeStartOffset;
-    auto computedOffsetWithinNamedRange = namedRangeStartOffset + offset * namedRangeOffsetDelta;
+    auto computedOffsetWithinNamedRange = namedRangeStartOffset + Style::evaluate<double>(offset) * namedRangeOffsetDelta;
 
     if (!animation)
         return computedOffsetWithinNamedRange;
@@ -278,7 +284,7 @@ static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKe
             auto rangeName = Style::convertRangeStringToSingleTimelineRangeName(timelineRangeOffset->rangeName);
             RefPtr offsetUnitValue = dynamicDowncast<CSSUnitValue>(timelineRangeOffset->offset);
             ASSERT(offsetUnitValue && offsetUnitValue->unitEnum() == CSSUnitType::CSS_PERCENTAGE);
-            keyframe.computedOffset = computedOffset(rangeName, offsetUnitValue->value() / 100, scrollTimeline, animation);
+            keyframe.computedOffset = computedOffset(rangeName, Style::Percentage<> { offsetUnitValue->value() }, scrollTimeline, animation);
         } else {
             keyframesWithDoubleOrNullOffset.append(&keyframe);
             if (auto* doubleValue = std::get_if<double>(&offset))
@@ -879,7 +885,7 @@ void KeyframeEffect::copyPropertiesFromSource(Ref<KeyframeEffect>&& source)
 static TimelineRangeOffset timelineRangeOffsetFromSpecifiedOffset(const BlendingKeyframe::Offset& specifiedOffset)
 {
     auto name = Style::convertSingleAnimationRangeNameToRangeString(specifiedOffset.name);
-    return TimelineRangeOffset { name, CSSNumericFactory::percent(specifiedOffset.value * 100) };
+    return TimelineRangeOffset { name, CSSNumericFactory::percent(specifiedOffset.value.value) };
 }
 
 auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
@@ -970,7 +976,10 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
         };
 
         auto& specifiedOffset = keyframe.specifiedOffset();
-        StyleRuleKeyframe::Key key { Style::convertSingleAnimationRangeNameToCSSValueID(specifiedOffset.name), specifiedOffset.value };
+        StyleRuleKeyframe::Key key {
+            Style::convertSingleAnimationRangeNameToCSSValueID(specifiedOffset.name),
+            Style::toCSS(specifiedOffset.value, elementStyle),
+        };
 
         for (auto& keyframeRule : keyframeRules) {
             if (compositeOperationForStyleRuleKeyframe(keyframeRule) != compositeOperation)
@@ -1007,7 +1016,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
         computedKeyframe.offset = [&] -> KeyframeOffset {
             if (keyframe.usesRangeOffset())
                 return timelineRangeOffsetFromSpecifiedOffset(keyframe.specifiedOffset());
-            return keyframe.specifiedOffset().value;
+            return Style::evaluate<double>(keyframe.specifiedOffset().value);
         }();
         computedKeyframe.computedOffset = keyframe.offset();
         // For CSS transitions, all keyframes should return "linear" since the effect's global timing function applies.
@@ -1215,11 +1224,11 @@ static BlendingKeyframe::Offset specifiedOffsetForParsedKeyframe(const KeyframeE
         auto rangeName = Style::convertRangeStringToSingleTimelineRangeName(timelineRangeOffset->rangeName);
         RefPtr offsetUnitValue = dynamicDowncast<CSSUnitValue>(timelineRangeOffset->offset);
         ASSERT(offsetUnitValue && offsetUnitValue->unitEnum() == CSSUnitType::CSS_PERCENTAGE);
-        return { rangeName, offsetUnitValue->value() / 100 };
+        return { rangeName, Style::Percentage<> { offsetUnitValue->value() } };
     }
 
     ASSERT(!std::isnan(keyframe.computedOffset));
-    return keyframe.computedOffset;
+    return Style::Percentage<> { keyframe.computedOffset * 100.0 };
 }
 
 void KeyframeEffect::updateBlendingKeyframes(Style::ComputedStyle& elementStyle, const Style::ResolutionContext& resolutionContext)
@@ -1443,6 +1452,8 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const Style::ComputedS
 
 void KeyframeEffect::computeCSSTransitionBlendingKeyframes(const Style::ComputedStyle& oldStyle, const Style::ComputedStyle& newStyle)
 {
+    using namespace CSS::Literals;
+
     ASSERT(document());
 
     if (m_blendingKeyframes.size())
@@ -1456,11 +1467,11 @@ void KeyframeEffect::computeCSSTransitionBlendingKeyframes(const Style::Computed
 
     BlendingKeyframes blendingKeyframes(m_blendingKeyframes.identifier());
 
-    BlendingKeyframe fromBlendingKeyframe(0, Style::ComputedStyle::clonePtr(oldStyle));
+    BlendingKeyframe fromBlendingKeyframe(0_css_percentage, Style::ComputedStyle::clonePtr(oldStyle));
     fromBlendingKeyframe.addProperty(property);
     blendingKeyframes.insert(WTF::move(fromBlendingKeyframe));
 
-    BlendingKeyframe toBlendingKeyframe(1, WTF::move(toStyle));
+    BlendingKeyframe toBlendingKeyframe(100_css_percentage, WTF::move(toStyle));
     toBlendingKeyframe.addProperty(property);
     blendingKeyframes.insert(WTF::move(toBlendingKeyframe));
 
@@ -1830,6 +1841,8 @@ void KeyframeEffect::getAnimatedStyle(std::unique_ptr<Style::ComputedStyle>& ani
 
 void KeyframeEffect::setAnimatedPropertiesInStyle(Style::ComputedStyle& targetStyle, const ComputedEffectTiming& computedTiming) const
 {
+    using namespace CSS::Literals;
+
     ASSERT(computedTiming.progress);
     ASSERT(computedTiming.currentIteration);
 
@@ -1857,8 +1870,8 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(Style::ComputedStyle& targetSt
     if (m_blendingKeyframes.isEmpty())
         return;
 
-    BlendingKeyframe propertySpecificKeyframeWithZeroOffset(0, Style::ComputedStyle::clonePtr(targetStyle));
-    BlendingKeyframe propertySpecificKeyframeWithOneOffset(1, Style::ComputedStyle::clonePtr(targetStyle));
+    BlendingKeyframe propertySpecificKeyframeWithZeroOffset(0_css_percentage, Style::ComputedStyle::clonePtr(targetStyle));
+    BlendingKeyframe propertySpecificKeyframeWithOneOffset(100_css_percentage, Style::ComputedStyle::clonePtr(targetStyle));
 
     for (auto property : properties) {
         auto interval = interpolationKeyframes(property, iterationProgress, propertySpecificKeyframeWithZeroOffset, propertySpecificKeyframeWithOneOffset);

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -27,6 +27,7 @@
 #include "CSSKeyframeRule.h"
 
 #include "CSSKeyframesRule.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSPropertyParserConsumer+Animations.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleProperties.h"
@@ -38,23 +39,23 @@
 
 namespace WebCore {
 
-void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
+void StyleRuleKeyframe::Key::writeToString(StringBuilder& builder) const
 {
     if (rangeName == CSSValueContain)
-        str.append("contain "_s);
+        builder.append("contain "_s);
     else if (rangeName == CSSValueCover)
-        str.append("cover "_s);
+        builder.append("cover "_s);
     else if (rangeName == CSSValueEntry)
-        str.append("entry "_s);
+        builder.append("entry "_s);
     else if (rangeName == CSSValueEntryCrossing)
-        str.append("entry-crossing "_s);
+        builder.append("entry-crossing "_s);
     else if (rangeName == CSSValueExit)
-        str.append("exit "_s);
+        builder.append("exit "_s);
     else if (rangeName == CSSValueExitCrossing)
-        str.append("exit-crossing "_s);
+        builder.append("exit-crossing "_s);
     else if (rangeName == CSSValueScroll)
-        str.append("scroll "_s);
-    str.append(offset * 100, '%');
+        builder.append("scroll "_s);
+    CSS::serializationForCSS(builder, CSS::defaultSerializationContext(), offset);
 }
 
 StyleRuleKeyframe::StyleRuleKeyframe(Ref<StyleProperties>&& properties)
@@ -75,7 +76,7 @@ Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Ref<StyleProperties>&& properti
     return adoptRef(*new StyleRuleKeyframe(WTF::move(properties)));
 }
 
-Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Vector<std::pair<CSSValueID, double>>&& keys, Ref<StyleProperties>&& properties)
+Ref<StyleRuleKeyframe> StyleRuleKeyframe::create(Vector<std::pair<CSSValueID, CSS::Percentage<>>>&& keys, Ref<StyleProperties>&& properties)
 {
     auto keyStructs = keys.map([](auto& pair) -> Key {
         return { pair.first, pair.second };

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CSSPrimitiveNumeric.h"
 #include "CSSRule.h"
 #include "StyleRule.h"
 
@@ -38,14 +39,14 @@ class StyleRuleCSSStyleProperties;
 class StyleRuleKeyframe final : public StyleRuleBase {
 public:
     static Ref<StyleRuleKeyframe> NODELETE create(Ref<StyleProperties>&&);
-    static Ref<StyleRuleKeyframe> create(Vector<std::pair<CSSValueID, double>>&& keys, Ref<StyleProperties>&&);
+    static Ref<StyleRuleKeyframe> create(Vector<std::pair<CSSValueID, CSS::Percentage<>>>&& keys, Ref<StyleProperties>&&);
     ~StyleRuleKeyframe();
 
     Ref<StyleRuleKeyframe> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
 
     struct Key {
         CSSValueID rangeName;
-        double offset;
+        CSS::Percentage<> offset;
 
         void writeToString(StringBuilder&) const;
         bool operator==(const Key&) const = default;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -39,56 +39,41 @@
 #include "CSSPropertyParserConsumer+Timeline.h"
 #include "CSSPropertyParserState.h"
 #include "CSSStringValue.h"
-#include "StylePrimitiveNumericTypes+DeprecatedConversions.h"
 
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange& range, CSS::PropertyParserState& state)
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> consumeKeyframeKeyList(CSSParserTokenRange& range, CSS::PropertyParserState& state)
 {
     // <keyframe-selector> = from | to | <percentage [0,100]> | <timeline-range-name> <percentage>
     // https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
+    //   and extended by
+    // https://drafts.csswg.org/scroll-animations/#named-range-keyframes
 
-    enum class RestrictedToZeroToHundredRange : bool { No, Yes };
-    auto consumeAndConvertPercentage = [&](CSSParserTokenRange& range, RestrictedToZeroToHundredRange restricted) -> std::optional<double> {
-        // FIXME: We use Style::deprecatedToStyle() to deal with calc() and % values.
-        // We will eventually want to return a CSS value that can be kept as-is on a
-        // BlendingKeyframe so that resolution happens when we have the necessary context
-        // when the keyframes are associated with a target element.
-        if (auto percentageValue = MetaConsumer<CSS::Percentage<>>::consume(range, state)) {
-            auto resolvedPercentage = Style::deprecatedToStyle(*percentageValue).value;
-            if (restricted == RestrictedToZeroToHundredRange::No)
-                return resolvedPercentage / 100;
-            if (resolvedPercentage >= 0 && resolvedPercentage <= 100)
-                return resolvedPercentage / 100;
-        }
-        return { };
-    };
-
-    auto timelineRange = [&](CSSParserTokenRange& range, CSSValueID id) -> std::optional<std::pair<CSSValueID, double>> {
+    auto timelineRange = [&](CSSParserTokenRange& range, CSSValueID id) -> std::optional<std::pair<CSSValueID, CSS::Percentage<>>> {
         if (CSSPropertyParserHelpers::isTimelineRangeName(id)) {
-            if (auto convertedPercentage = consumeAndConvertPercentage(range, RestrictedToZeroToHundredRange::No))
-                return { { id, *convertedPercentage } };
+            if (auto percentage = MetaConsumer<CSS::Percentage<>>::consume(range, state))
+                return { { id, WTF::move(*percentage) } };
         }
         return { };
     };
 
-    Vector<std::pair<CSSValueID, double>> result;
+    Vector<std::pair<CSSValueID, CSS::Percentage<>>> result;
     while (true) {
         range.consumeWhitespace();
 
         if (auto tokenValue = consumeIdent(range)) {
             auto valueId = tokenValue->valueID();
             if (valueId == CSSValueFrom)
-                result.append({ CSSValueNormal, 0 });
+                result.append({ CSSValueNormal, CSS::Percentage<> { 0 } });
             else if (valueId == CSSValueTo)
-                result.append({ CSSValueNormal, 1 });
+                result.append({ CSSValueNormal, CSS::Percentage<> { 100 } });
             else if (auto pair = timelineRange(range, valueId))
                 result.append(*pair);
             else
                 return { }; // Parser error, invalid value in keyframe selector
-        } else if (auto convertedPercentage = consumeAndConvertPercentage(range, RestrictedToZeroToHundredRange::Yes))
-            result.append({ CSSValueNormal, *convertedPercentage });
+        } else if (auto percentage = MetaConsumer<CSS::Percentage<CSS::ClosedPercentageRange>>::consume(range, state))
+            result.append({ CSSValueNormal, CSS::rangeExpandingCast<CSS::All>(*percentage) });
         else
             return { }; // Parser error, invalid value in keyframe selector
 
@@ -102,7 +87,7 @@ Vector<std::pair<CSSValueID, double>> consumeKeyframeKeyList(CSSParserTokenRange
     }
 }
 
-Vector<std::pair<CSSValueID, double>> parseKeyframeKeyList(const String& string, const CSSParserContext& context)
+Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(const String& string, const CSSParserContext& context)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp
@@ -152,7 +152,7 @@ std::optional<CSS::GridLine> consumeUnresolvedGridLine(CSSParserTokenRange& rang
         auto name = consumeUnresolvedCustomIdentForGridLine(range, state);
 
         if (consumeIdentRaw<CSSValueSpan>(range).has_value()) {
-            auto rangeCastedIndex = CSS::dynamicRangecast<CSS::Positive>(*index);
+            auto rangeCastedIndex = CSS::dynamicRangeNarrowingCast<CSS::Positive>(*index);
             if (!rangeCastedIndex)
                 return std::nullopt;
 
@@ -181,7 +181,7 @@ std::optional<CSS::GridLine> consumeUnresolvedGridLine(CSSParserTokenRange& rang
 
     if (consumeIdentRaw<CSSValueSpan>(range).has_value()) {
         if (index) {
-            auto rangeCastedIndex = CSS::dynamicRangecast<CSS::Positive>(*index);
+            auto rangeCastedIndex = CSS::dynamicRangeNarrowingCast<CSS::Positive>(*index);
             if (!rangeCastedIndex)
                 return std::nullopt;
 

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric+Forward.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric+Forward.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,33 +24,36 @@
 
 #pragma once
 
-#include "CSSPrimitiveNumeric+Forward.h"
-#include <wtf/Forward.h>
+#include <WebCore/CSSPrimitiveNumericRange.h>
 
 namespace WebCore {
-
-class CSSParserTokenRange;
-class CSSValue;
-enum CSSValueID : uint16_t;
-struct CSSParserContext;
-
 namespace CSS {
-struct PropertyParserState;
-}
 
-namespace CSSPropertyParserHelpers {
+// MARK: Integer Primitive
 
-// MARK: <keyframe-selector> consuming
-// https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
-Vector<std::pair<CSSValueID, CSS::Percentage<>>> consumeKeyframeKeyList(CSSParserTokenRange&, CSS::PropertyParserState&);
+template<Range = All, typename = int> struct Integer;
 
-// MARK: <keyframe-selector> parsing
-// https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector
-Vector<std::pair<CSSValueID, CSS::Percentage<>>> parseKeyframeKeyList(const String&, const CSSParserContext&);
+// MARK: Number Primitive
 
-// MARK: <keyframes-name> consuming
-// https://drafts.csswg.org/css-animations/#typedef-keyframes-name
-RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange&, CSS::PropertyParserState&);
+template<Range = All, typename = double> struct Number;
 
-} // namespace CSSPropertyParserHelpers
+// MARK: Percentage Primitive
+
+template<Range = All, typename = double> struct Percentage;
+
+// MARK: Dimension Primitives
+
+template<Range = All, typename = double> struct Angle;
+template<Range = All, typename = float> struct Length;
+template<Range = All, typename = double> struct Time;
+template<Range = All, typename = double> struct Frequency;
+template<Range = Nonnegative, typename = double> struct Resolution;
+template<Range = All, typename = double> struct Flex;
+
+// MARK: Dimension + Percentage Primitives
+
+template<Range = All, typename = float> struct AnglePercentage;
+template<Range = All, typename = float> struct LengthPercentage;
+
+} // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2024-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/CSSPrimitiveData.h>
+#include <WebCore/CSSPrimitiveNumeric+Forward.h>
 #include <WebCore/CSSPrimitiveNumericConcepts.h>
 #include <WebCore/CSSPrimitiveNumericRaw.h>
 #include <WebCore/CSSUnevaluatedCalc.h>
@@ -35,11 +36,6 @@
 
 namespace WebCore {
 namespace CSS {
-
-// MARK: - Forward Declarations
-
-template<NumericRaw> struct PrimitiveNumeric;
-template<Numeric, SpecificKeyword...> struct PrimitiveNumericOrKeyword;
 
 // MARK: - Primitive Numeric (Raw + UnevaluatedCalc)
 
@@ -171,55 +167,55 @@ private:
 
 // MARK: Integer Primitive
 
-template<Range R = All, typename V = int> struct Integer : PrimitiveNumeric<IntegerRaw<R, V>> {
+template<Range R, typename V> struct Integer : PrimitiveNumeric<IntegerRaw<R, V>> {
     using Base = PrimitiveNumeric<IntegerRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Number Primitive
 
-template<Range R = All, typename V = double> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
+template<Range R, typename V> struct Number : PrimitiveNumeric<NumberRaw<R, V>> {
     using Base = PrimitiveNumeric<NumberRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Percentage Primitive
 
-template<Range R = All, typename V = double> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
+template<Range R, typename V> struct Percentage : PrimitiveNumeric<PercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<PercentageRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Dimension Primitives
 
-template<Range R = All, typename V = double> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
+template<Range R, typename V> struct Angle : PrimitiveNumeric<AngleRaw<R, V>> {
     using Base = PrimitiveNumeric<AngleRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = float> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
+template<Range R, typename V> struct Length : PrimitiveNumeric<LengthRaw<R, V>> {
     using Base = PrimitiveNumeric<LengthRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = double> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
+template<Range R, typename V> struct Time : PrimitiveNumeric<TimeRaw<R, V>> {
     using Base = PrimitiveNumeric<TimeRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = double> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
+template<Range R, typename V> struct Frequency : PrimitiveNumeric<FrequencyRaw<R, V>> {
     using Base = PrimitiveNumeric<FrequencyRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = Nonnegative, typename V = double> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
+template<Range R, typename V> struct Resolution : PrimitiveNumeric<ResolutionRaw<R, V>> {
     using Base = PrimitiveNumeric<ResolutionRaw<R, V>>;
     using Base::Base;
 };
-template<Range R = All, typename V = double> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
+template<Range R, typename V> struct Flex : PrimitiveNumeric<FlexRaw<R, V>> {
     using Base = PrimitiveNumeric<FlexRaw<R, V>>;
     using Base::Base;
 };
 
 // MARK: Dimension + Percentage Primitives
 
-template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
+template<Range R, typename V> struct AnglePercentage : PrimitiveNumeric<AnglePercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<AnglePercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveDataMarkableTraits<AnglePercentage<R, V>>;
@@ -227,7 +223,7 @@ template<Range R = All, typename V = float> struct AnglePercentage : PrimitiveNu
     using Dimension = CSS::Angle<R, V>;
     using Percentage = CSS::Percentage<R, V>;
 };
-template<Range R = All, typename V = float> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
+template<Range R, typename V> struct LengthPercentage : PrimitiveNumeric<LengthPercentageRaw<R, V>> {
     using Base = PrimitiveNumeric<LengthPercentageRaw<R, V>>;
     using Base::Base;
     using MarkableTraits = PrimitiveDataMarkableTraits<LengthPercentage<R, V>>;
@@ -271,13 +267,15 @@ struct ReplacingRangeHelper<LengthPercentage<oldRange, V>, newRange> { using typ
 template<Numeric T, Range newRange>
 using ReplacingRange = typename ReplacingRangeHelper<T, newRange>::type;
 
-// `CSS::dynamicRangecast` converts a `CSS::PrimitiveNumeric` subtype with range `a` to one with range `b`,
-// returning `std::nullopt` if the value stored is a raw value that is not with range `b`. If the
-// value stored is a `calc()` value, the range cast always succeeds, as the range is only evaluated
-// for `calc()` during conversion to its `Style::PrimitiveNumeric` counterpart.
+// `CSS::dynamicRangeNarrowingCast` converts a `CSS::PrimitiveNumeric` subtype with range `a` to one
+// with range `b`, requiring that range `b` be a subrange of range `a`, returning `std::nullopt` if
+// the value stored is a raw value that is not with range `b`. If the value stored is a `calc()` value,
+// the range cast always succeeds, as the range is only evaluated for `calc()` during conversion to its
+// `Style::PrimitiveNumeric` counterpart.
 
 template<auto newRange, Numeric T>
-decltype(auto) dynamicRangecast(const T& value)
+    requires IsSubrange<newRange, T::range>
+auto dynamicRangeNarrowingCast(const T& value) -> std::optional<ReplacingRange<T, newRange>>
 {
     using Replacement = ReplacingRange<T, newRange>;
 
@@ -289,6 +287,59 @@ decltype(auto) dynamicRangecast(const T& value)
         },
         [](const typename T::Calc& calc) -> std::optional<Replacement> {
             return Replacement { typename Replacement::Calc { calc } };
+        }
+    );
+}
+
+template<auto newRange, Numeric T>
+    requires IsSubrange<newRange, T::range>
+auto dynamicRangeNarrowingCast(T&& value) -> std::optional<ReplacingRange<T, newRange>>
+{
+    using Replacement = ReplacingRange<T, newRange>;
+
+    return WTF::switchOn(WTF::move(value),
+        [](typename T::Raw&& raw) -> std::optional<Replacement> {
+            if (!isWithinRange<newRange>(raw.value))
+                return std::nullopt;
+            return Replacement { typename Replacement::Raw { raw.value } };
+        },
+        [](typename T::Calc&& calc) -> std::optional<Replacement> {
+            return Replacement { typename Replacement::Calc { WTF::move(calc) } };
+        }
+    );
+}
+
+// `CSS::rangeExpandingCast` converts a `CSS::PrimitiveNumeric` subtype with narrow range `a` to
+// an encompassing range `b`.
+
+template<auto newRange, Numeric T>
+    requires IsSubrange<T::range, newRange>
+auto rangeExpandingCast(const T& value) -> ReplacingRange<T, newRange>
+{
+    using Replacement = ReplacingRange<T, newRange>;
+
+    return WTF::switchOn(value,
+        [](const typename T::Raw& raw) {
+            return Replacement { typename Replacement::Raw { raw.value } };
+        },
+        [](const typename T::Calc& calc) {
+            return Replacement { typename Replacement::Calc { calc } };
+        }
+    );
+}
+
+template<auto newRange, Numeric T>
+    requires IsSubrange<T::range, newRange>
+auto rangeExpandingCast(T&& value) -> ReplacingRange<T, newRange>
+{
+    using Replacement = ReplacingRange<T, newRange>;
+
+    return WTF::switchOn(WTF::move(value),
+        [](typename T::Raw&& raw) {
+            return Replacement { typename Replacement::Raw { raw.value } };
+        },
+        [](typename T::Calc&& calc) {
+            return Replacement { typename Replacement::Calc { WTF::move(calc) } };
         }
     );
 }

--- a/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h
@@ -144,6 +144,20 @@ inline constexpr auto AllLayoutUnitClampedUnzoomed = Range { minValueForCssLengt
 inline constexpr auto NonnegativeLayoutUnitClamped = Range { 0, maxValueForCssLength, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Ignore };
 inline constexpr auto NonnegativeLayoutUnitClampedUnzoomed = Range { 0, maxValueForCssLength, RangeParseTimeBehavior::Default, RangeParseTimeBehavior::Ignore, RangeZoomOptions::Unzoomed };
 
+// Returns whether range `a` is equal to or is a subrange of range `b`.
+consteval bool isEqualOrSubrange(Range a, Range b)
+{
+    return a.min >= b.min && a.max <= b.max;
+}
+
+// Returns whether range `a` is a strict subrange of range `b`.
+consteval bool isSubrange(Range a, Range b)
+{
+    return isEqualOrSubrange(a, b) && (a.min != b.min || a.max != b.max);
+}
+
+template<Range a, Range b> concept IsSubrange = isSubrange(a, b);
+
 // Clamps a floating point value to within static `range`.
 template<Range range, std::floating_point T, typename U> constexpr T clampToRange(U value)
 {

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -80,6 +80,7 @@
 #include "StyleEasingFunction.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleKeyword+Mappings.h"
+#include "StylePrimitiveNumericTypes+DeprecatedConversions.h"
 #include "StyleProperties.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolveForDocument.h"
@@ -102,24 +103,6 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomStringHash.h>
-
-namespace WTF {
-
-struct StyleRuleKeyframeKeyHash {
-    static unsigned NODELETE hash(const WebCore::StyleRuleKeyframe::Key& p) { return pairIntHash(p.rangeName, p.offset); }
-    static bool NODELETE equal(const WebCore::StyleRuleKeyframe::Key& a, const WebCore::StyleRuleKeyframe::Key& b) { return a == b; }
-    static const bool safeToCompareToEmptyOrDeleted = true;
-};
-template<> struct HashTraits<WebCore::StyleRuleKeyframe::Key> : GenericHashTraits<WebCore::StyleRuleKeyframe::Key> {
-    static WebCore::StyleRuleKeyframe::Key NODELETE emptyValue() { return { WebCore::CSSValueDefault, 0 }; }
-    static bool NODELETE isEmptyValue(const WebCore::StyleRuleKeyframe::Key& value) { return value.rangeName == WebCore::CSSValueDefault; }
-
-    static void NODELETE constructDeletedValue(WebCore::StyleRuleKeyframe::Key& slot) { slot.rangeName = WebCore::CSSValueNone; }
-    static bool NODELETE isDeletedValue(const WebCore::StyleRuleKeyframe::Key& slot) { return slot.rangeName == WebCore::CSSValueNone; }
-};
-template<> struct DefaultHash<WebCore::StyleRuleKeyframe::Key> : StyleRuleKeyframeKeyHash { };
-
-}
 
 namespace WebCore {
 namespace Style {
@@ -442,6 +425,16 @@ bool Resolver::isAnimationNameValid(const AtomString& name) const
         || userAgentKeyframes().find(name) != userAgentKeyframes().end();
 }
 
+static std::pair<SingleAnimationRangeName, Percentage<>> deprecatedStyleRuleKeyframeKeyToStyle(const StyleRuleKeyframe::Key& key)
+{
+    auto offsetPercentage = deprecatedToStyle(key.offset);
+    auto offsetRangeName = convertCSSValueIDToSingleAnimationRangeName(key.rangeName);
+
+    if (offsetRangeName == SingleAnimationRangeName::Normal || offsetRangeName == SingleAnimationRangeName::Omitted)
+        offsetPercentage = CSS::clampToRange<CSS::ClosedPercentageRange, double>(offsetPercentage.value);
+    return { offsetRangeName, offsetPercentage };
+}
+
 Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& animationName, const TimingFunction* defaultTimingFunction) const
 {
     if (animationName.isEmpty())
@@ -489,14 +482,15 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     Ref keyframesRule = it->value;
     auto* keyframes = &keyframesRule->keyframes();
 
-    using KeyframeUniqueKey = std::tuple<StyleRuleKeyframe::Key, Ref<const TimingFunction>, CompositeOperation>;
+    using KeyframeUniqueKey = std::tuple<SingleAnimationRangeName, double, Ref<const TimingFunction>, CompositeOperation>;
     auto hasDuplicateKeys = [&]() -> bool {
         HashSet<KeyframeUniqueKey> uniqueKeyframeKeys;
         for (auto& keyframe : *keyframes) {
             auto compositeOperation = compositeOperationForKeyframe(keyframe);
             auto timingFunction = uniqueTimingFunctionForKeyframe(keyframe);
             for (auto key : keyframe->keys()) {
-                if (!uniqueKeyframeKeys.add({ key, timingFunction, compositeOperation }))
+                auto [offsetRangeName, offsetPercentage] = deprecatedStyleRuleKeyframeKeyToStyle(key);
+                if (!uniqueKeyframeKeys.add({ offsetRangeName, offsetPercentage.value / 100, timingFunction, compositeOperation }))
                     return true;
             }
         }
@@ -514,7 +508,8 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
         auto compositeOperation = compositeOperationForKeyframe(originalKeyframe);
         auto timingFunction = uniqueTimingFunctionForKeyframe(originalKeyframe);
         for (auto key : originalKeyframe->keys()) {
-            KeyframeUniqueKey uniqueKey { key, timingFunction, compositeOperation };
+            auto [offsetRangeName, offsetPercentage] = deprecatedStyleRuleKeyframeKeyToStyle(key);
+            KeyframeUniqueKey uniqueKey { offsetRangeName, offsetPercentage.value / 100, timingFunction, compositeOperation };
             if (RefPtr existingStyleRuleKeyframe = keyframesMap.get(uniqueKey)) {
                 protect(existingStyleRuleKeyframe->mutableProperties())->mergeAndOverrideOnConflict(originalKeyframe->properties());
                 if (existingStyleRuleKeyframe->keys()[0].rangeName == CSSValueNormal)
@@ -548,7 +543,8 @@ bool Resolver::keyframeStylesForAnimation(Element& element, const Style::Compute
     for (auto& keyframeRule : keyframeRules) {
         // Add this keyframe style to all the indicated key times
         for (auto& key : keyframeRule->keys()) {
-            BlendingKeyframe blendingKeyframe({ Style::convertCSSValueIDToSingleAnimationRangeName(key.rangeName), key.offset }, { nullptr });
+            auto [offsetRangeName, offsetPercentage] = deprecatedStyleRuleKeyframeKeyToStyle(key);
+            BlendingKeyframe blendingKeyframe({ offsetRangeName, offsetPercentage }, { nullptr });
             blendingKeyframe.setStyle(styleForKeyframe(element, elementStyle, context, keyframeRule.get(), blendingKeyframe));
             if (RefPtr timingFunctionCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction))
                 blendingKeyframe.setTimingFunction(createTimingFunctionDeprecated(timingFunctionCSSValue.releaseNonNull()));

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/HashTraits.h>
 
 namespace WebCore {
 
@@ -51,3 +52,10 @@ SingleAnimationRangeName convertRangeStringToSingleTimelineRangeName(const WTF::
 
 } // namespace Style
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::Style::SingleAnimationRangeName> : IntHash<WebCore::Style::SingleAnimationRangeName> { };
+template<> struct HashTraits<WebCore::Style::SingleAnimationRangeName> : StrongEnumHashTraits<WebCore::Style::SingleAnimationRangeName> { };
+
+} // namespace WTF


### PR DESCRIPTION
#### f9519e7ea110c2e4e06f3a34a690b0f596a3f879
<pre>
Move use of deprecatedToStyle out of CSS keyframe selector parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=318231">https://bugs.webkit.org/show_bug.cgi?id=318231</a>

Reviewed by Antoine Quint.

Moves use of Style::deprecatedToStyle out of &lt;keyframe-selector&gt; parsing and
down into the places where the keyframes are processed.

This allows us to better understand what code needs to change to actually
resolve the deprecated conversion.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric+Forward.h: Added.
    - Adds CSSPrimitiveNumeric+Forward.h, modeled on StylePrimitiveNumeric+Forward.h.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumeric.h:
    - Renames CSS::dynamicRangecast to CSS::dynamicRangeNarrowingCast and restricts it to cases
      where the range is getting narrowed (e.g. CSS::All to CSS::Nonnegative).
    - Adds CSS::rangeExpandingCast, restricted to expanding range ranges.

* Source/WebCore/css/values/primitives/CSSPrimitiveNumericRange.h:
    - Add some helpers for use in range cast restrictions.

* Source/WebCore/css/CSSKeyframeRule.cpp:
* Source/WebCore/css/CSSKeyframeRule.h:
    - Stores parsed offset as a CSS::Percentage&lt;&gt; instead of a double in StyleRuleKeyframe::Key.

* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/animation/BlendingKeyframes.cpp:
    - Use Style::Percentage&lt;&gt; for the specified offset value. In a followup, changing the
      computed offset to use Markable&lt;Style::Percentage&lt;&gt;&gt; would be a good additional improvement.

* Source/WebCore/animation/KeyframeEffect.cpp:
    - Perform the deprecated style conversion, clamping to 0-100 when appropriate.

* Source/WebCore/style/StyleResolver.cpp:
    - Perform the deprecated style conversion, clamping to 0-100 when appropriate.
    - Remove custom traits for StyleRuleKeyframe::Key by utilizing the built in std::tuple traits
      already being used.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.h:
    - Remove use of deprecatedToStyle(), returning CSS::Percentage&lt;&gt; instead.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.cpp:
    - Update for rename to CSS::dynamicRangeNarrowingCast.

* Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h:
    - Add trivial traits for the SingleAnimationRangeName enum.

Canonical link: <a href="https://commits.webkit.org/316393@main">https://commits.webkit.org/316393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32efd42f21e27d17f0a553741c8efc65d9bf59bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171966 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133797 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34074 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30019 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183938 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38272 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142498 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45550 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38490 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46230 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110892 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37489 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117918 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44748 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8742 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->