### PR TITLE
[iOS] Networking can get pinned in a MediaStreaming state if the WebContent process is suspended with MediaStreaming active

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -185,6 +185,7 @@ public:
     String stateString() const;
     bool isLaunching() const { return state() == State::Launching; }
     bool wasTerminated() const;
+    bool isSuspended() const { return m_isSuspended; }
 
     ProcessID processID() const { return m_processLauncher ? m_processLauncher->processID() : 0; }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2081,6 +2081,8 @@ void WebProcessProxy::didChangeThrottleState(ProcessThrottleState type)
 
     ASSERT(!m_backgroundToken || !m_foregroundToken);
     m_backgroundResponsivenessTimer->updateState();
+
+    updateMediaStreamingActivity();
 }
 
 void WebProcessProxy::didDropLastAssertion()
@@ -2156,6 +2158,9 @@ void WebProcessProxy::updateMediaStreamingActivity()
         return remotePage ? remotePage->mediaState().contains(MediaProducerMediaState::HasStreamingActivity) : false;
     });
     bool hasMediaStreamingWebPage = hasMediaStreamingMainPage || hasMediaStreamingRemotePage;
+
+    if (isSuspended())
+        hasMediaStreamingWebPage = false;
 
     if (!!m_mediaStreamingActivity == hasMediaStreamingWebPage)
         return;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1050,6 +1050,7 @@
 				WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm,
 				WebKit/WKWebView/mac/WKWebViewTitlebarSeparatorTests.mm,
 				WebKit/WKWebView/mac/WordBoundaryTypingAttributes.mm,
+				WebKit/WKWebView/MediaStreamingActivitySuspended.mm,
 				WebKit/WKWebView/MediaStreamTrackDetached.mm,
 				WebKit/WKWebView/MSEIsTypeSupportedCaching.mm,
 				WebKit/WKWebView/NoHistoryItemScrollToFragment.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaStreamingActivitySuspended.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaStreamingActivitySuspended.mm
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <notify.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+namespace TestWebKitAPI {
+
+static constexpr auto WebKitMediaStreamingActivityNotificationName = "com.apple.WebKit.mediaStreamingActivity";
+
+// rdar://180954825 — when a WebProcess holding a media streaming token is suspended, the
+// UIProcess must drop the token so the NetworkProcess gets notified that media streaming
+// has ended. Otherwise the cellular modem can stay pinned in an media-streaming state.
+TEST(WebKit, ManagedMSEMediaStreamingActivityClearedOnProcessSuspend)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [[configuration preferences] _setManagedMediaSourceEnabled:YES];
+    [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"file-with-managedmse"];
+
+    if (![[webView objectByEvaluatingJavaScript:@"window.ManagedMediaSource !== undefined"] boolValue])
+        return;
+    if (![[webView objectByEvaluatingJavaScript:@"isMP4Supported() || isWebMVP9Supported() || isWebMOpusSupported()"] boolValue])
+        return;
+
+    int token = NOTIFY_TOKEN_INVALID;
+    if (notify_register_check(WebKitMediaStreamingActivityNotificationName, &token) != NOTIFY_STATUS_OK)
+        return;
+
+    __block bool isMediaStreamingChanged = false;
+    __block bool isMediaStreaming = false;
+    int status = notify_register_dispatch(WebKitMediaStreamingActivityNotificationName, &token, mainDispatchQueueSingleton(), ^(int notifyToken) {
+        uint64_t state = 0;
+        notify_get_state(notifyToken, &state);
+        isMediaStreamingChanged = true;
+        isMediaStreaming = !!state;
+    });
+    if (status != NOTIFY_STATUS_OK)
+        return;
+
+    [webView objectByEvaluatingJavaScript:@"loadVideo()"];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_TRUE(isMediaStreaming);
+
+    isMediaStreamingChanged = false;
+    [webView _setThrottleStateForTesting:0];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_FALSE(isMediaStreaming);
+
+    notify_cancel(token);
+}
+
+TEST(WebKit, ManagedMSEMediaStreamingActivityClearedOnProcessCrash)
+{
+    RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+    [[configuration preferences] _setManagedMediaSourceEnabled:YES];
+    [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"file-with-managedmse"];
+
+    if (![[webView objectByEvaluatingJavaScript:@"window.ManagedMediaSource !== undefined"] boolValue])
+        return;
+    if (![[webView objectByEvaluatingJavaScript:@"isMP4Supported() || isWebMVP9Supported() || isWebMOpusSupported()"] boolValue])
+        return;
+
+    int token = NOTIFY_TOKEN_INVALID;
+    if (notify_register_check(WebKitMediaStreamingActivityNotificationName, &token) != NOTIFY_STATUS_OK)
+        return;
+
+    __block bool isMediaStreamingChanged = false;
+    __block bool isMediaStreaming = false;
+    int status = notify_register_dispatch(WebKitMediaStreamingActivityNotificationName, &token, mainDispatchQueueSingleton(), ^(int notifyToken) {
+        uint64_t state = 0;
+        notify_get_state(notifyToken, &state);
+        isMediaStreamingChanged = true;
+        isMediaStreaming = !!state;
+    });
+    if (status != NOTIFY_STATUS_OK)
+        return;
+
+    [webView objectByEvaluatingJavaScript:@"loadVideo()"];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_TRUE(isMediaStreaming);
+
+    isMediaStreamingChanged = false;
+    [webView _killWebContentProcess];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_FALSE(isMediaStreaming);
+
+    notify_cancel(token);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9d2c43b4dc9d9c47448c510c87e79ecaf40b60a4
<pre>
[iOS] Networking can get pinned in a MediaStreaming state if the WebContent process is suspended with MediaStreaming active
<a href="https://rdar.apple.com/179497684">rdar://179497684</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318235">https://bugs.webkit.org/show_bug.cgi?id=318235</a>

Reviewed by Eric Carlson.

ManagedMediaSource uses a timer to ensure it releases its MediaStreaming state after a timeout, should the
page not adequately buffer during the streaming period. If the process is suspended while this timer is active
the timer will never fire, and networking will be pinned in the MediaStreaming state.

Add a condition to WebProcessProxy::updateMediaStreamingActivity() which will release the MediaStreaming state
when the WebContent process is suspended.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaStreamingActivitySuspended.mm

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::isSuspended const):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didChangeThrottleState):
(WebKit::WebProcessProxy::updateMediaStreamingActivity):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/MediaStreamingActivitySuspended.mm: Added.
(TestWebKitAPI::TEST(WebKit, ManagedMSEMediaStreamingActivityClearedOnProcessSuspend)):
(TestWebKitAPI::TEST(WebKit, ManagedMSEMediaStreamingActivityClearedOnProcessCrash)):

Canonical link: <a href="https://commits.webkit.org/316279@main">https://commits.webkit.org/316279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69935d17f8143385a134aaad4d29014cae7f200b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129132 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/411f5399-a3f1-4674-b3b1-e30f52591728) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133589 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/baeba351-4a34-417a-954c-944b9a2df502) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114062 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b40a4ae1-c7a4-454f-af3c-aca1cb196cbb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33759 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29630 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145925 "Found 1 new API test failure: TestWebKitAPI.WebAuthenticationPanel.MultipleAccounts (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183549 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142160 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45162 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142055 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38395 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45841 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110476 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37269 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117530 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44360 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8499 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->