### PR TITLE
[CMake] Self-heal precompiled headers after a reconfigure in a relocated build directory

### DIFF
--- a/Source/cmake/ninja-wrapper
+++ b/Source/cmake/ninja-wrapper
@@ -16,6 +16,35 @@ if (getcwd() =~ m{/CMakeFiles/}) {
     exec($ninja, @ARGV);
 }
 
+# Self-heal PCHs in a relocated (APFS copy-on-write) build dir reused via a clang
+# VFS overlay (.pch-vfs-overlay.yaml, written by the relocating tooling) that
+# re-homes each .pch's baked paths so they need not be recompiled. A cmake
+# reconfigure rewrites the cmake_pch.* wrappers (new content, unchanged mtime), so
+# ninja keeps the now-stale .pch and clang rejects it; when a reconfigure is
+# pending and the overlay exists, reconfigure first, then touch any wrapper whose
+# content changed so ninja rebuilds just those .pch.
+if (-e ".pch-vfs-overlay.yaml" && `$ninja -n @ARGV 2>&1` =~ /\bRe-running CMake\b/) {
+    require File::Find;
+    my $snapshot = sub {
+        my %h;
+        File::Find::find({ no_chdir => 1, wanted => sub {
+            return unless m{(?:^|/)cmake_pch[.\w]*\.(?:hxx|h)$};
+            local $/;
+            open(my $f, '<', $_) or return;
+            $h{$_} = <$f>;
+            close($f);
+        } }, '.');
+        return %h;
+    };
+    my %before = $snapshot->();
+    system($ninja, 'build.ninja');
+    my %after = $snapshot->();
+    my $now = time;
+    for my $w (keys %after) {
+        utime($now, $now, $w) if !defined($before{$w}) || $before{$w} ne $after{$w};
+    }
+}
+
 # Real compilation
 my $bundlePolicy = $ENV{WK_UNIFIED_SOURCES_BUNDLE_POLICY};
 if (!defined($bundlePolicy)) {


### PR DESCRIPTION
#### e83d73a9ac3ac72d520bd780b79ad5d6d5c91dfb
<pre>
[CMake] Self-heal precompiled headers after a reconfigure in a relocated build directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=318245">https://bugs.webkit.org/show_bug.cgi?id=318245</a>
<a href="https://rdar.apple.com/181050574">rdar://181050574</a>

Reviewed by NOBODY (OOPS!).

A build directory can be reused from a different filesystem location than the
one it was generated in -- for example an APFS copy-on-write clone of a
checkout&apos;s source and build tree, used to spin up a cheap throwaway build. To
avoid recompiling every precompiled header at the new location, such a setup is
paired with a clang VFS overlay (-ivfsoverlay) that re-homes each .pch&apos;s baked
absolute input-file paths, so the copy-on-write .pch files validate and are
reused as-is.

That holds until cmake reconfigures (any change to a CMakeLists.txt or other
generator input). The reconfigure regenerates the cmake_pch.* wrapper headers
with the relocated paths -- new content -- but preserves their mtime. ninja&apos;s
up-to-date check is mtime-based, so it does not rebuild the now-stale .pch;
clang then loads the .pch, finds the wrapper&apos;s recorded size no longer matches,
rejects it (-Winvalid-pch), and the dependent compiles fail.

Handle this in the ninja wrapper: when a reconfigure is pending and the VFS
overlay is present, run the reconfigure first, then touch any cmake_pch.*
wrapper whose content actually changed so ninja rebuilds just those .pch files.
It is inert for a normal in-place build (no overlay file present), and only the
first reconfigure after relocation changes the wrappers, so it heals once and
then stays warm.

No new tests; this is build tooling for an out-of-tree relocated-build setup and
is not reachable from the layout or API test harness. Verified by hand: in a
relocated, overlay-reused build directory, edit a CMakeLists.txt and rebuild --
the affected PCHs rebuild and dependent compiles succeed, and a subsequent build
is a no-op.

* Source/cmake/ninja-wrapper:
Touch reconfigure-changed cmake_pch.* wrappers in a relocated, overlay-reused
build directory so ninja rebuilds the affected precompiled headers.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e83d73a9ac3ac72d520bd780b79ad5d6d5c91dfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/171602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/38937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180905 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129156 "Hash e83d73a9 for PR 68348 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6387cd70-94c5-46d6-838d-23b05f689658) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133595 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129156 "Hash e83d73a9 for PR 68348 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96351115-4a6c-48fe-81b4-b906b5095560) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114068 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e57b71b-a53b-4b92-97f4-c46e78ee819c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33779 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29654 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2603 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183573 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/32861 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142182 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45186 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142076 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45865 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30415 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110500 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37274 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204280 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44384 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8511 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44016 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43843 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->