### PR TITLE
[css-mixins-1] Serialize types

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom-expected.txt
@@ -13,21 +13,21 @@ PASS item()
 PASS Indexed property getter
 PASS @supports in body
 PASS CSSFunctionRule.name
-FAIL CSSFunctionRule.getParameters() assert_object_equals: property "type" expected "<length>" got "*"
-FAIL CSSFunctionRule.returnType assert_equals: expected "<length>" but got "*"
+PASS CSSFunctionRule.getParameters()
+PASS CSSFunctionRule.returnType
 PASS CSSFunctionRule escapes
 PASS CSSFunctionRule.cssText (--empty)
-FAIL CSSFunctionRule.cssText (--ret-length) assert_equals: expected "@function --ret-length() returns <length> { }" but got "@function --ret-length() { }"
-FAIL CSSFunctionRule.cssText (--ret-length-auto) assert_equals: expected "@function --ret-length-auto() returns type(<length> | auto) { }" but got "@function --ret-length-auto() { }"
+PASS CSSFunctionRule.cssText (--ret-length)
+PASS CSSFunctionRule.cssText (--ret-length-auto)
 PASS CSSFunctionRule.cssText (--param-single)
-FAIL CSSFunctionRule.cssText (--param-typed) assert_equals: expected "@function --param-typed(--x <length>) { }" but got "@function --param-typed(--x) { }"
-FAIL CSSFunctionRule.cssText (--param-typed-default) assert_equals: expected "@function --param-typed-default(--x <length>: 10px) { }" but got "@function --param-typed-default(--x: 10px) { }"
+PASS CSSFunctionRule.cssText (--param-typed)
+PASS CSSFunctionRule.cssText (--param-typed-default)
 PASS CSSFunctionRule.cssText (--param-default)
 PASS CSSFunctionRule.cssText (--param-multi)
-FAIL CSSFunctionRule.cssText (--param-multi-mixed) assert_equals: expected "@function --param-multi-mixed(--x: 10px, --y, --z <length>) { }" but got "@function --param-multi-mixed(--x: 10px, --y, --z) { }"
+PASS CSSFunctionRule.cssText (--param-multi-mixed)
 PASS CSSFunctionRule.cssText (--body-result)
 PASS CSSFunctionRule.cssText (--body-locals)
-FAIL CSSFunctionRule.cssText (--param-type-fn) assert_equals: expected "@function --param-type-fn(--x <length>) { }" but got "@function --param-type-fn(--x) { }"
+PASS CSSFunctionRule.cssText (--param-type-fn)
 PASS CSSFunctionRule.cssText (--param-type-fn-uni)
 PASS CSSFunctionRule.cssText (--ret-type-fn)
 PASS CSSFunctionRule.cssText (--ret-type-fn-uni)

--- a/Source/WebCore/css/CSSFunctionRule.cpp
+++ b/Source/WebCore/css/CSSFunctionRule.cpp
@@ -50,9 +50,11 @@ auto CSSFunctionRule::getParameters() const -> Vector<FunctionParameter>
 {
     return WTF::map(styleRuleFunction().parameters(), [](const auto& parameter) {
         RefPtr defaultValue = parameter.defaultValue;
+        StringBuilder type;
+        serializeCustomPropertySyntax(type, parameter.type);
         return FunctionParameter {
             .name = parameter.name,
-            .type = "*"_s, // FIXME: Implement.
+            .type = type.toString(),
             // FIXME: The spec says:
             //   "The default value of the function parameter, or `null` if the argument does not have a default".
             // But WPT tests currently expect the value to missing/undefined, not `null`, so we are using
@@ -64,7 +66,9 @@ auto CSSFunctionRule::getParameters() const -> Vector<FunctionParameter>
 
 String CSSFunctionRule::returnType() const
 {
-    return "*"_s;
+    StringBuilder builder;
+    serializeCustomPropertySyntax(builder, styleRuleFunction().returnType());
+    return builder.toString();
 }
 
 String CSSFunctionRule::cssText() const
@@ -78,14 +82,25 @@ String CSSFunctionRule::cssText() const
     for (auto& parameter : styleRuleFunction().parameters()) {
         builder.append(separator);
         serializeIdentifier(builder, parameter.name);
-        // FIXME: Serialize the type.
+
+        if (!parameter.type.isUniversal()) {
+            builder.append(' ');
+            serializeCustomPropertySyntaxAsCSSType(builder, parameter.type);
+        }
 
         if (RefPtr defaultValue = parameter.defaultValue)
             builder.append(": "_s, defaultValue->serialize());
         separator = ", "_s;
     }
 
-    builder.append(") { "_s);
+    builder.append(')');
+
+    if (auto& returnType = styleRuleFunction().returnType(); !returnType.isUniversal()) {
+        builder.append(" returns "_s);
+        serializeCustomPropertySyntaxAsCSSType(builder, returnType);
+    }
+
+    builder.append(" { "_s);
 
     for (unsigned index = 0; index < length(); ++index) {
         Ref rule = *item(index);

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -25,12 +25,14 @@
 #include "config.h"
 #include "CSSCustomPropertySyntax.h"
 
+#include "CSSMarkup.h"
 #include "CSSParserIdioms.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
 #include "CSSTokenizer.h"
 #include <wtf/SortedArrayMap.h>
 #include <wtf/text/ParsingUtilities.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
@@ -203,6 +205,76 @@ auto CSSCustomPropertySyntax::typeForTypeName(StringView dataTypeName) -> Type
         { "url"_s, Type::URL },
     }) };
     return typeMap.get(dataTypeName, Type::Unknown);
+}
+
+static ASCIILiteral typeNameForType(CSSCustomPropertySyntax::Type type)
+{
+    using Type = CSSCustomPropertySyntax::Type;
+    switch (type) {
+    case Type::Length: return "length"_s;
+    case Type::LengthPercentage: return "length-percentage"_s;
+    case Type::Percentage: return "percentage"_s;
+    case Type::Integer: return "integer"_s;
+    case Type::Number: return "number"_s;
+    case Type::Angle: return "angle"_s;
+    case Type::Time: return "time"_s;
+    case Type::Resolution: return "resolution"_s;
+    case Type::Color: return "color"_s;
+    case Type::Image: return "image"_s;
+    case Type::URL: return "url"_s;
+    case Type::CustomIdent: return "custom-ident"_s;
+    case Type::String: return "string"_s;
+    case Type::TransformFunction: return "transform-function"_s;
+    case Type::TransformList: return "transform-list"_s;
+    case Type::Ident:
+    case Type::Unknown:
+        break;
+    }
+    return { };
+}
+
+void serializeCustomPropertySyntax(StringBuilder& builder, const CSSCustomPropertySyntax& syntax)
+{
+    if (syntax.isUniversal()) {
+        builder.append('*');
+        return;
+    }
+
+    auto separator = ""_s;
+    for (auto& component : syntax.definition) {
+        builder.append(separator);
+        separator = " | "_s;
+
+        // The Ident type is a literal custom identifier rather than a named data type.
+        if (component.type == CSSCustomPropertySyntax::Type::Ident)
+            serializeIdentifier(builder, component.ident);
+        else
+            builder.append('<', typeNameForType(component.type), '>');
+
+        switch (component.multiplier) {
+        case CSSCustomPropertySyntax::Multiplier::Single:
+            break;
+        case CSSCustomPropertySyntax::Multiplier::SpaceList:
+            builder.append('+');
+            break;
+        case CSSCustomPropertySyntax::Multiplier::CommaList:
+            builder.append('#');
+            break;
+        }
+    }
+}
+
+void serializeCustomPropertySyntaxAsCSSType(StringBuilder& builder, const CSSCustomPropertySyntax& syntax)
+{
+    ASSERT(!syntax.isUniversal());
+    // A single syntax component is written bare. Anything else must be wrapped in type().
+    if (syntax.definition.size() == 1) {
+        serializeCustomPropertySyntax(builder, syntax);
+        return;
+    }
+    builder.append("type("_s);
+    serializeCustomPropertySyntax(builder, syntax);
+    builder.append(')');
 }
 
 }

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -27,6 +27,10 @@
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringParsingBuffer.h>
 
+namespace WTF {
+class StringBuilder;
+}
+
 namespace WebCore {
 
 class CSSParserTokenRange;
@@ -73,7 +77,6 @@ struct CSSCustomPropertySyntax {
     static std::optional<CSSCustomPropertySyntax> parse(StringView);
     static std::optional<CSSCustomPropertySyntax> consumeType(CSSParserTokenRange&);
 
-
     static CSSCustomPropertySyntax universal() { return { }; }
 
     bool NODELETE containsUnknownType() const;
@@ -82,5 +85,12 @@ private:
     template<typename CharacterType> static std::optional<Component> parseComponent(std::span<const CharacterType>);
     static Type typeForTypeName(StringView);
 };
+
+// Serializes to the <syntax> string form, e.g. "*", "<length>", "<length>+", "<color> | <length>".
+void serializeCustomPropertySyntax(StringBuilder&, const CSSCustomPropertySyntax&);
+
+// Serializes to the <css-type> form used in @function preludes: a single component is bare, while a
+// multi-component syntax is wrapped in type(). Must not be called on the universal syntax.
+void serializeCustomPropertySyntaxAsCSSType(StringBuilder&, const CSSCustomPropertySyntax&);
 
 }


### PR DESCRIPTION
#### a0291f16f65d6af683f9dc070d837206e8703bc5
<pre>
[css-mixins-1] Serialize types
<a href="https://bugs.webkit.org/show_bug.cgi?id=318225">https://bugs.webkit.org/show_bug.cgi?id=318225</a>
<a href="https://rdar.apple.com/181027296">rdar://181027296</a>

Reviewed by Tim Nguyen.

Add CSSCustomPropertySyntax serialization support and use it for @function serialization.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/at-function-cssom-expected.txt:
* Source/WebCore/css/CSSFunctionRule.cpp:
(WebCore::CSSFunctionRule::getParameters const):
(WebCore::CSSFunctionRule::returnType const):
(WebCore::CSSFunctionRule::cssText const):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::typeNameForType):
(WebCore::serializeCustomPropertySyntax):
(WebCore::serializeCustomPropertySyntaxAsCSSType):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.h:

Canonical link: <a href="https://commits.webkit.org/316190@main">https://commits.webkit.org/316190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b0bdfddbc6d3bbe70cb89e8ca897a3212d160f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171610 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb6129a6-b4e9-41c2-9a89-49a4526e7e0d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45167 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e514db8f-4125-4d0b-9a1f-29b3d6075a1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174568 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b871595e-68ee-4a2e-981a-63fb8937fef4) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29662 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183581 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38306 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44392 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/38945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->