### PR TITLE
Flash reloading models

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -815,8 +815,15 @@ void HTMLModelElement::reloadModelPlayer()
 #if ENABLE(MODEL_PROCESS) || ENABLE(GPU_PROCESS_MODEL)
     if (!m_modelPlayerProvider)
         m_modelPlayerProvider = document().page()->modelPlayerProvider();
+#if ENABLE(GPU_PROCESS_MODEL)
+    RefPtr<ModelPlayer> previousPlayer = modelPlayer;
+#endif
     if (RefPtr modelPlayerProvider = m_modelPlayerProvider) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
+#if ENABLE(GPU_PROCESS_MODEL)
+        if (modelPlayer && previousPlayer)
+            modelPlayer->adoptContentsDisplayDelegateFrom(*previousPlayer);
+#endif
         m_modelPlayer = modelPlayer.copyRef();
     }
     if (!modelPlayer) {

--- a/Source/WebCore/Modules/model-element/ModelPlayer.cpp
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.cpp
@@ -50,6 +50,11 @@ bool ModelPlayer::isPlaceholder() const
     return false;
 }
 
+bool ModelPlayer::isWebModelPlayerInstance() const
+{
+    return false;
+}
+
 std::optional<ModelPlayerAnimationState> ModelPlayer::currentAnimationState() const
 {
     return std::nullopt;
@@ -61,6 +66,10 @@ std::optional<std::unique_ptr<ModelPlayerTransformState>> ModelPlayer::currentTr
 }
 
 void ModelPlayer::reload(Model&, LayoutSize, ModelPlayerAnimationState&, std::unique_ptr<ModelPlayerTransformState>&&)
+{
+}
+
+void ModelPlayer::adoptContentsDisplayDelegateFrom(ModelPlayer&)
 {
 }
 

--- a/Source/WebCore/Modules/model-element/ModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayer.h
@@ -71,6 +71,7 @@ public:
 
     virtual ModelPlayerIdentifier identifier() const = 0;
     virtual bool NODELETE isPlaceholder() const;
+    virtual bool NODELETE isWebModelPlayerInstance() const;
 
     // Loading.
     virtual void load(Model&, LayoutSize, bool) = 0;
@@ -78,6 +79,7 @@ public:
 
     // Graphics.
     virtual void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) = 0;
+    virtual void NODELETE adoptContentsDisplayDelegateFrom(ModelPlayer&);
 
     virtual RefPtr<ImageBuffer> snapshotCurrentFrame(const FloatSize& deviceSize, const DestinationColorSpace&);
 

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -40,6 +40,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Observer.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/TypeCasts.h>
 #include <wtf/URL.h>
 
 OBJC_CLASS WKBridgeModelLoader;
@@ -72,7 +73,9 @@ public:
 
     WebCore::ModelPlayerIdentifier identifier() const final;
     bool isPlaceholder() const final;
+    bool isWebModelPlayerInstance() const final { return true; }
     void scheduleUpdateIfNeeded();
+    void releaseModelResources();
 
 private:
     WebModelPlayer(WebCore::Page&, WebCore::ModelPlayerClient&);
@@ -83,6 +86,7 @@ private:
     void load(WebCore::Model&, WebCore::LayoutSize, bool) final;
     void sizeDidChange(WebCore::LayoutSize) final;
     void configureGraphicsLayer(WebCore::GraphicsLayer&, WebCore::ModelPlayerGraphicsLayerConfiguration&&) final;
+    void adoptContentsDisplayDelegateFrom(WebCore::ModelPlayer&) final;
     RefPtr<WebCore::ImageBuffer> snapshotCurrentFrame(const WebCore::FloatSize& deviceSize, const WebCore::DestinationColorSpace&) final;
     void enterFullscreen() final;
     void handleMouseDown(const WebCore::LayoutPoint&, MonotonicTime) final;
@@ -131,6 +135,7 @@ private:
     void updateClockTimeOnAnimationState();
     bool render();
     void scheduleDisplayUpdate();
+    void notifyClientDidFinishLoading();
 
     void setStageMode(WebCore::StageModeOperation) final;
     void notifyEntityTransformUpdated();
@@ -181,6 +186,7 @@ private:
     bool m_isUpdateScheduled { false };
     bool m_isUpdating { false };
     bool m_needsEntityTransformNotification { false };
+    bool m_pendingClientFinishLoadingNotification { false };
 
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
     using ScreenPropertiesChangedObserver = Observer<void(WebCore::PlatformDisplayID)>;
@@ -196,5 +202,9 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebModelPlayer)
+static bool isType(const WebCore::ModelPlayer& player) { return player.isWebModelPlayerInstance(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -111,6 +111,10 @@ public:
     {
         m_contentsFormat = contentsFormat;
     }
+    void setModelPlayer(WebModelPlayer& modelPlayer)
+    {
+        m_modelPlayer = modelPlayer;
+    }
 private:
     ModelDisplayBufferDisplayDelegate(WebModelPlayer& modelPlayer, float contentsScale)
         : m_modelPlayer(modelPlayer)
@@ -201,6 +205,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
     m_displayTextureIndex = 0;
     m_hasRenderedFrame = false;
     m_isUpdateLoopRunning = false;
+    m_pendingClientFinishLoadingNotification = false;
     RefPtr document = corePage->localTopDocument();
     if (!document)
         return;
@@ -266,14 +271,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size,
                 protectedThis->m_didFinishLoading = true;
                 [protectedThis->m_modelLoader setLoop:protectedThis->m_isLooping];
                 protectedThis->m_cachedAnimationState = protectedThis->currentAnimationState();
-
-                client->didFinishLoading(protectedThis.get());
-                auto [center, extents] = protectedThis->boundingBoxCenterAndExtents();
-                client->didUpdateBoundingBox(protectedThis.get(), center, extents);
-                protectedThis->notifyEntityTransformUpdated();
-
-                if (auto environmentMap = protectedThis->m_environmentMap)
-                    protectedThis->setEnvironmentMap(WTF::move(*environmentMap));
+                protectedThis->m_pendingClientFinishLoadingNotification = true;
             }
             protectedThis->startUpdateLoopIfNeeded();
         });
@@ -492,6 +490,20 @@ void WebModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLaye
     graphicsLayer.setContentsDisplayDelegate(contentsDisplayDelegate(), WebCore::GraphicsLayer::ContentsLayerPurpose::Canvas);
 }
 
+void WebModelPlayer::adoptContentsDisplayDelegateFrom(WebCore::ModelPlayer& previousPlayer)
+{
+    auto* webPrevious = dynamicDowncast<WebModelPlayer>(previousPlayer);
+    if (!webPrevious)
+        return;
+
+    RefPtr delegate = std::exchange(webPrevious->m_contentsDisplayDelegate, nullptr);
+    if (!delegate)
+        return;
+
+    delegate->setModelPlayer(*this);
+    m_contentsDisplayDelegate = WTF::move(delegate);
+}
+
 const MachSendRight* WebModelPlayer::displayBuffer() const
 {
     if (m_displayTextureIndex >= m_displayBuffers.size())
@@ -667,6 +679,7 @@ bool WebModelPlayer::render()
                 protectedThis->updateScreenHeadroomFromPage();
             }
 
+            protectedThis->notifyClientDidFinishLoading();
             protectedThis->scheduleDisplayUpdate();
         });
     });
@@ -678,6 +691,30 @@ void WebModelPlayer::scheduleDisplayUpdate()
 {
     if (RefPtr graphicsLayer = m_graphicsLayer)
         graphicsLayer->setContentsNeedsDisplay();
+}
+
+void WebModelPlayer::notifyClientDidFinishLoading()
+{
+    if (!m_pendingClientFinishLoadingNotification)
+        return;
+
+    RefPtr client { m_client };
+    if (!client)
+        return;
+
+    m_pendingClientFinishLoadingNotification = false;
+
+    Ref protectedThis { *this };
+    client->didFinishLoading(protectedThis);
+
+    if (m_currentModel) {
+        auto [center, extents] = boundingBoxCenterAndExtents();
+        client->didUpdateBoundingBox(protectedThis, center, extents);
+    }
+    notifyEntityTransformUpdated();
+
+    if (auto environmentMap = m_environmentMap)
+        setEnvironmentMap(WTF::move(*environmentMap));
 }
 
 bool WebModelPlayer::supportsTransform(WebCore::TransformationMatrix transformationMatrix)
@@ -829,6 +866,22 @@ static bool disableReloading()
     return disableReloading;
 }
 
+void WebModelPlayer::releaseModelResources()
+{
+    m_currentModel = nullptr;
+    m_retainedData = nil;
+    m_didFinishLoading = false;
+    m_modelLoader = nil;
+    m_displayBuffers.clear();
+    m_environmentMap = std::nullopt;
+    m_isUpdateLoopRunning = false;
+    m_isUpdateScheduled = false;
+    m_isUpdating = false;
+    m_displayTextureIndex = 0;
+    m_hasRenderedFrame = false;
+    m_pendingClientFinishLoadingNotification = false;
+}
+
 void WebModelPlayer::visibilityStateDidChange()
 {
     // When the model becomes invisible, release memory-intensive resources.
@@ -842,17 +895,7 @@ void WebModelPlayer::visibilityStateDidChange()
         m_cachedTransformState = currentTransformState();
 
         // Model is no longer visible - release resources to save memory
-        m_currentModel = nullptr;
-        m_retainedData = nil;
-        m_didFinishLoading = false;
-        m_modelLoader = nil;
-        m_displayBuffers.clear();
-        m_environmentMap = std::nullopt;
-        m_isUpdateLoopRunning = false;
-        m_isUpdateScheduled = false;
-        m_isUpdating = false;
-        m_displayTextureIndex = 0;
-        m_hasRenderedFrame = false;
+        releaseModelResources();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
         m_cachedModelSource = nullptr;
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -112,6 +112,9 @@ void WebModelPlayerProvider::deleteModelPlayer(WebCore::ModelPlayer& modelPlayer
     Ref page = m_page.get();
     if (page->corePage() && page->corePage()->settings().modelProcessEnabled())
         WebProcess::singleton().modelProcessModelPlayerManager().deleteModelProcessModelPlayer(modelPlayer);
+#elif ENABLE(GPU_PROCESS_MODEL)
+    if (RefPtr webModelPlayer = dynamicDowncast<WebModelPlayer>(modelPlayer))
+        webModelPlayer->releaseModelResources();
 #else
     UNUSED_PARAM(modelPlayer);
 #endif


### PR DESCRIPTION
#### ebf24e410c080df5c8e1cec49f05590a905285bd
<pre>
Flash reloading models
<a href="https://bugs.webkit.org/show_bug.cgi?id=318248">https://bugs.webkit.org/show_bug.cgi?id=318248</a>
<a href="https://rdar.apple.com/181051202">rdar://181051202</a>

Reviewed by Ruthvik Konda.

Ensure model contents are re-populated during unload / reload
before display the surface contents again.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::reloadModelPlayer):
* Source/WebCore/Modules/model-element/ModelPlayer.cpp:
(WebCore::ModelPlayer::isWebModelPlayerInstance const):
(WebCore::ModelPlayer::adoptContentsDisplayDelegateFrom):
* Source/WebCore/Modules/model-element/ModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::adoptContentsDisplayDelegateFrom):
(WebKit::WebModelPlayer::render):
(WebKit::WebModelPlayer::notifyClientDidFinishLoading):
(WebKit::WebModelPlayer::visibilityStateDidChange):

Canonical link: <a href="https://commits.webkit.org/316453@main">https://commits.webkit.org/316453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce5ace64386f8923b7e3fba777d7b68125b20f7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46290 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e63b0f8c-3d29-48b6-9db7-2c2116098351) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45933 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/567de38d-19eb-4cf3-85b5-eafd9519f71d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175330 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114533 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5d6689c-a495-47fb-b9d8-0f64a8f42384) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30429 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184359 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45962 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142714 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38535 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45157 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->