### PR TITLE
Remove `TestShard` `pack`/`unpack` path-prefix compression

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
@@ -34,12 +34,10 @@ import time
 from webkitcorepy.string_utils import pluralize
 from webkitcorepy import TaskPool
 
-from webkitpy.common import message_pool
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.interrupt_debugging import log_stack_trace_on_signal
 from webkitpy.layout_tests.controllers import single_test_runner
 from webkitpy.layout_tests.models.test_run_results import TestRunResults
-from webkitpy.layout_tests.models.test_input import Test, TestInput
 from webkitpy.layout_tests.models import test_expectations
 from webkitpy.layout_tests.models import test_failures
 from webkitpy.layout_tests.models import test_results
@@ -530,56 +528,6 @@ class TestShard(object):
         self.name = name
         self.test_inputs = test_inputs
         self.needs_servers = test_inputs[0].needs_servers if len(test_inputs) > 0 else False
-
-    def shorten(self, string):
-        if not string:
-            return string
-        return string.replace('{}/'.format(self.name), '{}')
-
-    def expand(self, string):
-        if not string:
-            return string
-        return string.replace('{}', '{}/'.format(self.name))
-
-    def pack(self, test_input, mutation=None):
-        mutation = mutation if mutation else self.shorten
-        return TestInput(
-            test=Test(
-                test_path=mutation(test_input.test.test_path),
-                expected_text_path=mutation(test_input.test.expected_text_path),
-                expected_image_path=mutation(test_input.test.expected_image_path),
-                expected_checksum_path=mutation(test_input.test.expected_checksum_path),
-                expected_audio_path=mutation(test_input.test.expected_audio_path),
-                reference_files=(
-                    None
-                    if test_input.test.reference_files is None
-                    else tuple(
-                        (ref_type, mutation(ref_path))
-                        for ref_type, ref_path in test_input.test.reference_files
-                    )
-                ),
-                is_http_test=test_input.test.is_http_test,
-                is_websocket_test=test_input.test.is_websocket_test,
-                is_wpt_test=test_input.test.is_wpt_test,
-                is_wpt_crash_test=test_input.test.is_wpt_crash_test,
-            ), timeout=test_input.timeout,
-            is_slow=test_input.is_slow,
-            needs_servers=test_input.needs_servers,
-            should_dump_jsconsolelog_in_stderr=test_input.should_dump_jsconsolelog_in_stderr,
-            should_run_pixel_test=test_input.should_run_pixel_test,
-        )
-
-    def __getstate__(self):
-        return (
-            self.name,
-            [self.pack(i, mutation=self.shorten) for i in self.test_inputs],
-            self.needs_servers,
-        )
-
-    def __setstate__(self, state):
-        self.name = state[0]
-        self.test_inputs = [self.pack(i, mutation=self.expand) for i in state[1]]
-        self.needs_servers = state[2]
 
     def __repr__(self):
         return "TestShard(name='%s', test_inputs=%s, needs_servers=%s'" % (self.name, self.test_inputs, self.needs_servers)

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
@@ -27,7 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pickle
 import unittest
 
 from webkitpy.common.host_mock import MockHost
@@ -37,7 +36,6 @@ from webkitpy.layout_tests.controllers.layout_test_runner import (
     LayoutTestRunner,
     Sharder,
     TestRunInterruptedException,
-    TestShard,
 )
 from webkitpy.layout_tests.models import test_expectations, test_failures
 from webkitpy.layout_tests.models.test import Test
@@ -326,34 +324,3 @@ class SharderTests(unittest.TestCase):
              ('.', ['dom/html/level2/html/HTMLAnchorElement03.html']),
              ('.', ['ietestcenter/Javascript/11.1.5_4-4-c-1.html']),
              ('.', ['dom/html/level2/html/HTMLAnchorElement06.html'])])
-
-
-class ShardTests(unittest.TestCase):
-    def test_pickle(self):
-        tests = [
-            Test(
-                test_path="failures/expected/empty.html",
-            ),
-            Test(
-                test_path="failures/expected/mismatch.html",
-                reference_files=(
-                    (
-                        "!=",
-                        "/test.checkout/LayoutTests/failures/expected/mismatch-expected-mismatch.html",
-                    ),
-                ),
-            ),
-            Test(
-                test_path="failures/expected/image.html",
-                expected_text_path="/test.checkout/LayoutTests/failures/expected/image-expected.txt",
-                expected_image_path="/test.checkout/LayoutTests/failures/expected/image-expected.png",
-            ),
-            Test(
-                test_path="failures/expected/audio.html",
-                expected_audio_path="/test.checkout/LayoutTests/failures/expected/audio-expected.wav",
-            ),
-        ]
-        test_inputs = [TestInput(t) for t in tests]
-        shard = TestShard("failures/expected", test_inputs)
-        reloaded_shard = pickle.loads(pickle.dumps(shard))
-        self.assertEqual(shard, reloaded_shard)


### PR DESCRIPTION
#### d2cf4fa3541de9571c70aee9c67fedbb6a90b0e2
<pre>
Remove `TestShard` `pack`/`unpack` path-prefix compression
<a href="https://bugs.webkit.org/show_bug.cgi?id=318242">https://bugs.webkit.org/show_bug.cgi?id=318242</a>
<a href="https://rdar.apple.com/181048883">rdar://181048883</a>

Reviewed by Elliott Williams.

`TestShard.pack` reconstructed each `TestInput` while substituting the
shard name prefix into every string field via shorten/expand. The
dump+load round-trip for the full layout-tests suite takes ~2.1s
locally with pack and ~0.46s without (pickling within a single
process). This dwarfs the cost of a few MB of IPC it saves.

Additionally, the `TestShard` `__getstate__`/`__setstate__` requires
updates for every new field added to the underlying model classes, but
we cannot declare `__getstate__`/`__setstate__` on `TestInput` and
`Test` because it requires the context of the `TestShard`&apos;s name, thus
making it easy to forget, and easy to lose data as a result of this.

With that downside, and with the lack of a performance upside, we
simply drop this &quot;optimisation&quot; generally.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(TestShard.shorten): Deleted.
(TestShard.expand): Deleted.
(TestShard.pack): Deleted.
(TestShard.__getstate__): Deleted.
(TestShard.__setstate__): Deleted.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(ShardTests): Deleted.
(ShardTests.test_pickle): Deleted.

Canonical link: <a href="https://commits.webkit.org/316570@main">https://commits.webkit.org/316570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b051b225490334e6e9975eb216bee15bb024c584

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46763 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182304 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46439 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175802 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172165 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30901 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184838 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46434 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47112 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26229 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38095 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45629 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->