### PR TITLE
Fix bugs with gardening api-tests

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1072,7 +1072,7 @@ class RunAPITests(TestWithFailureCount, CustomFlagsMixin, ShellMixin):
         "--report", RESULTS_WEBKIT_URL,
     ]
     failedTestsFormatString = "%d api test%s failed or timed out"
-    test_summary_re = re.compile(r'Ran (?P<ran>\d+) tests of (?P<total>\d+) with (?P<passed>\d+) successful')
+    test_summary_re = re.compile(r'Ran (?P<ran>\d+) tests of (?P<total>\d+) with (?P<passed>\d+) successful(?: \((?P<expected>\d+) expected failures?\))?')
     cancelled_due_to_huge_logs = False
     line_count = 0
 
@@ -1145,7 +1145,8 @@ class RunAPITests(TestWithFailureCount, CustomFlagsMixin, ShellMixin):
 
         match = self.test_summary_re.match(line)
         if match:
-            self.failedTestCount = int(match.group('ran')) - int(match.group('passed'))
+            expected = int(match.group('expected')) if match.group('expected') else 0
+            self.failedTestCount = int(match.group('ran')) - int(match.group('passed')) - expected
 
     def handleExcessiveLogging(self):
         build_url = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1326,6 +1326,29 @@ class TestRunAPITests(BuildStepMixinAdditions, unittest.TestCase):
         expected_state_string = '5 api tests failed or timed out'
         return self.failureTest('wpe', 'wpe', 'release', expected_command, generated_stderr_output, expected_state_string)
 
+    def test_expected_failures_only_mac(self):
+        expected_command = f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --json-output={self.jsonFileName} --release --verbose --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
+        self.configureStep('mac', 'mac-highsierra', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', expected_command + ' 2>&1 | python3 Tools/Scripts/filter-test-logs api'],
+                        logfiles={'json': self.jsonFileName},
+                        env={'RESULTS_SERVER_API_KEY': 'test-api-key'},
+                        timeout=1200,
+                        )
+            .log('stdio', stderr='Ran 91 tests of 123 with 89 successful (2 expected failures)')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='run-api-tests')
+        return self.run_step()
+
+    def test_failure_excludes_expected_mac(self):
+        expected_command = f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --json-output={self.jsonFileName} --release --verbose --buildbot-master {CURRENT_HOSTNAME} --builder-name API-Tests --build-number 101 --buildbot-worker bot100 --report https://results.webkit.org'
+        generated_stderr_output = f'Failed: {expected_command}\nRan 91 tests of 123 with 89 successful (1 expected failures)'
+        expected_state_string = '1 api test failed or timed out'
+        return self.failureTest('mac', 'mac-highsierra', 'release', expected_command, generated_stderr_output, expected_state_string)
+
 
 class TestSetPermissions(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6021,9 +6021,10 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
             self.handleExcessiveLogging()
             return
 
-        match = re.search(r'Ran (?P<ran>\d+) tests of (?P<total>\d+) with (?P<passed>\d+) successful', line)
+        match = re.search(r'Ran (?P<ran>\d+) tests of (?P<total>\d+) with (?P<passed>\d+) successful(?: \((?P<expected>\d+) expected failures?\))?', line)
         if match:
-            self.failedTestCount = int(match.group('ran')) - int(match.group('passed'))
+            expected = int(match.group('expected')) if match.group('expected') else 0
+            self.failedTestCount = int(match.group('ran')) - int(match.group('passed')) - expected
 
     def handleExcessiveLogging(self):
         build_url = f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}'

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -5721,6 +5721,72 @@ All tests successfully passed!
         self.expect_outcome(result=SUCCESS, state_string='run-api-tests')
         return self.run_step()
 
+    def test_expected_failures_only_not_blocking(self):
+        self.setup_step(RunAPITests())
+        self.setProperty('fullPlatform', 'mac-catalina')
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'debug')
+
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --debug --verbose --json-output={self.jsonFileName} 2>&1 | Tools/Scripts/filter-test-logs api'],
+                        logfiles={'json': self.jsonFileName},
+                        timeout=20 * 60
+                        )
+            .log('stdio', stdout='''...
+worker/0 TestWTF.WTF_Variant.VisitorUsingSwitchOn Passed
+worker/0 exiting
+Ran 1888 tests of 1888 with 1882 successful (6 expected failures)
+------------------------------
+All tests passed! (6 expected failures)
+
+Expected failures (not blocking):
+    TestWebKitAPI.MediaSessionTest.MinimalCommands
+    TestWebKitAPI.NowPlayingTest.VideoElementWithMutedAudio
+    TestWebKitAPI.NowPlayingTest.VideoElementWithoutAudio
+    TestWebKitAPI.NowPlayingTest.VideoElementWithoutAudioPlayWithUserGesture
+    TestWebKitAPI.WKHTTPCookieStore.WebSocketCookiesFromRedirect
+    TestWebKitAPI.WKHTTPCookieStore.WebSocketCookiesThroughRedirect
+''')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='run-api-tests')
+        return self.run_step()
+
+    def test_unexpected_failures_counted_excluding_expected(self):
+        self.setup_step(RunAPITests())
+        self.setProperty('fullPlatform', 'mac-catalina')
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'debug')
+
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --debug --verbose --json-output={self.jsonFileName} 2>&1 | Tools/Scripts/filter-test-logs api'],
+                        logfiles={'json': self.jsonFileName},
+                        timeout=20 * 60
+                        )
+            .log('stdio', stdout='''...
+worker/0 TestWTF.WTF_Variant.VisitorUsingSwitchOn Passed
+worker/0 exiting
+Ran 1888 tests of 1888 with 1880 successful (6 expected failures)
+------------------------------
+Test suite failed
+
+** UNEXPECTED FAILURES **
+
+    TestWTF.WTF.StringConcatenate_Unsigned
+    TestWTF.WTF_Expected.Unexpected
+
+Expected failures (not blocking):
+    TestWebKitAPI.MediaSessionTest.MinimalCommands
+''')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='2 api tests failed or timed out')
+        return self.run_step()
+
 
 class TestRunAPITestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -121,6 +121,24 @@ class Manager(object):
                         continue
         return result
 
+    @staticmethod
+    def _expected_results_for_upload(expectation):
+        """Return the results-database `expected` string for an API-test expectation.
+
+        None means "expected to pass" (uploaded as a default pass); otherwise a
+        space-separated list of expected result states, so gardened and flaky tests
+        are not reported as unexpected failures on results.webkit.org.
+        """
+        if expectation is None or expectation.expected == PASS:
+            return None
+        status_to_upload_text = {
+            PASS: Upload.Expectations.PASS,
+            FAIL: Upload.Expectations.FAIL,
+            CRASH: Upload.Expectations.CRASH,
+            TIMEOUT: Upload.Expectations.TIMEOUT,
+        }
+        return ' '.join(text for status, text in status_to_upload_text.items() if status in expectation.expected) or None
+
     def _collect_tests(self, args):
         available_tests = []
         specified_binaries = self._binaries_for_arguments(args)
@@ -387,7 +405,10 @@ class Manager(object):
                     else:
                         unexpected_failures[test] = test_result
 
-        _log.info(f'Ran {len(runner.results) - disabled} tests of {original_test_count} with {len(successful)} successful')
+        summary = f'Ran {len(runner.results) - disabled} tests of {original_test_count} with {len(successful)} successful'
+        if expected_failures:
+            summary += f' ({len(expected_failures)} expected failures)'
+        _log.info(summary)
 
         result_dictionary = {
             'Skipped': [],
@@ -473,6 +494,15 @@ class Manager(object):
                 runner.STATUS_CRASHED: Upload.Expectations.CRASH,
                 runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
             }
+            upload_results = {}
+            for test, result in iteritems(runner.results):
+                if result[0] not in status_to_test_result:
+                    continue
+                upload_results[test] = Upload.create_test_result(
+                    expected=self._expected_results_for_upload(self._expectations.get_expectation(test, current_config)),
+                    actual=status_to_test_result[result[0]],
+                    time=int(result[2] * 1000),
+                )
             upload = Upload(
                 suite=self._options.suite or 'api-tests',
                 configuration=configuration_for_upload,
@@ -482,12 +512,8 @@ class Manager(object):
                     start_time=start_time,
                     end_time=end_time,
                     tests_skipped=len(result_dictionary['Skipped']),
-                ), results={
-                    test: Upload.create_test_result(
-                        actual=status_to_test_result[result[0]],
-                        time=int(result[2] * 1000),
-                    ) for test, result in iteritems(runner.results) if result[0] in status_to_test_result
-                },
+                ),
+                results=upload_results,
             )
             for url in self._options.report_urls:
                 self._stream.write_update(f'Uploading to {url} ...')

--- a/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager_unittest.py
@@ -25,6 +25,8 @@
 import unittest
 
 from webkitpy.api_tests.manager import Manager
+from webkitpy.api_tests.test_expectations import PASS, FAIL, CRASH, TIMEOUT
+from webkitexpectationspy.expectations import Expectation
 
 
 class ManagerTest(unittest.TestCase):
@@ -128,3 +130,22 @@ TestWebKitAPI.WKWebViewSwiftOverlayTests/evaluateJavaScriptYieldsExpectedRespons
         self.assertFalse(Manager._args_specify_individual_tests([]))
         self.assertFalse(Manager._args_specify_individual_tests(["WebKit"]))
         self.assertFalse(Manager._args_specify_individual_tests(["WebKit.SomeTest", "WebKit"]))
+
+    def test_expected_results_for_upload_no_expectation(self):
+        self.assertIsNone(Manager._expected_results_for_upload(None))
+
+    def test_expected_results_for_upload_pass(self):
+        self.assertIsNone(Manager._expected_results_for_upload(Expectation('TestWebKitAPI.WebKit.SomeTest', expected={PASS})))
+
+    def test_expected_results_for_upload_fail(self):
+        self.assertEqual('FAIL', Manager._expected_results_for_upload(Expectation('TestWebKitAPI.WebKit.SomeTest', expected={FAIL})))
+
+    def test_expected_results_for_upload_crash(self):
+        self.assertEqual('CRASH', Manager._expected_results_for_upload(Expectation('TestWebKitAPI.WebKit.SomeTest', expected={CRASH})))
+
+    def test_expected_results_for_upload_timeout(self):
+        self.assertEqual('TIMEOUT', Manager._expected_results_for_upload(Expectation('TestWebKitAPI.WebKit.SomeTest', expected={TIMEOUT})))
+
+    def test_expected_results_for_upload_flaky(self):
+        result = Manager._expected_results_for_upload(Expectation('TestWebKitAPI.WebKit.SomeTest', expected={PASS, FAIL}))
+        self.assertEqual({'PASS', 'FAIL'}, set(result.split()))


### PR DESCRIPTION
#### 99b8bb251a13c714e639d69aa47b185ee4a54939
<pre>
Fix bugs with gardening api-tests
<a href="https://rdar.apple.com/180065224">rdar://180065224</a>

Reviewed by Jonathan Bedard.

When gardening api-tests EWS does not consider the gardened ones as expected and will fail anyway,
additionally post-commit does not upload api-test results with expectations considered.
This change adjust api-test results to be compatible with both ews and post-commit.

* Tools/CISupport/build-webkit-org/steps.py:
(RunAPITests):
(RunAPITests.parseOutputLine):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/CISupport/ews-build/steps.py:
(RunAPITests.parseOutputLine):
* Tools/CISupport/ews-build/steps_unittest.py:
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager):
(Manager._expected_results_for_upload):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/manager_unittest.py:
(test_args_specify_individual_tests):
(test_expected_results_for_upload_no_expectation):
(test_expected_results_for_upload_pass):
(test_expected_results_for_upload_fail):
(test_expected_results_for_upload_crash):
(test_expected_results_for_upload_timeout):
(test_expected_results_for_upload_flaky):

Canonical link: <a href="https://commits.webkit.org/316208@main">https://commits.webkit.org/316208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d71e286d1492c4a9fadb02f3e0b4a1047a47b8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171686 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca533cd5-e92d-468b-bf66-d313ab0d2264) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45243 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/180989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b9c5146-5913-4e24-8ee1-f72273e2ff9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/36964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/180989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3090051-fdcd-401a-9ad6-5ca3f729f63a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/171006 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29739 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183657 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/171086 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45270 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38323 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44468 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43868 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->