### PR TITLE
Remove overrides from WebCore::RenderScrollbarPart::marginTop()

### DIFF
--- a/LayoutTests/scrollbars/custom-scrollbar-fractional-zoom-margin-crash-expected.txt
+++ b/LayoutTests/scrollbars/custom-scrollbar-fractional-zoom-margin-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/scrollbars/custom-scrollbar-fractional-zoom-margin-crash.html
+++ b/LayoutTests/scrollbars/custom-scrollbar-fractional-zoom-margin-crash.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+.scroller {
+    width: 100px;
+    height: 100px;
+    overflow-y: scroll;
+    zoom: 0.9;
+}
+.scroller::-webkit-scrollbar {
+    width: 15px;
+}
+.scroller::-webkit-scrollbar-track {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+.content {
+    height: 1000px;
+}
+</style>
+<div class="scroller">
+    <div class="content"></div>
+</div>
+<p>PASS if no crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+document.body.offsetHeight;
+</script>

--- a/Source/WebCore/rendering/RenderScrollbarPart.h
+++ b/Source/WebCore/rendering/RenderScrollbarPart.h
@@ -50,12 +50,6 @@ public:
     
     void paintIntoRect(GraphicsContext&, const LayoutPoint&, const LayoutRect&);
 
-    // Scrollbar parts needs to be rendered at device pixel boundaries.
-    LayoutUnit marginTop() const override { ASSERT(isIntegerValue(m_marginBox.top())); return m_marginBox.top(); }
-    LayoutUnit marginBottom() const override { ASSERT(isIntegerValue(m_marginBox.bottom())); return m_marginBox.bottom(); }
-    LayoutUnit marginLeft() const override { ASSERT(isIntegerValue(m_marginBox.left())); return m_marginBox.left(); }
-    LayoutUnit marginRight() const override { ASSERT(isIntegerValue(m_marginBox.right())); return m_marginBox.right(); }
-
     RenderBox* rendererOwningScrollbar() const;
 
 private:


### PR DESCRIPTION
#### 4631a8c67fe674490b870a20facd2c56c3313b80
<pre>
Remove overrides from WebCore::RenderScrollbarPart::marginTop()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274366">https://bugs.webkit.org/show_bug.cgi?id=274366</a>
<a href="https://rdar.apple.com/128355630">rdar://128355630</a>

Reviewed by Simon Fraser.

RenderScrollbarPart overrode marginTop()/marginBottom()/marginLeft()/marginRight()
to add an assert that required scrollbar-part margins to be whole integers.

This crashed the web process on google.com when signed in and zoomed.

After discussing with Simon, it was decided that fractional margins are not a
problem and we should instead simply remove the override.

* Source/WebCore/rendering/RenderScrollbarPart.h:
(WebCore::RenderScrollbarPart::marginTop): Deleted.
(WebCore::RenderScrollbarPart::marginBottom): Deleted.
(WebCore::RenderScrollbarPart::marginLeft): Deleted.
(WebCore::RenderScrollbarPart::marginRight): Deleted.
* LayoutTests/scrollbars/custom-scrollbar-fractional-zoom-margin-crash.html: Added.
* LayoutTests/scrollbars/custom-scrollbar-fractional-zoom-margin-crash-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/316741@main">https://commits.webkit.org/316741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29a04c92af5d3772844d57f7a054c5ed2c92c424

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181067 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129318 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133640 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94274 "20 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154124 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114112 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35643 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33905 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29817 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183735 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142329 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153716 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38724 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46028 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30479 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110663 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37326 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117716 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44546 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8575 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43946 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44178 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44005 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->