### PR TITLE
[iOS] 316168@main broke the build

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -39,7 +39,7 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
-OBJC_CLASS WebPlaybackControlObserver;
+OBJC_CLASS WebMediaSourceObserver;
 
 namespace WebCore {
 
@@ -91,9 +91,9 @@ public:
     virtual void timeRangeDidChange(MediaDeviceRoute&) { }
     virtual void readyDidChange(MediaDeviceRoute&) { }
     virtual void bufferingDidChange(MediaDeviceRoute&) { }
-    virtual void errorDidChange(MediaDeviceRoute&) { }
+    virtual void playbackErrorDidChange(MediaDeviceRoute&) { }
     virtual void audioOptionsDidChange(MediaDeviceRoute&) { }
-    virtual void playbackPositionDidChange(MediaDeviceRoute&) { }
+    virtual void currentPlaybackPositionDidChange(MediaDeviceRoute&) { }
     virtual void playingDidChange(MediaDeviceRoute&) { }
     virtual void playbackSpeedDidChange(MediaDeviceRoute&) { }
     virtual void scanSpeedDidChange(MediaDeviceRoute&) { }
@@ -120,16 +120,16 @@ public:
     MediaTimeRange timeRange() const;
     bool ready() const;
     bool buffering() const;
-    std::optional<MediaPlaybackSourceError> error() const;
+    std::optional<MediaPlaybackSourceError> playbackError() const;
     Vector<MediaSelectionOption> audioOptions() const;
-    MediaTime playbackPosition() const;
+    MediaTime currentPlaybackPosition() const;
     bool playing() const;
     float playbackSpeed() const;
     float scanSpeed() const;
     bool muted() const;
     float volume() const;
 
-    void setPlaybackPosition(MediaTime);
+    void setCurrentPlaybackPosition(MediaTime);
     void setPlaying(bool);
     void setPlaybackSpeed(float);
     void setScanSpeed(float);
@@ -141,7 +141,7 @@ private:
 
     WTF::UUID m_identifier;
     RetainPtr<WebMediaDevicePlatformRoute> m_platformRoute;
-    RetainPtr<WebPlaybackControlObserver> m_playbackControlObserver;
+    RetainPtr<WebMediaSourceObserver> m_mediaSourceObserver;
     WeakPtr<MediaDeviceRouteClient> m_client;
 #if HAVE(AVROUTING_FRAMEWORK)
     RetainPtr<WebMediaDevicePlatformRouteSession> m_routeSession;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -36,16 +36,14 @@
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
-#define FOR_EACH_READONLY_KEY_PATH(Macro) \
+#define FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
     Macro(timeRange, TimeRange, MediaTimeRange) \
     Macro(ready, Ready, bool) \
     Macro(buffering, Buffering, bool) \
     Macro(audioOptions, AudioOptions, Vector<MediaSelectionOption>) \
-    Macro(error, Error, std::optional<MediaPlaybackSourceError>) \
-    Macro(playbackPosition, PlaybackPosition, MediaTime) \
 \
 
-#define FOR_EACH_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
     Macro(playing, Playing, bool) \
     Macro(playbackSpeed, PlaybackSpeed, float) \
     Macro(scanSpeed, ScanSpeed, float) \
@@ -53,16 +51,43 @@
     Macro(volume, Volume, float) \
 \
 
-#define FOR_EACH_KEY_PATH(Macro) \
-    FOR_EACH_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_COMMON_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
 \
 
-#define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
+    Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
+\
+
+#define FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
+    Macro(currentPlaybackPosition, CurrentPlaybackPosition, MediaTime) \
+\
+
+#define FOR_EACH_MEDIA_SOURCE_KEY_PATH(Macro) \
+    FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
+\
+
+#define FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(Macro) \
+    FOR_EACH_COMMON_KEY_PATH(Macro) \
+\
+
+#define ADD_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
+    [_mediaSource addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebMediaSourceObserverContext]; \
+\
+
+#define REMOVE_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
+    [_mediaSource removeObserver:self forKeyPath:@#KeyPath context:WebMediaSourceObserverContext]; \
+\
+
+#define ADD_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_playbackControl addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebPlaybackControlObserverContext]; \
 \
 
-#define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define REMOVE_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_playbackControl removeObserver:self forKeyPath:@#KeyPath context:WebPlaybackControlObserverContext]; \
 \
 
@@ -83,30 +108,37 @@
 #define DEFINE_GETTER(KeyPath, SetterSuffix, Type) \
     Type MediaDeviceRoute::KeyPath() const \
     { \
-        return convert([m_playbackControlObserver playbackControl].KeyPath); \
+        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
+            return convert(playbackControl.get().KeyPath); \
+        return convert([m_mediaSourceObserver mediaSource].KeyPath); \
     } \
 \
 
 #define DEFINE_SETTER(KeyPath, SetterSuffix, Type) \
     void MediaDeviceRoute::set##SetterSuffix(Type KeyPath) \
     { \
-        [[m_playbackControlObserver playbackControl] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
+        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
+            return [playbackControl set##SetterSuffix:convert(WTF::move(KeyPath))]; \
+        [[m_mediaSourceObserver mediaSource] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
     } \
 \
 
 NS_ASSUME_NONNULL_BEGIN
 
+static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
 static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverContext;
 
-@interface WebPlaybackControlObserver : NSObject
+@interface WebMediaSourceObserver : NSObject
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route NS_DESIGNATED_INITIALIZER;
+@property (nonatomic, nullable, strong) AVMediaSource *mediaSource;
 @property (nonatomic, nullable, strong) AVPlaybackControl *playbackControl;
 @end
 
-@implementation WebPlaybackControlObserver {
+@implementation WebMediaSourceObserver {
     WeakPtr<WebCore::MediaDeviceRoute> _route;
+    RetainPtr<AVMediaSource> _mediaSource;
     RetainPtr<AVPlaybackControl> _playbackControl;
 }
 
@@ -119,6 +151,23 @@ static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverCont
     return self;
 }
 
+- (AVMediaSource * _Nullable)mediaSource
+{
+    return _mediaSource.get();
+}
+
+- (void)setMediaSource:(AVMediaSource * _Nullable)mediaSource
+{
+    if (mediaSource)
+        self.playbackControl = nil;
+
+    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
+
+    _mediaSource = mediaSource;
+
+    FOR_EACH_MEDIA_SOURCE_KEY_PATH(ADD_MEDIA_SOURCE_OBSERVER)
+}
+
 - (AVPlaybackControl * _Nullable)playbackControl
 {
     return _playbackControl.get();
@@ -126,29 +175,60 @@ static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverCont
 
 - (void)setPlaybackControl:(AVPlaybackControl * _Nullable)playbackControl
 {
-    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
+    if (playbackControl)
+        self.mediaSource = nil;
+
+    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
 
     _playbackControl = playbackControl;
 
-    FOR_EACH_KEY_PATH(ADD_OBSERVER)
+    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(ADD_PLAYBACK_CONTROL_OBSERVER)
+    ADD_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
+    ADD_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context
 {
-    if (context != WebPlaybackControlObserverContext) {
+    if (context != WebMediaSourceObserverContext && context != WebPlaybackControlObserverContext) {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
 
     dispatch_async(mainDispatchQueueSingleton(), ^{
-        FOR_EACH_KEY_PATH(OBSERVE_VALUE)
+        if (context == WebMediaSourceObserverContext) {
+            FOR_EACH_MEDIA_SOURCE_KEY_PATH(OBSERVE_VALUE)
+            ASSERT_NOT_REACHED();
+            return;
+        }
+
+        if ([keyPath isEqualToString:@"error"]) {
+            if (RefPtr route = _route.get()) {
+                if (RefPtr client = route->client())
+                    client->playbackErrorDidChange(*route);
+            }
+            return;
+        }
+        if ([keyPath isEqualToString:@"playbackPosition"]) {
+            if (RefPtr route = _route.get()) {
+                if (RefPtr client = route->client())
+                    client->currentPlaybackPositionDidChange(*route);
+            }
+            return;
+        }
+
+        FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(OBSERVE_VALUE)
         ASSERT_NOT_REACHED();
     });
 }
 
 - (void)dealloc
 {
-    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
+    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
+    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
+    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
     [super dealloc];
 }
 
@@ -178,11 +258,6 @@ static CMTime convert(MediaTime time)
 static MediaTime convert(CMTime time)
 {
     return PAL::toMediaTime(time);
-}
-
-static MediaTime convert(AVPlaybackUserInterfacePlaybackPosition *playbackPosition)
-{
-    return convert(playbackPosition.position);
 }
 
 static MediaTimeRange convert(CMTimeRange timeRange)
@@ -226,7 +301,7 @@ Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *plat
 MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
     : m_identifier { WTF::UUID::createVersion4() }
     , m_platformRoute { platformRoute }
-    , m_playbackControlObserver { adoptNS([[WebPlaybackControlObserver alloc] initWithRoute:*this]) }
+    , m_mediaSourceObserver { adoptNS([[WebMediaSourceObserver alloc] initWithRoute:*this]) }
 {
 }
 
@@ -240,10 +315,29 @@ WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
     return m_platformRoute.get();
 }
 
-void MediaDeviceRoute::setPlaybackPosition(MediaTime playbackPosition)
+std::optional<MediaPlaybackSourceError> MediaDeviceRoute::playbackError() const
 {
-    // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
-    [[m_playbackControlObserver playbackControl] seekToPosition:convert(WTF::move(playbackPosition)) tolerance:PAL::kCMTimeZero];
+    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
+        return convert(playbackControl.get().error);
+    return convert([m_mediaSourceObserver mediaSource].playbackError);
+}
+
+MediaTime MediaDeviceRoute::currentPlaybackPosition() const
+{
+    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
+        return convert(playbackControl.get().playbackPosition.position);
+    return convert([m_mediaSourceObserver mediaSource].currentPlaybackPosition);
+}
+
+void MediaDeviceRoute::setCurrentPlaybackPosition(MediaTime currentPlaybackPosition)
+{
+    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) {
+        // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
+        [playbackControl seekToPosition:convert(WTF::move(currentPlaybackPosition)) tolerance:PAL::kCMTimeZero];
+        return;
+    }
+
+    [m_mediaSourceObserver mediaSource].currentPlaybackPosition = convert(WTF::move(currentPlaybackPosition));
 }
 
 MediaDeviceRoute::~MediaDeviceRoute()
@@ -253,16 +347,22 @@ MediaDeviceRoute::~MediaDeviceRoute()
 #endif
 }
 
-FOR_EACH_KEY_PATH(DEFINE_GETTER)
-FOR_EACH_READWRITE_KEY_PATH(DEFINE_SETTER)
+FOR_EACH_COMMON_KEY_PATH(DEFINE_GETTER)
+FOR_EACH_COMMON_READWRITE_KEY_PATH(DEFINE_SETTER)
 
 } // namespace WebCore
 
-#undef FOR_EACH_READONLY_KEY_PATH
-#undef FOR_EACH_READWRITE_KEY_PATH
-#undef FOR_EACH_KEY_PATH
-#undef ADD_OBSERVER
-#undef REMOVE_OBSERVER
+#undef FOR_EACH_COMMON_READONLY_KEY_PATH
+#undef FOR_EACH_COMMON_READWRITE_KEY_PATH
+#undef FOR_EACH_COMMON_KEY_PATH
+#undef FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH
+#undef FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH
+#undef FOR_EACH_MEDIA_SOURCE_KEY_PATH
+#undef FOR_EACH_PLAYBACK_CONTROL_KEY_PATH
+#undef ADD_MEDIA_SOURCE_OBSERVER
+#undef REMOVE_MEDIA_SOURCE_OBSERVER
+#undef ADD_PLAYBACK_CONTROL_OBSERVER
+#undef REMOVE_PLAYBACK_CONTROL_OBSERVER
 #undef OBSERVE_VALUE
 #undef DEFINE_GETTER
 #undef DEFINE_SETTER

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -280,7 +280,7 @@ void MediaPlayerPrivateWirelessPlayback::seekToTarget(const SeekTarget& seekTarg
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, seekTarget);
-    route->setPlaybackPosition(seekTarget.time);
+    route->setCurrentPlaybackPosition(seekTarget.time);
 }
 
 bool MediaPlayerPrivateWirelessPlayback::paused() const
@@ -430,12 +430,12 @@ void MediaPlayerPrivateWirelessPlayback::readyDidChange(MediaDeviceRoute& route)
         setReadyState(MediaPlayerReadyState::HaveEnoughData);
 }
 
-void MediaPlayerPrivateWirelessPlayback::errorDidChange(MediaDeviceRoute& route)
+void MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange(MediaDeviceRoute& route)
 {
     ASSERT(&route == this->route());
-    ALWAYS_LOG(LOGIDENTIFIER, !!route.error());
+    ALWAYS_LOG(LOGIDENTIFIER, !!route.playbackError());
 
-    if (route.error())
+    if (route.playbackError())
         setNetworkState(route.ready() ? MediaPlayer::NetworkState::DecodeError : MediaPlayer::NetworkState::FormatError);
 }
 
@@ -448,14 +448,14 @@ void MediaPlayerPrivateWirelessPlayback::audioOptionsDidChange(MediaDeviceRoute&
         player->characteristicChanged();
 }
 
-void MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange(MediaDeviceRoute& route)
+void MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange(MediaDeviceRoute& route)
 {
     ASSERT(&route == this->route());
 
-    auto playbackPosition = route.playbackPosition();
-    ALWAYS_LOG(LOGIDENTIFIER, playbackPosition);
+    auto currentPlaybackPosition = route.currentPlaybackPosition();
+    ALWAYS_LOG(LOGIDENTIFIER, currentPlaybackPosition);
 
-    updateTimebaseTimeAndRate(playbackPosition, route.playing() ? route.playbackSpeed() : 0);
+    updateTimebaseTimeAndRate(currentPlaybackPosition, route.playing() ? route.playbackSpeed() : 0);
 
     auto currentTime = this->currentTime();
 
@@ -492,7 +492,7 @@ CMTimebaseRef MediaPlayerPrivateWirelessPlayback::ensureTimebase()
     dispatch_activate(m_timerSource.get());
 
     if (RefPtr route = this->route())
-        updateTimebaseTimeAndRate(route->playbackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
+        updateTimebaseTimeAndRate(route->currentPlaybackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
 
     return m_timebase.get();
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -129,9 +129,9 @@ private:
     // MediaDeviceRouteClient
     void timeRangeDidChange(MediaDeviceRoute&) final;
     void readyDidChange(MediaDeviceRoute&) final;
-    void errorDidChange(MediaDeviceRoute&) final;
+    void playbackErrorDidChange(MediaDeviceRoute&) final;
     void audioOptionsDidChange(MediaDeviceRoute&) final;
-    void playbackPositionDidChange(MediaDeviceRoute&) final;
+    void currentPlaybackPositionDidChange(MediaDeviceRoute&) final;
 
     CMTimebaseRef ensureTimebase();
     void destroyTimebase();


### PR DESCRIPTION
#### 3b938d7c56e7c4a20182231141f2acb96b626144
<pre>
[iOS] 316168@main broke the build
<a href="https://bugs.webkit.org/show_bug.cgi?id=318272">https://bugs.webkit.org/show_bug.cgi?id=318272</a>
<a href="https://rdar.apple.com/181058453">rdar://181058453</a>

Unreviewed build fix.

* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRouteClient::playbackErrorDidChange):
(WebCore::MediaDeviceRouteClient::currentPlaybackPositionDidChange):
(WebCore::MediaDeviceRouteClient::errorDidChange): Deleted.
(WebCore::MediaDeviceRouteClient::playbackPositionDidChange): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebMediaSourceObserver mediaSource]):
(-[WebMediaSourceObserver setMediaSource:]):
(-[WebMediaSourceObserver setPlaybackControl:]):
(-[WebMediaSourceObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WebMediaSourceObserver dealloc]):
(WebCore::MediaDeviceRoute::playbackError const):
(WebCore::MediaDeviceRoute::currentPlaybackPosition const):
(WebCore::MediaDeviceRoute::setCurrentPlaybackPosition):
(-[WebPlaybackControlObserver initWithRoute:]): Deleted.
(-[WebPlaybackControlObserver playbackControl]): Deleted.
(-[WebPlaybackControlObserver setPlaybackControl:]): Deleted.
(-[WebPlaybackControlObserver observeValueForKeyPath:ofObject:change:context:]): Deleted.
(-[WebPlaybackControlObserver dealloc]): Deleted.
(WebCore::MediaDeviceRoute::setPlaybackPosition): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::seekToTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::ensureTimebase):
(WebCore::MediaPlayerPrivateWirelessPlayback::errorDidChange): Deleted.
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:

Canonical link: <a href="https://commits.webkit.org/316205@main">https://commits.webkit.org/316205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3955ed2d8bb661b040ed1862bb928aa684d4582

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171709 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1d82277-8335-419d-b45b-e0fb29fa3737) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173574 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/46911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/181012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee2f580d-7817-44c3-9ae2-cf9dfd07fa07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174667 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/46911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f677207d-5a8f-4801-902d-0cc08360e8e0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/46911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/46911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/183680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/183680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/183680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/45973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26075 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/45973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/43950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->