### PR TITLE
resultsdbpy: Fix run-tests script to set AutoInstall directory before importing dependencies

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/run-tests
+++ b/Tools/Scripts/libraries/resultsdbpy/run-tests
@@ -30,10 +30,13 @@ import os
 import sys
 import unittest
 
-import resultsdbpy
-from webkitcorepy import AutoInstall
-
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _library in ['webkitcorepy', 'webkitscmpy', 'webkitflaskpy', 'webkitbugspy']:
+    _path = os.path.join(libraries, _library)
+    if os.path.isdir(_path) and _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from webkitcorepy import AutoInstall
 if sys.platform == 'darwin':
     is_root = not os.getuid()
     does_own_libraries = os.stat(libraries).st_uid == os.getuid()
@@ -41,6 +44,7 @@ if sys.platform == 'darwin':
         libraries = os.path.expanduser('~/Library/webkitpy')
 AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
 
+import resultsdbpy
 from cassandra.cqlengine.management import CQLENG_ALLOW_SCHEMA_MANAGEMENT
 
 


### PR DESCRIPTION
#### 4eddab6b02e0ff81a51144b30d40eba4bd3855a4
<pre>
resultsdbpy: Fix run-tests script to set AutoInstall directory before importing dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=318274">https://bugs.webkit.org/show_bug.cgi?id=318274</a>
<a href="https://rdar.apple.com/181066799">rdar://181066799</a>

Reviewed by NOBODY (OOPS!).

`run-tests` was importing `resultsdbpy` before calling `AutoInstall.set_directory()`, causing
the auto-install mechanism to not know where to install packages when the import chain triggered.
This resulted in `ModuleNotFoundError` for flask and other dependencies when they were not
already installed. Move the local library `sys.path` setup and `AutoInstall.set_directory()`
call before `import resultsdbpy` so packages are installed to the right location on first run.

* Tools/Scripts/libraries/resultsdbpy/run-tests:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eddab6b02e0ff81a51144b30d40eba4bd3855a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133624 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94261 "20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114096 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/171037 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35610 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33867 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29770 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183688 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142290 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/171117 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45301 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/45981 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30472 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110615 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37323 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44499 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8568 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->