### PR TITLE
[Writing Tools] Siri affordance appears after selecting and hovering text, but remains in the wrong place after you scroll the page

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1071,6 +1071,7 @@ private:
 
     const UniqueRef<PAL::HysteresisActivity> m_contentRelativeViewsHysteresis;
     std::unique_ptr<PAL::HysteresisActivity> m_pageScrollingHysteresis;
+    bool m_contentRelativeViewsNeedToBeRepositioned { false };
 
     RetainPtr<NSColorSpace> m_colorSpace;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1504,6 +1504,8 @@ void WebViewImpl::handleProcessSwapOrExit()
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     [m_appKitGestureController reset];
 #endif
+
+    m_contentRelativeViewsNeedToBeRepositioned = false;
 }
 
 void WebViewImpl::processWillSwap()
@@ -3862,7 +3864,7 @@ bool WebViewImpl::hasContentRelativeChildViews() const
 
 void WebViewImpl::suppressContentRelativeChildViews(ContentRelativeChildViewsSuppressionType type)
 {
-    if (!hasContentRelativeChildViews())
+    if (!hasContentRelativeChildViews() && !inputContextForSelectionUpdates())
         return;
 
     switch (type) {
@@ -3879,13 +3881,16 @@ void WebViewImpl::suppressContentRelativeChildViews(ContentRelativeChildViewsSup
 
 void WebViewImpl::contentRelativeViewsHysteresisTimerFired(PAL::HysteresisState state)
 {
-    if (!hasContentRelativeChildViews())
-        return;
+    bool started = state == PAL::HysteresisState::Started;
+    if (hasContentRelativeChildViews()) {
+        if (started)
+            suppressContentRelativeChildViews();
+        else
+            restoreContentRelativeChildViews();
+    }
 
-    if (state == PAL::HysteresisState::Started)
-        suppressContentRelativeChildViews();
-    else
-        restoreContentRelativeChildViews();
+    if (m_contentRelativeViewsNeedToBeRepositioned != started && std::exchange(m_contentRelativeViewsNeedToBeRepositioned, started))
+        [inputContextForSelectionUpdates() textInputClientDidUpdateSelection];
 }
 
 void WebViewImpl::pageScrollingHysteresisFired(PAL::HysteresisState state)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm
@@ -759,6 +759,47 @@ TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelecti
     EXPECT_TRUE(NSIsEmptyRect([webView unionRectInVisibleSelectedRange]));
 }
 
+TEST(EditorStateTests, NotifyTextInputClientAfterMagnificationChange)
+{
+    __block unsigned didUpdateSelectionCount = 0;
+
+    InstanceMethodSwizzler didUpdateSelectionSwizzler {
+        NSTextInputContext.class,
+        @selector(textInputClientDidUpdateSelection),
+        imp_implementationWithBlock(^{
+            didUpdateSelectionCount++;
+        })
+    };
+
+    RetainPtr configuration = configurationWithTextInputClientSelectionUpdatesEnabled();
+    RetainPtr webView = adoptNS([[TestWKWebView<NSTextInputClient> alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration]);
+    [webView setAllowsMagnification:YES];
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadHTMLString:@"<body>Hello world.</body>"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView mouseDownAtPoint:NSMakePoint(50, 390) simulatePressure:NO];
+    [webView mouseUpAtPoint:NSMakePoint(50, 390)];
+    [webView waitForPendingMouseEvents];
+    [webView waitForNextPresentationUpdate];
+
+    auto countBeforeFirstMagnification = didUpdateSelectionCount;
+    [webView setMagnification:2.0];
+    [webView waitForNextPresentationUpdate];
+
+    Util::waitForConditionWithLogging(^{
+        return didUpdateSelectionCount > countBeforeFirstMagnification;
+    }, 3, @"Timed out waiting for first call to -textInputClientDidUpdateSelection");
+
+    auto countBeforeSecondMagnification = didUpdateSelectionCount;
+    [webView setMagnification:1.0];
+    [webView waitForNextPresentationUpdate];
+
+    Util::waitForConditionWithLogging(^{
+        return didUpdateSelectionCount > countBeforeSecondMagnification;
+    }, 3, @"Timed out waiting for second call to -textInputClientDidUpdateSelection");
+}
+
 #endif // PLATFORM(MAC)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 7b38a3e97b1b1559fa0f526c8661c609e2078286
<pre>
[Writing Tools] Siri affordance appears after selecting and hovering text, but remains in the wrong place after you scroll the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=318263">https://bugs.webkit.org/show_bug.cgi?id=318263</a>
<a href="https://rdar.apple.com/180970146">rdar://180970146</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Invoke `-textInputClientDidUpdateSelection` after scrolling or zooming on macOS to update the Siri
Writing Tools affordance position and visibility. To do this, leverage the existing
`m_contentRelativeViewsHysteresis` activity timer and keep track of a new flag
(`m_contentRelativeViewsNeedToBeRepositioned`) that schedules an update on the `NSTextInputClient`
when reset, after scrolling/zooming ends.

Test: EditorStateTests.NotifyTextInputClientAfterMagnificationChange

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::handleProcessSwapOrExit):
(WebKit::WebViewImpl::suppressContentRelativeChildViews):
(WebKit::WebViewImpl::contentRelativeViewsHysteresisTimerFired):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, NotifyTextInputClientAfterMagnificationChange)):

Canonical link: <a href="https://commits.webkit.org/316271@main">https://commits.webkit.org/316271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b90a62375f7ad25408c93c0be488a289aaab1cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b359d92-b681-4015-b272-415fb37e46f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133636 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/400a6592-7f70-4b27-a1e8-c73564486bbc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114108 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eec2ece6-67c9-4dd1-a472-cee48bf6673c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35639 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29806 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183724 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36340 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142319 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45337 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38382 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46017 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110652 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37325 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44535 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8577 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43935 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44167 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->