### PR TITLE
[webkit-bot] Support the --issue flag and handle errors when reverting with git-webkit

### DIFF
--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -83,6 +83,25 @@ function extractRevision(text)
     return revisions;
 }
 
+export function buildGitWebkitRevertCommand(gitWebkitPath, revisions, reason, issueUrl)
+{
+    let args = [
+        gitWebkitPath,
+        "revert",
+        ...revisions,
+        "--pr",
+        "--draft",
+        "--defaults",
+    ];
+
+    if (issueUrl)
+        args.push("--issue", issueUrl);
+    else
+        args.push("--reason", reason);
+
+    return args;
+}
+
 export function extractRevisionsAndReason(args)
 {
     let revisions = [];
@@ -137,10 +156,22 @@ export function extractTextIfMentioned(text, id)
     // 2. Convert line-terminators to spaces. It is unlikely that we want to have line-terminators in webkitbot commands.
     text = text.replace(/(\r\n|\n|\r|\u2028|\u2029)/g, " ");
 
+    // 3. Strip Slack's auto-linked URLs: <https://url> → https://url, <https://url|label> → https://url
+    text = text.replace(/<(https?:\/\/[^|>]+)(?:\|[^>]*)?>/g, "$1");
+
     return text;
 }
 
 export default class WebKitBot {
+    postMessage(options)
+    {
+        return this._web.chat.postMessage({
+            unfurl_links: false,
+            unfurl_media: false,
+            ...options,
+        });
+    }
+
     constructor(webClient, auth)
     {
         this._taskQueue = new AsyncTaskQueue(defaultTaskLimit);
@@ -168,9 +199,11 @@ e.g. \`dry-revert 260220 Ensure it is working after refactoring\`
         if (process.env.USE_GIT_WEBKIT_REVERT === "true") {
             this._commands.set("revert-with-pr", {
                 description: "Creates a GitHub PR to revert the specified revision.",
-                usage: `\`revert-with-pr SVN_REVISION [SVN_REVISIONS] REASON\`
-e.g. \`revert-with-pr 260220 Ensure it is working after refactoring\`
-\`revert-with-pr 260220,260221 Ensure it is working after refactoring\``,
+                usage: `\`revert-with-pr REVISION [REVISIONS] REASON\` or \`revert-with-pr REVISION [REVISIONS] BUG_URL\`
+    Examples:
+    • \`revert-with-pr 260220 Ensure it is working after refactoring\`
+    • \`revert-with-pr 260220,260221 Ensure it is working after refactoring\`
+    • \`revert-with-pr 308300@main https://bugs.webkit.org/show_bug.cgi?id=308859\``,
                 operation: this.revertWithPRCommand.bind(this),
             });
         }
@@ -237,18 +270,36 @@ e.g. \`revert-with-pr 260220 Ensure it is working after refactoring\`
     {
         let {revisions, reason} = extractRevisionsAndReason(args);
 
-        if (!isASCII(reason)) {
-            await this._web.chat.postMessage({
+        // For revert-with-pr, check if the "reason" is actually a bug URL
+        let issueUrl = null;
+        if (usePR && reason) {
+            let bugId = parseBugId(reason);
+            if (bugId) {
+                issueUrl = `https://bugs.webkit.org/show_bug.cgi?id=${bugId}`;
+                reason = "";
+            }
+        }
+
+        if (!issueUrl && !isASCII(reason)) {
+            await this.postMessage({
                 channel: event.channel,
                 text: `<@${event.user}> webkit-patch only accepts an ASCII string for reason: \`${escapeForSlackText(reason)}\``,
             });
             return;
         }
 
-        dataLogLn(revisions, reason);
+        if (usePR && !reason && !issueUrl) {
+            await this.postMessage({
+                channel: event.channel,
+                text: `<@${event.user}> Please provide a reason or a bug URL.`,
+            });
+            return;
+        }
+
+        dataLogLn(revisions, reason, issueUrl);
         if (revisions.length) {
             try {
-                await this._web.chat.postMessage({
+                await this.postMessage({
                     channel: event.channel,
                     text: `<@${event.user}> Preparing revert for ${revisions.map((revision) => {
                         let revRepr = revision;
@@ -261,6 +312,7 @@ e.g. \`revert-with-pr 260220 Ensure it is working after refactoring\`
                     command: usePR ? "revert-with-pr" : "revert",
                     revisions,
                     reason,
+                    issueUrl,
                 });
 
                 let successMessage;
@@ -269,15 +321,44 @@ e.g. \`revert-with-pr 260220 Ensure it is working after refactoring\`
                 else
                     successMessage = `<@${event.user}> Created a revert patch https://webkit.org/b/${escapeForSlackText(result)}`;
 
-                await this._web.chat.postMessage({
+                await this.postMessage({
                     channel: event.channel,
                     text: successMessage,
                 });
             } catch (error) {
                 console.error(error);
                 let stderr = error.stderr;
+                let stdout = error.stdout;
                 console.error("STDERR ", stderr);
                 if (typeof stderr === "string") {
+                    if (usePR && stderr.indexOf("CONFLICT") !== -1) {
+                        let conflictFiles = [];
+                        for (let line of stderr.split("\n")) {
+                            let match = line.match(/CONFLICT.*Merge conflict in (.+)/);
+                            if (match)
+                                conflictFiles.push(match[1].trim());
+                        }
+                        // Check if a bug was already created before the conflict
+                        let createdBugMatch = typeof stdout === "string" && stdout.match(/https:\/\/bugs\.webkit\.org\/show_bug\.cgi\?id=\d+/);
+                        let message = `<@${event.user}> Failed to create revert PR due to merge conflicts.`;
+                        if (conflictFiles.length)
+                            message += `\nConflicting files:\n${escapeForSlackText(conflictFiles.map(f => `  • ${f}`).join("\n"))}`;
+                        if (createdBugMatch)
+                            message += `\nA bug was created at ${escapeForSlackText(createdBugMatch[0])}! Please close or reuse this bug for your revert.`;
+                        await this.postMessage({
+                            channel: event.channel,
+                            text: message,
+                        });
+                        return;
+                    }
+                    if (usePR && stderr.indexOf("already be reverted") !== -1) {
+                        await this.postMessage({
+                            channel: event.channel,
+                            text: `<@${event.user}> The commit(s) appear to already be reverted.`,
+                        });
+                        return;
+                    }
+                    // webkit-patch: merge conflict
                     {
                         let index = stderr.indexOf("Failed to apply reverse diff for revision");
                         if (index !== -1) {
@@ -294,7 +375,7 @@ e.g. \`revert-with-pr 260220 Ensure it is working after refactoring\`
                                 }
                             }
                             if (files.length !== 0) {
-                                await this._web.chat.postMessage({
+                                await this.postMessage({
                                     channel: event.channel,
                                     text: `<@${event.user}> Failed to create revert patch because of the following conflicts:
 \`\`\`
@@ -309,7 +390,7 @@ ${escapeForSlackText(files.join("\n"))}\`\`\``,
                         if (index !== -1) {
                             let line = stderr.slice(index).split("\n")[0].trim();
                             let matched = /#(\d+)/.match(line);
-                            await this._web.chat.postMessage({
+                            await this.postMessage({
                                 channel: event.channel,
                                 text: `<@${event.user}> Failed to create revert patch. Please ensure commit-queue@webkit.org is authorized to access ${matched ? ("bug " + escapeForSlackText(matched[1])) : "the bug"}.`
                             });
@@ -317,7 +398,7 @@ ${escapeForSlackText(files.join("\n"))}\`\`\``,
                         }
                     }
                 }
-                await this._web.chat.postMessage({
+                await this.postMessage({
                     channel: event.channel,
                     text: `<@${event.user}> Failed to create revert patch.` + (stderr ? `
 \`\`\`
@@ -327,7 +408,7 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
             return;
         }
 
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> Failed to parse revision and reason`,
         });
@@ -337,8 +418,18 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
     {
         let {revisions, reason} = extractRevisionsAndReason(args);
 
-        if (!isASCII(reason)) {
-            await this._web.chat.postMessage({
+        // Check if the "reason" is actually a bug URL
+        let issueUrl = null;
+        if (reason) {
+            let bugId = parseBugId(reason);
+            if (bugId) {
+                issueUrl = `https://bugs.webkit.org/show_bug.cgi?id=${bugId}`;
+                reason = "";
+            }
+        }
+
+        if (!issueUrl && !isASCII(reason)) {
+            await this.postMessage({
                 channel: event.channel,
                 text: `<@${event.user}> webkit-patch only accepts an ASCII string for reason: \`${escapeForSlackText(reason)}\``,
             });
@@ -346,29 +437,28 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
         }
 
         if (!revisions.length) {
-            await this._web.chat.postMessage({
+            let detail = issueUrl
+                ? `issue = \`${escapeForSlackText(issueUrl)}\``
+                : `reason = \`${escapeForSlackText(reason)}\``;
+            await this.postMessage({
                 channel: event.channel,
-                text: `<@${event.user}> No revision is found: reason = \`${escapeForSlackText(reason)}\``,
+                text: `<@${event.user}> No revision is found: ${detail}`,
             });
             return;
         }
 
-        let message = `revisions = \`${escapeForSlackText(revisions.join(","))}\`, reason = \`${escapeForSlackText(reason)}\``;
+        let message;
+        if (issueUrl)
+            message = `revisions = \`${escapeForSlackText(revisions.join(","))}\`, issue = \`${escapeForSlackText(issueUrl)}\``;
+        else
+            message = `revisions = \`${escapeForSlackText(revisions.join(","))}\`, reason = \`${escapeForSlackText(reason)}\``;
 
         if (process.env.USE_GIT_WEBKIT_REVERT === "true") {
-            const gitWebkitPath = path.resolve("BotWebKit", "Tools", "Scripts", "git-webkit");
-            let gitWebkitArgs = [
-                gitWebkitPath,
-                "revert",
-                ...revisions,
-                "--reason", reason,
-                "--pr",
-                "--draft",
-            ];
+            let gitWebkitArgs = buildGitWebkitRevertCommand("git-webkit", revisions, reason, issueUrl);
             message += `\nRevert command: \`${escapeForSlackText(gitWebkitArgs.join(" "))}\``;
         }
 
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> ${message}`,
         });
@@ -381,14 +471,14 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
 
     async pullCommand(event, command, args)
     {
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> Preparing pulling the latest WebKit checkout.`,
         });
         await this._taskQueue.postOrFailWhenExceedingLimit({
             command: "pull",
         });
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> Pulled the latest checkout.`,
         });
@@ -396,7 +486,7 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
 
     async pingCommand(event, command, args)
     {
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> pong`,
         });
@@ -408,13 +498,13 @@ ${escapeForSlackText(stderr)}\`\`\`` : ""),
             let commandName = args[0];
             let operation = this._commands.get(commandName);
             if (operation) {
-                await this._web.chat.postMessage({
+                await this.postMessage({
                     channel: event.channel,
                     text: `<@${event.user}> \`${escapeForSlackText(commandName)}\`: ${escapeForSlackText(operation.description)}
 Usage: ${escapeForSlackText(operation.usage)}`,
                 });
             } else {
-                await this._web.chat.postMessage({
+                await this.postMessage({
                     channel: event.channel,
                     text: `<@${event.user}> Unknown command \`${escapeForSlackText(commandName)}\``,
                 });
@@ -423,7 +513,7 @@ Usage: ${escapeForSlackText(operation.usage)}`,
             let commandNames = [];
             for (let key of this._commands.keys())
                 commandNames.push("`" + key + "`");
-            await this._web.chat.postMessage({
+            await this.postMessage({
                 channel: event.channel,
                 text: `<@${event.user}> Available commands: ${escapeForSlackText(commandNames.join(", "))}
 Type \`help COMMAND\` for help on my individual commands.`,
@@ -433,7 +523,7 @@ Type \`help COMMAND\` for help on my individual commands.`,
 
     async statusCommand(event, command, args)
     {
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> ${escapeForSlackText(String(this._taskQueue.length))} requests in queue.`,
         });
@@ -441,7 +531,7 @@ Type \`help COMMAND\` for help on my individual commands.`,
 
     async hiCommand(event, command, args)
     {
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `Hi <@${event.user}>!`,
         });
@@ -449,7 +539,7 @@ Type \`help COMMAND\` for help on my individual commands.`,
 
     async youThereCommand(event, command, args)
     {
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> yes`,
         });
@@ -458,7 +548,7 @@ Type \`help COMMAND\` for help on my individual commands.`,
     async unknownCommand(event, command, args)
     {
         dataLogLn("Unknown command: ", command);
-        await this._web.chat.postMessage({
+        await this.postMessage({
             channel: event.channel,
             text: `<@${event.user}> Unknown command \`${escapeForSlackText(command)}\``,
         });
@@ -469,7 +559,13 @@ Type \`help COMMAND\` for help on my individual commands.`,
         return new Promise((resolve, reject) => {
             let task = spawn(command, args, {
                 cwd: process.env.webkitWorkingDirectory,
-                env: {},
+                env: {
+                    PATH: process.env.PATH,
+                    HOME: process.env.HOME || "/root",
+                    // Needed to suppress long utf-8 warnings in logs
+                    LC_ALL: "C.UTF-8",
+                    LANG: "C.UTF-8",
+                },
                 stdio: "inherit",
             });
             task.on("close", (code) => {
@@ -500,13 +596,28 @@ Type \`help COMMAND\` for help on my individual commands.`,
 
         dataLogLn("6. Creating local 'main' ref");
         await this.execInWebKitDirectorySimple("git", ["checkout", "origin/main", "-b", "main"]);
+
+        dataLogLn("7. Cleaning up leftover branches");
+        try {
+            let {stdout} = await execFileAsync("git", ["for-each-ref", "--format", "%(refname:short)", "refs/heads/"], {
+                cwd: process.env.webkitWorkingDirectory,
+            });
+            for (let branch of stdout.split("\n").filter(b => b && b !== "main")) {
+                dataLogLn("Deleting branch:" + branch);
+                await execFileAsync("git", ["branch", "-D", branch], {
+                    cwd: process.env.webkitWorkingDirectory,
+                });
+            }
+        } catch (error) {
+            dataLogLn("Warning: Failed to clean up branches:" + error.message);
+        }
     }
 
     async generateRevertingPatchWithGitWebkit(revisions, reason, issueUrl = null)
     {
-        dataLogLn("Reverting with git-webkit: ", revisions, reason);
+        dataLogLn("Reverting with git-webkit: ", revisions, reason, issueUrl);
 
-        if (reason.startsWith("-"))
+        if (!issueUrl && reason.startsWith("-"))
             throw new Error(`The revert reason may not begin with - ("${reason}")`);
 
         await this.cleanUpWorkingCopy();
@@ -517,37 +628,55 @@ Type \`help COMMAND\` for help on my individual commands.`,
             const gitWebkitPath = path.resolve("BotWebKit", "Tools", "Scripts", "git-webkit");
             var pythonPath = which.sync("python3");
 
-            let args = [
-                gitWebkitPath,
-                "revert",
-                ...revisions,
-                "--reason", reason,
-                "--pr",
-                "--draft",
-            ];
+            let args = buildGitWebkitRevertCommand(gitWebkitPath, revisions, reason, issueUrl);
 
-            if (issueUrl)
-                args.push("--issue", issueUrl);
+            console.log("Running: " + pythonPath + " " + args.join(" "));
 
-            results = await execFileAsync(pythonPath, args, {
-                cwd: process.env.webkitWorkingDirectory,
-                env: {
-                    GIT_AUTHOR_NAME: "WebKit Revert Bot",
-                    GIT_AUTHOR_EMAIL: "revert-bot@webkit.org",
-                    GIT_COMMITTER_NAME: "WebKit Revert Bot",
-                    GIT_COMMITTER_EMAIL: "revert-bot@webkit.org",
-                    GIT_EDITOR: "true",
-                    GITHUB_COM_USERNAME: process.env.GITHUB_COM_USERNAME,
-                    GITHUB_COM_TOKEN: process.env.GITHUB_COM_TOKEN,
-                    BUGS_WEBKIT_ORG_USERNAME: process.env.BUGS_WEBKIT_ORG_USERNAME,
-                    BUGS_WEBKIT_ORG_PASSWORD: process.env.BUGS_WEBKIT_ORG_PASSWORD,
-                    http_proxy: process.env.http_proxy,
-                    https_proxy: process.env.http_proxy,
-                    PATH: process.env.PATH,
-                    HOME: process.env.HOME || "/root",
-                },
-                timeout: defaultTimeoutForRevert,
-                maxBuffer: 1024 * 1024 * 50,
+            results = await new Promise((resolve, reject) => {
+                let stdout = "";
+                let stderr = "";
+                let task = spawn(pythonPath, args, {
+                    cwd: process.env.webkitWorkingDirectory,
+                    env: {
+                        GIT_AUTHOR_NAME: "WebKit Revert Bot",
+                        GIT_AUTHOR_EMAIL: "revert-bot@webkit.org",
+                        GIT_COMMITTER_NAME: "WebKit Revert Bot",
+                        GIT_COMMITTER_EMAIL: "revert-bot@webkit.org",
+                        GIT_EDITOR: "true",
+                        GITHUB_COM_USERNAME: process.env.GITHUB_COM_USERNAME,
+                        GITHUB_COM_TOKEN: process.env.GITHUB_COM_TOKEN,
+                        BUGS_WEBKIT_ORG_USERNAME: process.env.BUGS_WEBKIT_ORG_USERNAME,
+                        BUGS_WEBKIT_ORG_PASSWORD: process.env.BUGS_WEBKIT_ORG_PASSWORD,
+                        http_proxy: process.env.http_proxy,
+                        https_proxy: process.env.http_proxy,
+                        PATH: process.env.PATH,
+                        HOME: process.env.HOME || "/root",
+                    },
+                    timeout: defaultTimeoutForRevert,
+                });
+                task.stdout.on("data", (data) => {
+                    process.stdout.write(data);
+                    stdout += data.toString();
+                });
+                task.stderr.on("data", (data) => {
+                    process.stderr.write(data);
+                    stderr += data.toString();
+                });
+                task.on("close", (code) => {
+                    if (code === 0)
+                        resolve({stdout, stderr});
+                    else {
+                        let error = new Error(`git-webkit exited with code ${code}`);
+                        error.stdout = stdout;
+                        error.stderr = stderr;
+                        reject(error);
+                    }
+                });
+                task.on("error", (error) => {
+                    error.stdout = stdout;
+                    error.stderr = stderr;
+                    reject(error);
+                });
             });
         } catch (error) {
             dataLogLn(error);
@@ -557,9 +686,9 @@ Type \`help COMMAND\` for help on my individual commands.`,
             throw newError;
         }
 
+        // stdout/stderr were already streamed live above; just parse the
+        // captured output for the PR URL (don't re-dump it).
         let {stdout, stderr} = results;
-        dataLogLn(stdout);
-        dataLogLn(stderr);
         let prUrl = parsePRUrl(stdout) || parsePRUrl(stderr);
         if (prUrl)
             return prUrl;
@@ -637,8 +766,8 @@ Type \`help COMMAND\` for help on my individual commands.`,
             return this.generateRevertingPatch(revisions, reason);
         }
         case "revert-with-pr": {
-            let {revisions, reason} = task;
-            return this.generateRevertingPatchWithGitWebkit(revisions, reason);
+            let {revisions, reason, issueUrl} = task;
+            return this.generateRevertingPatchWithGitWebkit(revisions, reason, issueUrl);
         }
         case "pull":
             return this.cleanUpWorkingCopy();


### PR DESCRIPTION
#### d0e78ef619435010cd969e67eee1655e992bb3f7
<pre>
[webkit-bot] Support the --issue flag and handle errors when reverting with git-webkit
<a href="https://bugs.webkit.org/show_bug.cgi?id=318275">https://bugs.webkit.org/show_bug.cgi?id=318275</a>
<a href="https://rdar.apple.com/181067423">rdar://181067423</a>

Reviewed by Aakash Jain.

Credit goes to Brianna Fan for the first draft of these changes.

The most important changes are adding support for the --issue flag (so a
revert can reuse an existing Bugzilla bug) and handling git-webkit errors
and merge conflicts. There are also a handful of smaller fixes. All of the
git-webkit revert behavior remains gated behind the USE_GIT_WEBKIT_REVERT
environment variable.

* Tools/WebKitBot/src/WebKitBot.mjs:
- buildGitWebkitRevertCommand: New shared helper for building git-webkit revert args.
- extractTextIfMentioned: Strip Slack auto-linked URLs.
- postMessage: New wrapper to disable link unfurling on all messages.
- revertCommand / revertWithPRCommand: Support bug URLs as the --issue argument; handle
  merge conflicts (list files, mention the created bug) and already-reverted errors.
- dryRevertCommand: Support bug URLs as the --issue argument; preview the git-webkit
  command when the feature flag is enabled.
- generateRevertingPatchWithGitWebkit: Switch from execFileAsync to spawn for real-time output.
- execInWebKitDirectorySimple: Fix locale warnings by passing PATH, HOME, LC_ALL, LANG.
- cleanUpWorkingCopy: Clean up leftover branches.

Canonical link: <a href="https://commits.webkit.org/316565@main">https://commits.webkit.org/316565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4304d5d74d0449781fe13c4a9284a331b7f4e374

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171763 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45680 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181066 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129317 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/173628 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/46965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/181066 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129317 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/174721 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/46965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181066 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/46965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/29816 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/46965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183734 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142328 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45347 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142219 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46027 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110662 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26228 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46027 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44545 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39098 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/43945 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44177 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44004 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->