### PR TITLE
[Smart Lists] Typing space attempts to convert my line to a bullet but erases the line in the process

### DIFF
--- a/LayoutTests/editing/smart-lists/smart-list-trigger-requires-marker-only-line-expected.txt
+++ b/LayoutTests/editing/smart-lists/smart-list-trigger-requires-marker-only-line-expected.txt
@@ -1,0 +1,33 @@
+Smart-list activation requires the just-typed space to immediately follow the marker, with no other content anywhere on the line. The first four cases verify that typing a space in a line that already contains content past the marker (mid-word, end-of-line, or immediately after the period) leaves the content as plain text. The last case should activate list formatting.
+
+Mid-word space:
+| "1. apple"
+| <br>
+| "2. cherryban <#selection-caret>ana"
+
+End-of-line space:
+| "1. apple"
+| <br>
+| "2. cherrybanana <#selection-caret>"
+
+Space after period:
+| "1. apple"
+| <br>
+| "2. <#selection-caret> abc"
+
+Mid-word space with bullet marker:
+| "* apple"
+| <br>
+| "* cherryban <#selection-caret>ana"
+
+Marker followed only by typed space (should activate):
+| <ol>
+|   class="Apple-decimal-list"
+|   start="1"
+|   style="list-style-type: decimal;"
+|   <li>
+|     "abc"
+|     <br>
+|   <li>
+|     <#selection-caret>
+|     <br>

--- a/LayoutTests/editing/smart-lists/smart-list-trigger-requires-marker-only-line.html
+++ b/LayoutTests/editing/smart-lists/smart-list-trigger-requires-marker-only-line.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SmartListsAvailable=true ] -->
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div id="test-midword" contenteditable></div>
+<div id="test-endword" contenteditable></div>
+<div id="test-afterperiod" contenteditable></div>
+<div id="test-midword-bullet" contenteditable></div>
+<div id="test-activates" contenteditable></div>
+
+<script>
+Markup.description('Smart-list activation requires the just-typed space to immediately follow the marker, with no other content anywhere on the line. The first four cases verify that typing a space in a line that already contains content past the marker (mid-word, end-of-line, or immediately after the period) leaves the content as plain text. The last case should activate list formatting.');
+
+function placeCaret(textNode, offset)
+{
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode, offset);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+// Typing a space mid-word should not trigger smart-list conversion.
+const midwordTarget = document.getElementById('test-midword');
+midwordTarget.innerHTML = '1. apple<br>2. cherrybanana';
+midwordTarget.focus();
+placeCaret(midwordTarget.lastChild, midwordTarget.lastChild.length - 3);
+typeCharacterCommand(' ');
+Markup.dump('test-midword', 'Mid-word space');
+
+// Typing a space after the trailing text should also not trigger smart-list conversion.
+const endwordTarget = document.getElementById('test-endword');
+endwordTarget.innerHTML = '1. apple<br>2. cherrybanana';
+endwordTarget.focus();
+placeCaret(endwordTarget.lastChild, endwordTarget.lastChild.length);
+typeCharacterCommand(' ');
+Markup.dump('test-endword', 'End-of-line space');
+
+// Typing a space right after the list marker in a line that has pre-existing text should not trigger smart-list conversion.
+const afterPeriodTarget = document.getElementById('test-afterperiod');
+afterPeriodTarget.innerHTML = '1. apple<br>2. abc';
+afterPeriodTarget.focus();
+placeCaret(afterPeriodTarget.lastChild, 2);
+typeCharacterCommand(' ');
+Markup.dump('test-afterperiod', 'Space after period');
+
+// Same mid-word case as above but with bullet-point ("*") markers instead of an ordered list.
+const midwordBulletTarget = document.getElementById('test-midword-bullet');
+midwordBulletTarget.innerHTML = '* apple<br>* cherrybanana';
+midwordBulletTarget.focus();
+placeCaret(midwordBulletTarget.lastChild, midwordBulletTarget.lastChild.length - 3);
+typeCharacterCommand(' ');
+Markup.dump('test-midword-bullet', 'Mid-word space with bullet marker');
+
+// Typing a space after the list marker and period, without other text on the line should trigger smart-list conversion.
+const activatesTarget = document.getElementById('test-activates');
+activatesTarget.innerHTML = '1. abc<br>2.';
+activatesTarget.focus();
+placeCaret(activatesTarget.lastChild, activatesTarget.lastChild.length);
+typeCharacterCommand(' ');
+Markup.dump('test-activates', 'Marker followed only by typed space (should activate)');
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -176,6 +176,18 @@ bool InsertTextCommand::applySmartListsIfNeeded()
         return false;
     }
 
+    auto lineEnd = logicalEndOfLine(endingSelection().visibleBase());
+    if (lineEnd.isNull() || lineEnd.isOrphan())
+        return false;
+
+    auto fullLineRange = VisibleSelection { lineStart, lineEnd }.firstRange();
+    if (!fullLineRange)
+        return false;
+
+    auto fullLineText = plainText(*fullLineRange);
+    if (fullLineText.find(' ') != notFound)
+        return false;
+
     // Create and parse the smart list for the previous line, if possible.
 
     auto smartListRangeForPreviousLine = [&] -> std::optional<SimpleRange> {


### PR DESCRIPTION
#### ff5472ad4fd43e4db15fcd014e675020d381ac78
<pre>
[Smart Lists] Typing space attempts to convert my line to a bullet but erases the line in the process
<a href="https://bugs.webkit.org/show_bug.cgi?id=318273">https://bugs.webkit.org/show_bug.cgi?id=318273</a>
<a href="https://rdar.apple.com/177363383">rdar://177363383</a>

Reviewed by Richard Robinson.

Currently, if the user does any of these three cases, smart lists will trigger:
Case 1: &quot;1. apple&lt;br&gt;2. cherrybanana&quot; --&gt; &quot;1. apple&lt;br&gt;2. cherryban ana&quot; (mid-space)
    * Note that case 1 will yield &quot;1.apple&lt;br&gt;2. ana&quot;
Case 2: &quot;1. apple&lt;br&gt;2. cherrybanana&quot; --&gt; &quot;1. apple&lt;br&gt;2. cherrybanana &quot; (trailing-space)
Case 3: &quot;1. apple&lt;br&gt;2. cherrybanana&quot; --&gt; &quot;1. apple&lt;br&gt;2.  cherrybanana&quot; (leading-space)

This causes a jarring effect when a user has pasted plain text that looks like a &quot;list&quot;,
but is actually a combination of &lt;div&gt;, &lt;p&gt;, or &lt;span&gt; and there is no &lt;ol&gt; or &lt;ul&gt; present.
The effect is typing a space in anywhere in a &quot;list&quot; item that is after the first item,
triggers smart list formatting. Then, the entire line of text leading up to the cursor is deleted,
and the list marker is added. This produces the &quot;erases the line in the process&quot; effect.

To fix this issue, tighten the criteria to `applySmartListsIfNeeded` so it has to be the second list item,
have the list marker only and nothing past the marker.

* LayoutTests/editing/smart-lists/smart-list-trigger-requires-marker-only-line-expected.txt: Added.
* LayoutTests/editing/smart-lists/smart-list-trigger-requires-marker-only-line.html: Added.
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):

Canonical link: <a href="https://commits.webkit.org/316412@main">https://commits.webkit.org/316412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4317c1317bd1d7dd6855ad223b5f841e47092b70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129523 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e634058-feb4-4349-98dc-0dd673e172c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133782 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0395bf7b-01e2-4a4f-81fe-4263557f6669) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114254 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6ba09d8-d18e-48c6-aa83-899466618f80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35811 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30022 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183941 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142499 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46233 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30646 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110896 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26140 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37487 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117921 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44751 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8741 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44151 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44383 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->