### PR TITLE
Guard against MessagePort confusion in the Network Process

### DIFF
--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -49,7 +49,7 @@ public:
     const MessagePortIdentifier& port2() const LIFETIME_BOUND { return m_ports[1]; }
 
     WEBCORE_EXPORT std::optional<ProcessIdentifier> NODELETE processForPort(const MessagePortIdentifier&);
-    bool NODELETE includesPort(const MessagePortIdentifier&);
+    WEBCORE_EXPORT bool NODELETE includesPort(const MessagePortIdentifier&);
     void entanglePortWithProcess(const MessagePortIdentifier&, ProcessIdentifier);
     void disentanglePort(const MessagePortIdentifier&);
     void closePort(const MessagePortIdentifier&);

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
@@ -71,6 +71,11 @@ void MessagePortChannelRegistry::messagePortChannelDestroyed(MessagePortChannel&
     m_openChannels.remove(channel.port1());
     m_openChannels.remove(channel.port2());
 
+    m_pendingTransferOrigins.remove(channel.port1());
+    m_pendingTransferOrigins.remove(channel.port2());
+    m_pendingTransferDestinations.remove(channel.port1());
+    m_pendingTransferDestinations.remove(channel.port2());
+
     LOG(MessagePorts, "Registry: After removing channel %s there are %u channels left in the registry:", channel.logString().utf8().data(), m_openChannels.size());
 }
 
@@ -155,6 +160,38 @@ MessagePortChannel* MessagePortChannelRegistry::existingChannelContainingPort(co
     ASSERT(isMainThread());
 
     return m_openChannels.get(port);
+}
+
+void MessagePortChannelRegistry::recordPendingTransferOrigin(const MessagePortIdentifier& port, ProcessIdentifier origin)
+{
+    ASSERT(isMainThread());
+    m_pendingTransferOrigins.set(port, origin);
+}
+
+bool MessagePortChannelRegistry::claimPendingTransferOrigin(const MessagePortIdentifier& port, ProcessIdentifier expected)
+{
+    ASSERT(isMainThread());
+    auto it = m_pendingTransferOrigins.find(port);
+    if (it == m_pendingTransferOrigins.end() || it->value != expected)
+        return false;
+    m_pendingTransferOrigins.remove(it);
+    return true;
+}
+
+void MessagePortChannelRegistry::recordPendingTransferDestination(const MessagePortIdentifier& port, ProcessIdentifier destination)
+{
+    ASSERT(isMainThread());
+    m_pendingTransferDestinations.set(port, destination);
+}
+
+bool MessagePortChannelRegistry::claimPendingTransferDestination(const MessagePortIdentifier& port, ProcessIdentifier expected)
+{
+    ASSERT(isMainThread());
+    auto it = m_pendingTransferDestinations.find(port);
+    if (it == m_pendingTransferDestinations.end() || it->value != expected)
+        return false;
+    m_pendingTransferDestinations.remove(it);
+    return true;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -56,8 +56,17 @@ public:
     WEBCORE_EXPORT void messagePortChannelCreated(MessagePortChannel&);
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 
+    // Used by the Networking process to accurately track the current owner of a given port.
+    // Necessary to accurately MESSAGE_CHECK many messages related to ports.
+    WEBCORE_EXPORT void recordPendingTransferOrigin(const MessagePortIdentifier&, ProcessIdentifier);
+    WEBCORE_EXPORT bool claimPendingTransferOrigin(const MessagePortIdentifier&, ProcessIdentifier expected);
+    WEBCORE_EXPORT void recordPendingTransferDestination(const MessagePortIdentifier&, ProcessIdentifier);
+    WEBCORE_EXPORT bool claimPendingTransferDestination(const MessagePortIdentifier&, ProcessIdentifier expected);
+
 private:
     HashMap<MessagePortIdentifier, WeakRef<MessagePortChannel>> m_openChannels;
+    HashMap<MessagePortIdentifier, ProcessIdentifier> m_pendingTransferOrigins;
+    HashMap<MessagePortIdentifier, ProcessIdentifier> m_pendingTransferDestinations;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1764,6 +1764,10 @@ WebSWServerConnection* NetworkConnectionToWebProcess::swConnection()
 
 void NetworkConnectionToWebProcess::createNewMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2)
 {
+    // Both ports clearly should originate from this web process.
+    MESSAGE_CHECK(port1.processIdentifier == m_webProcessIdentifier);
+    MESSAGE_CHECK(port2.processIdentifier == m_webProcessIdentifier);
+
     m_processEntangledPorts.add(port1);
     m_processEntangledPorts.add(port2);
     protect(m_networkProcess->messagePortChannelRegistry())->didCreateMessagePortChannel(port1, port2);
@@ -1771,24 +1775,55 @@ void NetworkConnectionToWebProcess::createNewMessagePortChannel(const MessagePor
 
 void NetworkConnectionToWebProcess::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
-    m_processEntangledPorts.add(local);
-    protect(m_networkProcess->messagePortChannelRegistry())->didEntangleLocalToRemote(local, remote, m_webProcessIdentifier);
+    CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
 
-    RefPtr channel = m_networkProcess->messagePortChannelRegistry().existingChannelContainingPort(local);
-    if (channel && channel->hasAnyMessagesPendingOrInFlight())
+    // A MessageChannel created on a stopped ScriptExecutionContext skips the CreateNewMessagePortChannel
+    // IPC, but still sends Disentangle/Entangle for the ensuing transfer.
+    // Allow a missing channel here, as there's no state to protect or verify.
+    RefPtr channel = registry->existingChannelContainingPort(local);
+    if (!channel)
+        return;
+
+    // Ports can be transferred to another process (cross origin) or within the same process.
+    // Even in same process transfers they can be disentangled before being reentangled.
+    // Allow for either case here.
+    MESSAGE_CHECK(registry->claimPendingTransferDestination(local, m_webProcessIdentifier)
+        || registry->claimPendingTransferOrigin(local, m_webProcessIdentifier));
+
+    MESSAGE_CHECK(channel->includesPort(remote));
+
+    // The local port must currently be in transit (no current owner).
+    MESSAGE_CHECK(!channel->processForPort(local));
+
+    m_processEntangledPorts.add(local);
+    registry->didEntangleLocalToRemote(local, remote, m_webProcessIdentifier);
+
+    if (channel->hasAnyMessagesPendingOrInFlight())
         m_connection->send(Messages::NetworkProcessConnection::MessagesAvailableForPort(local), 0);
 }
 
 void NetworkConnectionToWebProcess::messagePortDisentangled(const MessagePortIdentifier& port)
 {
-    m_processEntangledPorts.remove(port);
+    CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
+    RefPtr channel = registry->existingChannelContainingPort(port);
+    if (channel)
+        MESSAGE_CHECK(channel->processForPort(port) == m_webProcessIdentifier);
 
-    protect(m_networkProcess->messagePortChannelRegistry())->didDisentangleMessagePort(port);
+    m_processEntangledPorts.remove(port);
+    registry->didDisentangleMessagePort(port);
+
+    // Record that this process is the legitimate origin for any subsequent message that carries this port.
+    if (channel)
+        registry->recordPendingTransferOrigin(port, m_webProcessIdentifier);
 }
 
 void NetworkConnectionToWebProcess::messagePortClosed(const MessagePortIdentifier& port)
 {
-    protect(m_networkProcess->messagePortChannelRegistry())->didCloseMessagePort(port);
+    CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
+    if (RefPtr channel = registry->existingChannelContainingPort(port))
+        MESSAGE_CHECK(channel->processForPort(port) == m_webProcessIdentifier);
+
+    registry->didCloseMessagePort(port);
 }
 
 MessageBatchIdentifier NetworkConnectionToWebProcess::nextMessageBatchIdentifier(CompletionHandler<void()>&& deliveryCallback)
@@ -1801,10 +1836,20 @@ MessageBatchIdentifier NetworkConnectionToWebProcess::nextMessageBatchIdentifier
 
 void NetworkConnectionToWebProcess::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, std::optional<MessageBatchIdentifier>)>&& callback)
 {
+    CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
+    RefPtr channel = registry->existingChannelContainingPort(port);
+    MESSAGE_CHECK_COMPLETION(channel, callback({ }, std::nullopt));
     // A WebContent process may only receive messages for ports entangled to it.
-    MESSAGE_CHECK_COMPLETION(m_processEntangledPorts.contains(port), callback({ }, std::nullopt));
+    MESSAGE_CHECK_COMPLETION(channel->processForPort(port) == m_webProcessIdentifier, callback({ }, std::nullopt));
 
-    protect(m_networkProcess->messagePortChannelRegistry())->takeAllMessagesForPort(port, [this, protectedThis = Ref { *this }, callback = WTF::move(callback)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& deliveryCallback) mutable {
+    registry->takeAllMessagesForPort(port, [this, protectedThis = Ref { *this }, callback = WTF::move(callback)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& deliveryCallback) mutable {
+        // Now that the receiving process has been authenticated and is about to take possession,
+        // record the destination for any ports being transferred so the receiver can entangle them.
+        CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
+        for (auto& message : messages) {
+            for (auto& transferredPort : message.transferredPorts)
+                registry->recordPendingTransferDestination(transferredPort.first, m_webProcessIdentifier);
+        }
         callback(WTF::move(messages), nextMessageBatchIdentifier(WTF::move(deliveryCallback)));
     });
 }
@@ -1818,13 +1863,24 @@ void NetworkConnectionToWebProcess::didDeliverMessagePortMessages(MessageBatchId
 
 void NetworkConnectionToWebProcess::postMessageToRemote(MessageWithMessagePorts&& message, const MessagePortIdentifier& port)
 {
-    if (protect(m_networkProcess->messagePortChannelRegistry())->didPostMessageToRemote(WTF::move(message), port)) {
-        // Look up the process for that port
-        RefPtr channel = m_networkProcess->messagePortChannelRegistry().existingChannelContainingPort(port);
-        ASSERT(channel);
-        auto processIdentifier = channel->processForPort(port);
-        if (processIdentifier) {
-            if (RefPtr connectionToWebProcess = m_networkProcess->webProcessConnection(*processIdentifier))
+    CheckedRef registry = m_networkProcess->messagePortChannelRegistry();
+    RefPtr channel = registry->existingChannelContainingPort(port);
+    if (!channel)
+        return;
+
+    // The caller must own at least one port belonging to this channel.
+    auto otherPort = (channel->port1() == port) ? channel->port2() : channel->port1();
+    MESSAGE_CHECK(channel->processForPort(otherPort) == m_webProcessIdentifier
+        || channel->processForPort(port) == m_webProcessIdentifier);
+
+    // Each transferred port must have been disentangled by this same web process.
+    // It's invalid to be transfering a port this web process doesn't even own.
+    for (auto& transferredPort : message.transferredPorts)
+        MESSAGE_CHECK(registry->claimPendingTransferOrigin(transferredPort.first, m_webProcessIdentifier));
+
+    if (registry->didPostMessageToRemote(WTF::move(message), port)) {
+        if (auto destinationProcess = channel->processForPort(port)) {
+            if (RefPtr connectionToWebProcess = m_networkProcess->webProcessConnection(*destinationProcess))
                 connectionToWebProcess->m_connection->send(Messages::NetworkProcessConnection::MessagesAvailableForPort(port), 0);
         }
     }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3353,6 +3353,13 @@ void NetworkProcess::setCORSDisablingPatternsForPage(WebCore::ProcessIdentifier 
     m_extensionCORSDisablingPatterns.set(pageIdentifier, WTF::move(parsedPatterns));
 }
 
+void NetworkProcess::recordMessagePortTransferDestinationsForSiteIsolation(Vector<WebCore::MessagePortIdentifier>&& ports, WebCore::ProcessIdentifier destination, CompletionHandler<void()>&& completionHandler)
+{
+    for (auto& port : ports)
+        m_messagePortChannelRegistry.recordPendingTransferDestination(port, destination);
+    completionHandler();
+}
+
 #if PLATFORM(COCOA)
 void NetworkProcess::appPrivacyReportTestingData(PAL::SessionID sessionID, CompletionHandler<void(const AppPrivacyReportTestingData&)>&& completionHandler)
 {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -427,6 +427,8 @@ public:
     bool shouldDisableCORSForRequestTo(WebCore::PageIdentifier, const URL&) const;
     void setCORSDisablingPatternsForPage(WebCore::ProcessIdentifier, WebCore::PageIdentifier, Vector<String>&&);
 
+    void recordMessagePortTransferDestinationsForSiteIsolation(Vector<WebCore::MessagePortIdentifier>&&, WebCore::ProcessIdentifier destination, CompletionHandler<void()>&&);
+
 #if PLATFORM(COCOA)
     void appPrivacyReportTestingData(PAL::SessionID, CompletionHandler<void(const AppPrivacyReportTestingData&)>&&);
     void clearAppPrivacyReportTestingData(PAL::SessionID, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -250,6 +250,8 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     SetCORSDisablingPatternsForPage(WebCore::ProcessIdentifier webProcessIdentifier, WebCore::PageIdentifier pageIdentifier, Vector<String> patterns)
 
+    RecordMessagePortTransferDestinationsForSiteIsolation(Vector<WebCore::MessagePortIdentifier> ports, WebCore::ProcessIdentifier destination) -> ()
+
     AllowFileAccessFromWebProcess(WebCore::ProcessIdentifier processIdentifier, String url) -> ()
     AllowFilesAccessFromWebProcess(WebCore::ProcessIdentifier processIdentifier, Vector<String> urls) -> () ReplyCanDispatchOutOfOrder
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -49,6 +49,7 @@
 #include <WebCore/CookieChangeSubscription.h>
 #include <WebCore/ExceptionData.h>
 #include <WebCore/LegacySchemeRegistry.h>
+#include <WebCore/MessagePortChannelRegistry.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/NotificationData.h>
 #include <WebCore/SWServerRegistration.h>
@@ -405,9 +406,17 @@ void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
         return;
 
     // It's possible this specific worker cannot be re-run (e.g. its registration has been removed)
-    server->runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTF::move(message), sourceData = WTF::move(*sourceData)](auto* contextConnection) mutable {
-        if (contextConnection)
-            sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTF::move(message), WTF::move(sourceData) });
+    server->runServiceWorkerIfNecessary(destinationIdentifier, [protectedThis = Ref { *this }, destinationIdentifier, message = WTF::move(message), sourceData = WTF::move(*sourceData)](auto* contextConnection) mutable {
+        if (!contextConnection)
+            return;
+
+        // PostMessageToServiceWorker follows a different flow than normal MessagePort post message.
+        // We pre-record the destination so impending message checks pass.
+        Ref networkProcess = protectedThis->networkProcess();
+        CheckedRef registry = networkProcess->messagePortChannelRegistry();
+        for (auto& transferredPort : message.transferredPorts)
+            registry->recordPendingTransferDestination(transferredPort.first, contextConnection->webProcessIdentifier());
+        sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTF::move(message), WTF::move(sourceData) });
     });
 }
 
@@ -482,6 +491,12 @@ void WebSWServerConnection::postMessageToServiceWorkerClient(ScriptExecutionCont
         return;
 
     server->postMessageToServiceWorkerClient(destinationContextIdentifier, message, sourceIdentifier, sourceOrigin, [protectedThis = Ref { *this }] (auto destinationContextIdentifier, auto& message, auto sourceServiceWorkerData, auto& sourceOrigin) {
+        // PostMessageToServiceWorkerClient follows a different flow than normal MessagePort post message.
+        // We pre-record the destination so impending message checks pass.
+        Ref networkProcess = protectedThis->networkProcess();
+        CheckedRef registry = networkProcess->messagePortChannelRegistry();
+        for (auto& transferredPort : message.transferredPorts)
+            registry->recordPendingTransferDestination(transferredPort.first, destinationContextIdentifier.processIdentifier());
         protectedThis->send(Messages::WebSWClientConnection::PostMessageToServiceWorkerClient { destinationContextIdentifier, message, sourceServiceWorkerData, sourceOrigin }, 0);
     });
 }

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -37,6 +37,7 @@
 #include "WebSharedWorker.h"
 #include "WebSharedWorkerContextManagerConnectionMessages.h"
 #include "WebSharedWorkerServer.h"
+#include <WebCore/MessagePortChannelRegistry.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -162,6 +163,14 @@ void WebSharedWorkerServerToContextConnection::resumeSharedWorker(WebCore::Share
 void WebSharedWorkerServerToContextConnection::postConnectEvent(const WebSharedWorker& sharedWorker, const WebCore::TransferredMessagePort& port, CompletionHandler<void(bool)>&& completionHandler)
 {
     CONTEXT_CONNECTION_RELEASE_LOG("postConnectEvent: sharedWorkerIdentifier=%" PRIu64, sharedWorker.identifier().toUInt64());
+
+    // SharedWorkers follow a different flow than normal MessagePort events
+    // We pre-record the destination so impending message checks pass.
+    if (RefPtr connection = m_connection.get()) {
+        Ref networkProcess = connection->networkProcess();
+        CheckedRef registry = networkProcess->messagePortChannelRegistry();
+        registry->recordPendingTransferDestination(port.first, connection->webProcessIdentifier());
+    }
     sendWithAsyncReply(Messages::WebSharedWorkerContextManagerConnection::PostConnectEvent { sharedWorker.identifier(), port, sharedWorker.origin().clientOrigin }, WTF::move(completionHandler));
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -260,6 +260,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/MediaDeviceHashSalts.h>
 #include <WebCore/MediaStreamRequest.h>
+#include <WebCore/MessageWithMessagePorts.h>
 #include <WebCore/MixedContentChecker.h>
 #include <WebCore/ModalContainerTypes.h>
 #include <WebCore/NotImplemented.h>
@@ -18661,7 +18662,29 @@ void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameI
 
 void WebPageProxy::postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts& message, std::optional<WebCore::UserGestureTokenData>&& userGestureToken)
 {
-    sendToProcessContainingFrame(target, Messages::WebPage::RemotePostMessage(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
+    if (message.transferredPorts.isEmpty()) {
+        sendToProcessContainingFrame(target, Messages::WebPage::RemotePostMessage(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
+        return;
+    }
+
+    Ref destinationProcess = processContainingFrame(target);
+    RefPtr networkProcess = websiteDataStore().networkProcessIfExists();
+    if (!networkProcess) {
+        sendToProcessContainingFrame(target, Messages::WebPage::RemotePostMessage(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
+        return;
+    }
+    auto ports = WTF::map(message.transferredPorts, [](auto& transferredPort) {
+        return transferredPort.first;
+    });
+
+    // First, notify the NetworkProcess of all message ports that will be transfered.
+    // Then pass the message along to all web content processes to finalize the transfer.
+    networkProcess->sendWithAsyncReply(Messages::NetworkProcess::RecordMessagePortTransferDestinationsForSiteIsolation(WTF::move(ports), destinationProcess->coreProcessIdentifier()), [weakThis = WeakPtr { *this }, source, sourceOrigin, target, targetOrigin, message, userGestureToken = WTF::move(userGestureToken)] mutable {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        protectedThis->sendToProcessContainingFrame(target, Messages::WebPage::RemotePostMessage(source, sourceOrigin, target, targetOrigin, message, userGestureToken));
+    });
 }
 
 void WebPageProxy::renderTreeAsTextForTesting(WebCore::FrameIdentifier frameID, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior, CompletionHandler<void(String&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -109,7 +109,8 @@ void WebMessagePortChannelProvider::networkProcessConnectionClosed()
 void WebMessagePortChannelProvider::messagePortClosed(const MessagePortIdentifier& port)
 {
     m_inProcessPortMessages.remove(port);
-    m_portsKnownToNetworkProcess.remove(port);
+    if (!m_portsKnownToNetworkProcess.remove(port))
+        return;
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
 }
 

--- a/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
+++ b/Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm
@@ -213,6 +213,307 @@ TEST(MessagePortSecurity, CrossProcessMessageTheftViaTakeAllMessagesForPort)
     EXPECT_WK_STREQ([uiDelegateC waitForAlert], "stolen:0");
 }
 
+static constexpr auto receiverWithStartedPortBytes = R"PORTRESOURCE(
+<script>
+var worker = new SharedWorker('/worker.js');
+worker.port.addEventListener('message', function(event) {
+    if (event.data === 'here-is-port' && event.ports && event.ports.length > 0) {
+        var p = event.ports[0];
+        p.onmessage = function(e) { alert('received-' + e.data); };
+        window.storedPort = p;
+        alert('port-received');
+    }
+});
+worker.port.start();
+worker.port.postMessage('get-port');
+</script>
+)PORTRESOURCE"_s;
+
+TEST(MessagePortSecurity, CrossProcessTransferForcedCloseViaUnauthenticatedMessagePortIdentifier)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/sender"_s, { senderBytes } },
+        { "/receiver"_s, { receiverWithStartedPortBytes } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerBytes } },
+        { "/attacker"_s, { "<html><body>attacker</body></html>"_s } },
+    });
+
+    RetainPtr<_WKWebsiteDataStoreConfiguration> dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr<WKWebsiteDataStore> dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(config.get());
+    [config setWebsiteDataStore:dataStore.get()];
+
+    // `webViewA` (sender) creates a MessageChannel and transfers `port2` to a SharedWorker
+    // so that subsequent messaging across the channel is mediated by the NetworkProcess.
+    RetainPtr<TestNavigationDelegate> navDelegateA = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateA = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewA setNavigationDelegate:navDelegateA.get()];
+    [webViewA setUIDelegate:uiDelegateA.get()];
+    [webViewA loadRequest:server.request("/sender"_s)];
+    [navDelegateA waitForDidFinishNavigation];
+    EXPECT_WK_STREQ([uiDelegateA waitForAlert], "port-stored");
+
+    // `webViewB` (receiver) takes `port2` from the SharedWorker and starts it.
+    RetainPtr<TestNavigationDelegate> navDelegateB = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateB = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewB setNavigationDelegate:navDelegateB.get()];
+    [webViewB setUIDelegate:uiDelegateB.get()];
+    [webViewB loadRequest:server.request("/receiver"_s)];
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "port-received");
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewB _webProcessIdentifier]);
+
+    // Sanity check the channel pre-attack: a message from `webViewA` reaches `webViewB`.
+    [webViewA evaluateJavaScript:@"channel.port1.postMessage('pre-attack');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "received-pre-attack");
+
+    // Harvest `port2`'s identifier captured by the sender's outgoing-IPC listener.
+    NSString *port2ProcessString = [webViewA stringByEvaluatingJavaScript:@"port2ProcessId ? port2ProcessId.toString() : 'undefined'"];
+    NSString *port2PortString = [webViewA stringByEvaluatingJavaScript:@"port2PortId ? port2PortId.toString() : 'undefined'"];
+    EXPECT_FALSE([port2ProcessString isEqualToString:@"undefined"]);
+    EXPECT_FALSE([port2PortString isEqualToString:@"undefined"]);
+
+    RetainPtr<TestNavigationDelegate> navDelegateC = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateC = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewC = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewC setNavigationDelegate:navDelegateC.get()];
+    [webViewC setUIDelegate:uiDelegateC.get()];
+    [webViewC loadRequest:server.request("/attacker"_s)];
+    [navDelegateC waitForDidFinishNavigation];
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+    EXPECT_NE([webViewB _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+
+    NSString *ipcScript = [NSString stringWithFormat:
+        @"var net = IPC.connectionForProcessTarget('Networking');"
+        "var portId = [{type: 'uint64_t', value: BigInt('%@')}, {type: 'uint64_t', value: BigInt('%@')}];"
+        "net.sendMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_MessagePortClosed.name,"
+        "    [portId]);"
+        "net.sendSyncMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_TakeInvalidMessageStringForTesting.name,"
+        "    1000,"
+        "    []);"
+        "alert('attack-fired');", port2ProcessString, port2PortString];
+    [webViewC evaluateJavaScript:ipcScript completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateC waitForAlert], "attack-fired");
+
+    __block bool receivedPostAttack = false;
+    __block RetainPtr<NSString> receivedText;
+    uiDelegateB.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^handler)(void)) {
+        receivedText = message;
+        receivedPostAttack = true;
+        handler();
+    };
+
+    [webViewA evaluateJavaScript:@"channel.port1.postMessage('post-attack');" completionHandler:nil];
+
+    bool delivered = TestWebKitAPI::Util::runFor(&receivedPostAttack, 5_s);
+    EXPECT_TRUE(delivered);
+    if (delivered)
+        EXPECT_WK_STREQ(receivedText.get(), "received-post-attack");
+}
+
+TEST(MessagePortSecurity, CrossProcessTransferForcedDisentangleViaUnauthenticatedMessagePortIdentifier)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/sender"_s, { senderBytes } },
+        { "/receiver"_s, { receiverWithStartedPortBytes } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerBytes } },
+        { "/attacker"_s, { "<html><body>attacker</body></html>"_s } },
+    });
+
+    RetainPtr<_WKWebsiteDataStoreConfiguration> dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr<WKWebsiteDataStore> dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(config.get());
+    [config setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr<TestNavigationDelegate> navDelegateA = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateA = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewA setNavigationDelegate:navDelegateA.get()];
+    [webViewA setUIDelegate:uiDelegateA.get()];
+    [webViewA loadRequest:server.request("/sender"_s)];
+    [navDelegateA waitForDidFinishNavigation];
+    EXPECT_WK_STREQ([uiDelegateA waitForAlert], "port-stored");
+
+    RetainPtr<TestNavigationDelegate> navDelegateB = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateB = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewB setNavigationDelegate:navDelegateB.get()];
+    [webViewB setUIDelegate:uiDelegateB.get()];
+    [webViewB loadRequest:server.request("/receiver"_s)];
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "port-received");
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewB _webProcessIdentifier]);
+
+    [webViewA evaluateJavaScript:@"channel.port1.postMessage('pre-attack');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "received-pre-attack");
+
+    NSString *port2ProcessString = [webViewA stringByEvaluatingJavaScript:@"port2ProcessId ? port2ProcessId.toString() : 'undefined'"];
+    NSString *port2PortString = [webViewA stringByEvaluatingJavaScript:@"port2PortId ? port2PortId.toString() : 'undefined'"];
+    EXPECT_FALSE([port2ProcessString isEqualToString:@"undefined"]);
+    EXPECT_FALSE([port2PortString isEqualToString:@"undefined"]);
+
+    RetainPtr<TestNavigationDelegate> navDelegateC = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateC = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewC = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewC setNavigationDelegate:navDelegateC.get()];
+    [webViewC setUIDelegate:uiDelegateC.get()];
+    [webViewC loadRequest:server.request("/attacker"_s)];
+    [navDelegateC waitForDidFinishNavigation];
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+    EXPECT_NE([webViewB _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+
+    NSString *ipcScript = [NSString stringWithFormat:
+        @"var net = IPC.connectionForProcessTarget('Networking');"
+        "var portId = [{type: 'uint64_t', value: BigInt('%@')}, {type: 'uint64_t', value: BigInt('%@')}];"
+        "net.sendMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_MessagePortDisentangled.name,"
+        "    [portId]);"
+        "net.sendSyncMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_TakeInvalidMessageStringForTesting.name,"
+        "    1000,"
+        "    []);"
+        "alert('attack-fired');", port2ProcessString, port2PortString];
+    [webViewC evaluateJavaScript:ipcScript completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateC waitForAlert], "attack-fired");
+
+    __block bool receivedPostAttack = false;
+    __block RetainPtr<NSString> receivedText;
+    uiDelegateB.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^handler)(void)) {
+        receivedText = message;
+        receivedPostAttack = true;
+        handler();
+    };
+
+    [webViewA evaluateJavaScript:@"channel.port1.postMessage('post-attack');" completionHandler:nil];
+
+    bool delivered = TestWebKitAPI::Util::runFor(&receivedPostAttack, 5_s);
+    EXPECT_TRUE(delivered);
+    if (delivered)
+        EXPECT_WK_STREQ(receivedText.get(), "received-post-attack");
+}
+
+TEST(MessagePortSecurity, CrossProcessTransferForcedEntangleViaUnauthenticatedMessagePortIdentifier)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/sender"_s, { senderBytes } },
+        { "/receiver"_s, { receiverWithStartedPortBytes } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, sharedWorkerBytes } },
+        { "/attacker"_s, { "<html><body>attacker</body></html>"_s } },
+    });
+
+    RetainPtr<_WKWebsiteDataStoreConfiguration> dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr<WKWebsiteDataStore> dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(config.get());
+    [config setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr<TestNavigationDelegate> navDelegateA = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateA = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewA setNavigationDelegate:navDelegateA.get()];
+    [webViewA setUIDelegate:uiDelegateA.get()];
+    [webViewA loadRequest:server.request("/sender"_s)];
+    [navDelegateA waitForDidFinishNavigation];
+    EXPECT_WK_STREQ([uiDelegateA waitForAlert], "port-stored");
+
+    RetainPtr<TestNavigationDelegate> navDelegateB = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateB = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewB setNavigationDelegate:navDelegateB.get()];
+    [webViewB setUIDelegate:uiDelegateB.get()];
+    [webViewB loadRequest:server.request("/receiver"_s)];
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "port-received");
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewB _webProcessIdentifier]);
+
+    [webViewA evaluateJavaScript:@"channel.port1.postMessage('pre-attack');" completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateB waitForAlert], "received-pre-attack");
+
+    NSString *port2ProcessString = [webViewA stringByEvaluatingJavaScript:@"port2ProcessId ? port2ProcessId.toString() : 'undefined'"];
+    NSString *port2PortString = [webViewA stringByEvaluatingJavaScript:@"port2PortId ? port2PortId.toString() : 'undefined'"];
+    EXPECT_FALSE([port2ProcessString isEqualToString:@"undefined"]);
+    EXPECT_FALSE([port2PortString isEqualToString:@"undefined"]);
+
+    RetainPtr<TestNavigationDelegate> navDelegateC = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateC = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewC = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewC setNavigationDelegate:navDelegateC.get()];
+    [webViewC setUIDelegate:uiDelegateC.get()];
+    [webViewC loadRequest:server.request("/attacker"_s)];
+    [navDelegateC waitForDidFinishNavigation];
+    EXPECT_NE([webViewA _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+    EXPECT_NE([webViewB _webProcessIdentifier], [webViewC _webProcessIdentifier]);
+
+    NSString *ipcScript = [NSString stringWithFormat:
+        @"var net = IPC.connectionForProcessTarget('Networking');"
+        "var local = [{type: 'uint64_t', value: BigInt('%@')}, {type: 'uint64_t', value: BigInt('%@')}];"
+        "var remote = [{type: 'uint64_t', value: BigInt(0)}, {type: 'uint64_t', value: BigInt(0)}];"
+        "net.sendMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_EntangleLocalPortInThisProcessToRemote.name,"
+        "    [local, remote]);"
+        "net.sendSyncMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_TakeInvalidMessageStringForTesting.name,"
+        "    1000,"
+        "    []);"
+        "alert('attack-fired');", port2ProcessString, port2PortString];
+    [webViewC evaluateJavaScript:ipcScript completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateC waitForAlert], "attack-fired");
+
+    __block bool receivedPostAttack = false;
+    __block RetainPtr<NSString> receivedText;
+    uiDelegateB.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *, void (^handler)(void)) {
+        receivedText = message;
+        receivedPostAttack = true;
+        handler();
+    };
+
+    [webViewA evaluateJavaScript:@"channel.port1.postMessage('post-attack');" completionHandler:nil];
+
+    bool delivered = TestWebKitAPI::Util::runFor(&receivedPostAttack, 5_s);
+    EXPECT_TRUE(delivered);
+    if (delivered)
+        EXPECT_WK_STREQ(receivedText.get(), "received-post-attack");
+}
+
+TEST(MessagePortSecurity, CrossProcessTransferChannelCreationWithForgedProcessIdentifier)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/attacker"_s, { "<html><body>attacker</body></html>"_s } },
+    });
+
+    RetainPtr<_WKWebsiteDataStoreConfiguration> dataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    RetainPtr<WKWebsiteDataStore> dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:dataStoreConfiguration.get()]);
+    RetainPtr<WKWebViewConfiguration> config = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableIPCTestingAPI(config.get());
+    [config setWebsiteDataStore:dataStore.get()];
+
+    RetainPtr<TestNavigationDelegate> navDelegateC = adoptNS([TestNavigationDelegate new]);
+    RetainPtr<TestUIDelegate> uiDelegateC = adoptNS([TestUIDelegate new]);
+    RetainPtr<TestWKWebView> webViewC = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:config.get()]);
+    [webViewC setNavigationDelegate:navDelegateC.get()];
+    [webViewC setUIDelegate:uiDelegateC.get()];
+    [webViewC loadRequest:server.request("/attacker"_s)];
+    [navDelegateC waitForDidFinishNavigation];
+
+    NSString *ipcScript =
+        @"var net = IPC.connectionForProcessTarget('Networking');"
+        "var port1 = [{type: 'uint64_t', value: BigInt(1)}, {type: 'uint64_t', value: BigInt(42)}];"
+        "var port2 = [{type: 'uint64_t', value: BigInt(1)}, {type: 'uint64_t', value: BigInt(43)}];"
+        "net.sendMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_CreateNewMessagePortChannel.name,"
+        "    [port1, port2]);"
+        "net.sendSyncMessage(0,"
+        "    IPC.messages.NetworkConnectionToWebProcess_TakeInvalidMessageStringForTesting.name,"
+        "    1000,"
+        "    []);"
+        "alert('attack-fired');";
+    [webViewC evaluateJavaScript:ipcScript completionHandler:nil];
+    EXPECT_WK_STREQ([uiDelegateC waitForAlert], "attack-fired");
+}
+
 #endif // ENABLE(IPC_TESTING_API)
 
 // When a WebContent process detaches from its Networking process, then reattaches to a new one,


### PR DESCRIPTION
#### 899dd99924a82b239242807fe962e5e526dcb294
<pre>
Guard against MessagePort confusion in the Network Process
<a href="https://rdar.apple.com/175679886">rdar://175679886</a>

Reviewed by Alex Christensen.

The Networking process is in charge of transferring message port ownership between web processes,
as well as sending/fetching messages for web processes.

This patch teaches it to keep track of web ports are being transferred to and from, which enables
much more thorough message checking of message port operations based on where they currently belong.

Covered by new API tests.

* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp:
(WebCore::MessagePortChannelRegistry::messagePortChannelDestroyed):
(WebCore::MessagePortChannelRegistry::recordPendingTransferOrigin):
(WebCore::MessagePortChannelRegistry::claimPendingTransferOrigin):
(WebCore::MessagePortChannelRegistry::recordPendingTransferDestination):
(WebCore::MessagePortChannelRegistry::claimPendingTransferDestination):
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::createNewMessagePortChannel):
(WebKit::NetworkConnectionToWebProcess::entangleLocalPortInThisProcessToRemote):
(WebKit::NetworkConnectionToWebProcess::messagePortDisentangled):
(WebKit::NetworkConnectionToWebProcess::messagePortClosed):
(WebKit::NetworkConnectionToWebProcess::takeAllMessagesForPort):
(WebKit::NetworkConnectionToWebProcess::postMessageToRemote):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::postConnectEvent):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::messagePortClosed):
* Tools/TestWebKitAPI/Resources/cocoa/MessagePortSecurity.mm:
((MessagePortSecurity, CrossProcessForcedCloseViaUnauthenticatedMessagePortIdentifier)):
((MessagePortSecurity, CrossProcessForcedDisentangleViaUnauthenticatedMessagePortIdentifier)):
((MessagePortSecurity, CrossProcessForcedEntangleViaUnauthenticatedMessagePortIdentifier)):
((MessagePortSecurity, CrossProcessChannelCreationWithForgedProcessIdentifier)):

Canonical link: <a href="https://commits.webkit.org/316423@main">https://commits.webkit.org/316423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efbeeac051d372b6c6ee98e19db4b47c659cc306

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172268 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129824 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f07a355c-c301-44cd-bdef-88af8b2d9241) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133987 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bcc02428-c39b-40b7-a6a9-83d3beb6889b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37424 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114458 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfcd253c-eedc-42fe-8459-725adf5ecb87) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36058 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184253 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142750 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45858 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38505 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46536 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111253 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37706 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45053 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8986 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44685 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->