### PR TITLE
resultsdbpy: run-tests must add webkitcorepy to sys.path

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/run-tests
+++ b/Tools/Scripts/libraries/resultsdbpy/run-tests
@@ -30,8 +30,16 @@ import os
 import sys
 import unittest
 
-import resultsdbpy
-from webkitcorepy import AutoInstall
+def _maybe_add_webkitcorepy_path():
+    # Hopefully we're beside webkitcorepy, otherwise webkitcorepy will need to be installed.
+    libraries_path = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+    webkitcorepy_path = os.path.join(libraries_path, 'webkitcorepy')
+    if os.path.isdir(webkitcorepy_path) and os.path.isdir(os.path.join(webkitcorepy_path, 'webkitcorepy')) and webkitcorepy_path not in sys.path:
+        sys.path.insert(0, webkitcorepy_path)
+
+_maybe_add_webkitcorepy_path()
+
+from webkitcorepy import AutoInstall, Package, Version
 
 libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if sys.platform == 'darwin':
@@ -40,6 +48,10 @@ if sys.platform == 'darwin':
     if (is_root or not does_own_libraries):
         libraries = os.path.expanduser('~/Library/webkitpy')
 AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}'.format(sys.version_info[0])))
+
+AutoInstall.register(Package('webkitbugspy', Version(0, 3, 1)), local=True)
+
+import resultsdbpy
 
 from cassandra.cqlengine.management import CQLENG_ALLOW_SCHEMA_MANAGEMENT
 


### PR DESCRIPTION
#### 3f489e1231c6100cba425d7828e3cc211b30047b
<pre>
resultsdbpy: run-tests must add webkitcorepy to sys.path
<a href="https://bugs.webkit.org/show_bug.cgi?id=318274">https://bugs.webkit.org/show_bug.cgi?id=318274</a>
<a href="https://rdar.apple.com/181066799">rdar://181066799</a>

Reviewed by Elliott Williams.

Then, with the AutoInstaller available, we can register webkitbugspy
as a local package.

* Tools/Scripts/libraries/resultsdbpy/run-tests:
(_maybe_add_webkitcorepy_path):

Canonical link: <a href="https://commits.webkit.org/316549@main">https://commits.webkit.org/316549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/784108087a6df934a1264ef84cb3acb3cf113b89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129304 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f12857f-d7ae-42e6-ac27-8177fb5d0999) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133632 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94268 "2 flakes 19 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f02ec282-3722-47f1-9f1b-fa34f2d349ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114104 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edafb34a-ece1-47f6-94cf-17646d3fadbe) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/171070 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33894 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29803 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183721 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142316 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/171150 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45334 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142207 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46014 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110649 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37320 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44532 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8574 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43932 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44164 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/43991 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->