### PR TITLE
Add unit tests for CachedMatchFinder

### DIFF
--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -46,8 +46,8 @@ public:
 
     enum class CacheUnusable : bool { Oversized };
 
-    Expected<std::optional<SimpleRange>, CacheUnusable> findMatchFrom(const std::optional<SimpleRange>&, const String& target, FindOptions);
-    Expected<Vector<SimpleRange>, CacheUnusable> findMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
+    WEBCORE_EXPORT Expected<std::optional<SimpleRange>, CacheUnusable> findMatchFrom(const std::optional<SimpleRange>&, const String& target, FindOptions);
+    WEBCORE_EXPORT Expected<Vector<SimpleRange>, CacheUnusable> findMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
     WEBCORE_EXPORT Expected<unsigned, CacheUnusable> countMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
 
     WEBCORE_EXPORT static void setMaximumRunCountForTesting(std::optional<unsigned>);

--- a/Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp
@@ -26,10 +26,16 @@
 #include "config.h"
 #include "TestPageHarness.h"
 
+#include <WebCore/CSSPropertyNames.h>
+#include <WebCore/CSSValueKeywords.h>
 #include <WebCore/CachedMatchFinder.h>
 #include <WebCore/Element.h>
 #include <WebCore/FindOptions.h>
 #include <WebCore/HTMLCollection.h>
+#include <WebCore/ShadowRoot.h>
+#include <WebCore/SimpleRange.h>
+#include <WebCore/StyledElement.h>
+#include <WebCore/TextIterator.h>
 
 namespace TestWebKitAPI {
 
@@ -45,6 +51,360 @@ TEST(CachedMatchFinder, CountMatchesFindsMatches)
 
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result.value(), 2u);
+}
+
+TEST(CachedMatchFinder, CountMatchesReturnsZeroWhenNoMatches)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the lazy dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.countMatches(std::nullopt, "purple"_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 0u);
+}
+
+TEST(CachedMatchFinder, CountMatchesWithEmptyTargetReturnsZero)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.countMatches(std::nullopt, ""_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 0u);
+}
+
+TEST(CachedMatchFinder, CountMatchesRespectsLimit)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>brown brown brown brown</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.countMatches(std::nullopt, "brown"_s, { }, 2u);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 2u);
+}
+
+TEST(CachedMatchFinder, FindMatchesReturnsAllMatchingRanges)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.findMatches(std::nullopt, "brown"_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().size(), 2u);
+    EXPECT_EQ(plainText(result.value()[0]), "brown"_s);
+    EXPECT_EQ(plainText(result.value()[1]), "brown"_s);
+}
+
+TEST(CachedMatchFinder, FindMatchesReturnsEmptyVectorWhenNoMatches)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the lazy dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.findMatches(std::nullopt, "purple"_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value().isEmpty());
+}
+
+TEST(CachedMatchFinder, FindMatchesRespectsLimit)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>brown brown brown brown</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.findMatches(std::nullopt, "brown"_s, { }, 1u);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().size(), 1u);
+}
+
+TEST(CachedMatchFinder, FindMatchFromReturnsFirstMatchWhenStartingWithoutReferenceRange)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.findMatchFrom(std::nullopt, "brown"_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result.value().has_value());
+    EXPECT_EQ(plainText(*result.value()), "brown"_s);
+}
+
+TEST(CachedMatchFinder, FindMatchFromReturnsNulloptWhenNoMatches)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the lazy dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.findMatchFrom(std::nullopt, "purple"_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value().has_value());
+}
+
+TEST(CachedMatchFinder, FindMatchFromAdvancesPastReferenceRangeToNextMatch)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto firstMatch = finder.findMatchFrom(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(firstMatch.has_value());
+    ASSERT_TRUE(firstMatch.value().has_value());
+
+    auto secondMatch = finder.findMatchFrom(*firstMatch.value(), "brown"_s, { });
+    ASSERT_TRUE(secondMatch.has_value());
+    ASSERT_TRUE(secondMatch.value().has_value());
+    EXPECT_NE(*firstMatch.value(), *secondMatch.value());
+    EXPECT_EQ(plainText(*secondMatch.value()), "brown"_s);
+
+    auto thirdMatch = finder.findMatchFrom(*secondMatch.value(), "brown"_s, { });
+    ASSERT_TRUE(thirdMatch.has_value());
+    EXPECT_FALSE(thirdMatch.value().has_value());
+}
+
+TEST(CachedMatchFinder, FindMatchFromWithBackwardsOptionFindsPrecedingMatch)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto lastMatch = finder.findMatchFrom(std::nullopt, "brown"_s, FindOption::Backwards);
+    ASSERT_TRUE(lastMatch.has_value());
+    ASSERT_TRUE(lastMatch.value().has_value());
+
+    auto precedingMatch = finder.findMatchFrom(*lastMatch.value(), "brown"_s, FindOption::Backwards);
+    ASSERT_TRUE(precedingMatch.has_value());
+    ASSERT_TRUE(precedingMatch.value().has_value());
+    EXPECT_NE(*lastMatch.value(), *precedingMatch.value());
+
+    auto noMoreMatches = finder.findMatchFrom(*precedingMatch.value(), "brown"_s, FindOption::Backwards);
+    ASSERT_TRUE(noMoreMatches.has_value());
+    EXPECT_FALSE(noMoreMatches.value().has_value());
+}
+
+TEST(CachedMatchFinder, FindMatchFromWithoutWrapAroundStopsAtEndOfDocument)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>brown fox, then more brown text.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto allMatches = finder.findMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(allMatches.has_value());
+    ASSERT_EQ(allMatches.value().size(), 2u);
+
+    auto result = finder.findMatchFrom(allMatches.value().last(), "brown"_s, { });
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result.value().has_value());
+}
+
+TEST(CachedMatchFinder, FindMatchFromWithWrapAroundWrapsToBeginningOfDocument)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>brown fox, then more brown text.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto allMatches = finder.findMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(allMatches.has_value());
+    ASSERT_EQ(allMatches.value().size(), 2u);
+
+    auto result = finder.findMatchFrom(allMatches.value().last(), "brown"_s, FindOption::WrapAround);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result.value().has_value());
+    EXPECT_EQ(*result.value(), allMatches.value().first());
+}
+
+TEST(CachedMatchFinder, CaseInsensitiveOptionMatchesRegardlessOfCase)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>Brown paper, brown bag.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+
+    auto caseSensitiveResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(caseSensitiveResult.has_value());
+    EXPECT_EQ(caseSensitiveResult.value(), 1u);
+
+    auto caseInsensitiveResult = finder.countMatches(std::nullopt, "brown"_s, FindOption::CaseInsensitive);
+    ASSERT_TRUE(caseInsensitiveResult.has_value());
+    EXPECT_EQ(caseInsensitiveResult.value(), 2u);
+}
+
+TEST(CachedMatchFinder, AtWordStartsOptionExcludesMidWordMatches)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>unbrown brown</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+
+    auto withoutWordStarts = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(withoutWordStarts.has_value());
+    EXPECT_EQ(withoutWordStarts.value(), 2u);
+
+    auto withWordStarts = finder.countMatches(std::nullopt, "brown"_s, FindOption::AtWordStarts);
+    ASSERT_TRUE(withWordStarts.has_value());
+    EXPECT_EQ(withWordStarts.value(), 1u);
+}
+
+TEST(CachedMatchFinder, TextBufferCacheIsInvalidatedByDOMMutation)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p id=\"content\">The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto initialResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(initialResult.has_value());
+    EXPECT_EQ(initialResult.value(), 2u);
+
+    RefPtr content = testPage.getElementById("content"_s);
+    ASSERT_TRUE(content);
+    auto setInnerHTMLResult = content->setInnerHTML(String { "brown brown brown"_s });
+    EXPECT_FALSE(setInnerHTMLResult.hasException());
+
+    auto updatedResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(updatedResult.has_value());
+    EXPECT_EQ(updatedResult.value(), 3u);
+}
+
+TEST(CachedMatchFinder, TextBufferCacheIsInvalidatedByStyleChangeWithoutDOMMutation)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p id=\"content\" style=\"display: none;\">brown fox</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto hiddenResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(hiddenResult.has_value());
+    EXPECT_EQ(hiddenResult.value(), 0u);
+
+    RefPtr content = dynamicDowncast<StyledElement>(testPage.getElementById("content"_s));
+    ASSERT_TRUE(content);
+    content->setInlineStyleProperty(CSSPropertyDisplay, CSSValueBlock);
+    testPage.document().updateLayoutIgnorePendingStylesheets();
+
+    auto visibleResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(visibleResult.has_value());
+    EXPECT_EQ(visibleResult.value(), 1u);
+}
+
+TEST(CachedMatchFinder, FlatTreeAndLightTreeBufferCachesRemainIndependentAcrossRepeatedSwitches)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<div id=\"host\"><template shadowrootmode=\"open\"><p>brown fox</p></template></div>"_s);
+
+    RefPtr host = testPage.getElementById("host"_s);
+    ASSERT_TRUE(host);
+    ASSERT_TRUE(host->shadowRoot());
+
+    CachedMatchFinder finder(testPage.document());
+
+    for (unsigned index = 0; index < 3; ++index) {
+        auto flatTreeResult = finder.countMatches(std::nullopt, "brown"_s, { });
+        ASSERT_TRUE(flatTreeResult.has_value());
+        EXPECT_EQ(flatTreeResult.value(), 1u);
+
+        auto lightTreeResult = finder.countMatches(std::nullopt, "brown"_s, FindOption::DoNotTraverseFlatTree);
+        ASSERT_TRUE(lightTreeResult.has_value());
+        EXPECT_EQ(lightTreeResult.value(), 0u);
+    }
+}
+
+TEST(CachedMatchFinder, SearchResultCacheDistinguishesDifferentTargets)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+
+    auto brownResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(brownResult.has_value());
+    EXPECT_EQ(brownResult.value(), 2u);
+
+    auto foxResult = finder.countMatches(std::nullopt, "fox"_s, { });
+    ASSERT_TRUE(foxResult.has_value());
+    EXPECT_EQ(foxResult.value(), 1u);
+
+    auto brownResultAgain = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(brownResultAgain.has_value());
+    EXPECT_EQ(brownResultAgain.value(), 2u);
+}
+
+TEST(CachedMatchFinder, SearchResultCacheDistinguishesDifferentOptions)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>Brown paper, brown bag.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+
+    auto caseSensitiveResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(caseSensitiveResult.has_value());
+    EXPECT_EQ(caseSensitiveResult.value(), 1u);
+
+    auto caseInsensitiveResult = finder.countMatches(std::nullopt, "brown"_s, FindOption::CaseInsensitive);
+    ASSERT_TRUE(caseInsensitiveResult.has_value());
+    EXPECT_EQ(caseInsensitiveResult.value(), 2u);
+
+    auto caseSensitiveResultAgain = finder.countMatches(std::nullopt, "brown"_s, { });
+    ASSERT_TRUE(caseSensitiveResultAgain.has_value());
+    EXPECT_EQ(caseSensitiveResultAgain.value(), 1u);
+}
+
+TEST(CachedMatchFinder, FindMatchFromWithinShadowTreeUsesShadowIncludingAncestorTraversal)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<div id=\"host\"><template shadowrootmode=\"open\"><p>brown fox, brown dog</p></template></div>"_s);
+
+    RefPtr host = testPage.getElementById("host"_s);
+    ASSERT_TRUE(host);
+    RefPtr shadowRoot = host->shadowRoot();
+    ASSERT_TRUE(shadowRoot);
+
+    RefPtr paragraph = shadowRoot->firstElementChild();
+    ASSERT_TRUE(paragraph);
+    auto contentsRange = makeRangeSelectingNodeContents(*paragraph);
+    SimpleRange referenceRange { contentsRange.start, contentsRange.start };
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.findMatchFrom(referenceRange, "brown"_s, FindOption::DoNotTraverseFlatTree);
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result.value().has_value());
+    EXPECT_EQ(plainText(*result.value()), "brown"_s);
+}
+
+TEST(CachedMatchFinder, OversizedDocumentReturnsCacheUnusableError)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder::setMaximumRunCountForTesting(0u);
+
+    CachedMatchFinder finder(testPage.document());
+    auto countResult = finder.countMatches(std::nullopt, "brown"_s, { });
+    EXPECT_FALSE(countResult.has_value());
+    if (!countResult.has_value())
+        EXPECT_EQ(countResult.error(), CachedMatchFinder::CacheUnusable::Oversized);
+
+    auto matchesResult = finder.findMatches(std::nullopt, "brown"_s, { });
+    EXPECT_FALSE(matchesResult.has_value());
+    if (!matchesResult.has_value())
+        EXPECT_EQ(matchesResult.error(), CachedMatchFinder::CacheUnusable::Oversized);
+
+    auto matchFromResult = finder.findMatchFrom(std::nullopt, "brown"_s, { });
+    EXPECT_FALSE(matchFromResult.has_value());
+    if (!matchFromResult.has_value())
+        EXPECT_EQ(matchFromResult.error(), CachedMatchFinder::CacheUnusable::Oversized);
+
+    CachedMatchFinder::setMaximumRunCountForTesting(std::nullopt);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h
@@ -28,6 +28,7 @@
 #include "TestPlatformStrategies.h"
 #include <JavaScriptCore/InitializeThreading.h>
 #include <WebCore/Document.h>
+#include <WebCore/Element.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
 #include <WebCoreTestSupport/TestPage.h>
@@ -51,6 +52,8 @@ public:
     WebCore::Document& document() { return *m_page->localTopDocument(); }
 
     void loadHTML(const String& html) { WebCore::loadHTMLIntoTestPage(frame(), html); }
+
+    RefPtr<WebCore::Element> getElementById(const String& id) { return document().getElementById(id); }
 
 private:
     explicit TestPageHarness(Ref<WebCore::Page>&& page)


### PR DESCRIPTION
#### 24c5e3b2f50900a76dc0f4cd761ebb0c77b859ed
<pre>
Add unit tests for CachedMatchFinder
<a href="https://bugs.webkit.org/show_bug.cgi?id=318287">https://bugs.webkit.org/show_bug.cgi?id=318287</a>
<a href="https://rdar.apple.com/181072951">rdar://181072951</a>

Reviewed by Sammy Gill.

I added unit tests for the CachedMatchFinder.

Tests: Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp
       Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h

* Source/WebCore/editing/CachedMatchFinder.h:
* Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp:
(TestWebKitAPI::TEST(CachedMatchFinder, CountMatchesReturnsZeroWhenNoMatches)):
(TestWebKitAPI::TEST(CachedMatchFinder, CountMatchesWithEmptyTargetReturnsZero)):
(TestWebKitAPI::TEST(CachedMatchFinder, CountMatchesRespectsLimit)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchesReturnsAllMatchingRanges)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchesReturnsEmptyVectorWhenNoMatches)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchesRespectsLimit)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromReturnsFirstMatchWhenStartingWithoutReferenceRange)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromReturnsNulloptWhenNoMatches)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromAdvancesPastReferenceRangeToNextMatch)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromWithBackwardsOptionFindsPrecedingMatch)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromWithoutWrapAroundStopsAtEndOfDocument)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromWithWrapAroundWrapsToBeginningOfDocument)):
(TestWebKitAPI::TEST(CachedMatchFinder, CaseInsensitiveOptionMatchesRegardlessOfCase)):
(TestWebKitAPI::TEST(CachedMatchFinder, AtWordStartsOptionExcludesMidWordMatches)):
(TestWebKitAPI::TEST(CachedMatchFinder, TextBufferCacheIsInvalidatedByDOMMutation)):
(TestWebKitAPI::TEST(CachedMatchFinder, TextBufferCacheIsInvalidatedByStyleChangeWithoutDOMMutation)):
(TestWebKitAPI::TEST(CachedMatchFinder, FlatTreeAndLightTreeBufferCachesRemainIndependentAcrossRepeatedSwitches)):
(TestWebKitAPI::TEST(CachedMatchFinder, SearchResultCacheDistinguishesDifferentTargets)):
(TestWebKitAPI::TEST(CachedMatchFinder, SearchResultCacheDistinguishesDifferentOptions)):
(TestWebKitAPI::TEST(CachedMatchFinder, FlatTreeTraversalFindsMatchesInsideShadowTree)):
(TestWebKitAPI::TEST(CachedMatchFinder, FindMatchFromWithinShadowTreeUsesShadowIncludingAncestorTraversal)):
(TestWebKitAPI::TEST(CachedMatchFinder, OversizedDocumentReturnsCacheUnusableError)):
* Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h:
(TestWebKitAPI::TestPageHarness::getElementById):

Canonical link: <a href="https://commits.webkit.org/316920@main">https://commits.webkit.org/316920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4792d2eb3464ae884292e15c001f44295d18f3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131514 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65c48ec6-3489-42e8-9757-210e4f8d006e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135021 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb80eb24-4025-4752-a2f9-512f96415785) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115499 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/548026dc-1793-41e7-9ff4-7a7dd0654778) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35459 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31704 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185646 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143909 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47246 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38815 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47925 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113099 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38691 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46431 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10262 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45833 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->