### PR TITLE
TimeLabel re-formats on every timeupdate when its value is unchanged

### DIFF
--- a/LayoutTests/media/modern-media-controls/time-label/time-label-value-dedupes-expected.txt
+++ b/LayoutTests/media/modern-media-controls/time-label/time-label-value-dedupes-expected.txt
@@ -1,0 +1,28 @@
+Testing that setting TimeLabel.value to an unchanged value does not re-commit (and therefore does not re-format) the label.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial value and number of digits are committed once.
+PASS numberOfValueCommits is 1
+PASS timeLabel.element.textContent is "00:10"
+
+Setting the same value again does not mark the label dirty...
+PASS timeLabel.needsLayout is false
+PASS numberOfValueCommits is 1
+
+...but setting a different value does.
+PASS timeLabel.needsLayout is true
+PASS numberOfValueCommits is 2
+PASS timeLabel.element.textContent is "00:11"
+
+Transitioning to NaN re-commits, then a second NaN is deduped.
+PASS numberOfValueCommits is 3
+PASS timeLabel.element.textContent is "--:--"
+PASS timeLabel.needsLayout is false
+PASS numberOfValueCommits is 3
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/time-label/time-label-value-dedupes.html
+++ b/LayoutTests/media/modern-media-controls/time-label/time-label-value-dedupes.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing that setting <code>TimeLabel.value</code> to an unchanged value does not re-commit (and therefore does not re-format) the label.");
+
+const timeLabel = new TimeLabel(TimeLabel.Type.Elapsed);
+
+// Count how many times the "value" property is actually committed (each commit
+// performs two formatting passes plus a setAttribute).
+let numberOfValueCommits = 0;
+const originalCommitProperty = timeLabel.commitProperty.bind(timeLabel);
+timeLabel.commitProperty = function(propertyName) {
+    if (propertyName === "value")
+        numberOfValueCommits++;
+    originalCommitProperty(propertyName);
+};
+
+function commitAndReset() {
+    timeLabel.commit();
+}
+
+debug("Initial value and number of digits are committed once.");
+timeLabel.setValueWithNumberOfDigits(10, 4);
+commitAndReset();
+shouldBe("numberOfValueCommits", "1");
+shouldBeEqualToString("timeLabel.element.textContent", "00:10");
+
+debug("");
+debug("Setting the same value again does not mark the label dirty...");
+timeLabel.value = 10;
+shouldBeFalse("timeLabel.needsLayout");
+commitAndReset();
+shouldBe("numberOfValueCommits", "1");
+
+debug("");
+debug("...but setting a different value does.");
+timeLabel.value = 11;
+shouldBeTrue("timeLabel.needsLayout");
+commitAndReset();
+shouldBe("numberOfValueCommits", "2");
+shouldBeEqualToString("timeLabel.element.textContent", "00:11");
+
+debug("");
+debug("Transitioning to NaN re-commits, then a second NaN is deduped.");
+timeLabel.value = NaN;
+commitAndReset();
+shouldBe("numberOfValueCommits", "3");
+shouldBeEqualToString("timeLabel.element.textContent", "--:--");
+timeLabel.value = NaN;
+shouldBeFalse("timeLabel.needsLayout");
+commitAndReset();
+shouldBe("numberOfValueCommits", "3");
+
+debug("");
+
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-label.js
@@ -71,6 +71,12 @@ class TimeLabel extends LayoutNode
     }
     set value(value)
     {
+        // Avoid re-formatting the label (twice — once for textContent and once
+        // for the aria-label) when the value is unchanged. _performIdealLayout()
+        // writes this on every layout, which runs on each timeupdate.
+        if (value === this._value || (isNaN(value) && isNaN(this._value)))
+            return;
+
         this._value = value;
         this.markDirtyProperty("value");
     }


### PR DESCRIPTION
#### c8e5a371ab3ea0972719c4917b0b62757a332b90
<pre>
TimeLabel re-formats on every timeupdate when its value is unchanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=318288">https://bugs.webkit.org/show_bug.cgi?id=318288</a>
<a href="https://rdar.apple.com/181073565">rdar://181073565</a>

Reviewed by Eric Carlson.

TimeLabel&apos;s `value` setter unconditionally marked the &quot;value&quot; property
dirty, so it was re-committed on every layout even when the displayed
value had not changed. Because TimeControl._performIdealLayout() writes
each label&apos;s value on every layout, and layout runs on each timeupdate,
this repeatedly performed two independent formatting passes
(Intl.DurationFormat for textContent and formattedStringForDuration for
the aria-label) plus a setAttribute, all producing identical output.

Early-return from the setter when the value is unchanged, treating NaN
as equal to NaN so a loading label held at NaN also stops re-formatting.

Test: media/modern-media-controls/time-label/time-label-value-dedupes.html

* LayoutTests/media/modern-media-controls/time-label/time-label-value-dedupes-expected.txt: Added.
* LayoutTests/media/modern-media-controls/time-label/time-label-value-dedupes.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/time-label.js:
(TimeLabel.prototype.set value):

Canonical link: <a href="https://commits.webkit.org/316390@main">https://commits.webkit.org/316390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d2e1daf8ee811354727543c7c26f77e59af8c0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129326 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13f2bd19-c101-4912-b923-c0fc46f3c18b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133643 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94277 "1 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d95c9ee-4c33-4d9d-96a4-7b01f9a8f105) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114115 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6d3f627-c94f-4648-83d8-a2e836c23d4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33911 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29825 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183743 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142335 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38489 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46036 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30482 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/abort.tentative.https.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110671 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37331 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117724 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44554 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8578 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44186 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->