### PR TITLE
AX: VoiceOver does not re-resolve aria-labelledby when referenced element's    accessible name is provided by aria-label

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-updates-when-aria-label-changes-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-updates-when-aria-label-changes-expected.txt
@@ -1,0 +1,13 @@
+This test ensures an aria-labelledby reference recomputes its accessible name when the referenced element's name changes via aria-label, not just via text content.
+
+PASS: platformValueForW3CName(textSection) === 'Text name'
+PASS: platformValueForW3CName(labelSection) === 'Aria name'
+PASS: platformValueForW3CName(textSection) === 'New text name'
+PASS: platformValueForW3CName(labelSection) === 'New aria name'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+New text name
+
+Visual content

--- a/LayoutTests/accessibility/aria-labelledby-updates-when-aria-label-changes.html
+++ b/LayoutTests/accessibility/aria-labelledby-updates-when-aria-label-changes.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<section id="text-section" aria-labelledby="text-ref">
+    <p id="text-ref">Text name</p>
+</section>
+
+<section id="label-section" aria-labelledby="label-ref">
+    <p id="label-ref" role="img" aria-label="Aria name">Visual content</p>
+</section>
+
+<script>
+var output = "This test ensures an aria-labelledby reference recomputes its accessible name when the referenced element's name changes via aria-label, not just via text content.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var textSection = accessibilityController.accessibleElementById("text-section");
+    var labelSection = accessibilityController.accessibleElementById("label-section");
+
+    output += expect("platformValueForW3CName(textSection)", "'Text name'");
+    output += expect("platformValueForW3CName(labelSection)", "'Aria name'");
+
+    document.getElementById("text-ref").textContent = "New text name";
+    document.getElementById("label-ref").setAttribute("aria-label", "New aria name");
+
+    setTimeout(async function() {
+        output += await expectAsync("platformValueForW3CName(textSection)", "'New text name'");
+        output += await expectAsync("platformValueForW3CName(labelSection)", "'New aria name'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1473,12 +1473,14 @@ void AXObjectCache::handleTextChanged(AccessibilityObject* object)
                 // Inform this ancestor its textUnderElement-dependent data is now out-of-date.
                 postNotification(ancestor.get(), nullptr, AXNotification::TextUnderElementChanged);
             }
-
-            // Any objects this ancestor labeled now also need new AccessibilityText.
-            auto labeledObjects = ancestor->labelForObjects();
-            for (const auto& labeledObject : labeledObjects)
-                postNotification(&downcast<AccessibilityObject>(labeledObject.get()), nullptr, AXNotification::TextChanged);
         }
+
+        // Any objects this ancestor labeled now also need new AccessibilityText. This must run even
+        // when |object| is not static text: a name-source change like aria-label, alt, or title on an
+        // element referenced via aria-labelledby alters the referrer's accessible name just the same.
+        auto labeledObjects = ancestor->labelForObjects();
+        for (const auto& labeledObject : labeledObjects)
+            postNotification(&downcast<AccessibilityObject>(labeledObject.get()), nullptr, AXNotification::TextChanged);
     }
 
     postNotification(object, protect(object->document()).get(), AXNotification::TextChanged);


### PR DESCRIPTION
#### 66ebec86604f2eba2d21cc106d1ea7999faf06fb
<pre>
AX: VoiceOver does not re-resolve aria-labelledby when referenced element&apos;s    accessible name is provided by aria-label
<a href="https://bugs.webkit.org/show_bug.cgi?id=317597">https://bugs.webkit.org/show_bug.cgi?id=317597</a>
<a href="https://rdar.apple.com/180319221">rdar://180319221</a>

Reviewed by Dominic Mazzoni.

When an element references another via aria-labelledby, its accessible name
was not recomputed if the referenced element&apos;s name changed via aria-label
(or alt/title) — only text-content changes propagated. In the isolated tree
this left a stale cached name.

AXObjectCache::handleTextChanged walks the changed object&apos;s ancestors and
notifies the objects each one labels (labelForObjects()) so their names get
recomputed. That propagation was gated behind `if (isText)`, but aria-label,
alt, and title changes reach handleTextChanged with a non-static-text object,
so the labelledby referrer was never notified.

Hoist the labelForObjects() propagation out of the isText block so it runs for
every text/name change.

* LayoutTests/accessibility/aria-labelledby-updates-when-aria-label-changes-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-updates-when-aria-label-changes.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleTextChanged):

Canonical link: <a href="https://commits.webkit.org/316316@main">https://commits.webkit.org/316316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e02bf9481ac60c223588b6dd0df0426c95fbd0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129332 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82ed69ba-4621-4051-bebf-a4ec3f9c90dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133644 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9010311c-d087-49e6-956c-51636cab2a07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114116 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67f15924-6ebd-41ec-9961-63d21bff90a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33916 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183749 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142341 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38422 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46042 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110677 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37341 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117730 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44560 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43960 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44192 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44019 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->