### PR TITLE
TLF: Use historical flakiness information from EWS to ignore flaky tests

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -97,6 +97,7 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
     haltOnFailure = False
     flunkOnFailure = False
     FAILURE_MSG_IN_STRESS_MODE = 'Found test failures in stress mode'
+    SUCCESS_MSGS = ('Committed ', '@', 'Passed', 'Ignored pre-existing failure')
 
     def doStepIf(self, step):
         return self.getProperty('build_summary', False)
@@ -111,7 +112,7 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
         previous_build_summary = self.getProperty('build_summary', '')
         if self.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary:
             self.build.results = FAILURE
-        elif any(s in previous_build_summary for s in ('Committed ', '@', 'Passed', 'Ignored pre-existing failure')):
+        elif self.getProperty('force_build_success', False) or any(s in previous_build_summary for s in self.SUCCESS_MSGS):
             self.build.results = SUCCESS
         self.build.buildFinished([build_summary], self.build.results)
         return defer.returnValue(SUCCESS)

--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -26,16 +26,48 @@ import argparse
 import json
 import os
 import sys
-import twisted
-import re
+import time
 import urllib.parse
 
+from dataclasses import dataclass, field
+
 from .twisted_additions import TwistedAdditions
+from .utils import load_password, get_custom_suffix
 from twisted.internet import defer, reactor
 
 
+@dataclass
+class FlakyVerdict:
+    """Whether the results database can account for a test failing, and what says so."""
+    flaky_type: str = None
+    build_urls: set = field(default_factory=set)
+    pr_numbers: set = field(default_factory=set)
+    authors: set = field(default_factory=set)
+    request_failed: bool = False
+    intra_build_evidence: bool = False
+
+    @property
+    def is_flaky(self):
+        return self.flaky_type is not None
+
+    @property
+    def evidence(self):
+        """Whichever sets the rule that fired populated, sorted for a stable log line."""
+        return {
+            name: sorted(value)
+            for name, value in (
+                ('build_urls', self.build_urls),
+                ('pr_numbers', self.pr_numbers),
+                ('authors', self.authors),
+            ) if value
+        }
+
+
 class ResultsDatabase(object):
-    HOSTNAME = os.environ.get('RESULTS_SERVER_HOST', 'https://results.webkit.org').rstrip('/')
+    # Default to dev if not prod since resultsDB doesn't have a uat instance
+    custom_suffix = '' if get_custom_suffix() == '' else '-dev'
+    HOSTNAME = load_password('RESULTS_SERVER_HOST', default=f'https://results.webkit{custom_suffix}.org').rstrip('/')
+
     # TODO: Support more suites (Note, the API we're talking to already does)
     DEFAULT_SUITE = 'layout-tests'
     SUITES = ('layout-tests', 'api-tests', 'safer-cpp-checks', 'javascriptcore-tests')
@@ -52,6 +84,21 @@ class ResultsDatabase(object):
         'version_name',
         'sdk',
     ]
+
+    PRS_FOR_DIRTY_TREE_FLAKE = 2
+    AUTHORS_FOR_DIRTY_TREE_FLAKE = 1
+    PRS_FOR_BETWEEN_BUILD_FLAKE = 3
+    AUTHORS_FOR_BETWEEN_BUILD_FLAKE = 2
+
+    TESTS_PER_FLAKY_QUERY = 20
+    FLAKY_QUERY_LIMIT = 100
+    FLAKY_QUERY_TIMEOUT_SECONDS = 30
+    FLAKY_WINDOW_SECONDS = 3 * 24 * 60 * 60
+
+    # What EWS records in the flaky_type column, which the reporting side writes.
+    WITHIN_STEP_CLEAN_TREE = 'WithinStepCleanTree'
+    WITHIN_STEP_DIRTY_TREE = 'WithinStepDirtyTree'
+    BETWEEN_STEPS_DIRTY_TREE = 'BetweenStepsDirtyTree'
 
     @classmethod
     def platform_for_query(cls, platform):
@@ -234,6 +281,171 @@ class ResultsDatabase(object):
             logger(f"{url} did not store {', '.join(dropped)}\n")
             return False
         return True
+
+    @classmethod
+    def _evidence_in(cls, rows):
+        """Who was building across these rows, as a verdict with no type decided yet."""
+        evidence = FlakyVerdict()
+        for row in rows:
+            details = row.get('details') or {}
+            if build_url := details.get('build_url'):
+                evidence.build_urls.add(build_url)
+            if pr_number := details.get('pr_number'):
+                evidence.pr_numbers.add(pr_number)
+            evidence.authors |= {author for author in (details.get('authors') or []) if author}
+        return evidence
+
+    @classmethod
+    def _convict(cls, evidence, flaky_type, prs_needed, authors_needed):
+        if len(evidence.pr_numbers) >= prs_needed and len(evidence.authors) >= authors_needed:
+            evidence.flaky_type = flaky_type
+            return evidence
+
+    @classmethod
+    def _rows_by_flaky_type(cls, entries):
+        rows = {}
+        for entry in entries:
+            for row in entry.get('results', []):
+                rows.setdefault(row.get('flaky_type'), []).append(row)
+        return rows
+
+    @classmethod
+    def _is_intra_build_flake(cls, entries, logger):
+        rows = cls._rows_by_flaky_type(entries)
+        recognized = (cls.WITHIN_STEP_CLEAN_TREE, cls.WITHIN_STEP_DIRTY_TREE, cls.BETWEEN_STEPS_DIRTY_TREE)
+
+        if unrecognized := {name for name in rows if name and name not in recognized}:
+            logger(f"Ignored flakiness recorded as {', '.join(sorted(unrecognized))}\n")
+
+        if clean_tree := rows.get(cls.WITHIN_STEP_CLEAN_TREE):
+            evidence = cls._evidence_in(clean_tree)
+            evidence.flaky_type = 'CleanTree'
+            return evidence
+
+        with_change = rows.get(cls.WITHIN_STEP_DIRTY_TREE, []) + rows.get(cls.BETWEEN_STEPS_DIRTY_TREE, [])
+        return cls._convict(
+            cls._evidence_in(with_change), 'DirtyTree',
+            cls.PRS_FOR_DIRTY_TREE_FLAKE, cls.AUTHORS_FOR_DIRTY_TREE_FLAKE,
+        )
+
+    @classmethod
+    def _is_inter_build_flake(cls, entries, logger):
+        rows = [row for entry in entries for row in entry.get('results', [])]
+        evidence = cls._evidence_in(rows)
+
+        if verdict := cls._convict(
+            evidence, 'BetweenBuilds',
+            cls.PRS_FOR_BETWEEN_BUILD_FLAKE, cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE,
+        ):
+            return verdict
+
+        rows_without_an_author = sum(
+            1 for row in rows if not {a for a in ((row.get('details') or {}).get('authors') or []) if a}
+        )
+        if rows_without_an_author and len(evidence.authors) < cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE:
+            logger(
+                f'{rows_without_an_author} row(s) record no author, so the between-builds rule saw '
+                f'{len(evidence.authors)} of the {cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE} it needs '
+                f'across {len(evidence.pr_numbers)} pull request(s)\n'
+            )
+
+    @classmethod
+    def _parse_results_ews_response(cls, response, logger):
+        """The response body as a list of per-test entries, or None if it is not one."""
+        try:
+            entries = response.json()
+        except ValueError:
+            logger(f'Results database answered 200 with a body that is not json\n{response.content}\n')
+            return None
+        if not isinstance(entries, list) or any(not isinstance(entry, dict) for entry in entries):
+            logger(f'Results database answered 200 with an unexpected shape\n{response.content}\n')
+            return None
+        if any(not entry.get('test') for entry in entries):
+            logger(f'Results database answered 200 with an entry naming no test\n{response.content}\n')
+            return None
+        return entries
+
+    @classmethod
+    @defer.inlineCallbacks
+    def _query_flaky(cls, tests, flaky, configuration, suite, logger):
+        """Every test named, in chunks small enough to survive the request line, or None if any
+        chunk failed: a partial answer would read as an absence of history for the rest."""
+        base_params = {key: value for key, value in (configuration or {}).items() if key in cls.CONFIGURATION_KEYS}
+        base_params.update(dict(
+            suite=suite or cls.DEFAULT_SUITE, flaky='true' if flaky else 'false',
+            after_time=int(time.time() - cls.FLAKY_WINDOW_SECONDS), limit=cls.FLAKY_QUERY_LIMIT,
+        ))
+
+        url = f'{cls.HOSTNAME}/api/results-ews'
+        tests = list(tests)
+        by_test = {}
+
+        # Chunked because the names ride in the query string: a whole step's worth of long WPT
+        # paths overflows nginx's 8k request line, and a 414 fails every test in the batch.
+        for index in range(0, len(tests), cls.TESTS_PER_FLAKY_QUERY):
+            chunk = tests[index:index + cls.TESTS_PER_FLAKY_QUERY]
+            res = yield TwistedAdditions.request(
+                url, params=dict(base_params, tests=chunk), logger=logger,
+                timeout=cls.FLAKY_QUERY_TIMEOUT_SECONDS,
+            )
+
+            status = res.status_code if res else None
+            if status == 404:  # the endpoint's answer for a chunk with nothing recorded
+                continue
+            if status != 200:
+                logger(f"Failed to query {url} ({flaky=}, status {status})\n{getattr(res, 'content', None)}\n")
+                return None
+
+            entries = cls._parse_results_ews_response(res, logger)
+            if entries is None:
+                return None
+
+            for entry in entries:
+                by_test.setdefault(entry['test'], []).append(entry)
+
+        return by_test
+
+    @classmethod
+    @defer.inlineCallbacks
+    def flaky_verdicts_for(cls, tests, configuration=None, suite=None):
+        logs = []
+
+        def logger(log):
+            logs.append(log)
+
+        verdicts = {}
+        remaining = list(tests)
+        intra_build_rows = {}
+        for flaky, classify in ((True, cls._is_intra_build_flake), (False, cls._is_inter_build_flake)):
+            if not remaining:
+                break
+
+            result = yield cls._query_flaky(remaining, flaky, configuration, suite, logger)
+            if result is None:
+                for test in remaining:
+                    verdicts[test] = FlakyVerdict(request_failed=True)
+                return verdicts, ''.join(logs)
+            if flaky:
+                intra_build_rows = result
+
+            still_unexplained = []
+            for test in remaining:
+                if found := classify(result.get(test, []), logger):
+                    found.intra_build_evidence = bool(intra_build_rows.get(test))
+                    verdicts[test] = found
+                else:
+                    still_unexplained.append(test)
+            remaining = still_unexplained
+
+        for test in remaining:
+            verdicts[test] = FlakyVerdict()
+
+        if unsupported := sorted(
+            test for test, verdict in verdicts.items()
+            if verdict.flaky_type == 'BetweenBuilds' and not verdict.intra_build_evidence
+        ):
+            logger(f"BetweenBuilds with no within-build flakiness recorded: {', '.join(unsupported)}\n")
+        return verdicts, ''.join(logs)
 
     @classmethod
     def main(cls, args=None):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -33,7 +33,7 @@ from twisted.internet import defer, reactor, task
 
 from .layout_test_failures import LayoutTestFailures
 from .send_email import send_email_to_patch_author, send_email_to_bot_watchers, send_email_to_github_admin, FROM_EMAIL
-from .results_db import ResultsDatabase
+from .results_db import FlakyVerdict, ResultsDatabase
 from .twisted_additions import TwistedAdditions
 from .utils import load_password, get_custom_suffix
 
@@ -3903,6 +3903,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
     ENABLE_ADDITIONAL_ARGUMENTS = True
     EXIT_AFTER_FAILURES = '60'
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 60
+    SHOULD_IGNORE_FLAKY_TESTS = False
     STRESS_MODE = False
     command = ['python3', 'Tools/Scripts/run-webkit-tests',
                '--no-build',
@@ -3916,6 +3917,9 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         self.incorrectLayoutLines = []
         self.failing_tests_filtered = []
         self.preexisting_failures_in_results_db = []
+        self.flaky_failures_in_results_db = {}
+        self.unsupported_flakes_in_results_db = []
+        self.unknown_flakes_in_results_db = []
         self.layout_test_driver = None
 
     def doStepIf(self, step):
@@ -4043,6 +4047,9 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
                 yield self.filter_failures_using_results_db(first_results.failing_tests)
                 self.setProperty('first_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_first_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
+                self.setProperty('results-db_first_run_flaky', self.flaky_failures_in_results_db)
+                self.setProperty('results-db_first_run_flaky_unsupported', sorted(self.unsupported_flakes_in_results_db))
+                self.setProperty('results-db_first_run_flaky_unknown', sorted(self.unknown_flakes_in_results_db))
 
             yield self.report_to_results_db(first_results.flaky_results, flaky_type='WithinStepDirtyTree', stage='first-run')
 
@@ -4061,16 +4068,59 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
             if not has_commit:
                 yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
 
-        for test in failing_tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]:
-            data = yield ResultsDatabase.is_test_pre_existing_failure(
+        tests = failing_tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
+        pre_existing = {}
+        for test in tests:
+            pre_existing[test] = yield ResultsDatabase.is_test_pre_existing_failure(
                 test, configuration=configuration,
                 commit=identifier if has_commit else None,
             )
 
-            yield self._addToLog(self.results_db_log_name, f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
+        # Only tests the database does not already expect to fail need a flakiness verdict
+        unexplained = [test for test in tests if not pre_existing[test]['is_existing_failure']]
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(unexplained, configuration=configuration, suite=self.suite)
+        if flake_logs:
+            yield self._addToLog(self.results_db_log_name, flake_logs)
+
+        for test in tests:
+            data = pre_existing[test]
+            flake = flakes.get(test, FlakyVerdict(request_failed=True))
+            flake_summary = 'False'
             if data['is_existing_failure']:
                 self.preexisting_failures_in_results_db.append(test)
                 self.failing_tests_filtered.remove(test)
+            elif flake.is_flaky:
+                self.flaky_failures_in_results_db[test] = flake.flaky_type
+                if flake.flaky_type == 'BetweenBuilds' and not flake.intra_build_evidence:
+                    self.unsupported_flakes_in_results_db.append(test)
+                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
+                if self.SHOULD_IGNORE_FLAKY_TESTS:
+                    self.failing_tests_filtered.remove(test)
+            elif flake.request_failed:
+                self.unknown_flakes_in_results_db.append(test)
+                flake_summary = 'Unknown'
+
+            yield self._addToLog(
+                self.results_db_log_name,
+                f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\n"
+                f"Response from results-db: {data['raw_data']}\n{data['logs']}\npre-existing-flake={flake_summary}"
+            )
+
+        if self.flaky_failures_in_results_db:
+            action = 'Ignored' if self.SHOULD_IGNORE_FLAKY_TESTS else 'Would have ignored'
+            yield self._addToLog(
+                self.results_db_log_name,
+                f"\n{action} {len(self.flaky_failures_in_results_db)} flaky "
+                f"test(s): {', '.join(sorted(self.flaky_failures_in_results_db))}\n",
+            )
+
+    def results_db_ignore_message(self) -> str:
+        parts = []
+        if self.preexisting_failures_in_results_db:
+            parts.append(f"pre-existing failures: {', '.join(self.preexisting_failures_in_results_db)}")
+        if self.flaky_failures_in_results_db:
+            parts.append(f"flaky tests: {', '.join(sorted(self.flaky_failures_in_results_db))}")
+        return f"Ignored {'; '.join(parts)} based on results-db"
 
     def evaluateResult(self, cmd):
         result = SUCCESS
@@ -4123,11 +4173,12 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
             self.build.results = SUCCESS
             if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
                 self.setProperty('build_summary', message)
-        elif (self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
-            # This means all the tests which failed in this run were also failing or flaky in results database
-            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
+        elif ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and len(self.failing_tests_filtered) == 0):
+            # All tests that failed this run were pre-existing failures or known flaky in the results database
+            message = self.results_db_ignore_message()
             self.descriptionDone = message
             self.build.results = SUCCESS
+            self.setProperty('force_build_success', True)
             if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
                 self.setProperty('build_summary', message)
             steps_to_add += [ArchiveTestResults(), UploadTestResults(), ExtractTestResults()]
@@ -4169,9 +4220,13 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         status = self.name
 
         if self.results != SUCCESS:
-            if (self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
-                status = f"Ignored {len(self.preexisting_failures_in_results_db)} pre-existing failure based on results-db"
-                return {'step': status}
+            if ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and len(self.failing_tests_filtered) == 0):
+                counts = []
+                if self.preexisting_failures_in_results_db:
+                    counts.append(f"{len(self.preexisting_failures_in_results_db)} pre-existing")
+                if self.flaky_failures_in_results_db:
+                    counts.append(f"{len(self.flaky_failures_in_results_db)} flaky")
+                return {'step': f"Ignored {' and '.join(counts)} failure(s) based on results-db"}
             if self.incorrectLayoutLines:
                 status = ' '.join(self.incorrectLayoutLines)
                 return {'step': status}
@@ -4322,11 +4377,12 @@ class ReRunWebKitTests(RunWebKitTests):
             if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
                 self.setProperty('build_summary', message)
             self.build.addStepsAfterCurrentStep(steps_to_add)
-        elif (self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
-            # This means all the tests which failed in this run were also failing or flaky in results database
-            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
+        elif ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and len(self.failing_tests_filtered) == 0):
+            # All tests that failed this run were pre-existing failures or known flaky in the results database
+            message = self.results_db_ignore_message()
             self.descriptionDone = message
             self.build.results = SUCCESS
+            self.setProperty('force_build_success', True)
             if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
                 self.setProperty('build_summary', message)
             steps_to_add += [ArchiveTestResults(), UploadTestResults(identifier='rerun'), ExtractTestResults(identifier='rerun')]
@@ -4397,6 +4453,9 @@ class ReRunWebKitTests(RunWebKitTests):
                 yield self.filter_failures_using_results_db(second_results.failing_tests)
                 self.setProperty('second_run_failures_filtered', sorted(self.failing_tests_filtered))
                 self.setProperty('results-db_second_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
+                self.setProperty('results-db_second_run_flaky', self.flaky_failures_in_results_db)
+                self.setProperty('results-db_second_run_flaky_unsupported', sorted(self.unsupported_flakes_in_results_db))
+                self.setProperty('results-db_second_run_flaky_unknown', sorted(self.unknown_flakes_in_results_db))
 
             yield self.report_to_results_db(second_results.flaky_results, flaky_type='WithinStepDirtyTree', stage='second-run')
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -25,6 +25,7 @@ import json
 import logging
 import operator
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -48,6 +49,7 @@ from Shared.steps import *
 
 from . import send_email
 from .layout_test_failures import LayoutTestFailures
+from .results_db import FlakyVerdict
 from .steps import *
 
 # Workaround for https://github.com/buildbot/buildbot/issues/4669
@@ -3206,6 +3208,8 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
 
         self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
         self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(lambda cls, tests, **kwargs: defer.succeed((
+            {test: FlakyVerdict() for test in tests}, ''))))
         return step
 
     @defer.inlineCallbacks
@@ -3230,6 +3234,87 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         )
 
     @defer.inlineCallbacks
+    def test_a_flaky_verdict_is_recorded_without_ignoring_the_failure(self):
+        # SHOULD_IGNORE_FLAKY_TESTS is False, so the verdict is recorded but the test is not removed.
+        step = self._configure(set())
+        builds = [f'https://build.webkit.org/#/builders/1/builds/{number}' for number in (11, 12, 13)]
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({
+                test: (
+                    FlakyVerdict(flaky_type='DirtyTree', build_urls=set(builds))
+                    if test == 'flaky.html' else FlakyVerdict()
+                ) for test in tests
+            }, ''))))
+
+        yield step.filter_failures_using_results_db(['real.html', 'flaky.html'])
+
+        self.assertEqual(step.failing_tests_filtered, ['real.html', 'flaky.html'])
+        self.assertEqual(step.flaky_failures_in_results_db, {'flaky.html': 'DirtyTree'})
+        self.assertEqual(step.preexisting_failures_in_results_db, [])
+        self.assertEqual(step.results_db_ignore_message(), 'Ignored flaky tests: flaky.html based on results-db')
+
+    @defer.inlineCallbacks
+    def test_a_test_with_no_verdict_is_not_treated_as_sound(self):
+        # flaky_verdicts_for answers for every test it is given, so this cannot happen today. If that
+        # ever drifts, the failure must not read as a clean 'not flaky'.
+        step = self._configure(set())
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({}, ''))))
+
+        yield step.filter_failures_using_results_db(['real.html'])
+
+        self.assertEqual(step.failing_tests_filtered, ['real.html'])
+        self.assertEqual(step.flaky_failures_in_results_db, {})
+
+    @defer.inlineCallbacks
+    def test_the_ignore_message_covers_both_categories(self):
+        step = self._configure({'pre-existing.html'})
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({
+                test: (
+                    FlakyVerdict(flaky_type='CleanTree')
+                    if test == 'flaky.html' else FlakyVerdict()
+                ) for test in tests
+            }, ''))))
+
+        yield step.filter_failures_using_results_db(['pre-existing.html', 'flaky.html'])
+
+        self.assertEqual(step.failing_tests_filtered, ['flaky.html'])
+        self.assertEqual(
+            step.results_db_ignore_message(),
+            'Ignored pre-existing failures: pre-existing.html; flaky tests: flaky.html based on results-db',
+        )
+
+    @defer.inlineCallbacks
+    def test_set_build_summary_restores_success_from_the_property(self):
+        # buildbot overwrites build.results after the step that ignored the failures, so the verdict
+        # has to be restored here. Driven by a property rather than the summary's wording.
+        self.setup_step(SetBuildSummary())
+        self.setProperty('build_summary', 'Ignored flaky tests: flaky.html based on results-db')
+        self.setProperty('force_build_success', True)
+        self.build.results = FAILURE
+        self.expect_outcome(result=SUCCESS)
+        yield self.run_step()
+        self.assertEqual(self.build.results, SUCCESS)
+
+    def test_ignoring_every_failure_sets_the_property_set_build_summary_reads(self):
+        # The other half of the wiring: nothing else tells SetBuildSummary to keep this build green.
+        class Cmd:
+            rc = 1
+
+        self.setup_step(RunWebKitTests())
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        step.incorrectLayoutLines = []
+        step.failing_tests_filtered = []
+        step.preexisting_failures_in_results_db = ['pre-existing.html']
+        step.flaky_failures_in_results_db = ['flaky.html']
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda steps: None)
+
+        self.assertEqual(step.evaluateCommand(Cmd()), WARNINGS)
+        self.assertTrue(self.getProperty('force_build_success'))
+
+    @defer.inlineCallbacks
     def test_wpe_platform_is_translated_to_uppercase_for_results_db(self):
         configurations = []
 
@@ -3246,6 +3331,8 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         self.setProperty('configuration', 'release')
         self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
         self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(lambda cls, tests, **kwargs: defer.succeed((
+            {test: FlakyVerdict() for test in tests}, ''))))
 
         yield step.filter_failures_using_results_db(['real.html'])
         self.assertEqual(configurations, [dict(platform='WPE', style='release')])
@@ -3288,6 +3375,8 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         step._addToLog = lambda logName, message: defer.succeed(None)
         self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(fake_is_pre_existing))
         self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(lambda cls, tests, **kwargs: defer.succeed((
+            {test: FlakyVerdict() for test in tests}, ''))))
 
         cap = RunWebKitTests.MAX_FAILURES_TO_CHECK_RESULTS_DB
         failing_tests = [f'test{i}.html' for i in range(cap + 10)]
@@ -3689,6 +3778,26 @@ class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestC
             sorted(self.getProperty('first_run_results')),
             ['fast/b.html', 'fast/both.html', 'fast/flaky.html'],
         )
+
+    @defer.inlineCallbacks
+    def test_the_first_run_exports_the_verdicts_it_relied_on(self):
+        step = self.configureStep(RunWebKitTests, self.FLAKY_AND_REGRESSED)
+
+        def fake_filter(failing_tests):
+            step.failing_tests_filtered = list(failing_tests)
+            step.preexisting_failures_in_results_db = ['fast/b.html']
+            step.flaky_failures_in_results_db = {'fast/both.html': 'CleanTree'}
+            step.unsupported_flakes_in_results_db = ['fast/both.html']
+            step.unknown_flakes_in_results_db = ['fast/a.html']
+            return defer.succeed(None)
+
+        step.filter_failures_using_results_db = fake_filter
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.getProperty('results-db_first_run_flaky'), {'fast/both.html': 'CleanTree'})
+        self.assertEqual(self.getProperty('results-db_first_run_pre_existing'), ['fast/b.html'])
+        self.assertEqual(self.getProperty('results-db_first_run_flaky_unsupported'), ['fast/both.html'])
+        self.assertEqual(self.getProperty('results-db_first_run_flaky_unknown'), ['fast/a.html'])
 
     @defer.inlineCallbacks
     def test_the_rerun_reports_its_flakes_and_what_differed_from_the_first_run(self):
@@ -12111,3 +12220,378 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestIsTestFlakyClassifier(unittest.TestCase):
+    def _response(self, rows=None):
+        # rows=None simulates the find endpoint's 404 (no results for this test in that table).
+        if rows is None:
+            return TwistedAdditions.Response(status_code=404)
+        payload = [{'test': 'layout/test.html', 'configuration': {}, 'results': rows}]
+        return TwistedAdditions.Response(status_code=200, content=json.dumps(payload).encode('utf-8'))
+
+    def _flaky_row(self, flaky_type, build_url=None, pr_number=None, authors=None):
+        return {'flaky_type': flaky_type, 'details': {
+            'build_url': build_url, 'pr_number': pr_number, 'authors': authors or [],
+        }}
+
+    def _failed_row(self, pr_number=None, authors=None, build_url=None):
+        return {'details': {'pr_number': pr_number, 'authors': authors or [], 'build_url': build_url}}
+
+    def _mock(self, flaky_response, failed_response):
+        # The flaky table is asked first, then the failed one; route on which table was requested.
+        def fake_request(*args, **kwargs):
+            params = kwargs.get('params') or {}
+            return defer.succeed(flaky_response if params.get('flaky') == 'true' else failed_response)
+        return patch('ews-build.results_db.TwistedAdditions.request', fake_request)
+
+    @defer.inlineCallbacks
+    def test_a_clean_tree_flake_is_flaky(self):
+        flaky = self._response(rows=[self._flaky_row('WithinStepCleanTree', build_url='https://build/1/builds/7')])
+        with self._mock(flaky, self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertEqual(result.flaky_type, 'CleanTree')
+            self.assertEqual(result.build_urls, {'https://build/1/builds/7'})
+
+    @defer.inlineCallbacks
+    def test_two_dirty_tree_pull_requests_is_flaky(self):
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=n, authors=[author])
+            for n, author in enumerate(['alice', 'bob'], start=1)
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertEqual(result.flaky_type, 'DirtyTree')
+            self.assertEqual(result.pr_numbers, {1, 2})
+            self.assertEqual(result.authors, {'alice', 'bob'})
+            self.assertEqual(result.build_urls, {'https://build/1/builds/1', 'https://build/1/builds/2'})
+
+    @defer.inlineCallbacks
+    def test_retrying_one_pull_request_does_not_excuse_its_own_failure(self):
+        # build_url carries the build number, so an EWS retry is a distinct build.
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=99, authors=['alice'])
+            for n in range(1, 6)
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+
+    @defer.inlineCallbacks
+    def test_a_missing_pull_request_is_not_a_second_pull_request(self):
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=1, authors=['alice']),
+            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/2', authors=['bob']),
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+
+    @defer.inlineCallbacks
+    def test_dirty_tree_pull_requests_with_no_author_not_flaky(self):
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build_url=f'https://build/1/builds/{n}', pr_number=n)
+            for n in range(1, 4)
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            self.assertFalse(verdicts['layout/test.html'].is_flaky)
+
+    @defer.inlineCallbacks
+    def test_a_row_recording_no_flakiness_at_all_is_ignored(self):
+        # flaky_type is required in the flaky table, so a null means malformed data.
+        rows = [
+            self._flaky_row(None, build_url='https://build/1/builds/1'),
+            self._flaky_row('SomethingNewerReports', build_url='https://build/1/builds/2'),
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+
+        self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        self.assertIn('SomethingNewerReports', logs)
+
+    @defer.inlineCallbacks
+    def test_flakiness_recorded_under_an_unknown_name_is_reported(self):
+        # A results database holding a value this EWS does not know counts the row for nothing, which
+        # is what deploying the two halves out of order looks like.
+        rows = [self._flaky_row('SomethingNewerReports', build_url='https://build/1/builds/7')]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+
+        self.assertFalse(verdicts['layout/test.html'].is_flaky)
+        self.assertIn('SomethingNewerReports', logs)
+
+    @defer.inlineCallbacks
+    def test_dirty_tree_same_build_deduped_not_flaky(self):
+        rows = [
+            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/42', pr_number=7, authors=['alice'])
+            for _ in range(3)
+        ]
+        with self._mock(self._response(rows=rows), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertFalse(result.is_flaky)
+
+    @defer.inlineCallbacks
+    def test_a_verdict_records_whether_any_build_saw_the_flakiness(self):
+        failed = [self._failed_row(pr_number=n, authors=[a]) for n, a in enumerate(['alice', 'bob', 'alice'], start=1)]
+        with self._mock(self._response(), self._response(rows=failed)):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+        self.assertFalse(verdicts['layout/test.html'].intra_build_evidence)
+
+        short_of_a_verdict = [self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=9)]
+        with self._mock(self._response(rows=short_of_a_verdict), self._response(rows=failed)):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+        self.assertTrue(verdicts['layout/test.html'].intra_build_evidence)
+
+    @defer.inlineCallbacks
+    def test_a_conviction_keeps_its_evidence_when_a_later_query_fails(self):
+        convicted = [{'test': 'a.html', 'configuration': {}, 'results': [
+            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=1, authors=['alice']),
+            self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/2', pr_number=2, authors=['bob']),
+        ]}]
+        flaky = TwistedAdditions.Response(status_code=200, content=json.dumps(convicted).encode('utf-8'))
+
+        def fake_request(*args, **kwargs):
+            if (kwargs.get('params') or {}).get('flaky') == 'true':
+                return defer.succeed(flaky)
+            return defer.succeed(TwistedAdditions.Response(status_code=500))
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fake_request):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['a.html', 'b.html'], suite='layout-tests')
+
+        self.assertEqual(verdicts['a.html'].flaky_type, 'DirtyTree')
+        self.assertTrue(verdicts['a.html'].intra_build_evidence)
+        self.assertTrue(verdicts['b.html'].request_failed)
+
+    @defer.inlineCallbacks
+    def test_between_builds_reports_whether_any_build_saw_the_flakiness(self):
+        failed = [
+            self._failed_row(pr_number=n, authors=[author])
+            for n, author in enumerate(['alice', 'bob', 'alice'], start=1)
+        ]
+
+        with self._mock(self._response(), self._response(rows=failed)):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+        self.assertEqual(verdicts['layout/test.html'].flaky_type, 'BetweenBuilds')
+        self.assertIn('BetweenBuilds with no within-build flakiness recorded', logs)
+        self.assertIn('layout/test.html', logs)
+
+        # One dirty-tree row is short of a verdict on its own, but it is still an inconsistency
+        # some build observed, so this conviction is not the between-builds rule acting alone.
+        short_of_a_verdict = [self._flaky_row('WithinStepDirtyTree', build_url='https://build/1/builds/1', pr_number=9)]
+        with self._mock(self._response(rows=short_of_a_verdict), self._response(rows=failed)):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+        self.assertEqual(verdicts['layout/test.html'].flaky_type, 'BetweenBuilds')
+        self.assertNotIn('BetweenBuilds with no within-build flakiness recorded', logs)
+
+    @defer.inlineCallbacks
+    def test_between_builds_three_prs_two_authors_is_flaky(self):
+        rows = [
+            self._failed_row(pr_number=1, authors=['alice'], build_url='https://build/1/builds/1'),
+            self._failed_row(pr_number=2, authors=['bob'], build_url='https://build/1/builds/2'),
+            self._failed_row(pr_number=3, authors=['alice'], build_url='https://build/1/builds/3'),
+        ]
+        with self._mock(self._response(), self._response(rows=rows)):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertEqual(result.flaky_type, 'BetweenBuilds')
+            self.assertEqual(result.pr_numbers, {1, 2, 3})
+            self.assertEqual(result.build_urls, {
+                'https://build/1/builds/1', 'https://build/1/builds/2', 'https://build/1/builds/3',
+            })
+
+    @defer.inlineCallbacks
+    def test_between_builds_too_few_prs_not_flaky(self):
+        rows = [
+            self._failed_row(pr_number=1, authors=['alice']),
+            self._failed_row(pr_number=2, authors=['bob']),
+        ]
+        with self._mock(self._response(), self._response(rows=rows)):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertFalse(result.is_flaky)
+
+    @defer.inlineCallbacks
+    def test_between_builds_single_author_not_flaky(self):
+        # 3 PRs but all from one author-set -> fails the >=2 distinct author-sets floor.
+        rows = [self._failed_row(pr_number=n, authors=['alice']) for n in range(1, 4)]
+        with self._mock(self._response(), self._response(rows=rows)):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertFalse(result.is_flaky)
+
+    @defer.inlineCallbacks
+    def test_no_history_not_flaky(self):
+        with self._mock(self._response(), self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+            result = verdicts['layout/test.html']
+            self.assertFalse(result.is_flaky)
+
+    @defer.inlineCallbacks
+    def test_a_body_that_is_not_a_list_of_entries_is_a_failed_query(self):
+        for content, expected in (
+            (b'<html>502 Bad Gateway</html>', 'not json'),
+            (b'{"tests": []}', 'unexpected shape'),
+            (b'["a.html"]', 'unexpected shape'),
+        ):
+            malformed = TwistedAdditions.Response(status_code=200, content=content)
+            with self._mock(malformed, self._response()):
+                verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['a.html'], suite='layout-tests')
+
+            self.assertTrue(verdicts['a.html'].request_failed, content)
+            self.assertFalse(verdicts['a.html'].is_flaky, content)
+            self.assertIn(expected, logs, content)
+
+    @defer.inlineCallbacks
+    def test_asking_about_no_tests_does_not_query(self):
+        # Every failure being pre-existing leaves nothing to classify, and the endpoint rejects a
+        # query naming no test.
+        def fail_if_called(*args, **kwargs):
+            self.fail('queried the results database with no tests')
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fail_if_called):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for([], suite='layout-tests')
+
+        self.assertEqual(verdicts, {})
+        self.assertEqual(logs, '')
+
+    @defer.inlineCallbacks
+    def test_an_entry_naming_no_test_is_a_failed_query(self):
+        # A results database predating the batched endpoint answers without naming the test. Matching
+        # nothing, those entries would otherwise be dropped and every test would read as not flaky.
+        payload = [{'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/1')]}]
+        nameless = TwistedAdditions.Response(status_code=200, content=json.dumps(payload).encode('utf-8'))
+        with self._mock(nameless, self._response()):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(['a.html'], suite='layout-tests')
+
+        self.assertTrue(verdicts['a.html'].request_failed)
+        self.assertFalse(verdicts['a.html'].is_flaky)
+        self.assertIn('naming no test', logs)
+
+    @defer.inlineCallbacks
+    def test_a_batch_classifies_every_test_it_asked_about(self):
+        # Two of the three are convicted by the first table. Dropping them from the list while
+        # iterating it would skip the one in between, which would then read as not flaky.
+        rows = [
+            {'test': 'a.html', 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/1')]},
+            {'test': 'b.html', 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/2')]},
+        ]
+        flaky = TwistedAdditions.Response(status_code=200, content=json.dumps(rows).encode('utf-8'))
+        with self._mock(flaky, self._response()):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(
+                ['a.html', 'b.html', 'c.html'], suite='layout-tests',
+            )
+
+        self.assertEqual(verdicts['a.html'].flaky_type, 'CleanTree')
+        self.assertEqual(verdicts['b.html'].flaky_type, 'CleanTree')
+        self.assertFalse(verdicts['c.html'].is_flaky)
+
+    @defer.inlineCallbacks
+    def test_a_large_batch_is_split_across_requests(self):
+        tests = [f'imported/w3c/web-platform-tests/css/very/long/path/test-{n}.html' for n in range(45)]
+        captured = []
+
+        def fake_request(*args, **kwargs):
+            params = kwargs.get('params') or {}
+            captured.append(params)
+            asked = params['tests']
+            rows = [
+                {'test': test, 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url=f'build/{test}')]}
+                for test in asked
+            ] if params.get('flaky') == 'true' else []
+            if not rows:
+                return defer.succeed(TwistedAdditions.Response(status_code=404))
+            return defer.succeed(TwistedAdditions.Response(status_code=200, content=json.dumps(rows).encode('utf-8')))
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fake_request):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(tests, suite='layout-tests')
+
+        for params in captured:
+            self.assertLessEqual(len(params['tests']), ResultsDatabase.TESTS_PER_FLAKY_QUERY)
+        self.assertGreater(len(captured), 2)
+        self.assertLess(max(len(params['tests']) for params in captured), len(tests))
+        self.assertEqual(sorted(test for params in captured for test in params['tests']), sorted(tests))
+        self.assertEqual(sorted(verdicts), sorted(tests))
+        for test in tests:
+            self.assertEqual(verdicts[test].flaky_type, 'CleanTree', test)
+
+    @defer.inlineCallbacks
+    def test_a_chunk_with_no_history_does_not_stop_the_rest(self):
+        tests = [f'test-{n}.html' for n in range(45)]
+        answered = []
+
+        def fake_request(*args, **kwargs):
+            params = kwargs.get('params') or {}
+            answered.append(params['tests'])
+            if params.get('flaky') != 'true' or len(answered) == 1:
+                return defer.succeed(TwistedAdditions.Response(status_code=404))
+            rows = [
+                {'test': test, 'configuration': {}, 'results': [self._flaky_row('WithinStepCleanTree', build_url='build/1')]}
+                for test in params['tests']
+            ]
+            return defer.succeed(TwistedAdditions.Response(status_code=200, content=json.dumps(rows).encode('utf-8')))
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fake_request):
+            verdicts, _ = yield ResultsDatabase.flaky_verdicts_for(tests, suite='layout-tests')
+
+        first_chunk = answered[0]
+        self.assertTrue(all(not verdicts[test].is_flaky for test in first_chunk))
+        self.assertTrue(any(verdicts[test].is_flaky for test in tests if test not in first_chunk))
+
+    @defer.inlineCallbacks
+    def test_one_failed_chunk_fails_the_whole_query(self):
+        tests = [f'test-{n}.html' for n in range(45)]
+        responses = []
+
+        def fake_request(*args, **kwargs):
+            responses.append(None)
+            if len(responses) == 2:
+                return defer.succeed(TwistedAdditions.Response(status_code=414))
+            return defer.succeed(self._response())
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fake_request):
+            verdicts, logs = yield ResultsDatabase.flaky_verdicts_for(tests, suite='layout-tests')
+
+        self.assertIn('414', logs)
+        for test in tests:
+            self.assertTrue(verdicts[test].request_failed, test)
+            self.assertFalse(verdicts[test].is_flaky, test)
+
+    @defer.inlineCallbacks
+    def test_a_chunk_gets_longer_than_the_default_timeout(self):
+        captured = []
+
+        def fake_request(*args, **kwargs):
+            captured.append(kwargs.get('timeout'))
+            return defer.succeed(self._response())
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fake_request):
+            yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+
+        self.assertTrue(captured)
+        for timeout in captured:
+            self.assertEqual(timeout, ResultsDatabase.FLAKY_QUERY_TIMEOUT_SECONDS)
+            self.assertGreater(timeout, 10)
+
+    @defer.inlineCallbacks
+    def test_both_queries_are_bounded_to_the_flaky_window(self):
+        captured = []
+
+        def fake_request(*args, **kwargs):
+            captured.append(kwargs.get('params') or {})
+            return defer.succeed(self._response())
+
+        with patch('ews-build.results_db.TwistedAdditions.request', fake_request):
+            yield ResultsDatabase.flaky_verdicts_for(['layout/test.html'], suite='layout-tests')
+
+            self.assertEqual(ResultsDatabase.FLAKY_WINDOW_SECONDS, 3 * 24 * 60 * 60)
+            self.assertEqual([params.get('flaky') for params in captured], ['true', 'false'])
+            for params in captured:
+                self.assertEqual(params['suite'], 'layout-tests')
+                self.assertEqual(params['limit'], ResultsDatabase.FLAKY_QUERY_LIMIT)
+                # A list, so request() renders it as a repeated key rather than one comma-joined value.
+                self.assertEqual(params['tests'], ['layout/test.html'])
+                self.assertLessEqual(abs(params['after_time'] - (time.time() - 3 * 24 * 60 * 60)), 60)

--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -30,6 +30,7 @@ import json
 import os
 import re
 import twisted
+import urllib.parse
 
 from twisted.internet import defer, error, interfaces, protocol, reactor, task
 from twisted.python import log
@@ -243,7 +244,8 @@ class TwistedAdditions(object):
             defer.returnValue(None)
         hostname = '/'.join(url.split('/', 3)[:3])
         if params:
-            url = '{}?{}'.format(url, '&'.join([f'{key}={value}' for key, value in params.items()]))
+            # doseq so a list value becomes a repeated key
+            url = f'{url}?{urllib.parse.urlencode(params, doseq=True)}'
 
         headers = headers or {}
         if 'User-Agent' not in headers:


### PR DESCRIPTION
#### 24279dccdd79ccf2e03c043ea4c499f8738530a2
<pre>
TLF: Use historical flakiness information from EWS to ignore flaky tests
<a href="https://rdar.apple.com/157892382">rdar://157892382</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318291">https://bugs.webkit.org/show_bug.cgi?id=318291</a>

Reviewed by Aakash Jain.

`claude` summary:

EWS reports test failures and flakiness to results.webkit.org but never reads
any of it back, so a test already known to flake still fails the build and
blames whoever happened to be testing. `flaky_verdicts_for` consults that
history for every failure a step surfaced. A clean-tree flake convicts on one
build, since the change cannot have caused it. Convicting with the change in
the tree takes `PRS_FOR_DIRTY_TREE_FLAKE` pull requests, and blaming other
people&apos;s patches takes `PRS_FOR_BETWEEN_BUILD_FLAKE` and
`AUTHORS_FOR_BETWEEN_BUILD_FLAKE`. Counting builds would not do: `build_url`
carries the build number, so retrying one pull request would let a change that
genuinely made a test non-deterministic excuse its own failure.

Both rules tally the same three sets over the same rows, so they share
`_evidence_in`, `_convict` and `_rows_by_flaky_type`, and both report
`build_urls` — `results_db_details` always wrote them and only the reader
ignored them. A row with a null `flaky_type` no longer raises from `sorted()`
inside the code meant to make bad data visible.

Test names ride in the query string, and a step&apos;s worth of long WPT paths
overflows nginx&apos;s 8k request line, so `_query_flaky` asks about
`TESTS_PER_FLAKY_QUERY` at a time, each chunk allowed
`FLAKY_QUERY_TIMEOUT_SECONDS` rather than the 10s default that used to cover a
single test. A failed chunk fails the whole query, since a partial answer reads
as an absence of history for the rest. `TwistedAdditions.request` builds the
query with `urlencode(doseq=True)`, which repeats a key for a list value and
escapes names that carry their own query string.

Nothing is ignored yet. `SHOULD_IGNORE_FLAKY_TESTS` is False, so a verdict is
recorded and logged but no test leaves the failing set and no build changes
colour. `SetBuildSummary` reads a `force_build_success` property rather than
matching `SUCCESS_MSGS` against a step&apos;s summary text, so turning that flag on
does not depend on wording. `FlakyVerdict.intra_build_evidence` records whether
any build saw the test behave inconsistently, exported per run as
`results-db_*_run_flaky`, `_flaky_unsupported` and `_flaky_unknown`: the
between-builds rule is the only one that can convict without that evidence, so
whether it earns its place is a property query rather than a log scrape.

* Tools/CISupport/Shared/steps.py:
(SetBuildSummary):
(SetBuildSummary.run):
* Tools/CISupport/ews-build/results_db.py:
(FlakyVerdict):
(FlakyVerdict.is_flaky):
(FlakyVerdict.evidence):
(ResultsDatabase):
(ResultsDatabase._evidence_in):
(ResultsDatabase._convict):
(ResultsDatabase._rows_by_flaky_type):
(ResultsDatabase._is_intra_build_flake):
(ResultsDatabase._is_inter_build_flake):
(ResultsDatabase._parse_results_ews_response):
(ResultsDatabase._query_flaky):
(ResultsDatabase.flaky_verdicts_for):
(ResultsDatabase.flaky_verdicts_for.logger):
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTests):
(RunWebKitTests.__init__):
(RunWebKitTests.runCommand):
(RunWebKitTests.filter_failures_using_results_db):
(RunWebKitTests.results_db_ignore_message):
(RunWebKitTests.evaluateCommand):
(RunWebKitTests.getResultSummary):
(ReRunWebKitTests.evaluateCommand):
(ReRunWebKitTests.runCommand):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFilterLayoutTestFailuresUsingResultsDB._configure):
(TestFilterLayoutTestFailuresUsingResultsDB):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_flaky_verdict_is_recorded_without_ignoring_the_failure):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_test_with_no_verdict_is_not_treated_as_sound):
(TestFilterLayoutTestFailuresUsingResultsDB.test_the_ignore_message_covers_both_categories):
(TestFilterLayoutTestFailuresUsingResultsDB.test_set_build_summary_restores_success_from_the_property):
(TestFilterLayoutTestFailuresUsingResultsDB.test_ignoring_every_failure_sets_the_property_set_build_summary_reads):
(TestFilterLayoutTestFailuresUsingResultsDB.test_ignoring_every_failure_sets_the_property_set_build_summary_reads.Cmd):
(TestFilterLayoutTestFailuresUsingResultsDB.test_wpe_platform_is_translated_to_uppercase_for_results_db):
(TestFilterLayoutTestFailuresUsingResultsDB.test_caps_number_of_results_db_queries):
(TestLayoutTestStepsReportAsTheyRun):
(TestLayoutTestStepsReportAsTheyRun.test_the_first_run_exports_the_verdicts_it_relied_on):
(TestLayoutTestStepsReportAsTheyRun.test_the_first_run_exports_the_verdicts_it_relied_on.fake_filter):
* Tools/CISupport/ews-build/twisted_additions.py:
(TwistedAdditions.request):

Canonical link: <a href="https://commits.webkit.org/319616@main">https://commits.webkit.org/319616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8922631626baab4a28c9b91c38eb610c094e52f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/49760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146338 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/183871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/55679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142110 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/98675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/45791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/42740 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42368 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3399 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194162 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/181410 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/55627 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151521 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/40568 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56318 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/38993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151225 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45793 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/54829 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->