### PR TITLE
[JSC] Improve exception unwinding performance

### DIFF
--- a/JSTests/microbenchmarks/throw-new-error-from-deep-frames.js
+++ b/JSTests/microbenchmarks/throw-new-error-from-deep-frames.js
@@ -1,0 +1,18 @@
+(function() {
+    function thrower(n) {
+        if (n === 0) {
+            const e = new Error("boom");
+            e.code = 42;
+            throw e;
+        }
+        return thrower(n - 1);
+    }
+
+    let r = 0;
+    for (let i = 0; i < 50000; i++) {
+        try { thrower(40); } catch (e) { r = e.code; }
+    }
+
+    if (r !== 42)
+        throw new Error("Bad value!");
+})();

--- a/JSTests/microbenchmarks/throw-preallocated-error-from-deep-frames.js
+++ b/JSTests/microbenchmarks/throw-preallocated-error-from-deep-frames.js
@@ -1,0 +1,13 @@
+(function() {
+    const error = new Error("boom");
+    error.code = 42;
+    function thrower(n) { if (n === 0) throw error; return thrower(n - 1); }
+
+    let r = 0;
+    for (let i = 0; i < 100000; i++) {
+        try { thrower(40); } catch (e) { r = e.code; }
+    }
+
+    if (r !== 42)
+        throw new Error("Bad value!");
+})();

--- a/JSTests/microbenchmarks/throw-sentinel-from-deep-frames.js
+++ b/JSTests/microbenchmarks/throw-sentinel-from-deep-frames.js
@@ -1,0 +1,12 @@
+(function() {
+    const sentinel = { code: 42 };
+    function thrower(n) { if (n === 0) throw sentinel; return thrower(n - 1); }
+
+    let r = 0;
+    for (let i = 0; i < 100000; i++) {
+        try { thrower(40); } catch (e) { r = e.code; }
+    }
+
+    if (r !== 42)
+        throw new Error("Bad value!");
+})();

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -32,6 +32,8 @@
 #include <JavaScriptCore/BytecodeIndex.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>
+#include <JavaScriptCore/VMEntryRecord.h>
+#include <span>
 #include <wtf/HashMap.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
@@ -206,14 +208,16 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
 
     class UnwindFunctorBase {
     protected:
-        UnwindFunctorBase(VM& vm)
-            : m_vm(vm)
-        { }
+        inline UnwindFunctorBase(VM&);
 
         void copyCalleeSavesToEntryFrameCalleeSavesBuffer(StackVisitor&) const;
         void notifyDebuggerOfUnwinding(JSGlobalObject*, CallFrame*) const;
 
         VM& m_vm;
+#if ENABLE(ASSEMBLER)
+        std::span<const int8_t> m_vmCalleeSaveBufferSlotsByRegIndex;
+        VMEntryRecord* m_vmEntryRecord;
+#endif
     };
 } // namespace JSC
 

--- a/Source/JavaScriptCore/interpreter/InterpreterInlines.h
+++ b/Source/JavaScriptCore/interpreter/InterpreterInlines.h
@@ -173,28 +173,36 @@ ALWAYS_INLINE JSValue Interpreter::tryCallWithArguments(CachedCall& cachedCall, 
 }
 #endif
 
+inline UnwindFunctorBase::UnwindFunctorBase(VM& vm)
+    : m_vm(vm)
+#if ENABLE(ASSEMBLER)
+    , m_vmCalleeSaveBufferSlotsByRegIndex(RegisterSet::vmCalleeSaveBufferSlotsByRegIndex())
+    , m_vmEntryRecord(vm.topEntryFrame ? vmEntryRecord(vm.topEntryFrame) : nullptr)
+#endif
+{
+}
+
 inline void UnwindFunctorBase::copyCalleeSavesToEntryFrameCalleeSavesBuffer(StackVisitor& visitor) const
 {
 #if ENABLE(ASSEMBLER)
     CallFrame* callFrame = visitor->callFrame();
-    std::optional<RegisterAtOffsetList> currentCalleeSaves = visitor->calleeSaveRegistersForUnwinding();
+    const RegisterAtOffsetList* currentCalleeSaves = visitor->calleeSaveRegistersForUnwinding();
 
     if (!currentCalleeSaves)
         return;
 
-    RegisterAtOffsetList* allCalleeSaves = RegisterSet::vmCalleeSaveRegisterOffsets();
     auto dontCopyRegisters = RegisterSet::stackRegisters();
     CPURegister* frame = reinterpret_cast<CPURegister*>(callFrame->registers());
 
     unsigned registerCount = currentCalleeSaves->registerCount();
-    VMEntryRecord* record = vmEntryRecord(m_vm.topEntryFrame);
+    VMEntryRecord* record = m_vmEntryRecord;
     for (unsigned i = 0; i < registerCount; i++) {
         RegisterAtOffset currentEntry = currentCalleeSaves->at(i);
         if (dontCopyRegisters.contains(currentEntry.reg(), IgnoreVectors))
             continue;
-        RegisterAtOffset* calleeSavesEntry = allCalleeSaves->find(currentEntry.reg());
+        int8_t bufferSlot = m_vmCalleeSaveBufferSlotsByRegIndex[currentEntry.reg().index()];
 
-        if (!calleeSavesEntry) {
+        if (bufferSlot < 0) {
             if constexpr (!isARM_THUMB2())
                 RELEASE_ASSERT_NOT_REACHED();
             // This can happen on ARMv7, because there are more callee save
@@ -211,9 +219,7 @@ inline void UnwindFunctorBase::copyCalleeSavesToEntryFrameCalleeSavesBuffer(Stac
             // its frame.
             continue;
         }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        record->calleeSaveRegistersBuffer[calleeSavesEntry->offsetAsIndex()] = *(frame + currentEntry.offsetAsIndex());
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        record->calleeSaveRegistersBuffer[bufferSlot] = *(frame + currentEntry.offsetAsIndex());
     }
 #else
     UNUSED_PARAM(visitor);

--- a/Source/JavaScriptCore/interpreter/StackVisitor.cpp
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.cpp
@@ -348,13 +348,13 @@ StackVisitor::Frame::CodeType StackVisitor::Frame::codeType() const
 }
 
 #if ENABLE(ASSEMBLER)
-std::optional<RegisterAtOffsetList> StackVisitor::Frame::calleeSaveRegistersForUnwinding()
+const RegisterAtOffsetList* StackVisitor::Frame::calleeSaveRegistersForUnwinding()
 {
     if (!NUMBER_OF_CALLEE_SAVES_REGISTERS)
-        return std::nullopt;
+        return nullptr;
 
     if (isInlinedDFGFrame())
-        return std::nullopt;
+        return nullptr;
 
     if (isNativeCalleeFrame()) {
         auto* nativeCallee = callee().asNativeCallee();
@@ -363,7 +363,7 @@ std::optional<RegisterAtOffsetList> StackVisitor::Frame::calleeSaveRegistersForU
 #if ENABLE(WEBASSEMBLY)
             auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(nativeCallee);
             if (auto* calleeSaveRegisters = wasmCallee->calleeSaveRegisters())
-                return *calleeSaveRegisters;
+                return calleeSaveRegisters;
 #endif // ENABLE(WEBASSEMBLY)
             break;
         }
@@ -371,13 +371,13 @@ std::optional<RegisterAtOffsetList> StackVisitor::Frame::calleeSaveRegistersForU
             break;
         }
         }
-        return std::nullopt;
+        return nullptr;
     }
 
     if (CodeBlock* codeBlock = this->codeBlock())
-        return *codeBlock->jitCode()->calleeSaveRegisters();
+        return codeBlock->jitCode()->calleeSaveRegisters();
 
-    return std::nullopt;
+    return nullptr;
 }
 #endif // ENABLE(ASSEMBLER)
 

--- a/Source/JavaScriptCore/interpreter/StackVisitor.h
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.h
@@ -113,7 +113,7 @@ public:
         JS_EXPORT_PRIVATE LineColumn computeLineAndColumn() const;
 
 #if ENABLE(ASSEMBLER)
-        std::optional<RegisterAtOffsetList> calleeSaveRegistersForUnwinding();
+        const RegisterAtOffsetList* calleeSaveRegistersForUnwinding();
 #endif
 
         ClonedArguments* createArguments(VM&);

--- a/Source/JavaScriptCore/interpreter/VMEntryRecord.h
+++ b/Source/JavaScriptCore/interpreter/VMEntryRecord.h
@@ -44,8 +44,8 @@ struct VMEntryRecord {
     JSCell* const m_context;
     // The following two fields are sometimes treated as a pair in assembly code, making usages of the second one implicit.
     // To find them, look for loadpairq/storepairq of "VMEntryRecord::m_prevTopCallFrame" in *.asm files.
-    CallFrame* const m_prevTopCallFrame;
-    EntryFrame* const m_prevTopEntryFrame;
+    SUPPRESS_FORWARD_DECL_MEMBER CallFrame* const m_prevTopCallFrame;
+    SUPPRESS_FORWARD_DECL_MEMBER EntryFrame* const m_prevTopEntryFrame;
 
 #if !ENABLE(C_LOOP) && NUMBER_OF_CALLEE_SAVES_REGISTERS > 0
     CPURegister calleeSaveRegistersBuffer[NUMBER_OF_CALLEE_SAVES_REGISTERS];

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -32,6 +32,7 @@
 #include "GPRInfo.h"
 #include "MacroAssembler.h"
 #include "RegisterAtOffsetList.h"
+#include <wtf/NeverDestroyed.h>
 
 namespace JSC {
 
@@ -46,6 +47,23 @@ RegisterAtOffsetList* RegisterSet::vmCalleeSaveRegisterOffsets()
 #endif
     });
     return result;
+}
+
+std::span<const int8_t> RegisterSet::vmCalleeSaveBufferSlotsByRegIndex()
+{
+    static LazyNeverDestroyed<std::array<int8_t, Reg::maxIndex() + 1>> slots;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] () {
+        slots.construct();
+        slots->fill(-1);
+        RegisterAtOffsetList* list = vmCalleeSaveRegisterOffsets();
+        for (unsigned i = 0; i < list->registerCount(); i++) {
+            RegisterAtOffset entry = list->at(i);
+            ASSERT(entry.offsetAsIndex() >= 0 && entry.offsetAsIndex() <= INT8_MAX);
+            slots.get()[entry.reg().index()] = static_cast<int8_t>(entry.offsetAsIndex());
+        }
+    });
+    return slots.get();
 }
 
 RegisterSet RegisterSet::stackRegisters()

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -286,6 +286,7 @@ public:
     JS_EXPORT_PRIVATE static RegisterSet NODELETE calleeSaveRegisters();
     JS_EXPORT_PRIVATE static RegisterSet NODELETE vmCalleeSaveRegisters();
     JS_EXPORT_PRIVATE static RegisterAtOffsetList* vmCalleeSaveRegisterOffsets();
+    JS_EXPORT_PRIVATE static std::span<const int8_t> vmCalleeSaveBufferSlotsByRegIndex();
     JS_EXPORT_PRIVATE static RegisterSet NODELETE llintBaselineCalleeSaveRegisters();
     JS_EXPORT_PRIVATE static RegisterSet NODELETE dfgCalleeSaveRegisters();
     JS_EXPORT_PRIVATE static RegisterSet NODELETE ftlCalleeSaveRegisters();


### PR DESCRIPTION
#### 8e15aeeee3bc2d5257fec145a08f5532ae7447d7
<pre>
[JSC] Improve exception unwinding performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=318292">https://bugs.webkit.org/show_bug.cgi?id=318292</a>

Reviewed by Yusuke Suzuki.

I noticed that JSC is significantly slower than V8 at unwinding when an
exception is thrown from a deep call stack. Profiling shows that most of
the time is spent in per-frame callee-save bookkeeping during
Interpreter::unwind.

This patch applies three independent optimizations:

1. Make StackVisitor::Frame::calleeSaveRegistersForUnwinding() return
   const RegisterAtOffsetList* instead of std::optional&lt;RegisterAtOffsetList&gt;.
   Every list it returns is a long-lived object, so there is no need to
   heap-allocate and free a copy for every unwound frame.

2. Add an m_vmEntryRecord field to UnwindFunctorBase, computed once in the
   constructor, instead of calling vmEntryRecord() on every call to
   copyCalleeSavesToEntryFrameCalleeSavesBuffer.

3. Use a prebuilt table (RegisterSet::vmCalleeSaveBufferSlotsByRegIndex())
   that maps Reg::index() to the register&apos;s slot in the entry frame
   callee-save buffer, instead of doing a binary search per register.
   This turns each lookup from O(log n) into O(1).

                                                   Baseline                  Patched

throw-new-error-from-deep-frames              176.5424+-0.9251     ^    129.7769+-1.6492        ^ definitely 1.3604x faster
throw-preallocated-error-from-deep-frames
                                              265.7363+-2.6056     ^    175.6531+-2.0253        ^ definitely 1.5128x faster
throw-sentinel-from-deep-frames               266.3385+-1.5604     ^    176.2640+-1.5277        ^ definitely 1.5110x faster

Tests: JSTests/microbenchmarks/throw-new-error-from-deep-frames.js
       JSTests/microbenchmarks/throw-preallocated-error-from-deep-frames.js
       JSTests/microbenchmarks/throw-sentinel-from-deep-frames.js

* JSTests/microbenchmarks/throw-new-error-from-deep-frames.js: Added.
(thrower):
(i.catch):
* JSTests/microbenchmarks/throw-preallocated-error-from-deep-frames.js: Added.
(thrower):
(i.catch):
* JSTests/microbenchmarks/throw-sentinel-from-deep-frames.js: Added.
(thrower):
(i.catch):
* Source/JavaScriptCore/interpreter/Interpreter.h:
(JSC::UnwindFunctorBase::UnwindFunctorBase): Deleted.
* Source/JavaScriptCore/interpreter/InterpreterInlines.h:
(JSC::UnwindFunctorBase::UnwindFunctorBase):
(JSC::UnwindFunctorBase::copyCalleeSavesToEntryFrameCalleeSavesBuffer const):
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::Frame::calleeSaveRegistersForUnwinding):
* Source/JavaScriptCore/interpreter/StackVisitor.h:
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSet::vmCalleeSaveBufferSlotsByRegIndex):
* Source/JavaScriptCore/jit/RegisterSet.h:

Canonical link: <a href="https://commits.webkit.org/316511@main">https://commits.webkit.org/316511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/433bba94745ba5d2208901bccceb3c97b47326eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181839 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114554 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34408 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30443 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3154 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146566 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184373 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33647 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142847 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45976 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38586 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46654 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111382 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37784 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118405 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205064 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45171 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9071 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->