### PR TITLE
Cherry-pick(s) 095fa99180ff. rdar://181073780

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2627,9 +2627,15 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentReceiveBroadcast, (JSGlobalObject* g
             auto handler = [&vm, jsMemory](Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); };
             RefPtr<Wasm::Memory> memory;
             if (auto shared = std::get<RefPtr<SharedArrayBufferContents>>(WTF::move(content)))
+<<<<<<< HEAD
                 memory = Wasm::Memory::create(shared.releaseNonNull(), jsMemory->memory().addressType(), WTF::move(handler));
             else
                 memory = Wasm::Memory::createZeroSized(MemorySharingMode::Shared, jsMemory->memory().addressType(), WTF::move(handler));
+=======
+                memory = Wasm::Memory::create(shared.releaseNonNull(), WTF::move(handler));
+            else
+                memory = Wasm::Memory::createZeroSized(MemorySharingMode::Shared, WTF::move(handler));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
             jsMemory->adopt(memory.releaseNonNull());
             return jsMemory;
         }

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
@@ -106,7 +106,11 @@ void JSArrayBuffer::clearAssociatedWasmMemoryWrapper()
 template<typename Visitor>
 void JSArrayBuffer::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
+<<<<<<< HEAD
     auto* thisObject = uncheckedDowncast<JSArrayBuffer>(cell);
+=======
+    auto* thisObject = jsCast<JSArrayBuffer*>(cell);
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -92,10 +92,16 @@ Memory::Memory()
 {
 }
 
+<<<<<<< HEAD
 Memory::Memory(PageCount initial, PageCount maximum, MemorySharingMode sharingMode, AddressType addressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
     : m_handle(adoptRef(*new BufferMemoryHandle(BufferMemoryHandle::nullBasePointer(), 0, 0, initial, maximum, sharingMode, MemoryMode::BoundsChecking)))
     , m_growSuccessCallback(WTF::move(growSuccessCallback))
     , m_addressType(addressType)
+=======
+Memory::Memory(PageCount initial, PageCount maximum, MemorySharingMode sharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+    : m_handle(adoptRef(*new BufferMemoryHandle(BufferMemoryHandle::nullBasePointer(), 0, 0, initial, maximum, sharingMode, MemoryMode::BoundsChecking)))
+    , m_growSuccessCallback(WTF::move(growSuccessCallback))
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 {
     ASSERT(!initial.bytes());
     ASSERT(mode() == MemoryMode::BoundsChecking);
@@ -103,19 +109,32 @@ Memory::Memory(PageCount initial, PageCount maximum, MemorySharingMode sharingMo
     ASSERT(basePointer());
 }
 
+<<<<<<< HEAD
 Memory::Memory(Ref<BufferMemoryHandle>&& handle, AddressType addressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
     : m_handle(WTF::move(handle))
     , m_growSuccessCallback(WTF::move(growSuccessCallback))
     , m_addressType(addressType)
+=======
+Memory::Memory(Ref<BufferMemoryHandle>&& handle, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+    : m_handle(WTF::move(handle))
+    , m_growSuccessCallback(WTF::move(growSuccessCallback))
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 {
     dataLogLnIf(verbose, "Memory::Memory allocating ", *this);
 }
 
+<<<<<<< HEAD
 Memory::Memory(Ref<BufferMemoryHandle>&& handle, Ref<SharedArrayBufferContents>&& shared, AddressType addressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
     : m_handle(WTF::move(handle))
     , m_shared(WTF::move(shared))
     , m_growSuccessCallback(WTF::move(growSuccessCallback))
     , m_addressType(addressType)
+=======
+Memory::Memory(Ref<BufferMemoryHandle>&& handle, Ref<SharedArrayBufferContents>&& shared, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+    : m_handle(WTF::move(handle))
+    , m_shared(WTF::move(shared))
+    , m_growSuccessCallback(WTF::move(growSuccessCallback))
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 {
     dataLogLnIf(verbose, "Memory::Memory allocating ", *this);
 }
@@ -125,6 +144,7 @@ Ref<Memory> Memory::create()
     return adoptRef(*new Memory());
 }
 
+<<<<<<< HEAD
 Ref<Memory> Memory::create(Ref<BufferMemoryHandle>&& handle, AddressType addressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
 {
     return adoptRef(*new Memory(WTF::move(handle), addressType, WTF::move(growSuccessCallback)));
@@ -143,6 +163,26 @@ Ref<Memory> Memory::createZeroSized(MemorySharingMode sharingMode, AddressType a
 }
 
 RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, MemorySharingMode sharingMode, AddressType addressType, std::optional<MemoryMode> desiredMemoryMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+=======
+Ref<Memory> Memory::create(Ref<BufferMemoryHandle>&& handle, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+{
+    return adoptRef(*new Memory(WTF::move(handle), WTF::move(growSuccessCallback)));
+}
+
+Ref<Memory> Memory::create(Ref<SharedArrayBufferContents>&& shared, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+{
+    RefPtr<BufferMemoryHandle> handle = shared->memoryHandle();
+    ASSERT(handle);
+    return adoptRef(*new Memory(handle.releaseNonNull(), WTF::move(shared), WTF::move(growSuccessCallback)));
+}
+
+Ref<Memory> Memory::createZeroSized(MemorySharingMode sharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+{
+    return adoptRef(*new Memory(PageCount(0), PageCount(0), sharingMode, WTF::move(growSuccessCallback)));
+}
+
+RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, MemorySharingMode sharingMode, std::optional<MemoryMode> desiredMemoryMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback)
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 {
     ASSERT(initial);
     RELEASE_ASSERT(!maximum || maximum >= initial); // This should be guaranteed by our caller.
@@ -156,7 +196,11 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     if (maximum && !maximumBytes) {
         // User specified a zero maximum, initial size must also be zero.
         RELEASE_ASSERT(!initialBytes);
+<<<<<<< HEAD
         return createZeroSized(sharingMode, addressType, WTF::move(growSuccessCallback));
+=======
+        return createZeroSized(sharingMode, WTF::move(growSuccessCallback));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     }
     
     bool done = tryAllocate(vm,
@@ -185,13 +229,21 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         OSAllocator::protect(fastMemory + initialBytes, BufferMemoryHandle::fastMappedBytes() - initialBytes, readable, writable);
         switch (sharingMode) {
         case MemorySharingMode::Default: {
+<<<<<<< HEAD
             return Memory::create(adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Default, MemoryMode::Signaling)), addressType, WTF::move(growSuccessCallback));
+=======
+            return Memory::create(adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Default, MemoryMode::Signaling)), WTF::move(growSuccessCallback));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
         }
         case MemorySharingMode::Shared: {
             auto handle = adoptRef(*new BufferMemoryHandle(fastMemory, initialBytes, BufferMemoryHandle::fastMappedBytes(), initial, maximum, MemorySharingMode::Shared, MemoryMode::Signaling));
             auto span = handle->mutableSpan();
             auto content = SharedArrayBufferContents::create(span, maximumBytes, WTF::move(handle), nullptr, SharedArrayBufferContents::Mode::WebAssembly);
+<<<<<<< HEAD
             return Memory::create(WTF::move(content), addressType, WTF::move(growSuccessCallback));
+=======
+            return Memory::create(WTF::move(content), WTF::move(growSuccessCallback));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
         }
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -207,14 +259,22 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     switch (sharingMode) {
     case MemorySharingMode::Default: {
         if (!initialBytes)
+<<<<<<< HEAD
             return adoptRef(new Memory(initial, maximum, MemorySharingMode::Default, addressType, WTF::move(growSuccessCallback)));
+=======
+            return adoptRef(*new Memory(initial, maximum, MemorySharingMode::Default, WTF::move(growSuccessCallback)));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 
         void* slowMemory = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, initialBytes);
         if (!slowMemory) {
             BufferMemoryManager::singleton().freePhysicalBytes(initialBytes);
             return nullptr;
         }
+<<<<<<< HEAD
         return Memory::create(adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, initialBytes, initial, maximum, MemorySharingMode::Default, MemoryMode::BoundsChecking)), addressType, WTF::move(growSuccessCallback));
+=======
+        return Memory::create(adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, initialBytes, initial, maximum, MemorySharingMode::Default, MemoryMode::BoundsChecking)), WTF::move(growSuccessCallback));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     }
     case MemorySharingMode::Shared: {
         char* slowMemory = nullptr;
@@ -236,7 +296,11 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
         auto handle = adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, maximumBytes, initial, maximum, MemorySharingMode::Shared, MemoryMode::BoundsChecking));
         auto span = handle->mutableSpan();
         auto content = SharedArrayBufferContents::create(span, maximumBytes, WTF::move(handle), nullptr, SharedArrayBufferContents::Mode::WebAssembly);
+<<<<<<< HEAD
         return Memory::create(WTF::move(content), addressType, WTF::move(growSuccessCallback));
+=======
+        return Memory::create(WTF::move(content), WTF::move(growSuccessCallback));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     }
     }
     RELEASE_ASSERT_NOT_REACHED();
@@ -255,6 +319,10 @@ Expected<PageCount, GrowFailReason> Memory::growShared(VM& vm, PageCount delta)
     PageCount oldPageCount;
     PageCount newPageCount;
     Expected<int64_t, GrowFailReason> result;
+<<<<<<< HEAD
+=======
+
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     {
         std::optional<Locker<Lock>> locker;
         // m_shared may not be exist, if this is zero byte memory with zero byte maximum size.

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -52,6 +52,10 @@ namespace JSC {
 class LLIntOffsetsExtractor;
 
 namespace Wasm {
+<<<<<<< HEAD
+=======
+
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 class Memory final : public RefCounted<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Memory, JS_EXPORT_PRIVATE);
@@ -64,10 +68,17 @@ public:
     enum GrowSuccess { GrowSuccessTag };
 
     static Ref<Memory> create();
+<<<<<<< HEAD
     JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<BufferMemoryHandle>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<SharedArrayBufferContents>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     JS_EXPORT_PRIVATE static Ref<Memory> createZeroSized(MemorySharingMode, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     static RefPtr<Memory> tryCreate(VM&, PageCount initial, PageCount maximum, MemorySharingMode, AddressType, std::optional<MemoryMode> desiredMemoryMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+=======
+    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<BufferMemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<SharedArrayBufferContents>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> createZeroSized(MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    static RefPtr<Memory> tryCreate(VM&, PageCount initial, PageCount maximum, MemorySharingMode, std::optional<MemoryMode> desiredMemoryMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 
     JS_EXPORT_PRIVATE ~Memory();
 
@@ -100,16 +111,25 @@ public:
 
 private:
     Memory();
+<<<<<<< HEAD
     Memory(Ref<BufferMemoryHandle>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     Memory(Ref<BufferMemoryHandle>&&, Ref<SharedArrayBufferContents>&&, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     Memory(PageCount initial, PageCount maximum, MemorySharingMode, AddressType, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+=======
+    Memory(Ref<BufferMemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(Ref<BufferMemoryHandle>&&, Ref<SharedArrayBufferContents>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(PageCount initial, PageCount maximum, MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 
     Expected<PageCount, GrowFailReason> growShared(VM&, PageCount);
 
     Ref<BufferMemoryHandle> m_handle;
     RefPtr<SharedArrayBufferContents> m_shared;
     WTF::Function<void(GrowSuccess, PageCount, PageCount)> m_growSuccessCallback;
+<<<<<<< HEAD
     AddressType m_addressType;
+=======
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     // FIXME: If/When merging this into JSWebAssemblyMemory we should just use an unconditionalFinalizer.
 };
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -364,6 +364,7 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
             // We create a memory when it's a memory definition.
             auto* jsMemory = JSWebAssemblyMemory::create(vm, globalObject->webAssemblyMemoryStructure());
 
+<<<<<<< HEAD
             RefPtr<Memory> memory = Memory::tryCreate(vm, mem.initial(), mem.maximum(), mem.isShared() ? MemorySharingMode::Shared : MemorySharingMode::Default, mem.addressType(), std::nullopt,
                 [&vm, jsMemory](Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) {
                     jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount);
@@ -371,6 +372,13 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
             );
             if (!memory)
                 return exception(createOutOfMemoryError(globalObject));
+=======
+        RefPtr<Memory> memory = Memory::tryCreate(vm, moduleInformation.memory.initial(), moduleInformation.memory.maximum(), moduleInformation.memory.isShared() ? MemorySharingMode::Shared: MemorySharingMode::Default, std::nullopt,
+            [&vm, jsMemory](Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); }
+        );
+        if (!memory)
+            return exception(createOutOfMemoryError(globalObject));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
 
             jsMemory->adopt(memory.releaseNonNull());
             jsInstance->setMemory(vm, i, jsMemory);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -141,8 +141,15 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
 
     auto* jsMemory = JSWebAssemblyMemory::create(vm, webAssemblyMemoryStructure);
 
+<<<<<<< HEAD
     RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, addressType, desiredMemoryMode,
         [&vm, jsMemory] (Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); });
+=======
+    RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, desiredMemoryMode,
+        [&vm, jsMemory] (Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) {
+            jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount);
+        });
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
     if (!memory) {
         throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));
         return { };

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4105,10 +4105,17 @@ public:
                     fail();
                     return JSValue();
                 }
+<<<<<<< HEAD
                 memory = Wasm::Memory::create(contents.releaseNonNull(), result->memory().addressType(), WTF::move(handler));
             } else {
                 // zero size & max-size.
                 memory = Wasm::Memory::createZeroSized(JSC::MemorySharingMode::Shared, result->memory().addressType(), WTF::move(handler));
+=======
+                memory = Wasm::Memory::create(contents.releaseNonNull(), WTF::move(handler));
+            } else {
+                // zero size & max-size.
+                memory = Wasm::Memory::createZeroSized(JSC::MemorySharingMode::Shared, WTF::move(handler));
+>>>>>>> 095fa99180ff ([JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers)
             }
 
             result->adopt(memory.releaseNonNull());


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://181073780 to main. [095fa99180ff] caused a merge conflict. 

```
[JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers
https://bugs.webkit.org/show_bug.cgi?id=313473
rdar://175674018

Reviewed by Keith Miller.

Currently, ArrayBuffers that are created by WebAssembly.Memory.p.
toResizableBuffer do not keep that WebAssembly.Memory instance alive. This is a
memory safety footgun. While JS-originated resizable ABs reserve the virtual
memory of their max size up front, wasm-originated resizable ABs can either be
bounds-checking which do not reserve virtual memory up front, or signaling,
which do. Currently, because wasm-originated ArrayBuffers do not keep their
WebAssembly.Memory alive, non-wasm ArrayBuffer code has to be aware of this
implementation in case the WebAssembly.Memory gets collected. This complicates
the object representation space and is error-prone.

This PR simplifies this set up by making wasm-originated ArrayBuffers and their
originator WebAssembly.Memory exist in a GC lifetime cycle. This means
wasm-originated ABs _always_ delegate resizing to WebAssembly.Memory.

The weak pointer to the underlying Wasm::Memory in ArrayBuffers is no longer
needed and removed.

The spot fix to keep WebAssembly.Memory alive for the duration of
ArrayBuffer.prototype.resize from 305413.660@safari-7624-branch is also
reverted as this fix removes the need for it.

Test: JSTests/wasm/stress/wasm-resizable-buffer-resize-after-gc.js

* JSTests/wasm/stress/wasm-resizable-buffer-resize-after-gc.js: Added.
(flushStackRoots):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::resize):
(JSC::ArrayBuffer::setAssociatedWasmMemory): Deleted.
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/JSArrayBuffer.cpp:
(JSC::JSArrayBuffer::associatedWasmMemoryWrapper const):
(JSC::JSArrayBuffer::setAssociatedWasmMemoryWrapper):
(JSC::JSArrayBuffer::clearAssociatedWasmMemoryWrapper):
(JSC::JSArrayBuffer::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSArrayBuffer.h:
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::Memory):
(JSC::Wasm::Memory::create):
(JSC::Wasm::Memory::createZeroSized):
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::grow):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::adopt):
(JSC::JSWebAssemblyMemory::associateArrayBuffer):
(JSC::JSWebAssemblyMemory::disassociateArrayBuffer):
(JSC::JSWebAssemblyMemory::growSuccessCallback):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::WebAssemblyMemoryConstructor::createMemoryFromDescriptor):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTerminal):

Originally-landed-as: 305413.790@safari-7624-branch (095fa99180ff). rdar://181073780


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0589ba914269cd1e6aa4e3a3b8dc19fd962fcc2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171793 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45710 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181096 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129347 "") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173658 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/46995 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45350 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181096 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129347 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174751 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/46995 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181096 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/46995 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45350 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29846 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/46995 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183764 "") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33052 "") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36380 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45350 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/183764 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45377 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/183764 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46057 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110692 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46057 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117745 "") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204471 "") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44575 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39128 "") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/204471 "") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43975 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44207 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44034 "") | | | 
<!--EWS-Status-Bubble-End-->