### PR TITLE
[AppKit Gestures] Double-clicking to select a word when scrolled to the top with obscured content insets sometimes doesn't work

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1402,7 +1402,7 @@ OptionSet<DragSourceAction> EventHandler::updateDragSourceActionsAllowed() const
 }
 #endif // ENABLE(DRAG_SUPPORT)
 
-HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& point, OptionSet<HitTestRequest::Type> hitType) const
+HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& pointInContentsCoordinateSpace, OptionSet<HitTestRequest::Type> hitType) const
 {
     Ref frame = m_frame.get();
 
@@ -1411,7 +1411,7 @@ HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& point, Optio
     if (!frame->isRootFrame() && !hitType.contains(HitTestRequest::Type::SkipTransformToRootFrameCoordinates)) {
         Ref rootFrame = frame->rootFrame();
         if (RefPtr frameView = frame->view(), rootView = rootFrame->view(); frameView && rootView) {
-            IntPoint rootFramePoint = rootView->rootViewToContents(frameView->contentsToRootView(roundedIntPoint(point)));
+            IntPoint rootFramePoint = rootView->rootViewToContents(frameView->contentsToRootView(roundedIntPoint(pointInContentsCoordinateSpace)));
             return rootFrame->eventHandler().hitTestResultAtPoint(rootFramePoint, hitType);
         }
     }
@@ -1420,7 +1420,7 @@ HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& point, Optio
     if (RefPtr frameView = frame->view())
         frameView->updateLayoutAndStyleIfNeededRecursive();
 
-    auto result = HitTestResult { point };
+    auto result = HitTestResult { pointInContentsCoordinateSpace };
     RefPtr document = frame->document();
     if (!document)
         return result;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -185,7 +185,7 @@ public:
     WEBCORE_EXPORT void dispatchFakeMouseMoveEventSoon();
     void dispatchFakeMouseMoveEventSoonInQuad(const FloatQuad&);
 
-    WEBCORE_EXPORT HitTestResult hitTestResultAtPoint(const LayoutPoint&, OptionSet<HitTestRequest::Type>) const;
+    WEBCORE_EXPORT HitTestResult hitTestResultAtPoint(const LayoutPoint& pointInContentsCoordinateSpace, OptionSet<HitTestRequest::Type>) const;
 
     bool mousePressed() const { return m_mousePressed; }
     Node* mousePressNode() const { return m_mousePressNode; }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -347,16 +347,24 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
 
 static void selectionPositionInformation(WebPage& page, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
 {
+    // `request.point` is in the root-view coordinate space.
+
     RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.corePage()->mainFrame());
     if (!localMainFrame)
         return;
+
+    RefPtr frameView = localMainFrame->view();
+    if (!frameView)
+        return;
+
+    auto contentsPoint = frameView->rootViewToContents(request.point);
 
     constexpr OptionSet<WebCore::HitTestRequest::Type> hitType {
         WebCore::HitTestRequest::Type::ReadOnly,
         WebCore::HitTestRequest::Type::Active,
         WebCore::HitTestRequest::Type::AllowVisibleChildFrameContentOnly
     };
-    WebCore::HitTestResult result = localMainFrame->eventHandler().hitTestResultAtPoint(request.point, hitType);
+    WebCore::HitTestResult result = localMainFrame->eventHandler().hitTestResultAtPoint(contentsPoint, hitType);
     RefPtr hitNode = result.innerNode();
 
     // Hit test could return HTMLHtmlElement that has no renderer, if the body is smaller than the document.
@@ -428,7 +436,7 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
     }
 #if PLATFORM(MACCATALYST)
     bool isInsideFixedPosition;
-    WebCore::VisiblePosition caretPosition(renderer->visiblePositionForPoint(request.point, WebCore::HitTestSource::User));
+    WebCore::VisiblePosition caretPosition(renderer->visiblePositionForPoint(contentsPoint, WebCore::HitTestSource::User));
     info.caretRect = caretPosition.absoluteCaretBounds(&isInsideFixedPosition);
 #endif
 
@@ -440,6 +448,8 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
 
 static void textInteractionPositionInformation(WebPage& page, const WebCore::HTMLInputElement& input, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
 {
+    // `request.point` is in the root-view coordinate space.
+
     if (!input.list())
         return;
 
@@ -447,7 +457,12 @@ static void textInteractionPositionInformation(WebPage& page, const WebCore::HTM
     RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.corePage()->mainFrame());
     if (!localMainFrame)
         return;
-    WebCore::HitTestResult result = localMainFrame->eventHandler().hitTestResultAtPoint(request.point, hitType);
+
+    RefPtr frameView = localMainFrame->view();
+    if (!frameView)
+        return;
+
+    WebCore::HitTestResult result = localMainFrame->eventHandler().hitTestResultAtPoint(frameView->rootViewToContents(request.point), hitType);
     if (result.innerNode() == input.dataListButtonElement())
         info.preventTextInteraction = true;
 }
@@ -597,12 +612,18 @@ static RefPtr<WebCore::LocalDOMWindow> windowWithDoubleClickEventListener(RefPtr
 
 InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, const InteractionInformationRequest& request)
 {
+    // `request.point` is in the root-view coordinate space.
+
     InteractionInformationAtPosition info;
     info.request = request;
 
     WebCore::FloatPoint adjustedPoint;
     RefPtr localMainFrame = page.corePage()->localMainFrame();
     if (!localMainFrame)
+        return info;
+
+    RefPtr mainFrameView = localMainFrame->view();
+    if (!mainFrameView)
         return info;
 
     RefPtr nodeRespondingToClickEvents = localMainFrame->nodeRespondingToClickEvents(request.point, adjustedPoint);
@@ -627,7 +648,9 @@ InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, co
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 
     auto& eventHandler = localMainFrame->eventHandler();
-    auto hitTestResult = eventHandler.hitTestResultAtPoint(request.point, hitTestRequestTypes);
+
+    auto hitTestPoint = mainFrameView->rootViewToContents(request.point);
+    auto hitTestResult = eventHandler.hitTestResultAtPoint(hitTestPoint, hitTestRequestTypes);
 
 #if ENABLE(PDF_PLUGIN)
     RefPtr pluginView = hitTestResult.isOverWidget() ? WebPage::pluginViewForFrame(WTF::protect(hitTestResult.innerNodeFrame())) : nullptr;

--- a/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/API/View+WebViewModifiers.swift
@@ -167,6 +167,13 @@ extension View {
             .environment(\.webViewScrollEdgeEffectStyleContext, .init(style: style, edges: edges))
     }
 
+    // SPI for testing.
+    // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
+    @_spi(Testing)
+    public nonisolated func webViewObscuredContentInsets(_ insets: EdgeInsets) -> some View {
+        environment(\.webViewObscuredContentInsetsContext, insets)
+    }
+
     /// Manages the lifecycle of immersive environments requested by websites.
     ///
     /// Use this modifier to control authorization, presentation, and dismissal of

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/EnvironmentValues+Extras.swift
@@ -60,6 +60,9 @@ extension EnvironmentValues {
     @Entry
     var webViewScrollEdgeEffectStyleContext: ScrollEdgeEffectStyleContext? = nil
 
+    @Entry
+    var webViewObscuredContentInsetsContext: EdgeInsets? = nil
+
     #if ENABLE_MODEL_ELEMENT_IMMERSIVE
     @Entry
     var webViewImmersiveEnvironmentRequestContext: ImmersiveEnvironmentRequestContext? = nil

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/SwiftUI+Extras.swift
@@ -38,6 +38,16 @@ extension EdgeInsets {
     #endif
 }
 
+#if os(macOS)
+extension NSEdgeInsets {
+    init(_ edgeInsets: EdgeInsets, layoutDirection: LayoutDirection) {
+        let left = layoutDirection == .rightToLeft ? edgeInsets.trailing : edgeInsets.leading
+        let right = layoutDirection == .rightToLeft ? edgeInsets.leading : edgeInsets.trailing
+        self.init(top: edgeInsets.top, left: left, bottom: edgeInsets.bottom, right: right)
+    }
+}
+#endif
+
 extension ScrollGeometry {
     init(_ geometry: WKScrollGeometryAdapter) {
         self = ScrollGeometry(

--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -110,6 +110,10 @@ struct WebViewRepresentable {
             webView.obscuredContentInsets = .init(top: 0, left: 0, bottom: 0, right: 0)
             webView._automaticallyAdjustsContentInsets = true
         }
+
+        if let obscuredContentInsets = environment.webViewObscuredContentInsetsContext {
+            webView.obscuredContentInsets = NSEdgeInsets(obscuredContentInsets, layoutDirection: environment.layoutDirection)
+        }
         #endif
 
         if EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .always

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/AppKitGesturesTestsSupport.swift
@@ -55,6 +55,8 @@ actor Recap {
 protocol AppKitGestureTestSuite {
     static var text: String { get }
 
+    static var topInset: CGFloat { get }
+
     var recap: Recap { get }
 
     var page: WebPage { get }
@@ -65,6 +67,9 @@ protocol AppKitGestureTestSuite {
 }
 
 extension AppKitGestureTestSuite {
+    static var topInset: CGFloat {
+        0
+    }
 }
 
 @Suite(.serialized, .timeLimit(.minutes(1)))
@@ -88,7 +93,7 @@ private func convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: CG
 }
 
 @MainActor
-private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow) -> CGRect {
+private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow, topInset: CGFloat) -> CGRect {
     guard let contentViewController = window.contentViewController else {
         preconditionFailure()
     }
@@ -97,7 +102,8 @@ private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: D
         preconditionFailure()
     }
 
-    let inViewportCoordinates = CGRect(rectInViewportCoordinates)
+    var inViewportCoordinates = CGRect(rectInViewportCoordinates)
+    inViewportCoordinates.origin.y += topInset
 
     let inWindowCoordinates = CGRect(
         x: inViewportCoordinates.origin.x,
@@ -126,17 +132,17 @@ extension AppKitGestureTestSuite {
             JavaScriptMessages.BoundingClientRect(in: "div", range: range)
         )
 
-        let screenCoordinates = convertToCoreGraphicsScreenCoordinates(
-            rectInViewportCoordinates: viewportCoordinates,
-            window: window
-        )
-
+        let screenCoordinates = screenBounds(ofRectInViewportCoordinates: viewportCoordinates)
         return screenCoordinates
     }
 
     func screenBounds(ofElementWithID id: String) async throws -> CGRect {
         let viewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: id))
-        return convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: viewportCoordinates, window: window)
+        return convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: viewportCoordinates,
+            window: window,
+            topInset: Self.topInset
+        )
     }
 
     func screenBounds(ofPointInWindowCoordinates point: NSPoint) -> NSPoint {
@@ -144,7 +150,7 @@ extension AppKitGestureTestSuite {
     }
 
     func screenBounds(ofRectInViewportCoordinates point: DOMRect) -> CGRect {
-        convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: point, window: window)
+        convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: point, window: window, topInset: Self.topInset)
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
@@ -26,6 +26,7 @@
 import Foundation
 import struct Foundation.URL
 @_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
+@_spi(Testing) import _WebKit_SwiftUI
 import SwiftUI
 import struct Swift.String
 import struct _Concurrency.Task
@@ -45,6 +46,8 @@ extension AppKitGesturesTests {
         }
 
         static let text = "Here's to the crazy ones."
+
+        static let topInset: CGFloat = 100
 
         let recap = Recap.shared
 
@@ -67,6 +70,7 @@ extension AppKitGesturesTests {
                     VStack(spacing: 0) {
                         WebView(page)
                             .frame(width: windowSize.width, height: windowSize.height)
+                            .webViewObscuredContentInsets(EdgeInsets(top: Self.topInset, leading: 0, bottom: 0, trailing: 0))
                         Color.clear
                             .frame(height: contentHeight - windowSize.height)
                     }
@@ -205,6 +209,44 @@ extension AppKitGesturesTests.Embedded {
         await page.waitForNextPresentationUpdate()
 
         #expect(contentOffset.value != initialContentOffset)
+    }
+
+    @Test
+    func doubleClickingSelectsWordWhenScrolledToTopWithObscuredContentInset() async throws {
+        let html = """
+            <body style="margin: 0">
+                <h2 id="div" style="display: inline-block; margin: 0; font-size: 30px;">\(Self.text)</h2>
+                <input id="search" type="search" style="display: block; margin: 0; width: 320px; height: 300px;">
+            </body>
+            """
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await recap.play { composer in
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+        #expect(newSelection == crazySelection)
     }
 }
 


### PR DESCRIPTION
#### 191b1f341a7e02b3fa6b67fc479f7b9ed05a4acc
<pre>
[AppKit Gestures] Double-clicking to select a word when scrolled to the top with obscured content insets sometimes doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=318293">https://bugs.webkit.org/show_bug.cgi?id=318293</a>
<a href="https://rdar.apple.com/181076925">rdar://181076925</a>

Reviewed by Abrar Rahman Protyasha.

The calculations in `PositionInformationForWebPage.mm` were using the wrong coordinate space
when performing hit-testing. This underlying issue revealed itself when the page has a top content
inset applied, since then point is displaced and the wrong element is &quot;hit&quot;.

When the scroll position is roughly the same as the size of the content inset, they cancel each other
out, which is why the bug only reproduces on some scroll offsets, and only on certain page layouts
when there&apos;s a selectable and non-selectable element vertically near each other.

Fix by using the correct coordinate space.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::hitTestResultAtPoint const):
* Source/WebCore/page/EventHandler.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::selectionPositionInformation):
(WebKit::textInteractionPositionInformation):
(WebKit::positionInformationForWebPage):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.doubleClickingSelectsWordWhenScrolledToTopWithObscuredContentInset):

Canonical link: <a href="https://commits.webkit.org/316304@main">https://commits.webkit.org/316304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58e6523312bd65ea3c77a62235378af504ddecb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39306 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6c767b4-3d50-432a-ab63-b4feaf00847f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/181410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e17e5fb9-34d4-4821-b3b5-432b6f8d6c16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174929 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c41d90b1-42c3-4c9f-86bc-7fa8f1a79ded) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30024 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183943 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142501 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45555 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38411 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46235 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110898 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37488 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44753 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8743 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->