### PR TITLE
[Web Inspector] didClearWindowObject is dispatched twice for script-less frames

### DIFF
--- a/LayoutTests/inspector/page/resources/scriptless-subframe.html
+++ b/LayoutTests/inspector/page/resources/scriptless-subframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This subframe intentionally contains no JavaScript.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/page/setBootstrapScript-runs-once-per-navigation-expected.txt
+++ b/LayoutTests/inspector/page/setBootstrapScript-runs-once-per-navigation-expected.txt
@@ -1,0 +1,10 @@
+Tests that Page.setBootstrapScript is executed exactly once per navigation, including in script-less subframes.
+
+
+== Running test suite: Page.setBootstrapScript.RunsOncePerNavigation
+-- Running test case: Page.setBootstrapScript.NotExecutedTwiceInScriptlessSubframe
+Setting bootstrap script that counts its own executions...
+Adding a script-less subframe (its execution context is force-created on frameNavigated)...
+Bootstrap script executions in the script-less subframe: 1
+PASS: Bootstrap script should run exactly once in the script-less subframe.
+

--- a/LayoutTests/inspector/page/setBootstrapScript-runs-once-per-navigation.html
+++ b/LayoutTests/inspector/page/setBootstrapScript-runs-once-per-navigation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Page.setBootstrapScript.RunsOncePerNavigation");
+
+    suite.addTestCase({
+        name: "Page.setBootstrapScript.NotExecutedTwiceInScriptlessSubframe",
+        description: "Test that the bootstrap script runs exactly once in a script-less subframe (regression test for double didClearWindowObject dispatch).",
+        async test() {
+            InspectorTest.log("Setting bootstrap script that counts its own executions...");
+            await WI.networkManager.createBootstrapScript(`window.bootstrapScriptRunCount = (window.bootstrapScriptRunCount || 0) + 1;`);
+            WI.networkManager.bootstrapScriptEnabled = true;
+
+            InspectorTest.log("Adding a script-less subframe (its execution context is force-created on frameNavigated)...");
+            await InspectorTest.evaluateInPage(`
+                (function() {
+                    let iframe = document.createElement("iframe");
+                    iframe.src = "resources/scriptless-subframe.html";
+                    iframe.onload = () => {
+                        window.subframeBootstrapRunCount = iframe.contentWindow.bootstrapScriptRunCount;
+                        TestPage.dispatchEventToFrontend("SubframeLoaded");
+                    };
+                    document.body.appendChild(iframe);
+                })();
+            `);
+
+            await InspectorTest.awaitEvent("SubframeLoaded");
+
+            let runCount = await InspectorTest.evaluateInPage(`window.subframeBootstrapRunCount`);
+            InspectorTest.log(`Bootstrap script executions in the script-less subframe: ${runCount}`);
+            InspectorTest.expectEqual(runCount, 1, "Bootstrap script should run exactly once in the script-less subframe.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Page.setBootstrapScript is executed exactly once per navigation, including in script-less subframes.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -62,6 +62,7 @@
 #include "MemoryCache.h"
 #include "Page.h"
 #include "PageInspectorController.h"
+#include "PageRuntimeAgent.h"
 #include "RemoteFrame.h"
 #include "RenderObjectInlines.h"
 #include "RenderTheme.h"
@@ -774,6 +775,11 @@ void InspectorPageAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapp
 
     if (m_bootstrapScript.isEmpty())
         return;
+
+    if (auto* pageRuntimeAgent = Ref { m_instrumentingAgents.get() }->enabledPageRuntimeAgent()) {
+        if (pageRuntimeAgent->ignoreDidClearWindowObject())
+            return;
+    }
 
     frame.script().evaluateIgnoringException(ScriptSourceCode(m_bootstrapScript, JSC::SourceTaintedOrigin::Untainted, URL { "web-inspector://bootstrap.js"_str }));
 }

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -49,6 +49,7 @@
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -96,6 +97,7 @@ Inspector::Protocol::ErrorStringOr<void> PageRuntimeAgent::disable()
 
 void PageRuntimeAgent::frameNavigated(LocalFrame& frame)
 {
+    SetForScope ignoreDidClearWindowObject(m_ignoreDidClearWindowObject, true);
     // Ensure execution context is created for the frame even if it doesn't have scripts.
     mainWorldGlobalObject(frame);
 }
@@ -106,6 +108,10 @@ void PageRuntimeAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapper
     if (frameId.isEmpty())
         return;
 
+    if (m_ignoreDidClearWindowObject)
+        return;
+
+    SetForScope ignoreDidClearWindowObject(m_ignoreDidClearWindowObject, true);
     notifyContextCreated(frameId, frame.script().globalObject(world), world);
 }
 

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.h
@@ -65,6 +65,8 @@ public:
     void frameNavigated(LocalFrame&);
     void didClearWindowObjectInWorld(LocalFrame&, DOMWrapperWorld&);
 
+    bool ignoreDidClearWindowObject() const { return m_ignoreDidClearWindowObject; }
+
 private:
     Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&);
     void muteConsole();
@@ -78,6 +80,8 @@ private:
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
 
     WeakRef<Page> m_inspectedPage;
+
+    bool m_ignoreDidClearWindowObject { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### df88b37022bb15f2a79cf9f70731ecb2f4204454
<pre>
[Web Inspector] didClearWindowObject is dispatched twice for script-less frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=318294">https://bugs.webkit.org/show_bug.cgi?id=318294</a>

Reviewed by Devin Rousso.

PageRuntimeAgent forces a frame&apos;s main-world global object to be created
so script-less frames get an execution context. That creation re-enters
didClearWindowObjectInWorld, so Runtime.executionContextCreated was
dispatched twice and Page bootstrap scripts ran twice. Track the forced
dispatch on PageRuntimeAgent and skip the re-entrant one.

Test: inspector/page/setBootstrapScript-runs-once-per-navigation.html

* LayoutTests/inspector/page/resources/scriptless-subframe.html: Added.
* LayoutTests/inspector/page/setBootstrapScript-runs-once-per-navigation-expected.txt: Added.
* LayoutTests/inspector/page/setBootstrapScript-runs-once-per-navigation.html: Added.
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::didClearWindowObjectInWorld):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::frameNavigated):
(WebCore::PageRuntimeAgent::didClearWindowObjectInWorld):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.h:

Canonical link: <a href="https://commits.webkit.org/316294@main">https://commits.webkit.org/316294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c469fd3dbde6fbdf2ede78a5bf9610c2cda76ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39296 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181276 "Failed to checkout and rebase branch from PR 68389") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45518 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181276 "Failed to checkout and rebase branch from PR 68389") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174919 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181276 "Failed to checkout and rebase branch from PR 68389") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30014 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183933 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45545 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153877 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142383 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38407 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46225 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110886 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37481 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44743 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8736 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->