### PR TITLE
REGRESSION(298821@main): [iOS] RequestPointerLock IPC twice in succession can produce use-after-free of unretained GCMouseMoved block in WKMouseInteraction

### DIFF
--- a/LayoutTests/ipc/pointer-lock-double-lock-uaf-expected.txt
+++ b/LayoutTests/ipc/pointer-lock-double-lock-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/pointer-lock-double-lock-uaf.html
+++ b/LayoutTests/ipc/pointer-lock-double-lock-uaf.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true PointerLockEnabled=true ] -->
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function main() {
+    if (!window.IPC) {
+        testRunner?.notifyDone();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    if (window.testRunner && testRunner.setHasMouseDeviceForTesting)
+        testRunner.setHasMouseDeviceForTesting(true);
+
+    function sendPointerLock() {
+        return new Promise(resolve => {
+            CoreIPC.UI.WebPageProxy.RequestPointerLock(IPC.webPageProxyID, {}, () => resolve());
+        });
+    }
+
+    function sendPointerUnlock() {
+        return new Promise(resolve => {
+            CoreIPC.UI.WebPageProxy.RequestPointerUnlock(IPC.webPageProxyID, {}, () => resolve());
+        });
+    }
+
+    window.focus();
+
+    await sendPointerLock();
+    await sendPointerLock();
+    await sendPointerUnlock();
+
+    testRunner.notifyDone();
+}
+
+main().catch(() => {
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
+This test passes if WebKit does not crash.
+</body>
+</html>

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -592,6 +592,7 @@ webkit.org/b/115274 http/tests/security/contentSecurityPolicy/report-same-origin
 [ Debug ] http/tests/ipc/web-authenticator-get-assertion-spoofed-origin-crash.html [ Skip ]
 [ Debug ] http/tests/ipc/web-authenticator-make-credential-spoofed-origin-crash.html [ Skip ]
 [ Debug ] ipc/media-containment-bypass-create-player.html [ Crash ]
+[ Debug ] ipc/pointer-lock-double-lock-uaf.html [ Skip ]
 
 ### END OF (4) Features that are not supported in WebKit2 and likely never will be
 ########################################

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16779,8 +16779,8 @@ void WebPageProxy::closeOverlayedViews()
 #if ENABLE(POINTER_LOCK)
 void WebPageProxy::requestPointerLock(IPC::Connection& connection, CompletionHandler<void(bool)>&& completionHandler)
 {
+    MESSAGE_CHECK_COMPLETION_BASE(!m_isPointerLocked, connection, didDenyPointerLock(WTF::move(completionHandler)));
     ASSERT(!m_isPointerLockPending);
-    ASSERT(!m_isPointerLocked);
     m_isPointerLockPending = true;
 
     if (!isViewVisible() || !isViewFocused()) {
@@ -16811,7 +16811,11 @@ void WebPageProxy::didAllowPointerLock(CompletionHandler<void(bool)>&& completio
     if (!m_isPointerLockPending)
         return completionHandler(false);
 
-    ASSERT(!m_isPointerLocked);
+    if (m_isPointerLocked) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(false);
+    }
+
     m_isPointerLocked = true;
     m_isPointerLockPending = false;
 
@@ -16825,7 +16829,11 @@ void WebPageProxy::didDenyPointerLock(CompletionHandler<void(bool)>&& completion
     if (!m_isPointerLockPending)
         return completionHandler(false);
 
-    ASSERT(!m_isPointerLocked);
+    if (m_isPointerLocked) {
+        ASSERT_NOT_REACHED();
+        return completionHandler(false);
+    }
+
     m_isPointerLockPending = false;
 
     completionHandler(false);

--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -50,7 +50,7 @@ struct PointerLockState {
     bool isActive { false };
     bool isObservingNotifications { false };
     RetainPtr<GCMouse> currentMouse;
-    GCMouseMoved originalMouseMovedHandler { nil };
+    BlockPtr<void(GCMouseInput *, float, float)> originalMouseMovedHandler;
     std::optional<CGPoint> lockedCursorPosition;
 
     void reset()
@@ -477,6 +477,9 @@ inline static String pointerType(UITouchType type)
         return;
 #endif
 
+    if (_pointerLockState.isActive)
+        return;
+
     _pointerLockState.currentMouse = dynamic_objc_cast<GCMouse>([WebCore::getGCMouseClassSingleton() current]);
     if (!_pointerLockState.currentMouse)
         return;
@@ -497,7 +500,7 @@ inline static String pointerType(UITouchType type)
 
     [self _stopObservingMouseNotifications];
 
-    [[_pointerLockState.currentMouse mouseInput] setMouseMovedHandler:_pointerLockState.originalMouseMovedHandler];
+    [[_pointerLockState.currentMouse mouseInput] setMouseMovedHandler:_pointerLockState.originalMouseMovedHandler.get()];
     _pointerLockState.originalMouseMovedHandler = nil;
     _pointerLockState.currentMouse = nil;
 
@@ -564,7 +567,7 @@ inline static String pointerType(UITouchType type)
 {
     if (!mouse)
         return;
-    _pointerLockState.originalMouseMovedHandler = [[mouse mouseInput] mouseMovedHandler];
+    _pointerLockState.originalMouseMovedHandler = makeBlockPtr([[mouse mouseInput] mouseMovedHandler]);
     [[mouse mouseInput] setMouseMovedHandler:makeBlockPtr([weakSelf = WeakObjCPtr<WKMouseInteraction> { self }](GCMouseInput *mouseInput, float deltaX, float deltaY) {
         if (RetainPtr strongSelf = weakSelf.get())
             [strongSelf handleGameControllerMouseMove:deltaX deltaY:deltaY];

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig
@@ -30,7 +30,13 @@ PRODUCT_BUNDLE_IDENTIFIER = org.webkit.$(PRODUCT_NAME:rfc1034identifier);
 
 GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 
-OTHER_LDFLAGS = $(inherited) -lWebKitTestRunner -lPAL -lWebCoreTestSupport -framework CoreGraphics -framework Foundation -framework GraphicsServices -framework ImageIO -framework IOKit -framework JavaScriptCore -framework QuartzCore -framework UIKit -framework UniformTypeIdentifiers -framework WebKit;
+WK_GAMECONTROLLER_LDFLAGS = $(WK_GAMECONTROLLER_LDFLAGS_$(WK_PLATFORM_NAME))
+WK_GAMECONTROLLER_LDFLAGS_iphoneos = -framework GameController
+WK_GAMECONTROLLER_LDFLAGS_iphonesimulator = -framework GameController
+WK_GAMECONTROLLER_LDFLAGS_xros = -framework GameController
+WK_GAMECONTROLLER_LDFLAGS_xrsimulator = -framework GameController
+
+OTHER_LDFLAGS = $(inherited) -lWebKitTestRunner -lPAL -lWebCoreTestSupport -framework CoreGraphics -framework Foundation -framework GraphicsServices -framework ImageIO -framework IOKit -framework JavaScriptCore -framework QuartzCore -framework UIKit -framework UniformTypeIdentifiers -framework WebKit $(WK_GAMECONTROLLER_LDFLAGS);
 OTHER_LDFLAGS[sdk=watch*] = $(OTHER_LDFLAGS) -framework PepperUICore
 
 STRIP_STYLE = debugging;

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -55,6 +55,7 @@ OBJC_CLASS NSColor;
 OBJC_CLASS NSString;
 OBJC_CLASS UIKeyboardInputMode;
 OBJC_CLASS UIPasteboardConsistencyEnforcer;
+OBJC_CLASS GCMouse;
 OBJC_CLASS WKMouseDeviceObserver;
 OBJC_CLASS WKWebViewConfiguration;
 
@@ -66,6 +67,20 @@ class TestInvocation;
 class TestOptions;
 struct Options;
 struct TestCommand;
+
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+class FakeMouseDevice {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FakeMouseDevice);
+    WTF_MAKE_NONCOPYABLE(FakeMouseDevice);
+public:
+    FakeMouseDevice();
+    ~FakeMouseDevice();
+private:
+    RetainPtr<GCMouse> m_fakeMouse;
+    std::unique_ptr<ClassMethodSwizzler> m_currentSwizzler;
+    std::unique_ptr<ClassMethodSwizzler> m_miceSwizzler;
+};
+#endif
 
 class AsyncTask {
 public:
@@ -475,6 +490,10 @@ public:
     bool useWorkQueue() const { return m_useWorkQueue; }
 
     void setHasMouseDeviceForTesting(bool);
+
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+    std::unique_ptr<FakeMouseDevice> m_fakeMouseDevice;
+#endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     void exitImmersive();

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -50,6 +50,10 @@
 #import <wtf/MainThread.h>
 #import <wtf/SoftLinking.h>
 
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+#import <GameController/GameController.h>
+#endif
+
 SOFT_LINK_PRIVATE_FRAMEWORK(TextInput)
 SOFT_LINK_CLASS(TextInput, TIPreferencesController);
 
@@ -68,8 +72,14 @@ static unsigned globalKeyboardUpdateForChangedSelectionCount = 0;
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
 
+@interface GCMouse ()
+- (instancetype)initWithName:(NSString *)name additionalButtons:(uint32_t)additionalButtons;
+@end
+
 @interface WKMouseDeviceObserver
 + (WKMouseDeviceObserver *)sharedInstance;
+- (void)start;
+- (void)stop;
 - (void)_setHasMouseDeviceForTesting:(BOOL)hasMouseDevice;
 @end
 
@@ -137,6 +147,40 @@ static BOOL overrideEnhancedWindowingEnabled()
 #endif
 
 namespace WTR {
+
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+
+FakeMouseDevice::FakeMouseDevice()
+{
+    RetainPtr<WKMouseDeviceObserver> observer = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
+    [observer start];
+    m_fakeMouse = adoptNS([[GCMouse alloc] initWithName:@"TestMouse" additionalButtons:0]);
+    m_currentSwizzler = makeUnique<ClassMethodSwizzler>(GCMouse.class,
+        @selector(current),
+        imp_implementationWithBlock(^GCMouse *() {
+            return m_fakeMouse.get();
+        })
+    );
+    m_miceSwizzler = makeUnique<ClassMethodSwizzler>(GCMouse.class,
+        @selector(mice),
+        imp_implementationWithBlock(^NSArray<GCMouse *> *() {
+            return @[ m_fakeMouse.get() ];
+        })
+    );
+    [observer _setHasMouseDeviceForTesting:YES];
+}
+
+FakeMouseDevice::~FakeMouseDevice()
+{
+    RetainPtr<WKMouseDeviceObserver> observer = [NSClassFromString(@"WKMouseDeviceObserver") sharedInstance];
+    [observer _setHasMouseDeviceForTesting:NO];
+    m_currentSwizzler = nullptr;
+    m_miceSwizzler = nullptr;
+    m_fakeMouse = nil;
+    [observer stop];
+}
+
+#endif
 
 static bool isDoneWaitingForKeyboardToStartDismissing = true;
 static bool isDoneWaitingForKeyboardToDismiss = true;
@@ -475,6 +519,10 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
     if (shouldRestoreFirstResponder)
         [mainWebView()->platformView() becomeFirstResponder];
 
+#if HAVE(MOUSE_DEVICE_OBSERVATION)
+    m_fakeMouseDevice = nullptr;
+#endif
+
     return true;
 }
 
@@ -640,7 +688,11 @@ void TestController::unlockScreenOrientation()
 void TestController::setHasMouseDeviceForTesting(bool hasMouseDevice)
 {
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
-    [[NSClassFromString(@"WKMouseDeviceObserver") sharedInstance] _setHasMouseDeviceForTesting:hasMouseDevice];
+    if (hasMouseDevice) {
+        if (!m_fakeMouseDevice)
+            m_fakeMouseDevice = makeUnique<FakeMouseDevice>();
+    } else
+        m_fakeMouseDevice = nullptr;
 #else
     UNUSED_PARAM(hasMouseDevice);
 #endif


### PR DESCRIPTION
#### ffe2ea6689b543ec54a86570650be46c723f309d
<pre>
REGRESSION(298821@main): [iOS] RequestPointerLock IPC twice in succession can produce use-after-free of unretained GCMouseMoved block in WKMouseInteraction
<a href="https://rdar.apple.com/175672657">rdar://175672657</a>

Reviewed by Wenson Hsieh.

In 298821@main, we taught WKMouseInteraction to copy the
mouseMovedHandler block from the current GCMouse. However, since
WKMouseInteraction does not have ARC, the bare copy did not increase the
retain count of the block in question. Given we set a new block
immediately afterwards, the block we had just copied is released.

On a second RequestPointerLock IPC, the original mouseMovedHandler block
points to freed memory from the earlier IPC dance, and we end up with a
use-after-free.

To address this issue, we change the bare GCMouseMoved instance held on
by WKMouseInteraction to a BlockPtr. This ensures that the handler is
retained across the setter. Also, we add a pointerLockState.isActive gate
at the start of -beginPointerLockMouseTracking, so successive pointer
lock IPC messages would not be able to read a mouseMovedHandler block
from a previous lock regardless. Finally, we promote our UI process
m_isPointerLocked debug assertions into MESSAGE_CHECK invariants, which
would surface issues more readily in non-debug configurations (and,
importantly, without leading to a use-after-free in the process).

Test: ipc/pointer-lock-double-lock-uaf.html

* LayoutTests/ipc/pointer-lock-double-lock-uaf-expected.txt: Added.
* LayoutTests/ipc/pointer-lock-double-lock-uaf.html: Added.
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestPointerLock):
(WebKit::WebPageProxy::didAllowPointerLock):
(WebKit::WebPageProxy::didDenyPointerLock):
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseInteraction beginPointerLockMouseTracking]):
(-[WKMouseInteraction endPointerLockMouseTracking]):
(-[WKMouseInteraction _setupMouseMovedHandlerForMouse:]):
* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::FakeMouseDevice::FakeMouseDevice):
(WTR::FakeMouseDevice::~FakeMouseDevice):
(WTR::TestController::platformResetStateToConsistentValues):
(WTR::TestController::setHasMouseDeviceForTesting):
  Enhance TestRunner.setHasMouseDeviceForTesting() to also swizzle a
  fake GCMouse instance for testing, so that the system thinks an
  external mouse input device is connected. This matches TWKAPI&apos;s
  pointer lock test capabilities, and allows pointer lock tests to
  get past the GCMouse gate in -beginPointerLockMouseTracking.

Originally-landed-as: 305413.755@safari-7624-branch (3927a3556654). <a href="https://rdar.apple.com/181074364">rdar://181074364</a>
Canonical link: <a href="https://commits.webkit.org/316240@main">https://commits.webkit.org/316240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8ed7e398551b93916db4296426bdf3bd9213926

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181129 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133673 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174784 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114145 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29879 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183797 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142271 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38356 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46090 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110725 "Hash a8ed7e39 for PR 68390 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37366 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44608 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->