### PR TITLE
ExpressionInfo::Encoder computes the offset to Extension Islands incorrectly.

### DIFF
--- a/JSTests/stress/expression-info-multi-wide-encoding.js
+++ b/JSTests/stress/expression-info-multi-wide-encoding.js
@@ -1,0 +1,17 @@
+//@ skip if $memoryLimited
+//@ runDefault
+
+const PAD = " ".repeat(5000000);
+const src =
+  'function* gen(){var b;0+' + PAD + '(b,yield,1);null.x;} this.gen=gen;';
+(0, eval)(src);
+
+const it = gen();
+it.next();
+
+var stackStr;
+try {
+    it.next();
+} catch (e) {
+    stackStr = e.stack + 1;
+}

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -58,7 +58,7 @@ namespace JSC {
       Extension: [   11111b | 1b |    offset:26                                ]
       AbsInstPC: [   11111b | 0b |     value:26                                ]
       MultiWide: [   11110b | 1b |     111b | numFields:5 | fields[6]:18       ] [ value:32 ] ...
-        DuoWide: [   11110b | 1b | field2:3 | value2:10 | field1:3 | value1:10 ]
+        DuoWide: [   11110b | 1b | field1:3 | value1:10 | field2:3 | value2:10 ]
      SingleWide: [   11110b | 0b |  field:3 | value:23                         ]
    ExtensionEnd: [   11110b | 0b |     111b |     0:23                         ]
           Basic: [ instPC:5 |   divot:7 | start:6 |  end:6 | line:3 | column:5 ]
@@ -140,7 +140,7 @@ namespace JSC {
        over to the extension island. For all encodings, this is just a single word. The only
        exception is the MultiWide encoding, which are followed by N value words. Because the
        decoder expects these words to be contiguous, we move all the value words over too. The
-       slots of the original value words will not be replaced by no-ops (SingleWide with 0).
+       slots of the original value words will now be replaced by no-ops (SingleWide with 0).
 
     AbsInstPC and Chapters
     ======================
@@ -450,6 +450,7 @@ void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDe
         // being contiguous.
         unsigned numberOfFields = (firstValue >> multiSizeShift) & multiSizeMask;
 
+        unsigned locationOfExtensionIsland = m_expressionInfoEncodedInfo.size();
         m_expressionInfoEncodedInfo.append({ firstValue }); // MultiWide header.
         for (unsigned i = 1; i < numberOfFields; ++i) {
             auto fieldValue = m_expressionInfoEncodedInfo[infoIndex + i];
@@ -459,7 +460,10 @@ void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDe
         // Save the last field in firstValue, and let the extension emitter below append it.
         firstValue = m_expressionInfoEncodedInfo[infoIndex + numberOfFields].value;
         m_expressionInfoEncodedInfo[infoIndex + numberOfFields] = encodeSingle(FieldID::InstPC, 0); // Replace with a no-op.
-        goto emitExtension;
+
+        unsigned extensionOffset = locationOfExtensionIsland - infoIndex;
+        m_expressionInfoEncodedInfo[infoIndex] = encodeExtension(extensionOffset);
+        goto emitExtensionIsland;
     }
 
     // Handle Basic.
@@ -476,9 +480,11 @@ void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDe
     isBasic = true;
 
 emitExtension:
-    unsigned extensionOffset = m_expressionInfoEncodedInfo.size() - infoIndex;
-    m_expressionInfoEncodedInfo[infoIndex] = encodeExtension(extensionOffset);
-
+    {
+        unsigned extensionOffset = m_expressionInfoEncodedInfo.size() - infoIndex;
+        m_expressionInfoEncodedInfo[infoIndex] = encodeExtension(extensionOffset);
+    }
+emitExtensionIsland:
     // Because the Basic word is used as a terminator for the current Entry,
     // if the firstValue is a Basic word, it needs to come last. Otherwise, we should
     // just emit firstValue first. AbsInstPC and MultiWide relies on this for correctness.
@@ -490,7 +496,7 @@ emitExtension:
     else {
         // The wides array is really only to enable us to use encodeMultiHeader. Hence,
         // we don't really need to store instPCDelta as the value here. It can be any value
-        // since it's not ued. However, to avoid confusion, we'll just populate it consistently.
+        // since it's not used. However, to avoid confusion, we'll just populate it consistently.
         Wide wides[1] = { { instPCDelta, FieldID::InstPC } };
         m_expressionInfoEncodedInfo.append(encodeMultiHeader(1, wides));
         m_expressionInfoEncodedInfo.append({ instPCDelta });
@@ -1032,7 +1038,7 @@ void ExpressionInfo::dumpEncodedInfo(ExpressionInfo::EncodedInfo* start, Express
                 out.print(" DUO ", fieldID1, " ");
                 print<duoValueBits>(out, fieldID1, value >> duoFirstValueShift);
                 out.print(" ", fieldID2, " ");
-                print<duoValueBits>(out, fieldID2, value >> duoFirstValueShift);
+                print<duoValueBits>(out, fieldID2, value >> duoSecondValueShift);
                 out.println();
 
             } else {


### PR DESCRIPTION
#### 449c42b27f306b9b4906702b33d9f731dd558055
<pre>
ExpressionInfo::Encoder computes the offset to Extension Islands incorrectly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312525">https://bugs.webkit.org/show_bug.cgi?id=312525</a>
<a href="https://rdar.apple.com/174626446">rdar://174626446</a>

Reviewed by Yijia Huang.

When an Extension ExpressionInfo is emitted, it needs to encode a displacement offset from
its location to the location of its extension island.  For a MultiWide ExpressionInfo,
parts of its island has already been emitted (from copying the MultiWide record over).  As
a result, the size of m_expressionInfoEncodedInfo is no longer the same as the starting
offset of extension island.  As a result, the offset encoded in the Extension ExpressionInfo
will be incorrect.

The fix is simply to cache the location of the extension island before we start copying the
MultiWide ExpressionInfo over.  We will use this cached location to emit the Extension
ExpressionInfo instead of using m_expressionInfoEncodedInfo.size() as we do for other cases.

Also fixed some typos and errors in comments.

Also fixed the decoding of DuoWide field2 in ExpressionInfo::dumpEncodedInfo().  This is
only used for debugging code.

Test: JSTests/stress/expression-info-multi-wide-encoding.js

* JSTests/stress/expression-info-multi-wide-encoding.js: Added.
(catch):
* Source/JavaScriptCore/bytecode/ExpressionInfo.cpp:
(JSC::ExpressionInfo::Encoder::adjustInstPC):
(JSC::ExpressionInfo::dumpEncodedInfo):

Originally-landed-as: 305413.693@safari-7624-branch (e321c398762a). <a href="https://rdar.apple.com/181074668">rdar://181074668</a>
Canonical link: <a href="https://commits.webkit.org/316319@main">https://commits.webkit.org/316319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ecdfbf4c25cb651235fd7c58427fe6696f57a27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129357 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133658 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33938 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29856 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2708 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183774 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33062 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142360 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45387 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38425 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46067 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110702 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37351 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117755 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204481 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44585 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8616 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54615 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44217 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->