### PR TITLE
Modern media controls do redundant layout work on every slider commit and every drop-loop iteration

### DIFF
--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container-expected.txt
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container-expected.txt
@@ -1,0 +1,19 @@
+Testing that MacOSInlineMediaControls.layout() only re-lays out the button container that owns each dropped button, rather than both containers on every iteration of the drop loop.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS ready() became true
+
+The narrow layout must drop several buttons so the drop loop is exercised:
+PASS totalDroppedButtons > 2 is true
+
+Each container is laid out once up front plus once per button it owns that is dropped, so the
+combined count is (totalDropped + 4). Without the fix both containers are laid out on every
+loop iteration, giving at least (2 * totalDropped + 2), so this bound would not hold.
+PASS totalContainerLayouts < 2 * totalDroppedButtons + 2 is true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container.html
+++ b/LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing that <code>MacOSInlineMediaControls.layout()</code> only re-lays out the button container that owns each dropped button, rather than both containers on every iteration of the drop loop.");
+
+window.jsTestIsAsync = true;
+
+// Use a height below MinimumHeightToShowVolumeSlider (136) so the volume slider is never shown. Otherwise
+// the mute button is reparented into the volume-slider container, which lays out the right container an
+// extra time and would obscure what the drop loop itself does.
+const mediaControls = new MacOSInlineMediaControls({ width: 680, height: 120 });
+mediaControls.shouldUseSingleBarLayout = true;
+mediaControls.maximumRightContainerButtonCountOverride = 100; // A finite value larger than anything likely, so buttons only drop based on width.
+
+// Trigger a layout so that button widths become available and the override takes effect.
+mediaControls.needsLayout = true;
+scheduler.flushScheduledLayoutCallbacks();
+
+const droppableControls = [
+    mediaControls.fullscreenButton,
+    mediaControls.airplayButton,
+    mediaControls.muteButton,
+    mediaControls.skipBackButton,
+    mediaControls.skipForwardButton,
+    mediaControls.pipButton,
+    mediaControls.tracksButton,
+];
+
+function ready()
+{
+    return droppableControls.concat(mediaControls.playPauseButton).every(button => button.width > 0);
+}
+
+// Count top-level layout() calls on a container. ButtonsContainer.layout() re-enters itself through
+// the width setter, so a re-entrancy guard ensures we only count calls made from outside the container.
+function installLayoutCounter(container)
+{
+    const originalLayout = container.layout.bind(container);
+    container._layoutCount = 0;
+    container._inLayout = false;
+    container.layout = function() {
+        if (container._inLayout)
+            return originalLayout();
+        container._inLayout = true;
+        container._layoutCount++;
+        try {
+            return originalLayout();
+        } finally {
+            container._inLayout = false;
+        }
+    };
+}
+
+shouldBecomeEqual("ready()", "true", () => {
+    // Shrink to a width narrow enough to drop several buttons, exercising the drop loop.
+    mediaControls.width = 200;
+    scheduler.flushScheduledLayoutCallbacks();
+
+    installLayoutCounter(mediaControls.leftContainer);
+    installLayoutCounter(mediaControls.rightContainer);
+
+    // Perform a single layout pass and measure how often each container is laid out.
+    mediaControls.leftContainer._layoutCount = 0;
+    mediaControls.rightContainer._layoutCount = 0;
+    mediaControls.layout();
+
+    window.totalContainerLayouts = mediaControls.leftContainer._layoutCount + mediaControls.rightContainer._layoutCount;
+    window.totalDroppedButtons = mediaControls.leftContainer.children.filter(button => button.dropped).length + mediaControls.rightContainer.children.filter(button => button.dropped).length;
+
+    debug("");
+    debug("The narrow layout must drop several buttons so the drop loop is exercised:");
+    shouldBeTrue("totalDroppedButtons > 2");
+
+    debug("");
+    debug("Each container is laid out once up front plus once per button it owns that is dropped, so the");
+    debug("combined count is (totalDropped + 4). Without the fix both containers are laid out on every");
+    debug("loop iteration, giving at least (2 * totalDropped + 2), so this bound would not hold.");
+    shouldBeTrue("totalContainerLayouts < 2 * totalDroppedButtons + 2");
+
+    debug("");
+    finishJSTest();
+});
+
+</script>
+</body>

--- a/LayoutTests/media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes-expected.txt
+++ b/LayoutTests/media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes-expected.txt
@@ -1,0 +1,20 @@
+Testing that Slider.commit() only writes the fill flex-grow styles when the value actually changes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial fills reflect value = 0.5:
+PASS primaryFill.style.flexGrow is "50"
+PASS trackFill.style.flexGrow is "50"
+
+Poke sentinel values into the fills, then dirty an unrelated property (width). Since the value did not change, commit() must not rewrite the fills:
+PASS primaryFill.style.flexGrow is "999"
+PASS trackFill.style.flexGrow is "888"
+
+Now change the value; commit() must update both fills:
+PASS primaryFill.style.flexGrow is "25"
+PASS trackFill.style.flexGrow is "75"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes.html
+++ b/LayoutTests/media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<style type="text/css" media="screen">
+    .slider { position: absolute; }
+</style>
+<body>
+<script type="text/javascript">
+
+description("Testing that <code>Slider.commit()</code> only writes the fill <code>flex-grow</code> styles when the value actually changes.");
+
+const slider = new Slider(null);
+slider.width = 200;
+slider.value = 0.5;
+
+// The fill LayoutNodes are what commit() writes to; reference their elements directly since the
+// child elements are only inserted into the DOM tree during a scheduled layout pass.
+const primaryFill = slider._primaryFill.element;
+const trackFill = slider._trackFill.element;
+
+document.body.appendChild(slider.element);
+
+// Flush the initial layout so the fills reflect the current value.
+scheduler.flushScheduledLayoutCallbacks();
+
+debug("Initial fills reflect value = 0.5:");
+shouldBeEqualToString("primaryFill.style.flexGrow", "50");
+shouldBeEqualToString("trackFill.style.flexGrow", "50");
+
+debug("");
+debug("Poke sentinel values into the fills, then dirty an unrelated property (width). Since the value did not change, commit() must not rewrite the fills:");
+primaryFill.style.flexGrow = "999";
+trackFill.style.flexGrow = "888";
+slider.width = 300;
+scheduler.flushScheduledLayoutCallbacks();
+shouldBeEqualToString("primaryFill.style.flexGrow", "999");
+shouldBeEqualToString("trackFill.style.flexGrow", "888");
+
+debug("");
+debug("Now change the value; commit() must update both fills:");
+slider.value = 0.25;
+scheduler.flushScheduledLayoutCallbacks();
+shouldBeEqualToString("primaryFill.style.flexGrow", "25");
+shouldBeEqualToString("trackFill.style.flexGrow", "75");
+
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js
@@ -168,18 +168,21 @@ class InlineMediaControls extends MediaControls
         this.playPauseButton.style = Button.Styles.Bar;
         this.leftContainer.children = this.leftContainerButtons();
         this.rightContainer.children = this.rightContainerButtons();
-        this.rightContainer.children.concat(this.leftContainer.children).forEach(button => delete button.dropped);
+        for (let button of this.leftContainer.children)
+            delete button.dropped;
+        for (let button of this.rightContainer.children)
+            delete button.dropped;
         this.muteButton.style = this.preferredMuteButtonStyle;
         this.overflowButton.clearExtraContextMenuOptions();
+
+        // Ensure both button containers reflect the reset dropped state before we evaluate widths.
+        this.leftContainer.layout();
+        this.rightContainer.layout();
 
         for (let button of this.droppableButtons()) {
             // If the button is not enabled, we can skip it.
             if (!button.enabled)
                 continue;
-
-            // Ensure button containers are laid out with latest constraints.
-            this.leftContainer.layout();
-            this.rightContainer.layout();
 
             // Nothing left to do if the combined width of both containers and the time control is shorter than the available width.
             if (this.leftContainer.width + minimumCenterControlWidth + this.rightContainer.width < this.bottomControlsBar.width)
@@ -187,6 +190,12 @@ class InlineMediaControls extends MediaControls
 
             // This button must now be dropped.
             button.dropped = true;
+
+            // Only the container that owns the dropped button changed size, so lay out just that one.
+            if (this.leftContainer.children.includes(button))
+                this.leftContainer.layout();
+            else
+                this.rightContainer.layout();
 
             if (button !== this.overflowButton)
                 this.overflowButton.addExtraContextMenuOptions(button.contextMenuOptions);

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.js
@@ -71,8 +71,15 @@ class Slider extends SliderBase
     {
         super.commit();
 
-        this._primaryFill.element.style.flexGrow = 100 * this.value;
-        this._trackFill.element.style.flexGrow = 100 * (1 - this.value);
+        // commit() runs whenever any property is dirty (x, width, disabled…), but the fills
+        // only depend on the value, so avoid touching the DOM unless the value actually changed.
+        const value = this.value;
+        if (value === this._committedValue)
+            return;
+        this._committedValue = value;
+
+        this._primaryFill.element.style.flexGrow = 100 * value;
+        this._trackFill.element.style.flexGrow = 100 * (1 - value);
     }
 
 }


### PR DESCRIPTION
#### cf7301b97b8a0f47c33f746bb1593ece37f1ec82
<pre>
Modern media controls do redundant layout work on every slider commit and every drop-loop iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=318295">https://bugs.webkit.org/show_bug.cgi?id=318295</a>
<a href="https://rdar.apple.com/181078298">rdar://181078298</a>

Reviewed by NOBODY (OOPS!).

Two hot layout functions in the modern media controls do work that is
independent of what actually changed:

- Slider.commit() runs whenever any property is dirty (x, width,
  disabled, ...), but it unconditionally rewrote both fills&apos; flex-grow
  styles and re-read the value twice. Cache the value and only touch the
  DOM when it actually changes.

- InlineMediaControls.layout() laid out both button containers on every
  iteration of the drop loop, even though dropping a button only affects
  the container that owns it. Lay out both containers once up front, then
  re-lay out only the owning container when a button is dropped. Also
  stop allocating a throwaway concatenated array just to clear the
  dropped flags.

Both changes are behavior-preserving.

Tests: media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container.html
       media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes.html

* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container-expected.txt: Added.
* LayoutTests/media/modern-media-controls/macos-inline-media-controls/macos-inline-media-controls-drop-loop-relayouts-owning-container.html: Added.
* LayoutTests/media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes-expected.txt: Added.
* LayoutTests/media/modern-media-controls/slider/slider-commit-avoids-redundant-fill-writes.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.js:
(InlineMediaControls.prototype.layout):
* Source/WebCore/Modules/modern-media-controls/controls/slider.js:
(Slider.prototype.commit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf7301b97b8a0f47c33f746bb1593ece37f1ec82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181108 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129359 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133657 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94292 "1 flakes 19 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174763 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37056 "Found 1 new test failure: media/modern-media-controls/ios-inline-media-controls/ios-inline-media-dropping-controls.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114129 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35688 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33937 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29858 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146113 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33665 "Found 1 new test failure: media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183776 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36392 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38135 "Found 1 new test failure: media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142362 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142253 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46069 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30509 "Found 1 new test failure: media/modern-media-controls/macos-inline-media-controls/macos-inline-media-dropping-controls.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110704 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37352 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117757 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44587 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8605 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44219 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44046 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->