### PR TITLE
Compromised Web Content can use a navigation-response Download policy on a data: URL to write attacker-controlled bytes to disk

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1142,6 +1142,16 @@ void DocumentLoader::continueAfterContentPolicy(PolicyAction policy)
             return;
         }
 
+        // Defense-in-depth: refuse to download a data: URL through a top-frame navigation that
+        // wasn't initiated by the user or the API client, mirroring the existing check in the
+        // PolicyAction::Use branch. The primary defense lives in the UI process; this guards
+        // ports / future flows that don't share that boundary.
+        if (disallowDataRequest()) {
+            protect(frameLoader())->policyChecker().cannotShowMIMEType(m_response);
+            stopLoadingForPolicyChange();
+            return;
+        }
+
         if (RefPtr mainResourceLoader = this->mainResourceLoader())
             InspectorInstrumentation::continueWithPolicyDownload(*frame, *mainResourceLoader->identifier(), *this, m_response);
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -132,6 +132,7 @@ public:
 
     bool wasUserInitiated() const { return m_lastNavigationAction && !!m_lastNavigationAction->userGestureTokenIdentifier; }
     bool NODELETE isRequestFromClientOrUserInput() const;
+    bool isFromAPIClientRequest() const { return m_requestIsFromClientInput; }
     void NODELETE markRequestAsFromClientInput();
     void markAsFromLoadData() { m_isFromLoadData = true; }
     bool isFromLoadData() const { return m_isFromLoadData; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5924,6 +5924,19 @@ void WebPageProxy::receivedNavigationResponsePolicyDecision(WebCore::PolicyActio
     if (!hasRunningProcess())
         return completionHandler(PolicyDecision { });
 
+    // Refuse to convert a navigation response into a download when the request is a data: URL,
+    // unless the navigation was driven by the API client (e.g. -loadRequest: with a data: URL).
+    // Otherwise a compromised Web Content process could navigate to a data: URL with an unshowable
+    // MIME type and rely on the navigation delegate's stock "download unshowable responses"
+    // behavior to write attacker-controlled bytes to disk without user interaction. Legitimate
+    // downloads of data: URLs go through the navigation action policy (e.g. <a href="data:..." download>)
+    // or the explicit download API, neither of which reaches this code path.
+    if (action == PolicyAction::Download && request.url().protocolIsData()
+        && (!navigation || !navigation->isFromAPIClientRequest())) {
+        WEBPAGEPROXY_RELEASE_LOG(Loading, "receivedNavigationResponsePolicyDecision: refusing to download data: URL not initiated by API client");
+        action = PolicyAction::Ignore;
+    }
+
     Ref pageLoadState = internals().pageLoadState;
     auto transaction = pageLoadState->transaction();
 


### PR DESCRIPTION
#### f23ffb5a845006c8efbdf8a18a15f69a617fec00
<pre>
Compromised Web Content can use a navigation-response Download policy on a data: URL to write attacker-controlled bytes to disk
<a href="https://bugs.webkit.org/show_bug.cgi?id=315004">https://bugs.webkit.org/show_bug.cgi?id=315004</a>
<a href="https://rdar.apple.com/177019828">rdar://177019828</a>

Reviewed by Basuke Suzuki.

A compromised Web Content process can cause the UI process to write attacker-chosen
bytes to ~/Downloads/Unknown with no user interaction, no `download` attribute, and
no Content-Disposition header. The renderer opens a popup navigation to a
data:application/octet-stream;base64,&lt;payload&gt; URL; because the MIME type is not
showable, the navigation delegate&apos;s stock policy returns
WKNavigationResponsePolicyDownload. WebPageProxy::receivedNavigationResponsePolicyDecision
unconditionally mints a real DownloadProxy for the data: URL, the natural
WebFrame::startDownload -&gt; NetworkConnectionToWebProcess::StartDownload flow runs,
and the data: URL bytes land on disk. The renderer-supplied user-gesture token is
forged to bypass the popup blocker; everything downstream is stock behavior.

Refuse PolicyAction::Download for data: URLs in
WebPageProxy::receivedNavigationResponsePolicyDecision unless the navigation was
driven by the API client. The carve-out uses Navigation::m_requestIsFromClientInput
(set only by UIProcess paths such as -loadRequest:), not the renderer-supplied
isRequestFromClientOrUserInput flag. Legitimate data: URL downloads via
&lt;a href=&quot;data:...&quot; download&gt; use the navigation-action policy, and explicit downloads
via -[WKWebView startDownloadUsingRequest:] use a separate API path -- neither
reaches receivedNavigationResponsePolicyDecision.

As defense in depth, also extend the existing disallowDataRequest() check in
DocumentLoader::continueAfterContentPolicy to the PolicyAction::Download branch so
the same restriction that already applies to PolicyAction::Use applies to downloads.
The Web Content process is the compromised party in this report, so this is not the
primary defense, but it keeps non-Cocoa ports and future flows consistent.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::continueAfterContentPolicy):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::isFromAPIClientRequest const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationResponsePolicyDecision):

Originally-landed-as: 305413.929@safari-7624-branch (8aeb259135a8). <a href="https://rdar.apple.com/181074672">rdar://181074672</a>
Canonical link: <a href="https://commits.webkit.org/316344@main">https://commits.webkit.org/316344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd01785fe347dbc57d7100c4be8e1a8939bef83e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133674 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35695 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33956 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29880 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183798 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142381 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45411 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142272 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38446 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46091 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30527 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110751 "Hash fd01785f for PR 68393 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37371 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44609 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8623 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->