### PR TITLE
Type confusion via raw Exception cell returned to script from callPromisePairFunction when throwVMError bypasses sentinel check

### DIFF
--- a/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.navigate() called with zero arguments returns a valid NavigationResult and does not leak a raw JSC::Exception cell to JavaScript.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.constructor.name is "TypeError"
+PASS finishedError.constructor.name is "TypeError"
+PASS result.foo is 0xdead
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash.html
+++ b/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() called with zero arguments returns a valid NavigationResult and does not leak a raw JSC::Exception cell to JavaScript.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    // Calling navigate() with zero arguments hits the mandatory-argument check
+    // in the generated bindings, which previously returned a raw encoded
+    // JSC::Exception* cell to JavaScript instead of a NavigationResult. That
+    // cell could then be type-confused as a JSObject (e.g. by setting a
+    // property on it), corrupting its m_value field and crashing GC.
+    result = navigation.navigate();
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.constructor.name", "TypeError");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.constructor.name", "TypeError");
+
+    // Set a property on the result and force GC. If a raw JSC::Exception cell
+    // were exposed here, this would corrupt Exception::m_value with a Butterfly
+    // pointer, and the subsequent GC would crash when visitChildren tried to
+    // mark m_value as a JSCell.
+    result.foo = 0xdead;
+    shouldBe("result.foo", "0xdead");
+
+    if (window.GCController)
+        GCController.collect();
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -438,16 +438,24 @@ inline JSC::EncodedJSValue callPromisePairFunction(JSC::JSGlobalObject& lexicalG
 
     auto result = functor(globalObject, callFrame, DeferredPromise::create(globalObject, *promise1, DeferredPromise::Mode::RetainPromiseOnResolve), DeferredPromise::create(globalObject, *promise2, DeferredPromise::Mode::RetainPromiseOnResolve));
 
+    // The functor may have thrown — e.g. the generated missing-argument check
+    // returns throwVMError(...), which encodes a JSC::Exception* cell rather
+    // than an empty JSValue sentinel. Detect that before
+    // rejectPromisesWithExceptionIfAny clears the exception, so we never
+    // expose the raw Exception cell to JavaScript below.
+    bool functorThrew = !!catchScope.exception();
+
     rejectPromisesWithExceptionIfAny(lexicalGlobalObject, globalObject, *promise1, *promise2, catchScope);
 
     // FIXME: We could have error since any JS call can throw stack-overflow errors.
     // https://bugs.webkit.org/show_bug.cgi?id=203402
     RETURN_IF_EXCEPTION(catchScope, JSC::encodedJSValue());
 
-    // When the functor threw (e.g. during IDL argument conversion), its return
-    // value is an empty JSValue sentinel. Rebuild a valid result dictionary from
-    // the (now rejected) promises via convertDictionaryToJS.
-    if (!JSC::JSValue::decode(result)) [[unlikely]] {
+    // When the functor threw or returned an empty JSValue sentinel (e.g. IDL
+    // argument conversion failure), rebuild a valid result dictionary from the
+    // (now rejected) promises via convertDictionaryToJS rather than returning
+    // the functor's return value.
+    if (functorThrew || !JSC::JSValue::decode(result)) [[unlikely]] {
         result = JSC::JSValue::encode(convertDictionaryToJS(lexicalGlobalObject, globalObject, DictionaryType { DOMPromise::create(globalObject, *promise1), DOMPromise::create(globalObject, *promise2) }));
         RETURN_IF_EXCEPTION(catchScope, JSC::encodedJSValue());
     }


### PR DESCRIPTION
#### e75354878ca37205ff0f69e9e8dedefd20d8c479
<pre>
Type confusion via raw Exception cell returned to script from callPromisePairFunction when throwVMError bypasses sentinel check
<a href="https://bugs.webkit.org/show_bug.cgi?id=314944">https://bugs.webkit.org/show_bug.cgi?id=314944</a>
<a href="https://rdar.apple.com/177031898">rdar://177031898</a>

Reviewed by Ryosuke Niwa.

callPromisePairFunction&apos;s sentinel check `!JSValue::decode(result)` only catches the
zero empty-value sentinel returned by IDL argument conversion failures. When a
[ReturnsPromisePair] operation is called with fewer than the mandatory number of
arguments, the generated bindings hit the missing-argument check emitted by
CodeGeneratorJS.pm and `return throwVMError(...)`, which encodes a non-zero
JSC::Exception* cell rather than the empty sentinel. After
rejectPromisesWithExceptionIfAny clears the pending exception, the sentinel check
evaluates false and the raw Exception cell is returned to JavaScript.

The Exception cell has JSType=CellType (0), not JSObject. A subsequent property
store such as `victim.foo = 0xdead` goes through JSCell::putInline -&gt;
overridesPut() == false -&gt; asObject(this) -&gt; jsCast&lt;JSObject*&gt;. On production
ARM64 builds, ASSERT_WITH_SECURITY_IMPLICATION compiles to ((void)0), so the cast
is a bare static_cast — type confusion. The resulting put allocates a Butterfly,
clobbers Exception::m_value (offset +0x08) with the Butterfly pointer, and
writes the attacker-controlled value into property storage. The next GC then
crashes in Exception::visitChildrenImpl when visitor.append(m_value) treats the
Butterfly as a JSCell and SlotVisitor::drain dereferences an invalid StructureID.

This affects all [ReturnsPromisePair] IDL operations with mandatory arguments,
notably Navigation.navigate() / reload() / traverseTo() / back() / forward().

Fix callPromisePairFunction to capture catchScope.exception() before
rejectPromisesWithExceptionIfAny clears it. If the functor threw, always rebuild
a valid result dictionary from the (now rejected) promises via
convertDictionaryToJS rather than returning the functor&apos;s return value. This
covers throwVMError, any future throw paths inside the functor, and the existing
empty-sentinel case from IDL argument conversion failures.

The non-pair callPromiseFunction is unaffected: it already discards the functor&apos;s
return value.

Test: navigation-api/navigation-navigate-no-arguments-crash.html

* LayoutTests/navigation-api/navigation-navigate-no-arguments-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-navigate-no-arguments-crash.html: Added.
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::callPromisePairFunction):

Originally-landed-as: 305413.921@safari-7624-branch (5977997682c7). <a href="https://rdar.apple.com/181074612">rdar://181074612</a>
Canonical link: <a href="https://commits.webkit.org/316332@main">https://commits.webkit.org/316332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaba26f3b2ee791e8a7cc4765ee3958ec4630f6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133667 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33943 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29866 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183784 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142372 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142263 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38433 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46077 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110712 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37359 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117765 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44595 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8612 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/43995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->