### PR TITLE
Cherry-pick(s) 7e660535f175. rdar://181080223

### DIFF
--- a/LayoutTests/http/tests/webgpu/import-external-texture-cross-origin-video-expected.txt
+++ b/LayoutTests/http/tests/webgpu/import-external-texture-cross-origin-video-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Unable to get image data from canvas because the canvas has been tainted by cross-origin data.
+PASS: importExternalTexture threw SecurityError for a cross-origin tainted video

--- a/LayoutTests/http/tests/webgpu/import-external-texture-cross-origin-video.html
+++ b/LayoutTests/http/tests/webgpu/import-external-texture-cross-origin-video.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>importExternalTexture should throw SecurityError for cross-origin tainted video</title>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function log(msg) {
+    document.body.appendChild(document.createTextNode(msg + '\n'));
+}
+
+async function runTest() {
+    if (!navigator.gpu) {
+        log('SKIP: WebGPU not available');
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) {
+        log('SKIP: No WebGPU adapter');
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+    const device = await adapter.requestDevice();
+
+    // Load a video from a cross-origin URL (localhost vs 127.0.0.1).
+    // No crossorigin attribute means the video becomes origin-tainted.
+    const video = document.createElement('video');
+    video.muted = true;
+    video.playsInline = true;
+    // This test is served from 127.0.0.1:8000, so localhost:8000 is cross-origin.
+    video.src = 'http://localhost:8000/webgpu/resources/red-green.mp4';
+
+    await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Video load timed out')), 10000);
+        video.addEventListener('canplay', () => { clearTimeout(timeout); resolve(); }, { once: true });
+        video.addEventListener('error', () => { clearTimeout(timeout); reject(new Error('Video load error')); }, { once: true });
+        video.play().catch(() => {});
+    });
+
+    // Confirm the video is genuinely cross-origin tainted: canvas getImageData must throw.
+    const taintCheck = document.createElement('canvas');
+    taintCheck.width = 1;
+    taintCheck.height = 1;
+    const ctx = taintCheck.getContext('2d');
+    ctx.drawImage(video, 0, 0, 1, 1);
+    try {
+        ctx.getImageData(0, 0, 1, 1);
+        log('FAIL: Canvas did not block cross-origin pixel readback — video lacks CORS taint, test is invalid');
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    } catch (e) {
+        if (e.name !== 'SecurityError') {
+            log('FAIL: Canvas threw unexpected error: ' + e.name + ': ' + e.message);
+            if (window.testRunner)
+                testRunner.notifyDone();
+            return;
+        }
+        // SecurityError thrown — video is correctly tainted, proceed.
+    }
+
+    // importExternalTexture with a cross-origin tainted video must throw SecurityError.
+    try {
+        device.importExternalTexture({ source: video });
+        log('FAIL: importExternalTexture did not throw for a cross-origin tainted video');
+    } catch (e) {
+        if (e.name === 'SecurityError')
+            log('PASS: importExternalTexture threw SecurityError for a cross-origin tainted video');
+        else
+            log('FAIL: importExternalTexture threw unexpected error: ' + e.name + ': ' + e.message);
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTest().catch(e => {
+    document.body.appendChild(document.createTextNode('FAIL: ' + e.name + ': ' + e.message + '\n'));
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -393,6 +393,7 @@ private:
 };
 #endif
 
+<<<<<<< HEAD
 ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(GPUExternalTextureDescriptor&& externalTextureDescriptor)
 {
 #if ENABLE(VIDEO)
@@ -403,6 +404,11 @@ ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(GPUExterna
         return std::nullopt;
     };
 #endif
+=======
+ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(ScriptExecutionContext& context, const GPUExternalTextureDescriptor& externalTextureDescriptor)
+{
+    UNUSED_PARAM(context);
+>>>>>>> 7e660535f175 (WebGPU importExternalTexture bypasses Same-Origin Policy for cross-origin video pixel readback)
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     if (RefPtr externalTexture = externalTextureForDescriptor(externalTextureDescriptor)) {
@@ -438,8 +444,25 @@ ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(GPUExterna
 #else
     Ref videoElementRef = externalTextureDescriptor.source;
 #endif
+<<<<<<< HEAD
     if (auto exception = checkVideoElementOriginTaint(videoElementRef))
         return WTF::move(*exception);
+=======
+        if ((*videoElement)->taintsOrigin(*protect(context.securityOrigin()).get()))
+            return Exception { ExceptionCode::SecurityError, "GPUDevice.importExternalTexture: Cross origin external videos are not allowed in WebGPU"_s };
+
+        WeakPtr<HTMLVideoElement> videoElementPtr = videoElement->get();
+        m_videoElementToExternalTextureMap.set(*videoElementPtr, externalTexture.get());
+        m_previouslyImportedExternalTexture.first = *videoElement;
+        m_previouslyImportedExternalTexture.second = externalTexture.ptr();
+        videoElementPtr->requestVideoFrameCallback(GPUDeviceVideoFrameRequestCallback::create(externalTexture.get(), *videoElementPtr, *this, RefPtr { scriptExecutionContext() }.get()));
+        queueTaskKeepingObjectAlive(*this, TaskSource::WebGPU, [videoElementPtr, externalTextureRef = externalTexture](auto& gpuDevice) {
+            if (!videoElementPtr)
+                return;
+            auto it = gpuDevice.m_videoElementToExternalTextureMap.find(*videoElementPtr);
+            if (it == gpuDevice.m_videoElementToExternalTextureMap.end() || externalTextureRef.ptr() != it->value.get())
+                return;
+>>>>>>> 7e660535f175 (WebGPU importExternalTexture bypasses Same-Origin Policy for cross-origin video pixel readback)
 
     WeakPtr videoElementPtr = videoElementRef.ptr();
     m_videoElementToExternalTextureMap.set(videoElementRef, externalTexture.get());

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -118,8 +118,13 @@ public:
     ExceptionOr<Ref<GPUBuffer>> createBuffer(GPUBufferDescriptor&&);
     ExceptionOr<Ref<GPUTexture>> createTexture(GPUTextureDescriptor&&);
     std::optional<String> errorValidatingSupportedFormat(GPUTextureFormat) const;
+<<<<<<< HEAD
     ExceptionOr<Ref<GPUSampler>> createSampler(std::optional<GPUSamplerDescriptor>&&);
     ExceptionOr<Ref<GPUExternalTexture>> importExternalTexture(GPUExternalTextureDescriptor&&);
+=======
+    ExceptionOr<Ref<GPUSampler>> createSampler(const std::optional<GPUSamplerDescriptor>&);
+    ExceptionOr<Ref<GPUExternalTexture>> importExternalTexture(ScriptExecutionContext&, const GPUExternalTextureDescriptor&);
+>>>>>>> 7e660535f175 (WebGPU importExternalTexture bypasses Same-Origin Policy for cross-origin video pixel readback)
 
     ExceptionOr<Ref<GPUBindGroupLayout>> createBindGroupLayout(GPUBindGroupLayoutDescriptor&&);
     ExceptionOr<Ref<GPUPipelineLayout>> createPipelineLayout(GPUPipelineLayoutDescriptor&&);

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -43,8 +43,13 @@
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
+<<<<<<< HEAD
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
     GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor);
+=======
+    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor);
+    [CallWith=CurrentScriptExecutionContext] GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor);
+>>>>>>> 7e660535f175 (WebGPU importExternalTexture bypasses Same-Origin Policy for cross-origin video pixel readback)
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://181080223 to main. [7e660535f175] caused a merge conflict. 

```
WebGPU importExternalTexture bypasses Same-Origin Policy for cross-origin video pixel readback
https://bugs.webkit.org/show_bug.cgi?id=313357
rdar://172791493

Reviewed by Cameron McCormack.

Cross origin videos are required to throw a security issue according
to the specification.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:

Originally-landed-as: 305413.730@safari-7624-branch (7e660535f175). rdar://181080223


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec4e0436f84027bba7f245d0a612c27712475e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171843 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45760 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181146 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129397 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173708 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47045 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45400 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181146 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129397 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174801 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47045 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181146 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47045 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45400 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29896 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47045 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183814 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36430 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45400 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/183814 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45427 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/183814 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46107 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110742 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46107 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44625 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39178 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44025 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44257 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44084 "") | | | 
<!--EWS-Status-Bubble-End-->