### PR TITLE
Cherry-pick(s) 444a849510b9. rdar://181080334

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -1075,6 +1075,7 @@ void LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters(const 
     if (!renderView() || renderView()->renderTreeBeingDestroyed())
         m_anchorScrollAdjusters.clear();
     else {
+<<<<<<< HEAD
         // Collect the anchored boxes to unregister first: unregisterAnchorScrollAdjusterFor()
         // mutates m_anchorScrollAdjusters, which would invalidate this iteration.
         Vector<CheckedPtr<RenderBox>> anchoredToUnregister;
@@ -1084,6 +1085,17 @@ void LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters(const 
         }
         for (auto& anchored : anchoredToUnregister)
             unregisterAnchorScrollAdjusterFor(*anchored);
+=======
+        HashSet<CheckedRef<RenderBox>> anchoredToUnregister;
+
+        for (auto& adjuster : m_anchorScrollAdjusters) {
+            if (adjuster.invalidateForScroller(scroller))
+                anchoredToUnregister.add(*adjuster.anchored());
+        }
+
+        for (CheckedRef anchored : anchoredToUnregister)
+            unregisterAnchorScrollAdjusterFor(anchored);
+>>>>>>> 444a849510b9 ([css-anchor-position-1] removeScrollerFromAnchorScrollAdjusters mutates array when iterating through it)
     }
 }
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://181080334 to main. [444a849510b9] caused a merge conflict. 

```
[css-anchor-position-1] removeScrollerFromAnchorScrollAdjusters mutates array when iterating through it
rdar://175679565

Reviewed by Elika Etemad.

LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters iterates
through m_anchorScrollAdjusters, and unregisters adjusters belonging to the
scroller by calling unregisterAnchorScrollAdjusterFor. unregisterAnchorScrollAdjusterFor
in turn removes adjusters also from m_anchorScrollAdjusters, which is being iterated on.
Vectors are not safe to modify when iterating through. Change the loop to save the list
of adjusters to be removed in a HashSet, then remove the saved adjusters after.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html: Added.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters):

Originally-landed-as: 305413.802@safari-7624-branch (444a849510b9). rdar://181080334


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01015e4f0f8de1c02b1bc015ff26a5853a2cb055

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171845 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45762 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181148 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173710 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47047 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45402 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181148 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174803 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47047 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181148 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47047 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45402 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29898 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47047 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183816 "") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45402 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/183816 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45429 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/183816 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46109 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110744 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46109 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44627 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39180 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44027 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44259 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44086 "") | | | 
<!--EWS-Status-Bubble-End-->