### PR TITLE
Unreviewed, reverting 316224@main (1b4724a5fcc7)

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2004,6 +2004,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKJSBuffer {
+    header "_WKJSBuffer.h"
+    export *
+  }
+
   explicit module _WKSystemPreferences {
     header "_WKSystemPreferences.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2910,6 +2910,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKJSBuffer {
+    header "_WKJSBuffer.h"
+    export *
+  }
+
   explicit module _WKSystemPreferences {
     header "_WKSystemPreferences.h"
     export *

--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -977,6 +977,7 @@ list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/Cocoa/WKImmersiveEnvironment.h
     UIProcess/API/Cocoa/WKImmersiveEnvironmentDelegate.h
     UIProcess/API/Cocoa/WKJSHandle.h
+    UIProcess/API/Cocoa/WKJSScriptingBuffer.h
     UIProcess/API/Cocoa/WKJSSerializedNode.h
     UIProcess/API/Cocoa/WKWebExtension.h
     UIProcess/API/Cocoa/WKWebExtensionAction.h

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -148,6 +148,7 @@ public:
 #if ENABLE(INSPECTOR_EXTENSIONS)
         InspectorExtension,
 #endif
+        JSBuffer,
         KeyValueStorageManager,
         MediaCacheManager,
         MessageListener,

--- a/Source/WebKit/Shared/API/Cocoa/WebKit.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.h
@@ -43,6 +43,7 @@
 #import <WebKit/WKImmersiveEnvironment.h>
 #import <WebKit/WKImmersiveEnvironmentDelegate.h>
 #import <WebKit/WKJSHandle.h>
+#import <WebKit/WKJSScriptingBuffer.h>
 #import <WebKit/WKJSSerializedNode.h>
 #import <WebKit/WKNavigation.h>
 #import <WebKit/WKNavigationAction.h>

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -38,6 +38,7 @@
 #import "WKFrameInfoInternal.h"
 #import "WKHTTPCookieStoreInternal.h"
 #import "WKJSHandleInternal.h"
+#import "WKJSScriptingBufferInternal.h"
 #import "WKJSSerializedNodeInternal.h"
 #import "WKNSArray.h"
 #import "WKNSData.h"
@@ -88,6 +89,7 @@
 #import "_WKInspectorConfigurationInternal.h"
 #import "_WKInspectorDebuggableInfoInternal.h"
 #import "_WKInspectorInternal.h"
+#import "_WKJSBuffer.h"
 #import "_WKJSHandle.h"
 #import "_WKProcessPoolConfigurationInternal.h"
 #import "_WKResourceLoadInfoInternal.h"
@@ -539,6 +541,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::JSHandle:
         SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [_WKJSHandle alloc];
+        break;
+
+    case Type::JSBuffer:
+        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [_WKJSBuffer alloc];
         break;
 
     case Type::FormInfo:

--- a/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
+++ b/Source/WebKit/Shared/WebUserContentControllerDataTypes.h
@@ -81,7 +81,7 @@ struct WebScriptMessageHandlerData {
 };
 
 struct WebJSBufferData {
-    WebJSBufferData(const Ref<WebCore::SharedMemory>&, ContentWorldData&&, const String&);
+    WebJSBufferData(const RefPtr<WebCore::SharedMemory>&, ContentWorldData&&, const String&);
     WebJSBufferData(std::optional<WebCore::SharedMemoryHandle>&&, ContentWorldData&&, String&&);
     ~WebJSBufferData();
     std::optional<WebCore::SharedMemoryHandle> sharedMemoryHandle() const;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -504,6 +504,7 @@ UIProcess/API/APIHTTPCookieStore.cpp
 UIProcess/API/APIHitTestResult.cpp
 UIProcess/API/APIInspectorConfiguration.cpp
 UIProcess/API/APIInspectorExtension.cpp
+UIProcess/API/APIJSBuffer.cpp
 UIProcess/API/APIJSHandle.cpp
 UIProcess/API/APINavigation.cpp
 UIProcess/API/APINavigationData.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -367,6 +367,7 @@ UIProcess/API/Cocoa/WKFrameInfo.mm @nonARC
 UIProcess/API/Cocoa/WKHTTPCookieStore.mm @nonARC
 UIProcess/API/Cocoa/WKImmersiveEnvironment.mm @nonARC
 UIProcess/API/Cocoa/WKJSHandle.mm @nonARC
+UIProcess/API/Cocoa/WKJSScriptingBuffer.mm @nonARC
 UIProcess/API/Cocoa/WKJSSerializedNode.mm @nonARC
 UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm @nonARC
 UIProcess/API/Cocoa/WKNavigation.mm @nonARC

--- a/Source/WebKit/UIProcess/API/APIJSBuffer.cpp
+++ b/Source/WebKit/UIProcess/API/APIJSBuffer.cpp
@@ -24,30 +24,20 @@
  */
 
 #include "config.h"
-#include "WebUserContentControllerDataTypes.h"
+#include "APIJSBuffer.h"
 
 #include <WebCore/SharedMemory.h>
 
-namespace WebKit {
+namespace API {
 
-WebJSBufferData::WebJSBufferData(const RefPtr<WebCore::SharedMemory>& data, ContentWorldData&& worldData, const String& name)
-    : data(data)
-    , worldData(WTF::move(worldData))
-    , name(name) { }
+JSBuffer::JSBuffer(Ref<WebCore::SharedMemory>&& sharedMemory)
+    : m_sharedMemory(WTF::move(sharedMemory)) { }
 
-WebJSBufferData::WebJSBufferData(std::optional<WebCore::SharedMemoryHandle>&& handle, ContentWorldData&& worldData, String&& name)
-    : data(handle ? WebCore::SharedMemory::map(WTF::move(*handle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr)
-    , worldData(WTF::move(worldData))
-    , name(WTF::move(name)) { }
-
-WebJSBufferData::~WebJSBufferData() = default;
-
-std::optional<WebCore::SharedMemoryHandle> WebJSBufferData::sharedMemoryHandle() const
+Ref<WebCore::SharedMemory> JSBuffer::sharedMemory()
 {
-    RefPtr sharedMemory = data;
-    if (!sharedMemory)
-        return std::nullopt;
-    return sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
+    return m_sharedMemory;
 }
 
-} // namespace WebKit
+JSBuffer::~JSBuffer() = default;
+
+} // namespace API

--- a/Source/WebKit/UIProcess/API/APIJSBuffer.h
+++ b/Source/WebKit/UIProcess/API/APIJSBuffer.h
@@ -23,31 +23,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebUserContentControllerDataTypes.h"
+#pragma once
 
-#include <WebCore/SharedMemory.h>
+#include "APIObject.h"
 
-namespace WebKit {
-
-WebJSBufferData::WebJSBufferData(const RefPtr<WebCore::SharedMemory>& data, ContentWorldData&& worldData, const String& name)
-    : data(data)
-    , worldData(WTF::move(worldData))
-    , name(name) { }
-
-WebJSBufferData::WebJSBufferData(std::optional<WebCore::SharedMemoryHandle>&& handle, ContentWorldData&& worldData, String&& name)
-    : data(handle ? WebCore::SharedMemory::map(WTF::move(*handle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr)
-    , worldData(WTF::move(worldData))
-    , name(WTF::move(name)) { }
-
-WebJSBufferData::~WebJSBufferData() = default;
-
-std::optional<WebCore::SharedMemoryHandle> WebJSBufferData::sharedMemoryHandle() const
-{
-    RefPtr sharedMemory = data;
-    if (!sharedMemory)
-        return std::nullopt;
-    return sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
+namespace WebCore {
+class SharedMemory;
 }
 
-} // namespace WebKit
+namespace API {
+
+class JSBuffer final : public ObjectImpl<Object::Type::JSBuffer> {
+public:
+    explicit JSBuffer(Ref<WebCore::SharedMemory>&&);
+    virtual ~JSBuffer();
+
+    Ref<WebCore::SharedMemory> NODELETE sharedMemory();
+
+private:
+    Ref<WebCore::SharedMemory> m_sharedMemory;
+};
+
+} // namespace API
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(JSBuffer);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/WKFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! A WKJSScriptingBuffer object exposes an application controlled data buffer to JavaScript.
+ @discussion JavaScript has access to various WebKit extensions via the `window.webkit` object.
+ One such feature is `window.webkit.buffers` which provides access to named data buffers that can be
+ provided by the WebKit application.
+
+ To provide a data buffer to JavaScript the application first creates a `WKJSScriptingBuffer` object.
+ It then adds it to the appropriate `WKUserContentController` with an application provided name.
+
+ For example, if the application creates a `WKJSScriptingBuffer` and adds it to a web view's `WKUserContentController`
+ with the name `"mybuffer"`, then JavaScript can access it by referencing `window.webkit.buffers.mybuffer`
+ */
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+@interface WKJSScriptingBuffer : NSObject
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
+/*! @abstract Initializes the newly created `WKJSScriptingBuffer` object with the passed in `NSData` data
+ @param data The data to provide to the `window.webkit.buffers` JavaScript object.
+*/
+- (nullable instancetype)initWithData:(NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBuffer.mm
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKJSScriptingBufferInternal.h"
+
+#import "NetworkCacheData.h"
+#import "WKNSData.h"
+#import "_WKJSBuffer.h"
+#import <WebCore/SharedBuffer.h>
+#import <WebCore/SharedMemory.h>
+#import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/FileSystem.h>
+#import <wtf/Scope.h>
+#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/spi/cocoa/MachVMSPI.h>
+
+static bool isInReadOnlyRegion(std::span<const uint8_t> span)
+{
+    if (span.empty())
+        return false;
+
+    auto addr = reinterpret_cast<mach_vm_address_t>(const_cast<uint8_t*>(span.data()));
+    auto end = addr + span.size();
+    auto regionAddr = addr;
+    mach_vm_size_t regionSize = 0;
+    vm_region_basic_info_data_64_t info { };
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t vmObject = MACH_PORT_NULL;
+    auto scopeExit = makeScopeExit([&] {
+        if (vmObject != MACH_PORT_NULL)
+            mach_port_deallocate(mach_task_self(), vmObject);
+    });
+
+    auto kr = mach_vm_region(mach_task_self(), &regionAddr, &regionSize, VM_REGION_BASIC_INFO_64, (vm_region_info_t)&info, &count, &vmObject);
+    if (kr != KERN_SUCCESS)
+        return false;
+
+    auto regionEnd = regionAddr + regionSize;
+    return (info.protection & VM_PROT_READ) && !(info.protection & VM_PROT_WRITE) && addr >= regionAddr && end <= regionEnd;
+}
+
+@implementation WKJSScriptingBuffer
+
+- (instancetype)initWithData:(NSData *)data
+{
+    if (!(self = [super init]))
+        return nil;
+
+    RefPtr<WebCore::SharedMemory> sharedMemory;
+    auto dataSpan = span(data);
+
+    if (isInReadOnlyRegion(dataSpan))
+        sharedMemory = WebCore::SharedMemory::wrapMap(dataSpan, WebCore::SharedMemoryProtection::ReadOnly);
+
+    if (!sharedMemory) {
+        Ref sharedBuffer = WebCore::SharedBuffer::create(data);
+        sharedMemory = WebCore::SharedMemory::copyBuffer(sharedBuffer);
+    }
+
+    if (!sharedMemory) {
+        [self release];
+        return nil;
+    }
+
+    API::Object::constructInWrapper<API::JSBuffer>(self, sharedMemory.releaseNonNull());
+
+    return self;
+}
+
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKJSScriptingBuffer.class, self))
+        return;
+    SUPPRESS_UNRETAINED_ARG _buffer->API::JSBuffer::~JSBuffer();
+    [super dealloc];
+}
+
+- (API::Object&)_apiObject
+{
+    return *_buffer;
+}
+
+@end
+
+@implementation _WKJSBuffer
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBufferInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKJSScriptingBufferInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,31 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebUserContentControllerDataTypes.h"
-
-#include <WebCore/SharedMemory.h>
+#import "APIJSBuffer.h"
+#import "WKJSScriptingBuffer.h"
+#import "WKObject.h"
+#import "_WKJSBuffer.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
-WebJSBufferData::WebJSBufferData(const RefPtr<WebCore::SharedMemory>& data, ContentWorldData&& worldData, const String& name)
-    : data(data)
-    , worldData(WTF::move(worldData))
-    , name(name) { }
+template<> struct WrapperTraits<API::JSBuffer> {
+    using WrapperClass = _WKJSBuffer;
+};
 
-WebJSBufferData::WebJSBufferData(std::optional<WebCore::SharedMemoryHandle>&& handle, ContentWorldData&& worldData, String&& name)
-    : data(handle ? WebCore::SharedMemory::map(WTF::move(*handle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr)
-    , worldData(WTF::move(worldData))
-    , name(WTF::move(name)) { }
-
-WebJSBufferData::~WebJSBufferData() = default;
-
-std::optional<WebCore::SharedMemoryHandle> WebJSBufferData::sharedMemoryHandle() const
-{
-    RefPtr sharedMemory = data;
-    if (!sharedMemory)
-        return std::nullopt;
-    return sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
 }
 
-} // namespace WebKit
+@interface WKJSScriptingBuffer () <WKObject> {
+@package
+    AlignedStorage<API::JSBuffer> _buffer;
+}
+@end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class WKContentRuleList;
 @class WKContentWorld;
+@class WKJSScriptingBuffer;
 @class WKUserScript;
 @protocol WKScriptMessageHandler;
 @protocol WKScriptMessageHandlerWithReply;
@@ -149,7 +150,7 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  @param contentWorld The WKContentWorld to add the buffer to.
         The buffer will only be visible to JavaScript executing in that content world.
  */
-- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+- (void)addBuffer:(id)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 /*! @abstract Removes a previously added data buffer from the given `WKContentWorld
  @param name The name of the buffer to remove.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -32,6 +32,7 @@
 #import "WKContentRuleListInternal.h"
 #import "WKContentWorldInternal.h"
 #import "WKFrameInfoInternal.h"
+#import "WKJSScriptingBufferInternal.h"
 #import "WKNSArray.h"
 #import "WKScriptMessageHandler.h"
 #import "WKScriptMessageHandlerWithReply.h"
@@ -41,6 +42,7 @@
 #import "WebPageProxy.h"
 #import "WebScriptMessageHandler.h"
 #import "WebUserContentControllerProxy.h"
+#import "_WKJSBuffer.h"
 #import "_WKUserContentFilterInternal.h"
 #import "_WKUserContentWorldInternal.h"
 #import "_WKUserStyleSheetInternal.h"
@@ -48,10 +50,7 @@
 #import <WebCore/SecurityOriginData.h>
 #import <WebCore/SerializedScriptValue.h>
 #import <WebCore/WebCoreObjCExtras.h>
-#import <wtf/Scope.h>
 #import <wtf/TZoneMallocInlines.h>
-#import <wtf/cocoa/SpanCocoa.h>
-#import <wtf/spi/cocoa/MachVMSPI.h>
 
 @implementation WKUserContentController
 
@@ -232,44 +231,15 @@ private:
     protect(*_userContentControllerProxy)->removeAllUserMessageHandlers();
 }
 
-- (void)addBuffer:(NSData *)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world
+- (void)addBuffer:(id)buffer name:(NSString *)name contentWorld:(WKContentWorld *)world
 {
-    auto isInReadOnlyRegion = [] (std::span<const uint8_t> span) {
-        if (span.empty())
-            return false;
+    RetainPtr<WKJSScriptingBuffer> bufferToAdd;
+    if (RetainPtr data = dynamic_objc_cast<NSData>(buffer))
+        bufferToAdd = adoptNS([[WKJSScriptingBuffer alloc] initWithData:data.get()]);
+    else
+        bufferToAdd = dynamic_objc_cast<WKJSScriptingBuffer>(buffer);
 
-        auto addr = reinterpret_cast<mach_vm_address_t>(const_cast<uint8_t*>(span.data()));
-        auto end = addr + span.size();
-        auto regionAddr = addr;
-        mach_vm_size_t regionSize = 0;
-        vm_region_basic_info_data_64_t info { };
-        mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
-        mach_port_t vmObject = MACH_PORT_NULL;
-        auto scopeExit = makeScopeExit([&] {
-            if (vmObject != MACH_PORT_NULL)
-                mach_port_deallocate(mach_task_self(), vmObject);
-        });
-
-        auto kr = mach_vm_region(mach_task_self(), &regionAddr, &regionSize, VM_REGION_BASIC_INFO_64, (vm_region_info_t)&info, &count, &vmObject);
-        if (kr != KERN_SUCCESS)
-            return false;
-
-        auto regionEnd = regionAddr + regionSize;
-        return (info.protection & VM_PROT_READ) && !(info.protection & VM_PROT_WRITE) && addr >= regionAddr && end <= regionEnd;
-    };
-
-    RefPtr<WebCore::SharedMemory> sharedMemory;
-    auto dataSpan = span(buffer);
-    if (isInReadOnlyRegion(dataSpan))
-        sharedMemory = WebCore::SharedMemory::wrapMap(dataSpan, WebCore::SharedMemoryProtection::ReadOnly);
-    if (!sharedMemory)
-        sharedMemory = WebCore::SharedMemory::copyBuffer(WebCore::SharedBuffer::create(buffer));
-    if (!sharedMemory) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    protect(*_userContentControllerProxy)->addJSBuffer(sharedMemory.releaseNonNull(), Ref { *world->_contentWorld }, name);
+    protect(*_userContentControllerProxy)->addJSBuffer(Ref { *bufferToAdd->_buffer }, Ref { *world->_contentWorld }, name);
 }
 
 - (void)removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world
@@ -357,6 +327,16 @@ private:
 - (void)_removeAllUserStyleSheetsAssociatedWithContentWorld:(WKContentWorld *)contentWorld
 {
     protect(*_userContentControllerProxy)->removeAllUserStyleSheets(Ref { *contentWorld->_contentWorld });
+}
+
+- (void)_addBuffer:(_WKJSBuffer *)buffer contentWorld:(WKContentWorld *)world name:(NSString *)name
+{
+    [self addBuffer:buffer name:name contentWorld:world];
+}
+
+- (void)_removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world
+{
+    [self removeBufferWithName:name contentWorld:world];
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerPrivate.h
@@ -27,6 +27,7 @@
 
 @class WKContentWorld;
 @class WKUserScript;
+@class _WKJSBuffer;
 @class _WKUserContentFilter;
 @class _WKUserContentWorld;
 @class _WKUserStyleSheet;
@@ -44,6 +45,9 @@
 - (void)_removeUserContentFilter:(NSString *)userContentFilterName WK_API_AVAILABLE(macos(10.11), ios(9.0));
 - (void)_removeAllUserContentFilters WK_API_AVAILABLE(macos(10.11), ios(9.0));
 - (void)_addContentRuleList:(WKContentRuleList *)contentRuleList extensionBaseURL:(NSURL *)extensionBaseURL WK_API_AVAILABLE(macos(13.0), ios(16.0));
+
+- (void)_addBuffer:(_WKJSBuffer *)buffer contentWorld:(WKContentWorld *)world name:(NSString *)name WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
+- (void)_removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
 @property (nonatomic, readonly, copy) NSArray<_WKUserStyleSheet *> *_userStyleSheets WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (void)_addUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet WK_API_AVAILABLE(macos(10.12), ios(10.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSBuffer.h
@@ -23,31 +23,12 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebUserContentControllerDataTypes.h"
+#import <WebKit/WKJSScriptingBuffer.h>
 
-#include <WebCore/SharedMemory.h>
+NS_ASSUME_NONNULL_BEGIN
 
-namespace WebKit {
+WK_CLASS_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4))
+@interface _WKJSBuffer : WKJSScriptingBuffer
+@end
 
-WebJSBufferData::WebJSBufferData(const RefPtr<WebCore::SharedMemory>& data, ContentWorldData&& worldData, const String& name)
-    : data(data)
-    , worldData(WTF::move(worldData))
-    , name(name) { }
-
-WebJSBufferData::WebJSBufferData(std::optional<WebCore::SharedMemoryHandle>&& handle, ContentWorldData&& worldData, String&& name)
-    : data(handle ? WebCore::SharedMemory::map(WTF::move(*handle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr)
-    , worldData(WTF::move(worldData))
-    , name(WTF::move(name)) { }
-
-WebJSBufferData::~WebJSBufferData() = default;
-
-std::optional<WebCore::SharedMemoryHandle> WebJSBufferData::sharedMemoryHandle() const
-{
-    RefPtr sharedMemory = data;
-    if (!sharedMemory)
-        return std::nullopt;
-    return sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
-}
-
-} // namespace WebKit
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp
@@ -28,6 +28,7 @@
 
 #include "APIArray.h"
 #include "APIContentWorld.h"
+#include "APIJSBuffer.h"
 #include "APIUserScript.h"
 #include "APIUserStyleSheet.h"
 #include "InjectUserScriptImmediately.h"
@@ -154,7 +155,7 @@ UserContentControllerParameters WebUserContentControllerProxy::parametersForProc
     Vector<WebJSBufferData> buffers;
     for (auto& [pair, buffer] : m_buffers) {
         if (RefPtr world = API::ContentWorld::worldForIdentifier(pair.first))
-            buffers.append(WebJSBufferData { buffer, world->worldDataForProcess(process), pair.second });
+            buffers.append(WebJSBufferData { buffer->sharedMemory(), world->worldDataForProcess(process), pair.second });
     }
 
     auto messageHandlers = WTF::map(m_scriptMessageHandlers, [&](auto entry) {
@@ -451,11 +452,11 @@ void WebUserContentControllerProxy::removeAllContentRuleLists()
 }
 #endif
 
-void WebUserContentControllerProxy::addJSBuffer(Ref<WebCore::SharedMemory>&& buffer, API::ContentWorld& world, const String& name)
+void WebUserContentControllerProxy::addJSBuffer(API::JSBuffer& buffer, API::ContentWorld& world, const String& name)
 {
     m_buffers.set({ world.identifier(), name }, buffer);
     for (Ref process : m_processes)
-        process->send(Messages::WebUserContentController::AddJSBuffer(WebJSBufferData { buffer, world.worldDataForProcess(process), name }), identifier());
+        process->send(Messages::WebUserContentController::AddJSBuffer(WebJSBufferData { buffer.sharedMemory(), world.worldDataForProcess(process), name }), identifier());
 }
 
 void WebUserContentControllerProxy::removeJSBuffer(API::ContentWorld& world, const String& name)

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -52,10 +52,6 @@ class UserScript;
 class UserStyleSheet;
 }
 
-namespace WebCore {
-class SharedMemory;
-}
-
 namespace WebKit {
 
 class JavaScriptEvaluationResult;
@@ -117,7 +113,7 @@ public:
 #endif
     WebCoreUserStyleSheetData dataFromUserStyleSheet(const WebCore::UserStyleSheet&) const;
 
-    void addJSBuffer(Ref<WebCore::SharedMemory>&&, API::ContentWorld&, const String&);
+    void addJSBuffer(API::JSBuffer&, API::ContentWorld&, const String&);
     void removeJSBuffer(API::ContentWorld&, const String&);
 
     // Returns false if there was a name conflict.
@@ -151,7 +147,7 @@ private:
     const Ref<API::Array> m_userScripts;
     const Ref<API::Array> m_userStyleSheets;
     HashMap<ScriptMessageHandlerIdentifier, Ref<WebScriptMessageHandler>> m_scriptMessageHandlers;
-    HashMap<std::pair<WebKit::ContentWorldIdentifier, String>, Ref<WebCore::SharedMemory>> m_buffers;
+    HashMap<std::pair<WebKit::ContentWorldIdentifier, String>, Ref<API::JSBuffer>> m_buffers;
     mutable HashMap<String, IPC::TransferString> m_transferStringCache;
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1237,6 +1237,8 @@
 		513E462D1AD837560016234A /* WKSharingServicePickerDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 513E462B1AD837560016234A /* WKSharingServicePickerDelegate.h */; };
 		513FFB91201459C6002596EA /* WebMessagePortChannelProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 513FFB8F201459C2002596EA /* WebMessagePortChannelProvider.h */; };
 		514129941C6428BB0059E714 /* WebIDBConnectionToServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 514129921C6428100059E714 /* WebIDBConnectionToServer.h */; };
+		514246BF2F3F85EE002A3AEA /* WKJSScriptingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 514246BD2F3F85EE002A3AEA /* WKJSScriptingBuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		514246C02F3F85EE002A3AEA /* WKJSScriptingBufferInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 514246BE2F3F85EE002A3AEA /* WKJSScriptingBufferInternal.h */; };
 		514526ED271E1647000467B6 /* NetworkNotificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 514526EB271E1626000467B6 /* NetworkNotificationManager.h */; };
 		514526FF271FB7EC000467B6 /* NotificationManagerMessageHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 514526FE271FB7E8000467B6 /* NotificationManagerMessageHandler.h */; };
 		51452705271FBA40000467B6 /* NotificationManagerMessageHandlerMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51452701271FBA35000467B6 /* NotificationManagerMessageHandlerMessages.h */; };
@@ -2797,6 +2799,7 @@
 		FABBBC862D35B59A00820017 /* UnifiedSource139.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */; };
 		FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */ = {isa = PBXBuildFile; fileRef = FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */; };
 		FAC7C0C22D712E2900E7297E /* CoreIPCNumber.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC7C0C12D712AAF00E7297E /* CoreIPCNumber.mm */; };
+		FADAF3C82EA2F54D001ACE2E /* _WKJSBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = FADAF3C32EA2E992001ACE2E /* _WKJSBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FAE61CE62D0A5608000D238D /* UnifiedSource132.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */; };
 		FAE61CE72D0A5608000D238D /* UnifiedSource134.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */; };
 		FAE61CE82D0A5608000D238D /* UnifiedSource136.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */; };
@@ -6061,6 +6064,9 @@
 		513FFB8F201459C2002596EA /* WebMessagePortChannelProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebMessagePortChannelProvider.h; sourceTree = "<group>"; };
 		514129911C6428100059E714 /* WebIDBConnectionToServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebIDBConnectionToServer.cpp; sourceTree = "<group>"; };
 		514129921C6428100059E714 /* WebIDBConnectionToServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebIDBConnectionToServer.h; sourceTree = "<group>"; };
+		514246BC2F3F85DE002A3AEA /* WKJSScriptingBuffer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKJSScriptingBuffer.mm; sourceTree = "<group>"; };
+		514246BD2F3F85EE002A3AEA /* WKJSScriptingBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKJSScriptingBuffer.h; sourceTree = "<group>"; };
+		514246BE2F3F85EE002A3AEA /* WKJSScriptingBufferInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKJSScriptingBufferInternal.h; sourceTree = "<group>"; };
 		5143B25E1DDCDFD10014FAC6 /* _WKIconLoadingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKIconLoadingDelegate.h; sourceTree = "<group>"; };
 		5143B2611DDD0DA00014FAC6 /* APIIconLoadingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIIconLoadingClient.h; sourceTree = "<group>"; };
 		514526EB271E1626000467B6 /* NetworkNotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkNotificationManager.h; sourceTree = "<group>"; };
@@ -9283,6 +9289,9 @@
 		FAC8498E2A9E92DF00D407EF /* WebTransportSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportSession.h; path = Network/WebTransportSession.h; sourceTree = "<group>"; };
 		FAD05DAE2DCBD89800330C10 /* DragInitiationResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DragInitiationResult.h; path = ios/DragInitiationResult.h; sourceTree = "<group>"; };
 		FAD05DAF2DCBD8E100330C10 /* DragInitiationResult.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = DragInitiationResult.serialization.in; path = ios/DragInitiationResult.serialization.in; sourceTree = "<group>"; };
+		FADAF3C32EA2E992001ACE2E /* _WKJSBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKJSBuffer.h; sourceTree = "<group>"; };
+		FADAF3C62EA2EAA1001ACE2E /* APIJSBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIJSBuffer.h; sourceTree = "<group>"; };
+		FADAF3C72EA2EAA1001ACE2E /* APIJSBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = text; path = APIJSBuffer.cpp; sourceTree = "<group>"; };
 		FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource132.cpp; sourceTree = "<group>"; };
 		FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource134.cpp; sourceTree = "<group>"; };
 		FAE61CE12D0A5606000D238D /* UnifiedSource136.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource136.cpp; sourceTree = "<group>"; };
@@ -12868,6 +12877,7 @@
 				63DCF6AF2980C0E50016E213 /* _WKInspectorWindowInternal.h */,
 				31B362942141EBAD007BFA53 /* _WKInternalDebugFeature.h */,
 				31B362922141EBAC007BFA53 /* _WKInternalDebugFeature.mm */,
+				FADAF3C32EA2E992001ACE2E /* _WKJSBuffer.h */,
 				FA8B4F792E4A5F7300E419CD /* _WKJSHandle.h */,
 				2D790A9C1AD7050D00AB90B3 /* _WKLayoutMode.h */,
 				51C0C9791DDD78540032CAD3 /* _WKLinkIconParameters.h */,
@@ -13084,6 +13094,9 @@
 				51DB22E72F3EB13300BDCDCE /* WKJSHandle.h */,
 				51DB22E82F3EB13300BDCDCE /* WKJSHandle.mm */,
 				51DB22E92F3EB13300BDCDCE /* WKJSHandleInternal.h */,
+				514246BD2F3F85EE002A3AEA /* WKJSScriptingBuffer.h */,
+				514246BC2F3F85DE002A3AEA /* WKJSScriptingBuffer.mm */,
+				514246BE2F3F85EE002A3AEA /* WKJSScriptingBufferInternal.h */,
 				5116CE6E2F3F983800968E09 /* WKJSSerializedNode.h */,
 				5116CE6F2F3F983800968E09 /* WKJSSerializedNode.mm */,
 				5116CE702F3F983800968E09 /* WKJSSerializedNodeInternal.h */,
@@ -16038,6 +16051,8 @@
 				999B7F4F2554BA3F00F450A4 /* APIInspectorExtension.cpp */,
 				99BE3B1225422F4100C6551C /* APIInspectorExtension.h */,
 				996B2B9E25E2582C00719379 /* APIInspectorExtensionClient.h */,
+				FADAF3C72EA2EAA1001ACE2E /* APIJSBuffer.cpp */,
+				FADAF3C62EA2EAA1001ACE2E /* APIJSBuffer.h */,
 				FA58F4512E1DF3190098E1C8 /* APIJSHandle.cpp */,
 				FA58F4502E1DF3190098E1C8 /* APIJSHandle.h */,
 				7CE4D2061A46775700C7F152 /* APILegacyContextHistoryClient.h */,
@@ -17948,6 +17963,7 @@
 				99996A9F25004BCC004F7559 /* _WKInspectorPrivateForTesting.h in Headers */,
 				A5C0F0AB2000658200536536 /* _WKInspectorWindow.h in Headers */,
 				31B362952141EBCD007BFA53 /* _WKInternalDebugFeature.h in Headers */,
+				FADAF3C82EA2F54D001ACE2E /* _WKJSBuffer.h in Headers */,
 				FA8B4F7C2E4A5F7C00E419CD /* _WKJSHandle.h in Headers */,
 				2D790A9D1AD7050D00AB90B3 /* _WKLayoutMode.h in Headers */,
 				510F59111DDE297000412FF5 /* _WKLinkIconParameters.h in Headers */,
@@ -19493,6 +19509,8 @@
 				51DB22F22F3EB16E00BDCDCE /* WKJSHandle.h in Headers */,
 				51DB22F12F3EB16E00BDCDCE /* WKJSHandleInternal.h in Headers */,
 				FA84D6692E579F38004BDAA4 /* WKJSHandleRef.h in Headers */,
+				514246BF2F3F85EE002A3AEA /* WKJSScriptingBuffer.h in Headers */,
+				514246C02F3F85EE002A3AEA /* WKJSScriptingBufferInternal.h in Headers */,
 				5116CE712F3F983F00968E09 /* WKJSSerializedNode.h in Headers */,
 				5116CE722F3F983F00968E09 /* WKJSSerializedNodeInternal.h in Headers */,
 				2DD5E129210ADC7B00DB6012 /* WKKeyboardScrollingAnimator.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/JSBuffer.mm
@@ -28,22 +28,24 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKJSScriptingBuffer.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
 #import <WebKit/_WKContentWorldConfiguration.h>
+#import <WebKit/_WKJSBuffer.h>
 
 TEST(JSBuffer, Data)
 {
     static const char constantString[] = "Hello world!";
 
-    RetainPtr oddLength = [NSData dataWithBytes:"abc" length:3];
+    RetainPtr oddLength = adoptNS([[WKJSScriptingBuffer alloc] initWithData:[NSData dataWithBytes:"abc" length:3]]);
     RetainPtr evenLength = adoptNS([NSData dataWithBytes:"abcd" length:4]);
-    RetainPtr invalidSurrogatePair = [NSData dataWithBytes:"\x3d\xd8\x27\x00\xff\xff\x00\x00" length:8];
-    RetainPtr readOnlyBuffer = [NSData dataWithBytesNoCopy:(void *)constantString length:sizeof(constantString)-1 freeWhenDone:NO];
+    RetainPtr invalidSurrogatePair = adoptNS([[_WKJSBuffer alloc] initWithData:[NSData dataWithBytes:"\x3d\xd8\x27\x00\xff\xff\x00\x00" length:8]]);
+    RetainPtr readOnlyBuffer = adoptNS([[_WKJSBuffer alloc] initWithData:[NSData dataWithBytesNoCopy:(void *)constantString length:sizeof(constantString)-1 freeWhenDone:NO]]);
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [configuration.get().userContentController addBuffer:oddLength.get() name:@"oddLength" contentWorld:WKContentWorld.pageWorld];
     [configuration.get().userContentController addBuffer:evenLength.get() name:@"evenLength" contentWorld:WKContentWorld.pageWorld];
-    [configuration.get().userContentController addBuffer:invalidSurrogatePair.get() name:@"invalidSurrogatePair" contentWorld:WKContentWorld.pageWorld];
-    [configuration.get().userContentController addBuffer:readOnlyBuffer.get() name:@"readOnlyBuffer" contentWorld:WKContentWorld.pageWorld];
+    [configuration.get().userContentController _addBuffer:invalidSurrogatePair.get() contentWorld:WKContentWorld.pageWorld name:@"invalidSurrogatePair"];
+    [configuration.get().userContentController _addBuffer:readOnlyBuffer.get() contentWorld:WKContentWorld.pageWorld name:@"readOnlyBuffer"];
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
@@ -77,7 +79,7 @@ TEST(JSBuffer, IDLExposed)
 TEST(JSBuffer, EvaluateScript)
 {
     const uint8_t script[] = "didPass = true; 'PAS' + 'S'";
-    RetainPtr sourceBuffer = [NSData dataWithBytes:script length:std::size(script) - 1];
+    RetainPtr sourceBuffer = adoptNS([[WKJSScriptingBuffer alloc] initWithData:[NSData dataWithBytes:script length:std::size(script) - 1]]);
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
 
     RetainPtr contentWorldConfiguration = adoptNS([_WKContentWorldConfiguration new]);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UserContentController.mm
@@ -38,6 +38,7 @@
 #import <WebKit/WKContentWorld.h>
 #import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContentWorldPrivate.h>
+#import <WebKit/WKJSScriptingBuffer.h>
 #import <WebKit/WKJSSerializedNode.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKScriptMessage.h>
@@ -2076,7 +2077,7 @@ TEST(WKUserContentController, MessageHandlerInjectsWebKitNamespace)
 
 TEST(WKUserContentController, JSBufferInjectsWebKitNamespace)
 {
-    RetainPtr buffer = [NSData dataWithBytes:"abc" length:3];
+    RetainPtr buffer = adoptNS([[WKJSScriptingBuffer alloc] initWithData:[NSData dataWithBytes:"abc" length:3]]);
     RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
     [[configuration userContentController] addBuffer:buffer.get() name:@"testBuffer" contentWorld:WKContentWorld.pageWorld];
 


### PR DESCRIPTION
#### d07d26bec0dc38a2a81be193396bf0c599ceeac4
<pre>
Unreviewed, reverting <a href="https://commits.webkit.org/316224@main">316224@main</a> (1b4724a5fcc7)
<a href="https://bugs.webkit.org/show_bug.cgi?id=318298">https://bugs.webkit.org/show_bug.cgi?id=318298</a>
<a href="https://rdar.apple.com/181090174">rdar://181090174</a>

REGRESSION(a8a2a2ecbd85): &apos;WebKit/WKJSScriptingBuffer.h&apos; file not found

Reverted change:

    Remove WKJSScriptingBuffer
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318243">https://bugs.webkit.org/show_bug.cgi?id=318243</a>
    <a href="https://rdar.apple.com/181049251">rdar://181049251</a>
    <a href="https://commits.webkit.org/316224@main">316224@main</a> (1b4724a5fcc7)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d07d26bec0dc38a2a81be193396bf0c599ceeac4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45766 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181152 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cecea52e-1d59-47dd-98b8-7c15c93ac7b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45406 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb0b025f-0ec0-492d-9a79-dda64f94b3df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174807 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114160 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77b00194-5273-44a0-9d05-93ffcf1e1b72) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29902 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/33704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183820 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45433 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/153784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46113 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110748 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26081 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/37388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44631 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44031 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44090 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->