### PR TITLE
Cherry-pick(s) 99867d817a6d. rdar://180436711

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -406,11 +406,17 @@ void WebXRSession::shutdown(InitiatedBySystem initiatedBySystem)
 
     // 3. If the active immersive session is equal to session, set the active immersive session to null.
     // 4. Remove session from the list of inline sessions.
+<<<<<<< HEAD
     for (WeakPtr listener : m_sessionListeners) {
         if (RefPtr protectedListener = listener)
             protectedListener->onSessionEnded(*this);
     }
     m_sessionListeners.clear();
+=======
+    RefPtr xrSystem = m_xrSystem.get();
+    if (xrSystem)
+        xrSystem->sessionEnded(*this);
+>>>>>>> 99867d817a6d ([WebXR] Use-after-free when ending an XRSession whose owning WebXRSystem has been garbage collected)
 
     m_inputSources->clear();
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -192,6 +192,10 @@ private:
     std::unique_ptr<EndPromise> m_endPromise;
     Vector<WeakPtr<WebXRSessionListener>> m_sessionListeners;
 
+<<<<<<< HEAD
+=======
+    WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData> m_xrSystem;
+>>>>>>> 99867d817a6d ([WebXR] Use-after-free when ending an XRSession whose owning WebXRSystem has been garbage collected)
     XRSessionMode m_mode;
     ThreadSafeWeakPtr<PlatformXR::Device> m_device;
     FeatureList m_requestedFeatures;


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180436711 to main. [99867d817a6d] caused a merge conflict. 

```
[WebXR] Use-after-free when ending an XRSession whose owning WebXRSystem has been garbage collected
rdar://175674872

Reviewed by REVIEWER.

WebXRSession held a raw reference (WebXRSystem&) to its owning WebXRSystem.
When a session's wrapper lives in one realm but the XRSystem belongs to a
cross-realm iframe (e.g. via XRSystem.prototype.requestSession.call(childXR, ...)),
destroying the iframe can collect the child realm's JSDOMWindow / Navigator /
WebXRSystem while the parent-realm XRSession is still alive. Calling
session.end() then dereferences the stale pointer in shutdown() when it calls
m_xrSystem.sessionEnded(*this).

Fix by changing m_xrSystem from a raw reference to a
WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData> and guarding the
sessionEnded() call with a null check.

Test: webxr/xr-session-end-after-cross-realm-system-gc.html

* Source/WebCore/Modules/webxr/WebXRSession.h: Change m_xrSystem to WeakPtr.
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::shutdown): Guard sessionEnded call with a WeakPtr null check.
* LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html: Added.
* LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt: Added.

Originally-landed-as: 305413.844@safari-7624-branch (99867d817a6d). rdar://180436711


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac2e49b4741fd5dc074622ec8ecbd5655d16a880

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171852 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45769 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181155 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129406 "") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173717 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47054 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45409 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181155 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129406 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174810 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47054 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181155 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47054 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45409 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29905 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47054 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183823 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36439 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45409 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/183823 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45436 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/183823 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46116 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110752 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46116 "") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117804 "") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44634 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39187 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44034 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44266 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44093 "") | | | 
<!--EWS-Status-Bubble-End-->