### PR TITLE
Cherry-pick(s) 3927a3556654. rdar://181074364

### DIFF
--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -589,9 +589,12 @@ webkit.org/b/115274 http/tests/security/contentSecurityPolicy/report-same-origin
 [ Debug ] ipc/restrictedendpoints/deny-access-attachmentElement.html [ Skip ]
 [ Debug ] ipc/restrictedendpoints/deny-access-webPush.html [ Skip ]
 [ Debug ] ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html [ Skip ]
+<<<<<<< HEAD
 [ Debug ] http/tests/ipc/web-authenticator-get-assertion-spoofed-origin-crash.html [ Skip ]
 [ Debug ] http/tests/ipc/web-authenticator-make-credential-spoofed-origin-crash.html [ Skip ]
 [ Debug ] ipc/media-containment-bypass-create-player.html [ Crash ]
+=======
+>>>>>>> 3927a3556654 (REGRESSION(298821@main): [iOS] RequestPointerLock IPC twice in succession can produce use-after-free of unretained GCMouseMoved block in WKMouseInteraction)
 [ Debug ] ipc/pointer-lock-double-lock-uaf.html [ Skip ]
 
 ### END OF (4) Features that are not supported in WebKit2 and likely never will be


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://181074364 to main. The following sources [ffe2ea6689b5] will still need to be cherry-picked once the conflict is resolved.

```
REGRESSION(298821@main): [iOS] RequestPointerLock IPC twice in succession can produce use-after-free of unretained GCMouseMoved block in WKMouseInteraction
rdar://175672657

Reviewed by Wenson Hsieh.

In 298821@main, we taught WKMouseInteraction to copy the
mouseMovedHandler block from the current GCMouse. However, since
WKMouseInteraction does not have ARC, the bare copy did not increase the
retain count of the block in question. Given we set a new block
immediately afterwards, the block we had just copied is released.

On a second RequestPointerLock IPC, the original mouseMovedHandler block
points to freed memory from the earlier IPC dance, and we end up with a
use-after-free.

To address this issue, we change the bare GCMouseMoved instance held on
by WKMouseInteraction to a BlockPtr. This ensures that the handler is
retained across the setter. Also, we add a pointerLockState.isActive gate
at the start of -beginPointerLockMouseTracking, so successive pointer
lock IPC messages would not be able to read a mouseMovedHandler block
from a previous lock regardless. Finally, we promote our UI process
m_isPointerLocked debug assertions into MESSAGE_CHECK invariants, which
would surface issues more readily in non-debug configurations (and,
importantly, without leading to a use-after-free in the process).

Test: ipc/pointer-lock-double-lock-uaf.html

* LayoutTests/ipc/pointer-lock-double-lock-uaf-expected.txt: Added.
* LayoutTests/ipc/pointer-lock-double-lock-uaf.html: Added.
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestPointerLock):
(WebKit::WebPageProxy::didAllowPointerLock):
(WebKit::WebPageProxy::didDenyPointerLock):
* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseInteraction beginPointerLockMouseTracking]):
(-[WKMouseInteraction endPointerLockMouseTracking]):
(-[WKMouseInteraction _setupMouseMovedHandlerForMouse:]):
* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::FakeMouseDevice::FakeMouseDevice):
(WTR::FakeMouseDevice::~FakeMouseDevice):
(WTR::TestController::platformResetStateToConsistentValues):
(WTR::TestController::setHasMouseDeviceForTesting):
  Enhance TestRunner.setHasMouseDeviceForTesting() to also swizzle a
  fake GCMouse instance for testing, so that the system thinks an
  external mouse input device is connected. This matches TWKAPI's
  pointer lock test capabilities, and allows pointer lock tests to
  get past the GCMouse gate in -beginPointerLockMouseTracking.

Originally-landed-as: 305413.755@safari-7624-branch (3927a3556654). rdar://181074364


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2431734093f3777feb6a91bf2663b4bc8aa4793f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171867 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45784 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181170 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129421 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47069 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45424 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181170 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129421 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174825 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47069 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181170 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47069 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45424 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29920 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47069 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183838 "") | 
| | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45424 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/183838 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45451 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/183838 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46131 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110768 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46131 "") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117819 "Build is in progress. Recent messages:") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44649 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39202 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44049 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44281 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44108 "") | | | 
<!--EWS-Status-Bubble-End-->