### PR TITLE
containsPlainText() re-scans the document head and misses matches past the first search-buffer fill

### DIFF
--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -2406,7 +2406,7 @@ bool containsPlainText(const String& document, const String& target, FindOptions
     SearchBuffer buffer { target, options };
     StringView remainingText { document };
     while (!remainingText.isEmpty()) {
-        size_t charactersAppended = buffer.append(document);
+        size_t charactersAppended = buffer.append(remainingText);
         remainingText = remainingText.substring(charactersAppended);
         if (remainingText.isEmpty())
             buffer.reachedBreak();

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -253,6 +253,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp
         Tests/WebCore/StyleGradient.cpp
+        Tests/WebCore/TextIterator.cpp
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp
         Tests/WebCore/URLParserTextEncoding.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 				WebCore/SVGImageCasts.cpp,
 				WebCore/TextBoundaries.cpp,
 				WebCore/TextCodec.cpp,
+				WebCore/TextIterator.cpp,
 				WebCore/TimeRanges.cpp,
 				WebCore/TransformationMatrix.cpp,
 				WebCore/U2fCommandConstructorTest.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextIterator.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <WebCore/TextIterator.h>
+#include <wtf/text/StringBuilder.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+// SearchBuffer's capacity is max(target.length() * 8, 8192) characters, so for a
+// short target a document longer than 8192 characters spans more than one buffer
+// fill. These cover both the in-buffer case and the multi-fill streaming case.
+
+TEST(TextIteratorTest, ContainsPlainTextMatchWithinFirstBuffer)
+{
+    EXPECT_TRUE(containsPlainText("the quick brown fox"_s, "brown"_s, { }));
+}
+
+TEST(TextIteratorTest, ContainsPlainTextNoMatch)
+{
+    EXPECT_FALSE(containsPlainText("the quick brown fox"_s, "purple"_s, { }));
+}
+
+TEST(TextIteratorTest, ContainsPlainTextMatchPastFirstBufferFill)
+{
+    StringBuilder builder;
+    for (unsigned i = 0; i < 20000; ++i)
+        builder.append('a');
+    builder.append("needle"_s);
+    auto document = builder.toString();
+
+    EXPECT_TRUE(containsPlainText(document, "needle"_s, { }));
+    EXPECT_FALSE(containsPlainText(document, "haystack"_s, { }));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### e20361406fa4eff234e8bd59de694af6d82dfe72
<pre>
containsPlainText() re-scans the document head and misses matches past the first search-buffer fill
<a href="https://bugs.webkit.org/show_bug.cgi?id=318304">https://bugs.webkit.org/show_bug.cgi?id=318304</a>
<a href="https://rdar.apple.com/181100516">rdar://181100516</a>

Reviewed by Darin Adler.

SearchBuffer::append() consumes characters from the front of the given
text up to the remaining buffer capacity and returns the count consumed,
so the caller must feed it the unconsumed tail each iteration. The loop
in containsPlainText() advanced remainingText by that count but passed
the full `document` to append() every time, re-appending the same head.

Documents that fit in the buffer were consumed in one pass, hiding the
bug. Larger documents re-scanned the head forever and never examined
text past the first buffer fill, returning false for matches present
later in the string. Pass remainingText to append() instead.

Test: Tools/TestWebKitAPI/Tests/WebCore/TextIterator.cpp

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::containsPlainText):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/TextIterator.cpp: Added.
(TestWebKitAPI::TEST(TextIteratorTest, ContainsPlainTextMatchWithinFirstBuffer)):
(TestWebKitAPI::TEST(TextIteratorTest, ContainsPlainTextNoMatch)):
(TestWebKitAPI::TEST(TextIteratorTest, ContainsPlainTextMatchPastFirstBufferFill)):

Canonical link: <a href="https://commits.webkit.org/316442@main">https://commits.webkit.org/316442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4899ea667cc760f63ad7f73d209bd529f7078e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181172 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129423 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133708 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94329 "20 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114179 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33990 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29922 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183840 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142414 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45453 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142305 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38527 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46133 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30563 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110770 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37403 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117821 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44651 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8658 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44110 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->