### PR TITLE
Dynamic stylesheet mutation loses running view transition group keyframes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function-expected.txt
@@ -1,5 +1,5 @@
 
 PASS The transform property with ease on ::view-transition-group()
 PASS The sizing properties with linear on ::view-transition-group()
-FAIL Changing the timing function of ::view-transition-group() when animating assert_equals: transform at 50% with linear expected "matrix(1, 0, 0, 1, 200, 0)" but got "matrix(1, 0, 0, 1, 300, 0)"
+PASS Changing the timing function of ::view-transition-group() when animating
 

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -735,8 +735,10 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
     Ref keyframes = StyleRuleKeyframes::create(AtomString(makeString("-ua-view-transition-group-anim-"_s, name)));
     keyframes->wrapperAppendKeyframe(WTF::move(keyframe));
 
-    // We can add this to the normal namespace, since we recreate the resolver when the view-transition ends.
-    resolver->addKeyframeStyle(WTF::move(keyframes));
+    // Register through the document scope so the keyframes are re-established if the resolver
+    // is recreated (e.g. by a stylesheet mutation) during the transition. The keyframes are
+    // discarded when the transition ends and the view transition styles are cleared.
+    document()->styleScope().addViewTransitionKeyframes(WTF::move(keyframes));
 }
 
 // https://drafts.csswg.org/css-view-transitions/#setup-transition-pseudo-elements

--- a/Source/WebCore/style/StyleDocumentScope.cpp
+++ b/Source/WebCore/style/StyleDocumentScope.cpp
@@ -30,6 +30,7 @@
 
 #include "CSSCounterStyleRegistry.h"
 #include "CSSFontSelector.h"
+#include "CSSKeyframesRule.h"
 #include "CSSStyleSheet.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentInlines.h"
@@ -82,6 +83,9 @@ void DocumentScope::createDocumentResolver()
 
     m_resolver->ruleSets().setDynamicViewTransitionsStyle(m_dynamicViewTransitionsStyle.get());
 
+    for (auto& keyframes : m_viewTransitionKeyframes)
+        m_resolver->addKeyframeStyle(keyframes.copyRef());
+
     protect(m_document->fontSelector())->buildStarted();
 
     m_resolver->ruleSets().initializeUserStyle();
@@ -95,6 +99,17 @@ void DocumentScope::clearViewTransitionStyles()
 {
     clearResolver();
     m_dynamicViewTransitionsStyle = nullptr;
+    m_viewTransitionKeyframes.clear();
+}
+
+void DocumentScope::addViewTransitionKeyframes(Ref<StyleRuleKeyframes>&& rule)
+{
+    // Add to the existing resolver, if any, and retain the keyframes so they can be
+    // re-established when the resolver is recreated (e.g. by a stylesheet mutation)
+    // during the transition.
+    if (RefPtr resolver = resolverIfExists())
+        resolver->addKeyframeStyle(rule.copyRef());
+    m_viewTransitionKeyframes.append(WTF::move(rule));
 }
 
 void DocumentScope::releaseMemory()

--- a/Source/WebCore/style/StyleDocumentScope.h
+++ b/Source/WebCore/style/StyleDocumentScope.h
@@ -24,6 +24,8 @@
 
 namespace WebCore {
 
+class StyleRuleKeyframes;
+
 namespace Style {
 
 // Style scope for the document tree. Owns the document-level state that is shared
@@ -52,6 +54,7 @@ public:
     void didChangeExtensionStyleSheets();
 
     void clearViewTransitionStyles();
+    void addViewTransitionKeyframes(Ref<StyleRuleKeyframes>&&);
 
     MatchResultCache& matchResultCache() LIFETIME_BOUND;
 
@@ -86,6 +89,7 @@ private:
     WTF::String m_preferredStylesheetSetName;
 
     RefPtr<RuleSet> m_dynamicViewTransitionsStyle;
+    Vector<Ref<StyleRuleKeyframes>> m_viewTransitionKeyframes;
 
     std::optional<MediaQueryViewportState> m_viewportStateOnPreviousMediaQueryEvaluation;
     WeakHashMap<Element, LayoutSize, WeakPtrImplWithEventTargetData> m_queryContainerDimensionsOnLastUpdate;


### PR DESCRIPTION
#### 39f1479785a288de9b888aff68ebd47cb71817df
<pre>
Dynamic stylesheet mutation loses running view transition group keyframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318305">https://bugs.webkit.org/show_bug.cgi?id=318305</a>
<a href="https://rdar.apple.com/181100818">rdar://181100818</a>

Reviewed by Tim Nguyen.

The UA @keyframes for the group animation were added directly to the style
resolver&apos;s keyframe map, which is destroyed when the resolver is cleared by a
stylesheet mutation during the transition. Retain them on the DocumentScope
(like the dynamic view transition style rules) and re-establish them when the
resolver is recreated, clearing them when the transition ends.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function-expected.txt:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupDynamicStyleSheet):
* Source/WebCore/style/StyleDocumentScope.cpp:
(WebCore::Style::DocumentScope::createDocumentResolver):
(WebCore::Style::DocumentScope::clearViewTransitionStyles):
(WebCore::Style::DocumentScope::addViewTransitionKeyframes):
* Source/WebCore/style/StyleDocumentScope.h:

Canonical link: <a href="https://commits.webkit.org/316436@main">https://commits.webkit.org/316436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7264d1465dcbf7b91560983caf8cbd23e4e7621c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129651 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc2ddcf2-58db-4141-87e5-e17928e592c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133864 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98ac1968-954b-4b0d-bdd6-e4a65758020e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99cb71e8-ad10-4140-99e1-92c36b1b6c14) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30150 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184070 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142608 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45681 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38522 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46361 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111024 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37580 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118049 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44879 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8845 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44279 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44338 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->