### PR TITLE
View transition transform test fails due to float vs double blending precision

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL The transform property with ease on ::view-transition-group() assert_equals: transform with ease at 50% expected "matrix(1, 0, 0, 1, 260.480682, 0)" but got "matrix(1, 0, 0, 1, 260.480678, 0)"
+PASS The transform property with ease on ::view-transition-group()
 PASS The sizing properties with linear on ::view-transition-group()
 FAIL Changing the timing function of ::view-transition-group() when animating assert_equals: transform at 50% with linear expected "matrix(1, 0, 0, 1, 200, 0)" but got "matrix(1, 0, 0, 1, 300, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function.html
@@ -59,7 +59,7 @@ promise_test(async t => {
     "The default timing function"
   );
 
-  assert_equals(
+  assert_matrix_equals(
     getComputedStyle(document.documentElement,
       "::view-transition-group(target)").transform,
     getComputedStyle(ref).transform,


### PR DESCRIPTION
#### 9a435fce25792e3a7e4dba6a6487acc7cc76d51b
<pre>
View transition transform test fails due to float vs double blending precision
<a href="https://bugs.webkit.org/show_bug.cgi?id=318306">https://bugs.webkit.org/show_bug.cgi?id=318306</a>
<a href="https://rdar.apple.com/181101209">rdar://181101209</a>

Reviewed by Geoffrey Garen.

The &quot;transform with ease at 50%&quot; subtest compares the ::view-transition-group()
transform against a live translate() reference using exact string equality. The
matrix components differ by very small amounts, likely due to float/double
precision differences. Compare the transform components with tolerance using
assert_matrix_equals instead.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/dynamic-stylesheet-animations-timing-function.html:

Canonical link: <a href="https://commits.webkit.org/316352@main">https://commits.webkit.org/316352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daebedcb40294da6257244a4ebc3dc49ebde03f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181530 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f70445f-c842-4233-ab99-a8b2d274bf8b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45647 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0842f2d-28e4-4e30-a5b5-df75e38b90b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175048 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114334 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0df5f57f-8467-4182-b473-71418729776e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30143 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184063 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38450 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46354 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111017 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37576 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44872 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8843 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44272 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44331 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->