### PR TITLE
DataTransferItemList::didSetStringData recomputes convertToASCIILowercase() instead of reusing cached value

### DIFF
--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -178,7 +178,7 @@ Vector<Ref<DataTransferItem>>& DataTransferItemList::ensureItems() const
 
 static void removeStringItemOfLowercasedType(Vector<Ref<DataTransferItem>>& items, const String& lowercasedType)
 {
-    auto index = items.findIf([lowercasedType](auto& item) {
+    auto index = items.findIf([&lowercasedType](auto& item) {
         return !item->isFile() && item->type() == lowercasedType;
     });
     if (index == notFound)
@@ -212,7 +212,7 @@ void DataTransferItemList::didSetStringData(const String& type)
         return;
 
     String lowercasedType = type.convertToASCIILowercase();
-    removeStringItemOfLowercasedType(*m_items, type.convertToASCIILowercase());
+    removeStringItemOfLowercasedType(*m_items, lowercasedType);
 
     m_items->append(DataTransferItem::create(*this, lowercasedType, DataTransferItem::Kind::String));
 }


### PR DESCRIPTION
#### 10b8dc99403e192b8b8a969079e2feb72dba51ac
<pre>
DataTransferItemList::didSetStringData recomputes convertToASCIILowercase() instead of reusing cached value
<a href="https://bugs.webkit.org/show_bug.cgi?id=318311">https://bugs.webkit.org/show_bug.cgi?id=318311</a>
<a href="https://rdar.apple.com/181102368">rdar://181102368</a>

Reviewed by Charlie Wolfe.

didSetStringData() computed lowercasedType from type.convertToASCIILowercase()
and then called type.convertToASCIILowercase() a second time when passing the
argument to removeStringItemOfLowercasedType(), redundantly recomputing the
lowercased string. Reuse the already-computed local instead.

Also capture lowercasedType by reference rather than by value in the
removeStringItemOfLowercasedType() findIf lambda, since the lambda runs
synchronously and the string outlives the call, avoiding an unnecessary
String ref-count churn.

No change in behavior.

* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::removeStringItemOfLowercasedType):
(WebCore::DataTransferItemList::didSetStringData):

Canonical link: <a href="https://commits.webkit.org/316349@main">https://commits.webkit.org/316349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/664ea0a4534d7e91e42470a4bc1d084c8dc1ceda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181178 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129429 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133714 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114185 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29928 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183846 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142419 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45459 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142310 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38452 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46139 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110776 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37409 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117827 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44657 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8662 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44057 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44289 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->