### PR TITLE
intersectsForTesting returns containment instead of intersection for ComposedTreeIncludingPseudoElements

### DIFF
--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -253,7 +253,7 @@ bool intersectsForTesting(TreeType type, const SimpleRange& a, const SimpleRange
     case ComposedTree:
         return intersects<ComposedTree>(a, b);
     case ComposedTreeIncludingPseudoElements:
-        return contains<ComposedTreeIncludingPseudoElements>(a, b);
+        return intersects<ComposedTreeIncludingPseudoElements>(a, b);
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -342,7 +342,7 @@ bool intersectsForTesting(TreeType type, const SimpleRange& range, const Node& n
     case ComposedTree:
         return intersects<ComposedTree>(range, node);
     case ComposedTreeIncludingPseudoElements:
-        return contains<ComposedTreeIncludingPseudoElements>(range, node);
+        return intersects<ComposedTreeIncludingPseudoElements>(range, node);
     }
     ASSERT_NOT_REACHED();
     return false;


### PR DESCRIPTION
#### 1e918ac8743bc5f87b5887f471ff091e1b1857b5
<pre>
intersectsForTesting returns containment instead of intersection for ComposedTreeIncludingPseudoElements
<a href="https://bugs.webkit.org/show_bug.cgi?id=318317">https://bugs.webkit.org/show_bug.cgi?id=318317</a>
<a href="https://rdar.apple.com/181104146">rdar://181104146</a>

Reviewed by NOBODY (OOPS!).

Both intersectsForTesting overloads in SimpleRange.cpp handled the
ComposedTreeIncludingPseudoElements case by calling contains&lt;&gt; instead
of intersects&lt;&gt;, a copy/paste error: every other tree-type case (Tree,
ShadowIncludingTree, ComposedTree) calls intersects&lt;&gt;. As a result, for
that tree type the function returned whether the outer range fully
contained the inner range/node rather than whether they merely overlap,
so overlapping-but-not-contained inputs wrongly reported false.

This code is only reachable from tests via Internals, so there is no
product-code impact, but the testing predicate was returning the wrong
answer.

* Source/WebCore/dom/SimpleRange.cpp:
(WebCore::intersectsForTesting):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e918ac8743bc5f87b5887f471ff091e1b1857b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181186 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129437 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94489d3f-4670-41ab-bb51-4d50b437e152) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133721 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94342 "4 flakes 22 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4173e0dd-96a9-42b6-837d-aa25bbc3e5a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114192 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f0a8033-9aae-4ac9-96ec-8b2c1630bab7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35739 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29936 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183854 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142427 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45467 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46147 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110784 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37415 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117835 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44665 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8670 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44297 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->