### PR TITLE
Dynamic orient/markerUnits changes on SVGMarkerElement don't repaint referencing element

### DIFF
--- a/LayoutTests/svg/repaint/marker-markerUnits-dynamic-update-repaint-expected.txt
+++ b/LayoutTests/svg/repaint/marker-markerUnits-dynamic-update-repaint-expected.txt
@@ -1,0 +1,5 @@
+ (repaint rects
+  (rect 8 8 10 10)
+  (rect 108 108 100 100)
+)
+

--- a/LayoutTests/svg/repaint/marker-markerUnits-dynamic-update-repaint.html
+++ b/LayoutTests/svg/repaint/marker-markerUnits-dynamic-update-repaint.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVGMarkerElement: dynamic 'markerUnits' attribute change repaints the referencing element</title>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+</head>
+<body>
+<!-- Changing a marker's 'markerUnits' attribute must invalidate/repaint the referencing element.
+     Without the fix, setAttribute('markerUnits', ...) stores the base value but schedules no
+     repaint, so the recorded repaint-rect list is empty. -->
+<svg width="300" height="300">
+    <defs>
+        <marker id="marker" markerUnits="strokeWidth" refX="0" refY="0" markerWidth="200" markerHeight="200" style="overflow:visible">
+            <rect x="-10" y="-10" width="20" height="20" fill="green"/>
+        </marker>
+    </defs>
+    <path d="M150,150 L250,150" fill="none" stroke="none" stroke-width="5" marker-start="url(#marker)"/>
+</svg>
+<script>
+function repaintTest()
+{
+    document.getElementById("marker").setAttribute("markerUnits", "userSpaceOnUse");
+}
+runRepaintTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/marker-orient-dynamic-update-repaint-expected.txt
+++ b/LayoutTests/svg/repaint/marker-orient-dynamic-update-repaint-expected.txt
@@ -1,0 +1,6 @@
+ (repaint rects
+  (rect 8 8 40 10)
+  (rect 118 148 80 20)
+  (rect 148 118 20 80)
+)
+

--- a/LayoutTests/svg/repaint/marker-orient-dynamic-update-repaint.html
+++ b/LayoutTests/svg/repaint/marker-orient-dynamic-update-repaint.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVGMarkerElement: dynamic 'orient' attribute change repaints the referencing element</title>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+</head>
+<body>
+<!-- Changing a marker's 'orient' attribute must invalidate/repaint the referencing element.
+     Without the fix, setAttribute('orient', ...) stores the base value but schedules no
+     repaint, so the recorded repaint-rect list is empty. -->
+<svg width="300" height="300">
+    <defs>
+        <marker id="marker" orient="0" markerUnits="userSpaceOnUse" refX="0" refY="0" markerWidth="200" markerHeight="200" style="overflow:visible">
+            <rect x="-40" y="-10" width="80" height="20" fill="green"/>
+        </marker>
+    </defs>
+    <path d="M150,150 L250,150" fill="none" stroke="none" marker-start="url(#marker)"/>
+</svg>
+<script>
+function repaintTest()
+{
+    document.getElementById("marker").setAttribute("orient", "90");
+}
+runRepaintTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -75,13 +75,13 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
         auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(*this, newValue);
         if (propertyValue != SVGMarkerUnitsType::Unknown)
             Ref { m_markerUnits }->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
-        return;
+        break;
     }
     case AttributeNames::orientAttr: {
         auto pair = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(*this, newValue);
         m_orientAngle->setBaseValInternal(pair.first);
         Ref { m_orientType }->setBaseValInternal(pair.second);
-        return;
+        break;
     }
     case AttributeNames::refXAttr:
         Ref { m_refX }->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));


### PR DESCRIPTION
#### aeebf22258151fda6a4262d15107025125332642
<pre>
Dynamic orient/markerUnits changes on SVGMarkerElement don&apos;t repaint referencing element
<a href="https://bugs.webkit.org/show_bug.cgi?id=318321">https://bugs.webkit.org/show_bug.cgi?id=318321</a>
<a href="https://rdar.apple.com/181106538">rdar://181106538</a>

Reviewed by Simon Fraser.

SVGMarkerElement::attributeChanged() handled the markerUnitsAttr and
orientAttr cases with an early return; instead of break;, unlike every
other attribute and every peer resource element (pattern/mask/etc.).
The new base value was parsed and stored, but the return skipped the
SVGElement::attributeChanged() call at the end of the switch, so
svgAttributeChanged() -&gt; invalidateMarkerResource() never ran and the
referencing element was not repainted until an unrelated invalidation.

Fix by falling through with break; so both attributes invalidate the
marker resource, matching the other cases.

Tests: svg/repaint/marker-markerUnits-dynamic-update-repaint.html
 svg/repaint/marker-orient-dynamic-update-repaint.html

* LayoutTests/svg/repaint/marker-markerUnits-dynamic-update-repaint-expected.txt: Added.
* LayoutTests/svg/repaint/marker-markerUnits-dynamic-update-repaint.html: Added.
* LayoutTests/svg/repaint/marker-orient-dynamic-update-repaint-expected.txt: Added.
* LayoutTests/svg/repaint/marker-orient-dynamic-update-repaint.html: Added.
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/316350@main">https://commits.webkit.org/316350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da79167005a36e4e1498f5ce3e7b131d4c2f8f83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171886 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129440 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133724 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174844 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114195 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34006 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33735 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183857 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142430 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142321 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46150 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110793 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37419 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117838 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44668 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8674 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44068 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->