### PR TITLE
Off-by-one out-of-bounds read in KanjiCode::judge()

### DIFF
--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -212,12 +212,12 @@ auto KanjiCode::judge(std::span<const uint8_t> string) -> Type
                 } else if (0x81 <= string[i] && string[i] <= 0x9f) {
                     /* SJIS only */
                     code = Type::SJIS;
-                    if ((string.size() - i >= 1) && ((0x40 <= string[i + 1] && string[i + 1] <= 0x7e) || (0x80 <= string[i + 1] && string[i + 1] <= 0xfc)))
+                    if ((string.size() - i > 1) && ((0x40 <= string[i + 1] && string[i + 1] <= 0x7e) || (0x80 <= string[i + 1] && string[i + 1] <= 0xfc)))
                         return code;
                 } else if (0xfd <= string[i] && string[i] <= 0xfe) {
                     /* EUC only */
                     code = Type::EUC;
-                    if ((string.size() - i >= 1) && (0xa1 <= string[i + 1] && string[i + 1] <= 0xfe))
+                    if ((string.size() - i > 1) && (0xa1 <= string[i + 1] && string[i + 1] <= 0xfe))
                         return code;
                 } else if (string[i] <= 0x7f)
                     ;


### PR DESCRIPTION
#### 94ff9f23ee9c041c4bb9b657469a327ebb79ae12
<pre>
Off-by-one out-of-bounds read in KanjiCode::judge()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318680">https://bugs.webkit.org/show_bug.cgi?id=318680</a>

Reviewed by Chris Dumez.

KanjiCode::judge() scans response bytes to guess a Japanese encoding
during charset autodetection. Two branches guard the string[i + 1]
lookahead with (string.size() - i &gt;= 1), which is always true inside the
while (i &lt; string.size()) loop, so when the final byte (i == size - 1)
falls in 0x81..0x9f or 0xfd..0xfe the code reads string[i + 1], one past
the end of the span. string is a std::span and WebKit builds with
hardened libc++, so this is caught as a safe release-assert crash, not a
heap-buffer-overflow or a security bug. The sibling hiragana/katakana
branches already use the correct (string.size() - i &gt; 1) guard; this
makes the two SJIS/EUC lead-byte branches match. Inputs that actually
have a following byte take the same branch as before.

* Source/WebCore/loader/TextResourceDecoder.cpp:
(KanjiCode::judge):

Canonical link: <a href="https://commits.webkit.org/317011@main">https://commits.webkit.org/317011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c72a4fb369de6a07d449827acc744d19fcbbd3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134760 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95160 "2 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155416 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115235 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36819 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35169 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185313 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143616 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46916 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143485 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38854 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47595 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31748 "Found 60 new test failures: compositing/backing/solid-color-with-paints-into-ancestor.html css3/text-decoration/text-decoration-line-grammar-error-3.html fast/canvas/webgl/context-attributes-alpha.html fast/canvas/webgl/copy-tex-image-and-sub-image-2d.html fast/canvas/webgl/tex-input-validation.html fast/canvas/webgl/webgl-clear-composited-notshowing.html fast/css/getComputedStyle-font-variant-shorthand-crash.html fast/mediastream/microphone-interruption-and-audio-session.html imported/w3c/web-platform-tests/largest-contentful-paint/observe-svg-data-uri-image.html imported/w3c/web-platform-tests/svg/linking/reftests/media-fragment-spatial-invalid-negative-width.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112696 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38433 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119344 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46101 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9860 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->