### PR TITLE
[css-mixins-1] Resolve names in @function in the scope where the function was defined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-expected.txt
@@ -7,7 +7,7 @@ PASS Combining functions from various scopes
 PASS ::part() can not see inner functions
 PASS ::slotted() can see inner functions
 PASS :host can see inner functions
-FAIL Outer functions can't see inner functions assert_equals: expected "20px C" but got "C C"
-FAIL Outer functions can't see inner functions (local vars) assert_equals: expected "22px C" but got "C C"
-FAIL Function with same name in different scopes assert_equals: expected "24px" but got ""
+PASS Outer functions can't see inner functions
+PASS Outer functions can't see inner functions (local vars)
+PASS Function with same name in different scopes
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1425,7 +1425,7 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const Style::ComputedS
 
     BlendingKeyframes blendingKeyframes(AtomString { backingStyleAnimationName->name });
     if (m_target) {
-        Style::Scope::resolveTreeScopedReference(protect(*m_target), *backingStyleAnimationName, [&](const Style::Scope& scope, const AtomString&) {
+        Style::resolveTreeScopedReference(protect(*m_target), *backingStyleAnimationName, [&](const Style::Scope& scope, const Style::ScopedName&) {
             ASSERT(scope.resolverIfExists());
             return protect(scope.resolverIfExists())->keyframeStylesForAnimation(protect(*m_target), unanimatedStyle, resolutionContext, blendingKeyframes, backingStyleAnimation.timingFunction().value.ptr());
         });

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -145,9 +145,6 @@ public:
     static Scope* forOrdinal(Element&, ScopeOrdinal);
     static const Scope* forOrdinal(const Element&, ScopeOrdinal);
 
-    // The provided function is called for all the relevant scopes until it finds a name match from a scope and returns a truthy value.
-    template<typename F> static auto resolveTreeScopedReference(const Element&, const ScopedName&, const F&&);
-
     const CustomPropertyRegistry& customPropertyRegistry() const LIFETIME_BOUND { return m_customPropertyRegistry.get(); }
     CustomPropertyRegistry& customPropertyRegistry() LIFETIME_BOUND { return m_customPropertyRegistry.get(); }
     const CSSCounterStyleRegistry& counterStyleRegistry() const LIFETIME_BOUND { return m_counterStyleRegistry.get(); }
@@ -245,24 +242,28 @@ inline void Scope::flushPendingUpdate()
         flushPendingSelfUpdate();
 }
 
-template<typename F>
-auto Scope::resolveTreeScopedReference(const Element& element, const ScopedName& reference, const F&& function)
+// Resolves a tree-scoped reference per https://drafts.csswg.org/css-scoping-1/#shadow-names.
+// The provided function is called, for each relevant scope, with the scope and the reference's name
+// paired with that scope's ordinal (as a ScopedName), until it returns a truthy value.
+template<std::invocable<const Scope&, ScopedName> F>
+auto resolveTreeScopedReference(const Element& element, const ScopedName& reference, const F&& function)
 {
-    using ReturnType = std::invoke_result_t<F, Scope, AtomString>;
+    using ReturnType = std::invoke_result_t<F, Scope, ScopedName>;
 
-    // https://drafts.csswg.org/css-scoping-1/#shadow-names
     // "Whenever a tree-scoped reference is dereferenced to find the CSS construct it is referencing,
     // first search only the tree-scoped names associated with the same root as the tree-scoped reference must be searched."
     CheckedPtr firstScope = Scope::forOrdinal(element, reference.scopeOrdinal);
     if (!firstScope)
         return ReturnType { };
 
-    if (auto result = function(*firstScope, reference.name))
+    auto scopeOrdinal = reference.scopeOrdinal;
+    if (auto result = function(*firstScope, ScopedName { reference.name, scopeOrdinal }))
         return result;
 
     // "If no relevant tree-scoped name is found, and the root is a shadow root, then repeat this search in the root’s host’s node tree."
     for (CheckedPtr hostScope = firstScope->hostScope(); hostScope; hostScope = hostScope->hostScope()) {
-        if (auto result = function(*hostScope, reference.name))
+        --scopeOrdinal;
+        if (auto result = function(*hostScope, ScopedName { reference.name, scopeOrdinal }))
             return result;
     }
     return ReturnType { };

--- a/Source/WebCore/style/StyleSubstitutionContext.h
+++ b/Source/WebCore/style/StyleSubstitutionContext.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "StyleScopeOrdinal.h"
 #include <wtf/GenericHashKey.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/AtomString.h>
@@ -33,18 +34,22 @@ namespace WebCore {
 namespace Style {
 
 // https://drafts.csswg.org/css-values-5/#substitution-context
-// A substitution context is «dependency type, name».
+// A substitution context is the dependency type plus values specific to that type: a property name
+// for Property, an attribute name for Attribute, and the custom function for Function.
 struct SubstitutionContext {
     enum class Type : uint8_t { Property, Attribute, Function };
     Type type;
     AtomString name;
+    // For Function contexts, the scope the function resolved in. Tree-scoping means distinct functions
+    // can share a name, and (name, scope) identifies the function.
+    ScopeOrdinal functionScopeOrdinal { ScopeOrdinal::Element };
 
     bool operator==(const SubstitutionContext&) const = default;
 };
 
 inline void add(Hasher& hasher, const SubstitutionContext& context)
 {
-    add(hasher, context.type, context.name);
+    add(hasher, context.type, context.name, context.functionScopeOrdinal);
 }
 
 // https://drafts.csswg.org/css-values-5/#guarded

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -222,7 +222,7 @@ bool SubstitutionResolver::substituteFirstValid(CSSParserTokenRange range, Vecto
 // Registers each parameter with its type, resolves argument styles, then updates registrations
 // to universal syntax with resolved values as initial values.
 // Returns resolved argument properties to prepend to the body rule, or nullptr on failure.
-RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>& parameters, const Vector<Vector<CSSParserToken>>& arguments, LocalPropertyRegistry& registrations)
+RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>& parameters, const Vector<Vector<CSSParserToken>>& arguments, LocalPropertyRegistry& registrations, ScopeOrdinal definitionScope)
 {
     // A parameter without a default requires a corresponding argument. A missing one makes the whole
     // invocation guaranteed-invalid (unlike a supplied-but-invalid argument, which defaults below).
@@ -286,7 +286,7 @@ RefPtr<MutableStyleProperties> SubstitutionResolver::resolveAndRegisterDashedFun
     // The hypothetical element acts as a child of the calling element, inheriting its computed custom
     // properties on demand, so defaults like `var(--caller-prop)` or `inherit` resolve against it.
     auto argumentMatchResult = MatchResult::create();
-    argumentMatchResult->authorDeclarations.append({ WTF::move(argumentRule) });
+    argumentMatchResult->authorDeclarations.append({ .properties = WTF::move(argumentRule), .styleScopeOrdinal = definitionScope });
 
     auto builderContext = BuilderContext {
         .document = m_styleBuilder.state().document(),
@@ -334,16 +334,21 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     auto scopedFunctionName = ScopedName { functionName.toAtomString(), m_styleBuilder.state().styleScopeOrdinal() };
 
     CheckedPtr element = m_styleBuilder.state().element();
-    auto customFunction = Scope::resolveTreeScopedReference(*element, scopedFunctionName, [](const Scope& scope, const AtomString& name) -> CheckedPtr<const CustomFunction> {
+    auto resolved = resolveTreeScopedReference(*element, scopedFunctionName, [](const Scope& scope, const ScopedName& scopedName) -> std::optional<std::pair<CheckedRef<const CustomFunction>, ScopeOrdinal>> {
         RefPtr resolver = scope.resolverIfExists();
         CheckedPtr registry = resolver ? resolver->customFunctionRegistry() : nullptr;
-        return registry ? registry->functionForName(name) : nullptr;
+        CheckedPtr function = registry ? registry->functionForName(scopedName.name) : nullptr;
+        if (!function)
+            return { };
+        return std::pair { function.releaseNonNull(), scopedName.scopeOrdinal };
     });
 
-    if (!customFunction)
+    if (!resolved)
         return false;
 
-    auto guard = m_styleBuilder.state().guardSubstitutionContext({ SubstitutionContext::Type::Function, scopedFunctionName.name });
+    auto& [customFunction, foundScopeOrdinal] = *resolved;
+
+    auto guard = m_styleBuilder.state().guardSubstitutionContext({ SubstitutionContext::Type::Function, scopedFunctionName.name, foundScopeOrdinal });
 
     if (guard.isCyclicContext())
         return false;
@@ -377,7 +382,7 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     // "Let registrations be an initially empty set of custom property registrations."
     auto registrations = LocalPropertyRegistry { };
 
-    auto resolvedArgumentProperties = resolveAndRegisterDashedFunctionArguments(parameters, *substitutedArguments, registrations);
+    auto resolvedArgumentProperties = resolveAndRegisterDashedFunctionArguments(parameters, *substitutedArguments, registrations, foundScopeOrdinal);
     if (!resolvedArgumentProperties)
         return false;
 
@@ -391,9 +396,11 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     }
 
     // "Let body rule be the function body."
+    // The body resolves tree-scoped references (var(), nested dashed-functions) relative to the scope
+    // where the function was defined, not the calling element's scope.
     auto bodyMatchResult = MatchResult::create();
     bodyMatchResult->authorDeclarations.append({ *resolvedArgumentProperties });
-    bodyMatchResult->authorDeclarations.append({ customFunction->properties });
+    bodyMatchResult->authorDeclarations.append({ .properties = customFunction->properties, .styleScopeOrdinal = foundScopeOrdinal });
 
     // "Resolve function styles using custom function, body rule, registrations, and calling context."
     // The hypothetical element acts as a child of the calling element, inheriting its computed custom

--- a/Source/WebCore/style/StyleSubstitutionResolver.h
+++ b/Source/WebCore/style/StyleSubstitutionResolver.h
@@ -28,6 +28,7 @@
 #include "CSSParserTokenRange.h"
 #include "StyleCustomProperty.h"
 #include "StyleRuleFunction.h"
+#include "StyleScopeOrdinal.h"
 
 namespace WebCore {
 
@@ -66,7 +67,7 @@ private:
     bool substituteVariableFunction(CSSParserTokenRange, CSSValueID, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteFirstValid(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteDashedFunction(StringView functionName, CSSParserTokenRange, Vector<CSSParserToken>&);
-    RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&);
+    RefPtr<MutableStyleProperties> resolveAndRegisterDashedFunctionArguments(const Vector<StyleRuleFunction::Parameter>&, const Vector<Vector<CSSParserToken>>&, LocalPropertyRegistry&, ScopeOrdinal definitionScope);
     bool substituteAttrFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
     bool substituteInternalAutoBaseFunction(CSSParserTokenRange, Vector<CSSParserToken>&, const CSSParserContext&);
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1695,9 +1695,9 @@ std::unique_ptr<Style::ComputedStyle> TreeResolver::generatePositionOption(const
 
         // "If an at-rule or property defines a name that other CSS constructs can refer to it by, ... it must be defined as a tree-scoped name."
         // https://drafts.csswg.org/css-scoping-1/#shadow-names
-        return Style::Scope::resolveTreeScopedReference(protect(styleable.element), *fallback.ruleAndTactics.rule, [](const Style::Scope& scope, const AtomString& name) -> RefPtr<const StyleProperties> {
+        return Style::resolveTreeScopedReference(protect(styleable.element), *fallback.ruleAndTactics.rule, [](const Style::Scope& scope, const Style::ScopedName& scopedName) -> RefPtr<const StyleProperties> {
             auto& ruleSet = scope.resolverIfExists()->ruleSets().authorStyle();
-            RefPtr rule = ruleSet.positionTryRuleForName(name);
+            RefPtr rule = ruleSet.positionTryRuleForName(scopedName.name);
             if (!rule)
                 return nullptr;
             return rule->properties();

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -364,9 +364,9 @@ void Styleable::cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimati
 
 static bool keyframesRuleExistsForAnimation(Element& element, const Style::ScopedName& animationName)
 {
-    return Style::Scope::resolveTreeScopedReference(element, animationName, [](const Style::Scope& scope, const AtomString& name) -> bool {
+    return Style::resolveTreeScopedReference(element, animationName, [](const Style::Scope& scope, const Style::ScopedName& scopedName) -> bool {
         if (RefPtr resolver = scope.resolverIfExists())
-            return resolver->isAnimationNameValid(name);
+            return resolver->isAnimationNameValid(scopedName.name);
         return false;
     });
 }


### PR DESCRIPTION
#### d0f53b880e13dd2d3c97dd7b55450fc5abf6cdb5
<pre>
[css-mixins-1] Resolve names in @function in the scope where the function was defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=318322">https://bugs.webkit.org/show_bug.cgi?id=318322</a>
<a href="https://rdar.apple.com/181107185">rdar://181107185</a>

Reviewed by Alan Baradlay.

If a function is defined in a different scope than the caller the names in the function body
must be resolved in the definition scope.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-shadow-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
* Source/WebCore/style/StyleScope.h:
(WebCore::Style::resolveTreeScopedReference):
(WebCore::Style::Scope::resolveTreeScopedReference): Deleted.

Provide ScopedName resolved for the tested scope to the argument callable.
Also make standalone and use std::invocable concept for better error messages.

* Source/WebCore/style/StyleSubstitutionContext.h:
(WebCore::Style::add):

Include the function&apos;s scope in the substitution context so same-named functions in
different scopes are not treated as a cycle.

* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::resolveAndRegisterDashedFunctionArguments):
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

Initialize body and argument declarations with the function scope, and key the cycle guard
on the resolved function scope.

* Source/WebCore/style/StyleSubstitutionResolver.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::generatePositionOption):
* Source/WebCore/style/Styleable.cpp:
(WebCore::keyframesRuleExistsForAnimation):

Canonical link: <a href="https://commits.webkit.org/316257@main">https://commits.webkit.org/316257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fa528d423107939accf83ea0730f35b2945d622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181193 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20023502-c20a-47c3-90fd-bbf3f267bb48) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133729 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b17cf57-e78a-4cdb-9ddd-803b6cec7d21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174848 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114200 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/def4c212-85de-4861-baf5-6f7a89951c24) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29943 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183861 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142434 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45474 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142325 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38370 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46154 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110798 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37423 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44672 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44072 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44131 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->