### PR TITLE
feConvolveMatrix: removing an invalid order attribute leaves the filter permanently disabled

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal-expected.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<!-- Reference: feConvolveMatrix with no order attribute uses the 3x3 default
+     and halves the RGB channels, producing dark green. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <filter id="f" filterUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+      <feConvolveMatrix divisor="2" preserveAlpha="true"
+                        kernelMatrix="0 0 0  0 1 0  0 0 0"/>
+    </filter>
+  </defs>
+  <rect width="100" height="100" fill="rgb(0, 200, 0)" filter="url(#f)"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Filter Effects: removing an invalid order attribute reverts feConvolveMatrix to the 3x3 default</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#element-attrdef-feconvolvematrix-order">
+<link rel="match" href="reference/feconvolvematrix-order-removal-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+<!-- The filter starts with an invalid order="0", which disables it. Removing
+     the order attribute must revert feConvolveMatrix to its valid 3x3 default
+     (per spec, order is optional and defaults to 3), re-enabling the filter.
+     The filter halves the RGB channels, so a working filter renders the green
+     square dark green, matching the reference. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <filter id="f" filterUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+      <feConvolveMatrix id="convolve" order="0" divisor="2" preserveAlpha="true"
+                        kernelMatrix="0 0 0  0 1 0  0 0 0"/>
+    </filter>
+  </defs>
+  <rect width="100" height="100" fill="rgb(0, 200, 0)" filter="url(#f)"/>
+</svg>
+<script>
+  waitForAtLeastOneFrame().then(() => {
+    document.getElementById("convolve").removeAttribute("order");
+    takeScreenshot();
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/feconvolvematrix-order-removal-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/feconvolvematrix-order-removal-ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<!-- Reference: feConvolveMatrix with no order attribute uses the 3x3 default
+     and halves the RGB channels, producing dark green. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <filter id="f" filterUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+      <feConvolveMatrix divisor="2" preserveAlpha="true"
+                        kernelMatrix="0 0 0  0 1 0  0 0 0"/>
+    </filter>
+  </defs>
+  <rect width="100" height="100" fill="rgb(0, 200, 0)" filter="url(#f)"/>
+</svg>

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -70,6 +70,13 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::orderAttr: {
+        if (newValue.isEmpty()) {
+            // A removed or absent order attribute is valid; the spec default is 3x3.
+            m_orderX->setBaseValInternal(initialOrderValue);
+            m_orderY->setBaseValInternal(initialOrderValue);
+            m_hasInvalidOrderAttribute = false;
+            break;
+        }
         auto result = parseNumberOptionalNumber(newValue);
         if (!result || result->first < 1 || result->second < 1) {
             m_orderX->setBaseValInternal(initialOrderValue);


### PR DESCRIPTION
#### 3ec2988be5d6d7bc4fcf584274e086a8911870a8
<pre>
feConvolveMatrix: removing an invalid order attribute leaves the filter permanently disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=318325">https://bugs.webkit.org/show_bug.cgi?id=318325</a>
<a href="https://rdar.apple.com/181109552">rdar://181109552</a>

Reviewed by Taher Ali.

When feConvolveMatrix parses an invalid order (e.g. order=&quot;0&quot;), it sets
m_hasInvalidOrderAttribute so createFilterEffect() bails out and the filtered
element is not displayed. Removing the order attribute produces an empty value,
which parseNumberOptionalNumber() rejects, so the code took the parse-failure
path and kept m_hasInvalidOrderAttribute set. The filter therefore stayed
disabled even though a missing order attribute is valid and defaults to 3x3.

Treat an empty/absent order value as the valid 3x3 default: reset orderX/orderY
to the initial value and clear m_hasInvalidOrderAttribute, distinct from a
present-but-malformed value which continues to invalidate the primitive.

Tests: imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal.html
 imported/w3c/web-platform-tests/css/filter-effects/reference/feconvolvematrix-order-removal-ref.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/feconvolvematrix-order-removal.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/feconvolvematrix-order-removal-ref.html: Added.
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/317005@main">https://commits.webkit.org/317005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/481c9652776a2bc31d1afaab06c7d7a9caafecba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129447 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133730 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94348 "1 flakes 19 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a46df0e-4a35-4644-9c26-48d524b0247a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114201 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34011 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29946 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146175 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183864 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36480 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142436 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142327 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38851 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46157 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30585 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110804 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37425 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117845 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44675 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8680 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44075 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->