### PR TITLE
Cherry-pick(s) b74450614238. rdar://181073985

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -116,7 +116,7 @@ public:
 #endif
     static void setNotifyOptions();
 
-#if PLATFORM(MAC)
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     static String getHomeDirectory();
 #endif
 


### PR DESCRIPTION
This is an automatic cherry-pick for rdar://181073985 to test against CI.
```
REGRESSION(305413.785@safari-7624-branch): [ Build-Failure ] [ GlowG safari-7624-branch ] error: out-of-line definition of 'getHomeDirectory' does not match any declaration in 'WebKit::AuxiliaryProcess' And 1 other
rdar://175985538

Reviewed by Jonathan Bedard.

Broaden the guard on the declaration to match the file's compilation scope, basically to include Mac Catalyst.

* Source/WebKit/Shared/AuxiliaryProcess.h:

Originally-landed-as: 305413.791@safari-7624-branch (b74450614238). rdar://181073985


```
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8080b908418a0df47db15be54355d6ed438e304c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181197 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129448 "Failed to checkout and rebase branch from PR 68427") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133731 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129448 "Failed to checkout and rebase branch from PR 68427") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35749 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34012 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183865 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36481 "Failed to checkout and rebase branch from PR 68427") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38210 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142437 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45478 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46158 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30586 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110805 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37426 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117846 "Failed to checkout and rebase branch from PR 68427") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44676 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8681 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44076 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->