### PR TITLE
Unable to upload PDF file on iOS

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UploadDirectory.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UploadDirectory.mm
@@ -25,8 +25,6 @@
 
 #import "config.h"
 
-#if PLATFORM(MAC)
-
 #import "Helpers/cocoa/DragAndDropSimulator.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
@@ -67,6 +65,8 @@
 }
 
 @end
+
+#if PLATFORM(MAC)
 
 TEST(WebKit, UploadDirectory)
 {
@@ -176,4 +176,56 @@ TEST(WebKit, BlockedUploadDirectory)
     EXPECT_FALSE(error);
 }
 
-#endif
+#endif // PLATFORM(MAC)
+
+TEST(WebKit, AllowTempUploadDirectory)
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error = nil;
+    NSURL *directory = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"/UploadDirectory"] isDirectory:YES];
+    [fileManager removeItemAtPath:directory.path error:nil];
+    EXPECT_TRUE([fileManager createDirectoryAtURL:directory withIntermediateDirectories:YES attributes:nil error:&error]);
+    EXPECT_FALSE(error);
+    NSData *testData = [@"testdata" dataUsingEncoding:NSUTF8StringEncoding];
+    EXPECT_TRUE([fileManager createFileAtPath:[directory.path stringByAppendingPathComponent:@"testfile"] contents:testData attributes:nil]);
+
+    {
+        using namespace TestWebKitAPI;
+        HTTPServer server([] (Connection connection) {
+            connection.receiveHTTPRequest([=](Vector<char>&&) {
+                constexpr auto response =
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Type: text/html\r\n"
+                "Content-Length: 133\r\n\r\n"
+                "<form id='form' action='/upload.php' method='post' enctype='multipart/form-data'><input id='file' type='file' name='testname'></form>"_s;
+                connection.send(response, [=] {
+                    connection.receiveHTTPRequest([=](Vector<char>&& request) {
+                        EXPECT_TRUE(contains(request.span(), "Content-Length: 192\r\n"_span));
+                        size_t headerEnd = find(request.span(), "\r\n\r\n"_span);
+                        EXPECT_TRUE(headerEnd != notFound);
+                        EXPECT_EQ(request.size() - (headerEnd + strlen("\r\n\r\n")), 192u);
+                        constexpr auto secondResponse =
+                        "HTTP/1.1 200 OK\r\n"
+                        "Content-Length: 0\r\n\r\n"_s;
+                        connection.send(secondResponse);
+                    });
+                });
+            });
+        });
+
+        RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+        RetainPtr delegate = adoptNS([[UploadDelegate alloc] initWithDirectory:directory]);
+        [webView setUIDelegate:delegate.get()];
+
+        [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/", server.port()]]]];
+
+        [webView clickOnElementID:@"file"];
+        while (![delegate sentDirectory])
+            TestWebKitAPI::Util::spinRunLoop();
+        [webView evaluateJavaScript:@"document.getElementById('form').submit()" completionHandler:nil];
+        [webView _test_waitForDidFinishNavigation];
+    }
+
+    EXPECT_TRUE([fileManager removeItemAtPath:directory.path error:&error]);
+    EXPECT_FALSE(error);
+}


### PR DESCRIPTION
#### e66a3f3e64dc73619754a681d54a11428e430338
<pre>
Unable to upload PDF file on iOS
<a href="https://rdar.apple.com/178568342">rdar://178568342</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=316262">https://bugs.webkit.org/show_bug.cgi?id=316262</a>

Reviewed by Chris Dumez

In <a href="https://rdar.apple.com/174670487">rdar://174670487</a>, we compiled a list of paths where the Networking process has unconditional sandbox
access, and blocked files from under these paths to be uploaded. In this list we also included the
parent of the temp folder of the Networking process. This is too restrictive, since WKFileUploadPanel
places files under that directory for uploads. We should only include the actual temp folder of the
Networking folder in this list.

The reason we used the parent folder, was that the Networking process is actually granted read access
to the parent of its temp folder as well. This sandbox extension from the UI process should also be
removed, but that is out of scope for now. This is being tracked in <a href="https://rdar.apple.com/178551436">rdar://178551436</a>.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::addPathsBlockedForSandboxExtensions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UploadDirectory.mm:
(TEST(WebKit, AllowTempUploadDirectory)):

Originally-landed-as: 305413.881@safari-7624.4-branch (439d7dfd8a9e). <a href="https://rdar.apple.com/181073758">rdar://181073758</a>
Canonical link: <a href="https://commits.webkit.org/316391@main">https://commits.webkit.org/316391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e554c017617c4a7fcbe76b77e81f69ed64cd388

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114365 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35949 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30182 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146375 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33938 "Found 1 new test failure: platform/mac/media/audio-session-deactivated-when-suspended.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184103 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38412 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142640 "Found 1 new test failure: fast/repaint/selection-rl.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45713 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142524 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46393 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111069 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37610 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44911 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->