### PR TITLE
Cherry-pick 307450@main (39eb51251d8f). https://bugs.webkit.org/show_bug.cgi?id=275100

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,7 +1,5 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -26,10 +24,10 @@ Got context: "[object OffscreenCanvasRenderingContext2D]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgl
 Got context: "[object WebGLRenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgpu
 Got context: "null"
 Got exception: "InvalidStateError: The object is in an invalid state."

--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d

--- a/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
+++ b/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
@@ -1,2 +1,1 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 This test passes if it does not crash.

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,8 +1,5 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -27,10 +24,10 @@ Got context: "[object OffscreenCanvasRenderingContext2D]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgl
 Got context: "[object WebGLRenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x8192
 Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x8192
 Testing height: 100000000 type: webgpu
 Got context: "[object GPUCanvasContext]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d

--- a/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,8 +1,5 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -27,10 +24,10 @@ Got context: "[object OffscreenCanvasRenderingContext2D]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgl
 Got context: "[object WebGLRenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgpu
 Got context: "[object GPUCanvasContext]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."

--- a/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -393,7 +393,6 @@ html/canvas/CanvasRenderingContext2D.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/CanvasStyle.cpp
 html/canvas/GPUCanvasContextCocoa.mm
-html/canvas/ImageBitmapRenderingContext.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/canvas/PlaceholderRenderingContext.cpp
 html/parser/HTMLConstructionSite.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8736,7 +8736,7 @@ std::optional<RenderingContext> Document::getCSSCanvasContext(const String& type
     RefPtr element = getCSSCanvasElement(name);
     if (!element)
         return std::nullopt;
-    element->setCSSCanvasContextSize({ width, height });
+    element->setSizeForControllingContext({ width, height });
     auto context = element->getContext(type);
     if (!context)
         return std::nullopt;

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -45,7 +45,6 @@ class CanvasRenderingContext;
 class Element;
 class Event;
 class GraphicsContext;
-class GraphicsContextStateSaver;
 class Image;
 class ImageBuffer;
 class IntRect;
@@ -129,8 +128,6 @@ public:
     bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
     void recordLastFillText(const String&);
 
-    void resetGraphicsContextState() const;
-
     void setNoiseInjectionSalt(NoiseInjectionHashSalt salt) { m_canvasNoiseHashSalt = salt; }
     bool havePendingCanvasNoiseInjection() const { return m_canvasNoiseInjection.haveDirtyRects(); }
 
@@ -164,7 +161,6 @@ private:
     mutable IntSize m_size;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
     mutable std::atomic<size_t> m_imageBufferMemoryCost { 0 };
-    mutable std::unique_ptr<GraphicsContextStateSaver> m_contextStateSaver;
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 
     String m_lastFillText;

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -79,11 +79,6 @@ public:
 
     RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
-    size_t memoryCost() const;
-#if ENABLE(RESOURCE_USAGE)
-    size_t externalMemoryCost() const;
-#endif
-
     void setOriginClean() { m_originClean = true; }
     void setOriginTainted() { m_originClean = false; }
     bool originClean() const { return m_originClean; }
@@ -160,7 +155,6 @@ private:
 
     mutable IntSize m_size;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
-    mutable std::atomic<size_t> m_imageBufferMemoryCost { 0 };
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 
     String m_lastFillText;

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -53,9 +53,6 @@ CustomPaintCanvas::CustomPaintCanvas(ScriptExecutionContext& context, unsigned w
 CustomPaintCanvas::~CustomPaintCanvas()
 {
     notifyObserversCanvasDestroyed();
-
-    m_context = nullptr; // Ensure this goes away before the ImageBuffer.
-    setImageBuffer(nullptr);
 }
 
 RefPtr<PaintRenderingContext2D> CustomPaintCanvas::getContext()

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -59,6 +59,7 @@ public:
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
     void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
+    void setSizeForControllingContext(IntSize) { };
 
     Image* copiedImage() const final;
     void clearCopiedImage() const final;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -623,8 +623,6 @@ void HTMLCanvasElement::didUpdateSizeProperties()
     // If the size of an existing buffer matches, we can just clear it instead of reallocating.
     // This optimization is only done for 2D canvases for now.
     if (hasCreatedImageBuffer() && oldSize == newSize && m_context && m_context->is2d() && buffer() && m_context->colorSpace() == buffer()->colorSpace() && m_context->pixelFormat() == buffer()->pixelFormat()) {
-        if (!m_didClearImageBuffer)
-            clearImageBuffer();
         return;
     }
 
@@ -899,7 +897,6 @@ void HTMLCanvasElement::createImageBuffer() const
     ASSERT(!hasCreatedImageBuffer());
 
     const_cast<HTMLCanvasElement*>(this)->setHasCreatedImageBuffer(true);
-    m_didClearImageBuffer = true;
     setImageBuffer(allocateImageBuffer());
 
 #if USE(CA) || USE(SKIA)
@@ -947,24 +944,9 @@ Image* HTMLCanvasElement::copiedImage() const
     return m_copiedImage.get();
 }
 
-void HTMLCanvasElement::clearImageBuffer() const
-{
-    ASSERT(hasCreatedImageBuffer());
-    ASSERT(!m_didClearImageBuffer);
-    ASSERT(m_context);
-
-    m_didClearImageBuffer = true;
-
-    if (RefPtr canvas = dynamicDowncast<CanvasRenderingContext2D>(*m_context)) {
-        // No need to undo transforms/clip/etc. because we are called right after the context is reset.
-        canvas->clearRect(0, 0, width(), height());
-    }
-}
-
 void HTMLCanvasElement::clearCopiedImage() const
 {
     m_copiedImage = nullptr;
-    m_didClearImageBuffer = false;
 }
 
 bool HTMLCanvasElement::virtualHasPendingActivity() const

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -615,8 +615,6 @@ void HTMLCanvasElement::didUpdateSizeProperties()
 
     if (RefPtr context = dynamicDowncast<CanvasRenderingContext2D>(m_context.get()))
         context->reset();
-    else
-        resetGraphicsContextState();
 
     IntSize oldSize = size();
     IntSize newSize(w, h);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -151,9 +151,6 @@ HTMLCanvasElement::~HTMLCanvasElement()
     // avoided in destructors, but works as long as it's done before HTMLCanvasElement destructs completely.
     notifyObserversCanvasDestroyed();
     removeCanvasNeedingPreparationForDisplayOrFlush();
-
-    m_context = nullptr; // Ensure this goes away before the ImageBuffer.
-    setImageBuffer(nullptr);
 }
 
 bool HTMLCanvasElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
@@ -175,8 +172,10 @@ void HTMLCanvasElement::collectPresentationalHintsForAttribute(const QualifiedNa
 
 void HTMLCanvasElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == widthAttr || name == heightAttr)
-        didUpdateSizeProperties();
+    if (name == widthAttr || name == heightAttr) {
+        if (!isControlledByOffscreen())
+            didUpdateSizeProperties();
+    }
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
@@ -220,14 +219,13 @@ ExceptionOr<void> HTMLCanvasElement::setWidth(unsigned value)
     return { };
 }
 
-void HTMLCanvasElement::setCSSCanvasContextSize(const IntSize& newSize)
+void HTMLCanvasElement::setSizeForControllingContext(IntSize newSize)
 {
     if (newSize == size())
         return;
-
     m_ignoreDidUpdateSizeProperties = true;
-    setWidth(newSize.width());
-    setHeight(newSize.height());
+    setAttributeWithoutSynchronization(widthAttr, AtomString::number(limitToOnlyHTMLNonNegative(newSize.width(), defaultWidth)));
+    setAttributeWithoutSynchronization(heightAttr, AtomString::number(limitToOnlyHTMLNonNegative(newSize.height(), defaultHeight)));
     m_ignoreDidUpdateSizeProperties = false;
     didUpdateSizeProperties();
 }
@@ -605,45 +603,27 @@ void HTMLCanvasElement::didDraw(const std::optional<FloatRect>& rect, ShouldAppl
 
 void HTMLCanvasElement::didUpdateSizeProperties()
 {
-    if (m_ignoreDidUpdateSizeProperties || isControlledByOffscreen())
+    if (m_ignoreDidUpdateSizeProperties)
         return;
-
-    bool hadImageBuffer = hasCreatedImageBuffer();
 
     int w = limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(widthAttr), defaultWidth);
     int h = limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(heightAttr), defaultHeight);
 
-    if (RefPtr context = dynamicDowncast<CanvasRenderingContext2D>(m_context.get()))
-        context->reset();
-
     IntSize oldSize = size();
     IntSize newSize(w, h);
-    // If the size of an existing buffer matches, we can just clear it instead of reallocating.
-    // This optimization is only done for 2D canvases for now.
-    if (hasCreatedImageBuffer() && oldSize == newSize && m_context && m_context->is2d() && buffer() && m_context->colorSpace() == buffer()->colorSpace() && m_context->pixelFormat() == buffer()->pixelFormat()) {
-        return;
-    }
-
-    setSize(newSize);
-    setHasCreatedImageBuffer(false);
-    setImageBuffer(nullptr);
+    bool sizeChanged = oldSize != newSize;
+    CanvasBase::setSize(newSize);
     clearCopiedImage();
-
-    if (m_context) {
-        if (RefPtr context = dynamicDowncast<GPUBasedCanvasRenderingContext>(*m_context))
-            context->reshape();
-    }
-
+    if (m_context)
+        m_context->didUpdateCanvasSizeProperties(sizeChanged);
     if (CheckedPtr canvasRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer())) {
-        if (oldSize != size()) {
+        if (sizeChanged) {
             canvasRenderer->canvasSizeChanged();
             if (canvasRenderer->hasAcceleratedCompositing())
                 canvasRenderer->contentChanged(ContentChangeType::Canvas);
         }
-        if (hadImageBuffer)
-            canvasRenderer->repaint();
+        canvasRenderer->repaint();
     }
-
     notifyObserversCanvasResized();
 }
 
@@ -888,48 +868,6 @@ ExceptionOr<Ref<MediaStream>> HTMLCanvasElement::captureStream(std::optional<dou
 SecurityOrigin* HTMLCanvasElement::securityOrigin() const
 {
     return &protectedDocument()->securityOrigin();
-}
-
-void HTMLCanvasElement::createImageBuffer() const
-{
-    ASSERT(!hasCreatedImageBuffer());
-
-    const_cast<HTMLCanvasElement*>(this)->setHasCreatedImageBuffer(true);
-    setImageBuffer(allocateImageBuffer());
-
-#if USE(CA) || USE(SKIA)
-    if (m_context && m_context->is2d()) {
-        // Recalculate compositing requirements if acceleration state changed.
-        const_cast<HTMLCanvasElement*>(this)->invalidateStyleAndLayerComposition();
-#if USE(SKIA)
-        if (CheckedPtr renderer = renderBox()) {
-            if (usesContentsAsLayerContents())
-                renderer->contentChanged(ContentChangeType::Canvas);
-        }
-#endif
-    }
-#endif
-}
-
-void HTMLCanvasElement::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)
-{
-    IntSize oldSize = size();
-    setHasCreatedImageBuffer(true);
-    setImageBuffer(WTF::move(buffer));
-
-    if (isControlledByOffscreen() && oldSize != size()) {
-        setAttributeWithoutSynchronization(widthAttr, AtomString::number(width()));
-        setAttributeWithoutSynchronization(heightAttr, AtomString::number(height()));
-
-        if (CheckedPtr canvasRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer())) {
-            canvasRenderer->canvasSizeChanged();
-            canvasRenderer->contentChanged(ContentChangeType::Canvas);
-        }
-
-        notifyObserversCanvasResized();
-    }
-
-    CanvasBase::didDraw(FloatRect(FloatPoint(), size()));
 }
 
 Image* HTMLCanvasElement::copiedImage() const

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -177,7 +177,6 @@ private:
     void didUpdateSizeProperties();
 
     void createImageBuffer() const final;
-    void clearImageBuffer() const;
 
     bool usesContentsAsLayerContents() const;
 
@@ -189,7 +188,6 @@ private:
     std::optional<FloatRect> computeDirtyRectangleIfNeeded(const std::optional<FloatRect>&) const;
 
     bool m_ignoreDidUpdateSizeProperties { false };
-    mutable bool m_didClearImageBuffer { false };
 #if ENABLE(WEBGL)
     bool m_hasRelevantWebGLEventListener { false };
 #endif

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -77,7 +77,6 @@ public:
 
     WEBCORE_EXPORT ExceptionOr<void> setWidth(unsigned);
     WEBCORE_EXPORT ExceptionOr<void> setHeight(unsigned);
-    void setCSSCanvasContextSize(const IntSize& newSize);
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
     ExceptionOr<std::optional<RenderingContext>> getContext(JSC::JSGlobalObject&, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
@@ -131,10 +130,6 @@ public:
 
     SecurityOrigin* securityOrigin() const final;
 
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275100): Only some canvas rendering contexts need an ImageBuffer.
-    // It would be better to have the contexts own the buffers.
-    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
-
     bool needsPreparationForDisplay();
     void prepareForDisplay();
     void dynamicRangeLimitDidChange(PlatformDynamicRangeLimit);
@@ -153,6 +148,8 @@ public:
     void deref() const final { HTMLElement::deref(); }
 
     using HTMLElement::scriptExecutionContext;
+
+    void setSizeForControllingContext(IntSize) final;
 
 private:
     HTMLCanvasElement(const QualifiedName&, Document&);
@@ -175,8 +172,6 @@ private:
     bool canStartSelection() const final;
 
     void didUpdateSizeProperties();
-
-    void createImageBuffer() const final;
 
     bool usesContentsAsLayerContents() const;
 

--- a/Source/WebCore/html/HTMLCanvasElement.idl
+++ b/Source/WebCore/html/HTMLCanvasElement.idl
@@ -38,8 +38,6 @@ typedef (
     ActiveDOMObject,
     JSCustomMarkFunction,
     JSGenerateToNativeObject,
-    ReportExtraMemoryCost,
-    ReportExternalMemoryCost,
     Exposed=Window
 ] interface HTMLCanvasElement : HTMLElement {
     [CEReactions=NotNeeded, CallTracer=InspectorCanvasCallTracer] attribute unsigned long width;

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -154,7 +154,6 @@ void OffscreenCanvas::setHeight(unsigned newHeight)
 
 void OffscreenCanvas::didUpdateSizeProperties()
 {
-    resetGraphicsContextState();
     if (RefPtr context = dynamicDowncast<OffscreenCanvasRenderingContext2D>(m_context.get()))
         context->reset();
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -131,41 +131,46 @@ OffscreenCanvas::~OffscreenCanvas()
 {
     notifyObserversCanvasDestroyed();
     removeCanvasNeedingPreparationForDisplayOrFlush();
-
-    m_context = nullptr; // Ensure this goes away before the ImageBuffer.
-    setImageBuffer(nullptr);
 }
 
 void OffscreenCanvas::setWidth(unsigned newWidth)
 {
     if (m_detached)
         return;
-    setSize(IntSize(newWidth, height()));
-    didUpdateSizeProperties();
+    IntSize newSize(newWidth, height());
+    bool sizeChanged = newSize != size();
+    if (sizeChanged)
+        setSize(newSize);
+    didUpdateSizeProperties(sizeChanged);
 }
 
 void OffscreenCanvas::setHeight(unsigned newHeight)
 {
     if (m_detached)
         return;
-    setSize(IntSize(width(), newHeight));
-    didUpdateSizeProperties();
+    IntSize newSize(width(), newHeight);
+    bool sizeChanged = newSize != size();
+    if (sizeChanged)
+        setSize(newSize);
+    didUpdateSizeProperties(sizeChanged);
 }
 
-void OffscreenCanvas::didUpdateSizeProperties()
+void OffscreenCanvas::setSizeForControllingContext(IntSize newSize)
 {
-    if (RefPtr context = dynamicDowncast<OffscreenCanvasRenderingContext2D>(m_context.get()))
-        context->reset();
+    // Controlling context size change semantics are different to width, height assignment.
+    if (size() == newSize)
+        return;
+    setSize(newSize);
+    didUpdateSizeProperties(true);
+}
 
-    setHasCreatedImageBuffer(false);
-    setImageBuffer(nullptr);
+void OffscreenCanvas::didUpdateSizeProperties(bool sizeChanged)
+{
     clearCopiedImage();
-
+    if (m_context)
+        m_context->didUpdateCanvasSizeProperties(sizeChanged);
     notifyObserversCanvasResized();
     scheduleCommitToPlaceholderCanvas();
-
-    if (RefPtr context = dynamicDowncast<GPUBasedCanvasRenderingContext>(m_context.get()))
-        context->reshape();
 }
 
 #if ENABLE(WEBGL)
@@ -291,10 +296,11 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
     if (size().isEmpty())
         return { RefPtr<ImageBitmap> { nullptr } };
     clearCopiedImage();
+    bool bitmapOriginClean = originClean();
     RefPtr buffer = m_context->transferToImageBuffer();
     if (!buffer)
         return Exception { ExceptionCode::UnknownError }; // UnknownError is used for DOM out-of-memory.
-    return { ImageBitmap::create(buffer.releaseNonNull(), originClean()) };
+    return { ImageBitmap::create(buffer.releaseNonNull(), bitmapOriginClean) };
 }
 
 static String toEncodingMimeType(const String& mimeType)
@@ -434,20 +440,6 @@ void OffscreenCanvas::scheduleCommitToPlaceholderCanvas()
             commitToPlaceholderCanvas();
         });
     }
-}
-
-void OffscreenCanvas::createImageBuffer() const
-{
-    const_cast<OffscreenCanvas*>(this)->setHasCreatedImageBuffer(true);
-    setImageBuffer(allocateImageBuffer());
-}
-
-void OffscreenCanvas::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)
-{
-    setHasCreatedImageBuffer(true);
-    setImageBuffer(WTF::move(buffer));
-
-    CanvasBase::didDraw(FloatRect(FloatPoint(), size()));
 }
 
 void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<void(CanvasBase&)>&& task)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -128,8 +128,7 @@ public:
 
     void setWidth(unsigned);
     void setHeight(unsigned);
-
-    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
+    void setSizeForControllingContext(IntSize) final;
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
@@ -173,8 +172,7 @@ private:
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
 
-    void didUpdateSizeProperties();
-    void createImageBuffer() const final;
+    void didUpdateSizeProperties(bool sizeChanged);
 
     void scheduleCommitToPlaceholderCanvas();
 

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -56,8 +56,6 @@ enum OffscreenRenderingContextType
     Conditional=OFFSCREEN_CANVAS,
     ConditionalForWorker=OFFSCREEN_CANVAS_IN_WORKERS,
     EnabledForContext,
-    ReportExtraMemoryCost,
-    ReportExternalMemoryCost,
     Exposed=(Window,Worker)
 ] interface OffscreenCanvas : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor([EnforceRange] unsigned long width, [EnforceRange] unsigned long height);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -94,17 +94,6 @@ void CanvasRenderingContext::deref() const
     m_canvas->deref();
 }
 
-RefPtr<ImageBuffer> CanvasRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
-{
-    // This will be removed once all contexts store their own buffers.
-    return canvasBase().buffer();
-}
-
-bool CanvasRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
-{
-    return false;
-}
-
 bool CanvasRenderingContext::delegatesDisplay() const
 {
 #if USE(SKIA)
@@ -225,15 +214,8 @@ void CanvasRenderingContext::checkOrigin(const CSSStyleImageValue&)
     m_canvas->setOriginTainted();
 }
 
-void CanvasRenderingContext::updateMemoryCostOnAllocation(bool hasNewBuffer)
+void CanvasRenderingContext::updateMemoryCost(size_t newMemoryCost) const
 {
-    // FIXME: once the ImageBuffer is moved to 2D context, all different context
-    // types calculate the memory use in their own way.
-    size_t newMemoryCost = 0;
-    if (hasNewBuffer) {
-        if (RefPtr buffer = canvasBase().buffer())
-            newMemoryCost = buffer->memoryCost();
-    }
     size_t oldMemoryCost = m_memoryCost.load(std::memory_order_relaxed);
     m_memoryCost.store(newMemoryCost, std::memory_order_relaxed);
     if (newMemoryCost) {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -129,6 +129,12 @@ public:
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
+    void updateMemoryCostOnAllocation(bool hasNewBuffer);
+    size_t memoryCost() const;
+#if ENABLE(RESOURCE_USAGE)
+    size_t externalMemoryCost() const;
+#endif
+
 protected:
     enum class Type : uint8_t {
         CanvasElement2D,
@@ -159,6 +165,8 @@ protected:
     void checkOrigin(const URL&);
     void checkOrigin(const CSSStyleImageValue&);
 
+    mutable std::atomic<size_t> m_memoryCost { 0 };
+
     bool m_isInPreparationForDisplayOrFlush { false };
     bool m_hasActiveInspectorCanvasCallTracer { false };
 
@@ -167,6 +175,7 @@ private:
 
     WeakRef<CanvasBase> m_canvas;
     const Type m_type;
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -80,6 +80,10 @@ public:
 
     virtual void clearAccumulatedDirtyRect() { }
 
+    // Called when the canvas size properties are assigned.
+    // The canvas will already have the new size.
+    virtual void didUpdateCanvasSizeProperties(bool sizeChanged) = 0;
+
     // Canvas 2DContext drawing buffer is the same as display buffer.
     // WebGL, WebGPU draws to drawing buffer. The draw buffer is then swapped to
     // display buffer during preparation and compositor composites the display buffer.
@@ -91,8 +95,8 @@ public:
     };
 
     // Draws the source buffer to the canvasBase().buffer().
-    virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer);
-    virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const;
+    virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) = 0;
+    virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const = 0;
     bool delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
@@ -129,7 +133,7 @@ public:
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
-    void updateMemoryCostOnAllocation(bool hasNewBuffer);
+    void updateMemoryCost(size_t newMemoryCost) const;
     size_t memoryCost() const;
 #if ENABLE(RESOURCE_USAGE)
     size_t externalMemoryCost() const;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -34,6 +34,8 @@ enum RenderingMode {
     CustomIsReachable,
     JSCustomMarkFunction,
     CallTracer=InspectorCanvasCallTracer,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=Window
 ] interface CanvasRenderingContext2D {
     // back-reference to the canvas

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -57,6 +57,7 @@
 #include "FloatQuad.h"
 #include "GeometryUtilities.h"
 #include "Gradient.h"
+#include "GraphicsClient.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLVideoElement.h"
@@ -97,6 +98,8 @@ namespace WebCore {
 using namespace HTMLNames;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CanvasRenderingContext2DBase);
+
+static constexpr InterpolationQuality defaultInterpolationQuality = InterpolationQuality::Low;
 
 static constexpr ImageSmoothingQuality defaultSmoothingQuality = ImageSmoothingQuality::Low;
 
@@ -256,46 +259,39 @@ CanvasRenderingContext2DBase::CanvasRenderingContext2DBase(CanvasBase& canvas, C
     ASSERT(is2dBase());
 }
 
-void CanvasRenderingContext2DBase::unwindStateStack()
-{
-    // Ensure that the state stack in the ImageBuffer's context
-    // is cleared before destruction, to avoid assertions in the
-    // GraphicsContext dtor.
-    size_t stackSize = m_stateStack.size();
-    if (stackSize <= 1)
-        return;
-    m_stateStack.shrink(1);
-    auto* context = existingDrawingContext();
-    if (!context)
-        return;
-    for (;stackSize > 1; --stackSize)
-        context->restore();
-}
-
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
 {
 #if ASSERT_ENABLED
-    unwindStateStack();
+    size_t restoreCount = m_stateStack.size() - 1;
+    for (size_t i = 0; i < restoreCount; ++i)
+        restore();
+    m_stateStack.first() = State();
+    if (RefPtr buffer = m_buffer)
+        buffer->context().restore();
 #endif
 }
 
 bool CanvasRenderingContext2DBase::isAccelerated() const
 {
-    auto* context = existingDrawingContext();
-    return context && context->renderingMode() == RenderingMode::Accelerated;
+    return m_buffer && m_buffer->context().renderingMode() == RenderingMode::Accelerated;
+}
+
+RefPtr<ImageBuffer> CanvasRenderingContext2DBase::surfaceBufferToImageBuffer(SurfaceBuffer)
+{
+    return buffer();
 }
 
 bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
 {
     // Before the first draw (or first access to the drawing buffer), the drawing buffer is transparent black.
     // Currently the canvas does not support alpha == false.
-    return !canvasBase().hasCreatedImageBuffer();
+    return !m_hasCreatedImageBuffer;
 }
 
 #if USE(SKIA)
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext2DBase::layerContentsDisplayDelegate()
 {
-    if (auto buffer = canvasBase().buffer())
+    if (RefPtr buffer = this->buffer())
         return buffer->layerContentsDisplayDelegate();
     return nullptr;
 }
@@ -313,26 +309,43 @@ bool CanvasRenderingContext2DBase::hasDeferredOperations() const
 void CanvasRenderingContext2DBase::flushDeferredOperations()
 {
     m_hasDeferredOperations = false;
-    if (RefPtr buffer = canvasBase().buffer())
+    if (RefPtr buffer = this->buffer())
         buffer->flushDrawingContextAsync();
 }
 
 void CanvasRenderingContext2DBase::reset()
 {
-    unwindStateStack();
+    // CanvasRenderingContext2D.reset() behaves exactly like width/height self-assignment,
+    // `ctx.width = ctx.width`.
+    didUpdateCanvasSizeProperties(false);
+}
 
-    ASSERT(m_stateStack.size() == 1);
+void CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties(bool sizeChanged)
+{
+    size_t restoreCount = m_stateStack.size() - 1;
+    for (size_t i = 0; i < restoreCount; ++i)
+        restore();
     m_stateStack.first() = State();
-
     m_path.clear();
     m_unrealizedSaveCount = 0;
     m_cachedContents.emplace<CachedContentsTransparent>();
     m_hasDeferredOperations = false;
     clearAccumulatedDirtyRect();
-    if (auto* c = existingDrawingContext()) {
-        c->restore();
-        c->save();
-        c->clearRect(FloatRect { { }, canvasBase().size() });
+    if (sizeChanged) {
+        m_hasCreatedImageBuffer = false;
+        if (m_buffer) {
+#if ASSERT_ENABLED
+            Ref { *m_buffer }->context().restore();
+#endif
+            m_buffer = nullptr;
+            updateMemoryCost(0);
+        }
+        InspectorInstrumentation::didChangeCanvasSize(*this);
+    } else if (RefPtr buffer = m_buffer) {
+        auto& context = buffer->context();
+        context.restore();
+        context.save();
+        context.clearRect(FloatRect { { }, canvasBase().size() });
     }
 }
 
@@ -2435,18 +2448,11 @@ const Vector<CanvasRenderingContext2DBase::State, 1>& CanvasRenderingContext2DBa
 
 GraphicsContext* CanvasRenderingContext2DBase::drawingContext() const
 {
-    if (auto* paintContext = dynamicDowncast<PaintRenderingContext2D>(*this))
-        return paintContext->ensureDrawingContext();
-    if (auto* buffer = canvasBase().buffer())
+    if (auto* paintContext = dynamicDowncast<PaintRenderingContext2D>(*this)) [[unlikely]]
+        return paintContext->drawingContext();
+    if (RefPtr buffer = this->buffer())
         return &buffer->context();
     return nullptr;
-}
-
-GraphicsContext* CanvasRenderingContext2DBase::existingDrawingContext() const
-{
-    if (!canvasBase().hasCreatedImageBuffer())
-        return nullptr;
-    return drawingContext();
 }
 
 GraphicsContext* CanvasRenderingContext2DBase::effectiveDrawingContext() const
@@ -2461,14 +2467,15 @@ GraphicsContext* CanvasRenderingContext2DBase::effectiveDrawingContext() const
 
 AffineTransform CanvasRenderingContext2DBase::baseTransform() const
 {
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275100): The image buffer from CanvasBase should be moved to CanvasRenderingContext2DBase.
-    ASSERT(canvasBase().hasCreatedImageBuffer());
-    return canvasBase().buffer()->baseTransform();
+    if (auto* paintContext = dynamicDowncast<PaintRenderingContext2D>(*this)) [[unlikely]]
+        return paintContext->baseTransform();
+    ASSERT(m_hasCreatedImageBuffer);
+    return buffer()->baseTransform();
 }
 
 void CanvasRenderingContext2DBase::prepareForDisplay()
 {
-    if (auto buffer = canvasBase().buffer())
+    if (RefPtr buffer = this->buffer())
         buffer->prepareForDisplay();
 }
 
@@ -2659,7 +2666,7 @@ void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy)
 
 void CanvasRenderingContext2DBase::putImageData(ImageData& data, int dx, int dy, int dirtyX, int dirtyY, int dirtyWidth, int dirtyHeight)
 {
-    RefPtr buffer = canvasBase().buffer();
+    RefPtr buffer = this->buffer();
     if (!buffer)
         return;
 
@@ -3101,7 +3108,7 @@ std::optional<RenderingMode> CanvasRenderingContext2DBase::renderingModeForTesti
 
 std::optional<CanvasRenderingContext2DBase::RenderingMode> CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting()
 {
-    if (auto* buffer = canvasBase().buffer()) {
+    if (RefPtr buffer = this->buffer()) {
         buffer->ensureBackendCreated();
         if (buffer->hasBackend())
             return buffer->renderingMode();
@@ -3228,6 +3235,51 @@ void CanvasRenderingContext2DBase::setWordSpacing(const String& wordSpacing)
 
     modifiableState().wordSpacing = CSS::serializationForCSS(CSS::defaultSerializationContext(), *rawLength);
     modifiableState().font.setWordSpacing(pixels);
+}
+
+RefPtr<ImageBuffer> CanvasRenderingContext2DBase::buffer() const
+{
+    if (m_hasCreatedImageBuffer)
+        return m_buffer;
+    m_hasCreatedImageBuffer = true;
+    RefPtr buffer = allocateImageBuffer();
+    if (!buffer)
+        return nullptr;
+    auto& context = buffer->context();
+    context.setShadowsIgnoreTransforms(true);
+    context.setImageInterpolationQuality(defaultInterpolationQuality);
+    context.setStrokeThickness(1);
+    // Save the initial state, so that `reset()` can restore it.
+    context.save();
+    updateMemoryCost(buffer->memoryCost());
+    m_buffer = buffer;
+
+#if USE(CA) || USE(SKIA)
+    // Recalculate compositing requirements if acceleration state changed.
+    if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(canvasBase())) {
+        canvasElement->invalidateStyleAndLayerComposition();
+#if USE(SKIA)
+        if (CheckedPtr renderer = canvasElement->renderBox()) {
+            if (renderer->hasAcceleratedCompositing() && delegatesDisplay())
+                renderer->contentChanged(ContentChangeType::Canvas);
+        }
+#endif
+    }
+#endif
+    return buffer;
+}
+
+RefPtr<ImageBuffer> CanvasRenderingContext2DBase::allocateImageBuffer() const
+{
+    if (!canvasBase().validateArea())
+        return nullptr;
+    RefPtr scriptExecutionContext = canvasBase().scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    RenderingMode renderingMode = !willReadFrequently() && canvasBase().shouldAccelerate() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
+    if (auto renderingModeForTesting = this->renderingModeForTesting())
+        renderingMode = *renderingModeForTesting;
+    return ImageBuffer::create(canvasBase().size(), renderingMode, RenderingPurpose::Canvas, 1, colorSpace(), pixelFormat(), scriptExecutionContext->graphicsClient());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -264,14 +264,12 @@ void CanvasRenderingContext2DBase::unwindStateStack()
     size_t stackSize = m_stateStack.size();
     if (stackSize <= 1)
         return;
-
-    // We need to keep the last state because it is tracked by CanvasBase::m_contextStateSaver.
+    m_stateStack.shrink(1);
     auto* context = existingDrawingContext();
-    while (m_stateStack.size() > 1) {
-        m_stateStack.removeLast();
-        if (context)
-            context->restore();
-    }
+    if (!context)
+        return;
+    for (;stackSize > 1; --stackSize)
+        context->restore();
 }
 
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
@@ -332,7 +330,8 @@ void CanvasRenderingContext2DBase::reset()
     m_hasDeferredOperations = false;
     clearAccumulatedDirtyRect();
     if (auto* c = existingDrawingContext()) {
-        canvasBase().resetGraphicsContextState();
+        c->restore();
+        c->save();
         c->clearRect(FloatRect { { }, canvasBase().size() });
     }
 }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -344,12 +344,9 @@ protected:
     void realizeSaves();
     State& modifiableState() { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
 
-    // These methods are de-virtualized for performance reasons.
     GraphicsContext* drawingContext() const;
     GraphicsContext* effectiveDrawingContext() const;
-
-    virtual GraphicsContext* existingDrawingContext() const;
-    virtual AffineTransform baseTransform() const;
+    AffineTransform baseTransform() const;
 
     enum class DidDrawOption {
         ApplyTransform = 1 << 0,
@@ -398,6 +395,14 @@ protected:
     bool usesCSSCompatibilityParseMode() const { return m_usesCSSCompatibilityParseMode; }
 
     void updateStateTransform(const AffineTransform&);
+
+    RefPtr<ImageBuffer> allocateImageBuffer() const;
+    bool hasCreatedImageBuffer() const { return m_hasCreatedImageBuffer; }
+    RefPtr<ImageBuffer> buffer() const;
+    RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
+    RefPtr<ImageBuffer> createImageForNoiseInjection() const;
+    void didUpdateCanvasSizeProperties(bool) override;
+
 private:
     struct CachedContentsTransparent {
     };
@@ -426,7 +431,6 @@ private:
     DestinationColorSpace colorSpace() const final;
     bool willReadFrequently() const final;
 
-    void unwindStateStack();
     void realizeSavesLoop();
     void setStrokeColorImpl(Color&& color, String&& unparsedColor = { });
     void setFillColorImpl(Color&& color, String&& unparsedColor = { });
@@ -480,6 +484,7 @@ private:
 
     template<class T> void fullCanvasCompositedDrawImage(T&, const FloatRect&, const FloatRect&, CompositeOperator);
 
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const override;
 #if USE(SKIA)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
@@ -498,13 +503,15 @@ private:
     void evictCachedImageData();
 
     static constexpr unsigned MaxSaveCount = 1024 * 16;
-    Vector<State, 1> m_stateStack;
+    mutable RefPtr<ImageBuffer> m_buffer;
+    Vector<State, 1> m_stateStack; // References go m_stateStack -> targetSwitcher -> m_buffer, so destroy state stack first.
     FloatRect m_dirtyRect;
     unsigned m_unrealizedSaveCount { 0 };
     bool m_usesCSSCompatibilityParseMode;
     mutable Variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
     CanvasRenderingContext2DSettings m_settings;
     bool m_hasDeferredOperations { false };
+    mutable bool m_hasCreatedImageBuffer { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -41,7 +41,6 @@ public:
     void deref() const final { CanvasRenderingContext::deref(); }
     USING_CAN_MAKE_WEAKPTR(CanvasRenderingContext);
 
-    virtual void reshape() = 0;
 protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&, CanvasRenderingContext::Type);
 

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -28,6 +28,8 @@
 [
     ActiveDOMObject,
     EnabledBySetting=WebGPUEnabled,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     SecureContext,
     SkipVTableValidation,

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -58,10 +58,11 @@ public:
     void prepareForDisplay() override;
     PixelFormat pixelFormat() const override;
     bool isOpaque() const override;
-    void reshape() override;
-
+    void didUpdateCanvasSizeProperties(bool) override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) override;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
+
     // GPUCanvasContext methods:
     CanvasType canvas() override;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;
@@ -94,6 +95,7 @@ private:
     void updateScreenHeadroom(float, bool suppressEDR);
     void updateScreenHeadroomFromScreenProperties();
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
+    void updateMemoryCost() const;
 
     struct Configuration {
         Ref<GPUDevice> device;
@@ -123,6 +125,7 @@ private:
     bool m_suppressEDR { false };
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };
+    RefPtr<ImageBuffer> m_readDisplayBuffer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -32,6 +32,7 @@
 #include "GPUPresentationContext.h"
 #include "GPUPresentationContextDescriptor.h"
 #include "GPUTextureDescriptor.h"
+#include "GraphicsClient.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "GraphicsLayerEnums.h"
 #include "ImageBitmap.h"
@@ -341,7 +342,13 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
 
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
 {
-    auto buffer = canvasBase().allocateImageBuffer();
+    RefPtr scriptExecutionContext = canvasBase().scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    const auto size = canvasBase().size();
+    if (size.isEmpty())
+        return nullptr;
+    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
     if (!buffer)
         return nullptr;
     Ref<ImageBuffer> bufferRef = buffer.releaseNonNull();

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -279,12 +279,14 @@ std::optional<double> GPUCanvasContextCocoa::getEffectiveDynamicRangeLimitValue(
 #endif // ENABLE(PIXEL_FORMAT_RGBA16F)
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
 
-void GPUCanvasContextCocoa::reshape()
+void GPUCanvasContextCocoa::didUpdateCanvasSizeProperties(bool)
 {
     if (RefPtr currentTexture = m_currentTexture) {
         currentTexture->destroy();
         m_currentTexture = nullptr;
     }
+    m_readDisplayBuffer = nullptr;
+    updateMemoryCost();
     auto newSize = canvasBase().size();
     auto newWidth = static_cast<GPUIntegerCoordinate>(newSize.width());
     auto newHeight = static_cast<GPUIntegerCoordinate>(newSize.height());
@@ -313,9 +315,21 @@ void GPUCanvasContextCocoa::reshape()
 
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuffer)
 {
+    RefPtr scriptExecutionContext = canvasBase().scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    const auto size = canvasBase().size();
+    if (size.isEmpty())
+        return nullptr;
+    if (!m_readDisplayBuffer) {
+        m_readDisplayBuffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
+        updateMemoryCost();
+    }
+    RefPtr<ImageBuffer> buffer = m_readDisplayBuffer;
+
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     if (!m_configuration)
-        return canvasBase().buffer();
+        return buffer;
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=294654 - OffscreenCanvas may not reflect the display the OffscreenCanvas is displayed on during background / resume
 #if HAVE(SUPPORT_HDR_DISPLAY)
@@ -324,20 +338,20 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
 #endif
 
     auto frameCount = m_configuration->frameCount;
-    m_compositorIntegration->prepareForDisplay(frameCount, [weakThis = WeakPtr { *this }, frameCount] {
+    m_compositorIntegration->prepareForDisplay(frameCount, [weakThis = WeakPtr { *this }, frameCount, buffer] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
         RefPtr base = protectedThis->canvasBase();
         base->clearCopiedImage();
-        if (RefPtr buffer = base->buffer(); buffer && protectedThis->m_configuration) {
+        if (buffer && protectedThis->m_configuration) {
             buffer->flushDrawingContext();
             protectedThis->m_compositorIntegration->paintCompositedResultsToCanvas(*buffer, frameCount);
             protectedThis->present(frameCount);
         }
     });
-    return canvasBase().buffer();
+    return buffer;
 }
 
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
@@ -481,6 +495,8 @@ void GPUCanvasContextCocoa::unconfigure()
     m_presentationContext->unconfigure();
     m_configuration = std::nullopt;
     m_currentTexture = nullptr;
+    m_readDisplayBuffer = nullptr;
+    updateMemoryCost();
     ASSERT(!isConfigured());
 }
 
@@ -563,7 +579,8 @@ void GPUCanvasContextCocoa::prepareForDisplay()
 {
     if (!isConfigured())
         return;
-
+    m_readDisplayBuffer = nullptr;
+    updateMemoryCost();
     ASSERT(m_configuration->frameCount < m_configuration->renderBuffers.size());
 
     auto frameIndex = m_configuration->frameCount;
@@ -581,7 +598,22 @@ void GPUCanvasContextCocoa::prepareForDisplay()
 void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
 {
     m_compositingResultsNeedsUpdating = true;
+    if (m_readDisplayBuffer) {
+        m_readDisplayBuffer = nullptr;
+        updateMemoryCost();
+    }
     markCanvasChanged();
+}
+
+void GPUCanvasContextCocoa::updateMemoryCost() const
+{
+    // Computes only a rough ballpark figure to drive garbage collection.
+    size_t newMemoryCost = 0;
+    if (m_readDisplayBuffer)
+        newMemoryCost += Ref { *m_readDisplayBuffer }->memoryCost();
+    if (m_currentTexture)
+        newMemoryCost += m_width * m_height * 4;
+    CanvasRenderingContext::updateMemoryCost(newMemoryCost);
 }
 
 

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -64,83 +64,25 @@ ImageBitmapCanvas ImageBitmapRenderingContext::canvas()
     return &downcast<HTMLCanvasElement>(base.get());
 }
 
-void ImageBitmapRenderingContext::setOutputBitmap(RefPtr<ImageBitmap> imageBitmap)
+ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<ImageBitmap> imageBitmap)
 {
-    // 1. If a bitmap argument was not provided, then:
-
     if (!imageBitmap) {
-        // 1.1. Set context's bitmap mode to blank.
-        // 1.2. Let canvas be the canvas element to which context is bound.
-        // 1.3. Set context's output bitmap to be transparent black with an
-        //      intrinsic width equal to the numeric value of canvas's width attribute
-        //      and an intrinsic height equal to the numeric value of canvas's height
-        //      attribute, those values being interpreted in CSS pixels.
         setBlank();
-        // 1.4. Set the output bitmap's origin-clean flag to true.
         canvasBase().setOriginClean();
-        return;
+        return { };
     }
-
-    // 2. If a bitmap argument was provided, then:
-
-    // 2.1. Set context's bitmap mode to valid.
-
-    m_bitmapMode = BitmapMode::Valid;
-
-    // 2.2. Set context's output bitmap to refer to the same underlying
-    //      bitmap data as bitmap, without making a copy.
-    //      Note: the origin-clean flag of bitmap is included in the
-    //      bitmap data to be referenced by context's output bitmap.
-
+    if (imageBitmap->isDetached())
+        return Exception { ExceptionCode::InvalidStateError };
     if (imageBitmap->originClean())
         canvasBase().setOriginClean();
     else
         canvasBase().setOriginTainted();
     canvasBase().setImageBufferAndMarkDirty(imageBitmap->takeImageBuffer());
-}
-
-ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<ImageBitmap> imageBitmap)
-{
-    // 1. Let bitmapContext be the ImageBitmapRenderingContext object on which
-    //    the transferFromImageBitmap() method was called.
-
-    // 2. If imageBitmap is null, then run the steps to set an ImageBitmapRenderingContext's
-    //    output bitmap, with bitmapContext as the context argument and no bitmap argument,
-    //    then abort these steps.
-
-    if (!imageBitmap) {
-        setOutputBitmap(nullptr);
-        return { };
-    }
-
-    // 3. If the value of imageBitmap's [[Detached]] internal slot is set to true,
-    //    then throw an "InvalidStateError" DOMException and abort these steps.
-
-    if (imageBitmap->isDetached())
-        return Exception { ExceptionCode::InvalidStateError };
-
-    // 4. Run the steps to set an ImageBitmapRenderingContext's output bitmap,
-    //    with the context argument equal to bitmapContext, and the bitmap
-    //    argument referring to imageBitmap's underlying bitmap data.
-
-    setOutputBitmap(imageBitmap);
-
-    // 5. Set the value of imageBitmap's [[Detached]] internal slot to true.
-    // 6. Unset imageBitmap's bitmap data.
-
-    // Note that the algorithm in the specification is currently a bit
-    // muddy here. The setOutputBitmap step above had to transfer ownership
-    // from the imageBitmap to this object, which requires a detach and unset,
-    // so this step isn't necessary, but we'll do it anyway.
-
-    imageBitmap->close();
-
     return { };
 }
 
 void ImageBitmapRenderingContext::setBlank()
 {
-    m_bitmapMode = BitmapMode::Blank;
     // FIXME: What is the point of creating a full size transparent buffer that
     // can never be changed? Wouldn't a 1x1 buffer give the same rendering? The
     // only reason I can think of is toDataURL(), but that doesn't seem like

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -66,40 +66,57 @@ ImageBitmapCanvas ImageBitmapRenderingContext::canvas()
 
 ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<ImageBitmap> imageBitmap)
 {
-    if (!imageBitmap) {
-        setBlank();
-        canvasBase().setOriginClean();
+    RefPtr<ImageBuffer> newBuffer;
+    bool originClean = true;
+    if (imageBitmap) {
+        if (imageBitmap->isDetached())
+            return Exception { ExceptionCode::InvalidStateError };
+        originClean = imageBitmap->originClean();
+        newBuffer = imageBitmap->takeImageBuffer();
+    } else if (!m_buffer)
         return { };
-    }
-    if (imageBitmap->isDetached())
-        return Exception { ExceptionCode::InvalidStateError };
-    if (imageBitmap->originClean())
-        canvasBase().setOriginClean();
-    else
-        canvasBase().setOriginTainted();
-    canvasBase().setImageBufferAndMarkDirty(imageBitmap->takeImageBuffer());
-    return { };
-}
 
-void ImageBitmapRenderingContext::setBlank()
-{
-    // FIXME: What is the point of creating a full size transparent buffer that
-    // can never be changed? Wouldn't a 1x1 buffer give the same rendering? The
-    // only reason I can think of is toDataURL(), but that doesn't seem like
-    // a good enough argument to waste memory.
-    auto buffer = ImageBuffer::create(FloatSize(canvasBase().width(), canvasBase().height()), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-    canvasBase().setImageBufferAndMarkDirty(WTF::move(buffer));
+    Ref canvasBase = this->canvasBase();
+    if (originClean)
+        canvasBase->setOriginClean();
+    else
+        canvasBase->setOriginTainted();
+    if (newBuffer) {
+        IntSize newSize = newBuffer->truncatedLogicalSize();
+        updateMemoryCost(newBuffer->memoryCost());
+        m_buffer = newBuffer.releaseNonNull();
+        canvasBase->setSizeForControllingContext(newSize);
+    } else {
+        m_buffer = nullptr;
+        updateMemoryCost(0);
+    }
+    canvasBase->didDraw(FloatRect { { }, canvasBase->size() });
+    return { };
 }
 
 RefPtr<ImageBuffer> ImageBitmapRenderingContext::transferToImageBuffer()
 {
-    if (!canvasBase().hasCreatedImageBuffer())
-        return canvasBase().allocateImageBuffer();
-    RefPtr result = canvasBase().buffer();
-    if (!result)
-        return nullptr;
-    setBlank();
+    Ref canvasBase = this->canvasBase();
+    auto size = canvasBase->size();
+    if (!m_buffer)
+        return ImageBuffer::create(size, RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    RefPtr result = std::exchange(m_buffer, { });
+    updateMemoryCost(0);
+    canvasBase->setOriginClean();
+    canvasBase->didDraw(FloatRect { { }, size });
     return result;
+}
+
+RefPtr<ImageBuffer> ImageBitmapRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
+{
+    if (!m_buffer) {
+        RefPtr buffer = ImageBuffer::create(Ref { canvasBase() }->size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+        if (buffer) {
+            updateMemoryCost(buffer->memoryCost());
+            m_buffer = WTF::move(buffer);
+        }
+    }
+    return m_buffer;
 }
 
 }

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -48,19 +48,11 @@ class ImageBitmapRenderingContext final : public CanvasRenderingContext {
     WTF_MAKE_TZONE_ALLOCATED(ImageBitmapRenderingContext);
 public:
     static std::unique_ptr<ImageBitmapRenderingContext> create(CanvasBase&, ImageBitmapRenderingContextSettings&&);
-
-    enum class BitmapMode {
-        Valid,
-        Blank
-    };
-
     ~ImageBitmapRenderingContext();
 
     ImageBitmapCanvas canvas();
 
     ExceptionOr<void> transferFromImageBitmap(RefPtr<ImageBitmap>);
-
-    BitmapMode bitmapMode() { return m_bitmapMode; }
     bool hasAlpha() { return m_settings.alpha; }
 
 private:
@@ -68,10 +60,8 @@ private:
 
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
-    void setOutputBitmap(RefPtr<ImageBitmap>);
     void setBlank();
 
-    BitmapMode m_bitmapMode { BitmapMode::Blank };
     ImageBitmapRenderingContextSettings m_settings;
 };
 

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -55,13 +55,16 @@ public:
     ExceptionOr<void> transferFromImageBitmap(RefPtr<ImageBitmap>);
     bool hasAlpha() { return m_settings.alpha; }
 
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return !m_buffer; }
+    void didUpdateCanvasSizeProperties(bool) final { }
+
 private:
     ImageBitmapRenderingContext(CanvasBase&, ImageBitmapRenderingContextSettings&&);
 
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
-    void setBlank();
-
+    RefPtr<ImageBuffer> m_buffer;
     ImageBitmapRenderingContextSettings m_settings;
 };
 

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl
@@ -30,6 +30,8 @@ typedef (HTMLCanvasElement) ImageBitmapCanvas;
 #endif
 
 [
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface ImageBitmapRenderingContext {

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -130,9 +130,9 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
 
 RefPtr<ImageBuffer> OffscreenCanvasRenderingContext2D::transferToImageBuffer()
 {
-    if (!canvasBase().hasCreatedImageBuffer())
-        return canvasBase().allocateImageBuffer();
-    auto* buffer = canvasBase().buffer();
+    if (!hasCreatedImageBuffer())
+        return allocateImageBuffer();
+    RefPtr buffer = this->buffer();
     if (!buffer)
         return nullptr;
     // As the canvas context state is stored in GraphicsContext, which is owned

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -29,6 +29,8 @@
     Conditional=OFFSCREEN_CANVAS,
     ConditionalForWorker=OFFSCREEN_CANVAS_IN_WORKERS,
     EnabledForContext,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     JSCustomMarkFunction,
     TaggedWrapper,

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -44,12 +44,14 @@ public:
 
     virtual ~PaintRenderingContext2D();
 
-    GraphicsContext* ensureDrawingContext() const;
-    GraphicsContext* existingDrawingContext() const final;
-    AffineTransform baseTransform() const final;
+    GraphicsContext* drawingContext() const;
+    AffineTransform baseTransform() const;
 
     CustomPaintCanvas& canvas() const;
     void replayDisplayList(GraphicsContext& target) const;
+
+protected:
+    void didUpdateCanvasSizeProperties(bool) final;
 
 private:
     PaintRenderingContext2D(CustomPaintCanvas&);

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -73,6 +73,10 @@ public:
 
     PlaceholderRenderingContextSource& source() const { return m_source; }
 
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final;
+    void didUpdateCanvasSizeProperties(bool) final;
+
 private:
     PlaceholderRenderingContext(HTMLCanvasElement&);
     void setContentsToLayer(GraphicsLayer&) final;
@@ -80,6 +84,7 @@ private:
     bool isOpaque() const final { return m_opaque; }
 
     const Ref<PlaceholderRenderingContextSource> m_source;
+    RefPtr<ImageBuffer> m_buffer;
     bool m_opaque { false };
 };
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -63,6 +63,8 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     GenerateIsReachable=ImplCanvasBase,
     JSCustomMarkFunction,
     DoNotCheckConstants,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface WebGL2RenderingContext {

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.idl
@@ -47,6 +47,8 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     JSCustomMarkFunction,
     DoNotCheckConstants,
     ExportMacro=WEBCORE_EXPORT,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface WebGLRenderingContext {

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -833,7 +833,13 @@ RefPtr<VideoFrame> WebGLRenderingContextBase::surfaceBufferToVideoFrame(SurfaceB
 
 RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
 {
-    auto buffer = protectedCanvasBase()->allocateImageBuffer();
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    const auto size = m_defaultFramebuffer->size();
+    if (size.isEmpty())
+        return nullptr;
+    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
     if (!buffer)
         return nullptr;
     if (compositingResultsNeedUpdating())

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -481,6 +481,7 @@ std::unique_ptr<WebGLRenderingContextBase> WebGLRenderingContextBase::create(Can
     renderingContext->initializeNewContext(context.releaseNonNull());
     renderingContext->suspendIfNeeded();
     InspectorInstrumentation::didCreateCanvasRenderingContext(*renderingContext);
+    renderingContext->updateMemoryCost();
     if (renderingContext->m_context->isContextLost())
         renderingContext->forceContextLost();
     return renderingContext;
@@ -533,7 +534,8 @@ void WebGLRenderingContextBase::initializeNewContext(Ref<GraphicsContextGL> cont
 void WebGLRenderingContextBase::initializeContextState()
 {
     m_errors = { };
-    m_canvasBufferContents = SurfaceBuffer::DrawingBuffer;
+    m_readDisplayBuffer = nullptr;
+    m_readDrawingBuffer = nullptr;
     m_compositingResultsNeedUpdating = false;
     m_activeTextureUnit = 0;
     m_packParameters = { };
@@ -679,7 +681,10 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
         return;
 
     m_compositingResultsNeedUpdating = true;
-    m_canvasBufferContents = std::nullopt;
+    if (m_readDrawingBuffer) {
+        m_readDrawingBuffer = nullptr;
+        updateMemoryCost();
+    }
     markCanvasChanged();
 }
 
@@ -757,19 +762,40 @@ bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::Cal
     return combinedClear;
 }
 
+// Temporary function to create image buffer for backing store reads until NativeImages are used.
+static RefPtr<ImageBuffer> createImageBufferForWebGLContextReads(IntSize size, ScriptExecutionContext& scriptExecutionContext)
+{
+    return ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext.graphicsClient());
+}
 
 RefPtr<ImageBuffer> WebGLRenderingContextBase::surfaceBufferToImageBuffer(SurfaceBuffer sourceBuffer)
 {
-    RefPtr buffer = protectedCanvasBase()->buffer();
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    auto size = m_defaultFramebuffer->size();
+    if (size.isEmpty())
+        return nullptr;
+    RefPtr<ImageBuffer> buffer;
+    if (sourceBuffer == SurfaceBuffer::DrawingBuffer) {
+        if (m_readDrawingBuffer)
+            return m_readDrawingBuffer;
+        m_readDrawingBuffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
+        updateMemoryCost();
+        buffer = m_readDrawingBuffer;
+    } else {
+        if (m_readDisplayBuffer)
+            return m_readDisplayBuffer;
+        m_readDisplayBuffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
+        updateMemoryCost();
+        buffer = m_readDisplayBuffer;
+    }
     if (isContextLost())
         return buffer;
     if (!buffer)
         return buffer;
-    if (m_canvasBufferContents == sourceBuffer)
-        return buffer;
     if (sourceBuffer == SurfaceBuffer::DrawingBuffer)
         clearIfComposited(CallerTypeOther);
-    m_canvasBufferContents = sourceBuffer;
     // FIXME: Remote ImageBuffers do not flush the buffers that are drawn to a buffer.
     // Avoid leaking the WebGL content in the cases where a WebGL canvas element is drawn to a Context2D
     // canvas element repeatedly.
@@ -839,7 +865,7 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
     const auto size = m_defaultFramebuffer->size();
     if (size.isEmpty())
         return nullptr;
-    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
+    RefPtr buffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
     if (!buffer)
         return nullptr;
     if (compositingResultsNeedUpdating())
@@ -854,7 +880,7 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
     return buffer;
 }
 
-void WebGLRenderingContextBase::reshape()
+void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
 {
     if (isContextLost())
         return;
@@ -863,9 +889,10 @@ void WebGLRenderingContextBase::reshape()
     if (newSize == m_defaultFramebuffer->size())
         return;
 
-    // We don't have to mark the canvas as dirty, since the newly created image buffer will also start off
-    // clear (and this matches what reshape will do).
+    m_readDrawingBuffer = nullptr;
+    m_readDisplayBuffer = nullptr;
     m_defaultFramebuffer->reshape(newSize);
+    updateMemoryCost();
 
     auto& textureUnit = m_textureUnits[m_activeTextureUnit];
     RefPtr context = m_context;
@@ -5271,6 +5298,7 @@ void WebGLRenderingContextBase::maybeRestoreContext()
 
     if (auto context = graphicsClient->createGraphicsContextGL(resolveGraphicsContextGLAttributes(m_creationAttributes, isWebGL2(), *scriptExecutionContext))) {
         initializeNewContext(context.releaseNonNull());
+        updateMemoryCost();
         if (!m_context->isContextLost()) {
             // Context lost state is reset only here: context creation succeeded
             // and initialization calls did not observe context loss. This means
@@ -5670,7 +5698,9 @@ void WebGLRenderingContextBase::prepareForDisplay()
     m_defaultFramebuffer->markAllUnpreservedBuffersDirty();
 
     m_compositingResultsNeedUpdating = false;
-    m_canvasBufferContents = std::nullopt;
+    m_readDisplayBuffer = nullptr;
+    m_readDrawingBuffer = nullptr;
+    updateMemoryCost();
 
     if (hasActiveInspectorCanvasCallTracer()) [[unlikely]]
         InspectorInstrumentation::didFinishRecordingCanvasFrame(*this);
@@ -5684,6 +5714,25 @@ void WebGLRenderingContextBase::updateActiveOrdinal()
 bool WebGLRenderingContextBase::isOpaque() const
 {
     return !m_attributes.alpha;
+}
+
+void WebGLRenderingContextBase::updateMemoryCost() const
+{
+    // Computes only a rough ballpark figure to drive garbage collection.
+    size_t newMemoryCost = 0;
+    if (m_readDisplayBuffer)
+        newMemoryCost += Ref { *m_readDisplayBuffer }->memoryCost();
+    if (m_readDrawingBuffer)
+        newMemoryCost += Ref { *m_readDrawingBuffer }->memoryCost();
+    size_t area = m_defaultFramebuffer->size().unclampedArea();
+    size_t bytesPerSample = 4;
+    if (m_attributes.depth)
+        bytesPerSample += 4;
+    else if (m_attributes.stencil)
+        bytesPerSample += 1;
+    size_t samplesPerPixel = m_attributes.antialias ? 4 : 1;
+    newMemoryCost += area * samplesPerPixel * bytesPerSample;
+    CanvasRenderingContext::updateMemoryCost(newMemoryCost);
 }
 
 WebCoreOpaqueRoot root(WebGLRenderingContextBase* context)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -429,9 +429,10 @@ public:
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
-    void reshape() override;
+    void didUpdateCanvasSizeProperties(bool) override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
 
     RefPtr<ByteArrayPixelBuffer> drawingBufferToPixelBuffer();
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
@@ -588,6 +589,7 @@ protected:
     virtual void uncacheDeletedBuffer(const AbstractLocker&, WebGLBuffer*);
     bool needsPreparationForDisplay() const final { return true; }
     void updateActiveOrdinal();
+    void updateMemoryCost() const;
 
     struct ContextLostState {
         ContextLostState(LostContextMode mode)
@@ -707,7 +709,8 @@ protected:
     int m_numGLErrorsToConsoleAllowed;
 
     bool m_compositingResultsNeedUpdating { false };
-    std::optional<SurfaceBuffer> m_canvasBufferContents;
+    RefPtr<ImageBuffer> m_readDrawingBuffer;
+    RefPtr<ImageBuffer> m_readDisplayBuffer;
 
     // Enabled extension objects.
     // FIXME: Move some of these to WebGLRenderingContext, the ones not needed for WebGL2

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -423,7 +423,7 @@ Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(b
     if (auto attributes = buildObjectForCanvasContextAttributes(m_context.get()))
         canvas->setContextAttributes(attributes.releaseNonNull());
 
-    if (size_t memoryCost = m_context->canvasBase().memoryCost())
+    if (size_t memoryCost = m_context->memoryCost())
         canvas->setMemoryCost(memoryCost);
 
     if (captureBacktrace) {

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1118,7 +1118,7 @@ void InspectorInstrumentation::didChangeCanvasSizeImpl(InstrumentingAgents& inst
         canvasAgent->didChangeCanvasSize(context);
 }
 
-void InspectorInstrumentation::didChangeCanvasMemoryImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)
+void InspectorInstrumentation::didChangeCanvasMemoryImpl(InstrumentingAgents& instrumentingAgents, const CanvasRenderingContext& context)
 {
     if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
         canvasAgent->didChangeCanvasMemory(context);

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -316,7 +316,7 @@ public:
     static void didChangeCSSCanvasClientNodes(CanvasBase&);
     static void didCreateCanvasRenderingContext(CanvasRenderingContext&);
     static void didChangeCanvasSize(CanvasRenderingContext&);
-    static void didChangeCanvasMemory(CanvasRenderingContext&);
+    static void didChangeCanvasMemory(const CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
     static void didEnableExtension(WebGLRenderingContextBase&, const String&);
@@ -521,7 +521,7 @@ private:
     static void didChangeCSSCanvasClientNodesImpl(InstrumentingAgents&, CanvasBase&);
     static void didCreateCanvasRenderingContextImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didChangeCanvasSizeImpl(InstrumentingAgents&, CanvasRenderingContext&);
-    static void didChangeCanvasMemoryImpl(InstrumentingAgents&, CanvasRenderingContext&);
+    static void didChangeCanvasMemoryImpl(InstrumentingAgents&, const CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrameImpl(InstrumentingAgents&, CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
     static void didEnableExtensionImpl(InstrumentingAgents&, WebGLRenderingContextBase&, const String&);
@@ -1444,7 +1444,7 @@ inline void InspectorInstrumentation::didChangeCanvasSize(CanvasRenderingContext
         didChangeCanvasSizeImpl(*agents, context);
 }
 
-inline void InspectorInstrumentation::didChangeCanvasMemory(CanvasRenderingContext& context)
+inline void InspectorInstrumentation::didChangeCanvasMemory(const CanvasRenderingContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -377,7 +377,7 @@ void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context
     if (!inspectorCanvas)
         return;
 
-    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().canvasBase().memoryCost());
+    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().memoryCost());
 }
 
 void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect&)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -366,7 +366,7 @@ void InspectorCanvasAgent::didChangeCanvasSize(CanvasRenderingContext& context)
     m_frontendDispatcher->canvasSizeChanged(inspectorCanvas->identifier(), size.width(), size.height());
 }
 
-void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context)
+void InspectorCanvasAgent::didChangeCanvasMemory(const CanvasRenderingContext& context)
 {
     RefPtr<InspectorCanvas> inspectorCanvas;
 
@@ -707,7 +707,7 @@ RefPtr<InspectorCanvas> InspectorCanvasAgent::assertInspectorCanvas(Inspector::P
     return inspectorCanvas;
 }
 
-RefPtr<InspectorCanvas> InspectorCanvasAgent::findInspectorCanvas(CanvasRenderingContext& context)
+RefPtr<InspectorCanvas> InspectorCanvasAgent::findInspectorCanvas(const CanvasRenderingContext& context)
 {
     for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
         if (&inspectorCanvas->canvasContext() == &context)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -96,7 +96,7 @@ public:
     // InspectorInstrumentation
     void didCreateCanvasRenderingContext(CanvasRenderingContext&);
     void didChangeCanvasSize(CanvasRenderingContext&);
-    void didChangeCanvasMemory(CanvasRenderingContext&);
+    void didChangeCanvasMemory(const CanvasRenderingContext&);
     void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
     void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     void consoleStopRecordingCanvas(CanvasRenderingContext&);
@@ -111,7 +111,7 @@ public:
     void recordAction(CanvasRenderingContext&, String&&, InspectorCanvasProcessedArguments&& = { });
 
     RefPtr<InspectorCanvas> assertInspectorCanvas(Inspector::Protocol::ErrorString&, const String& canvasId);
-    RefPtr<InspectorCanvas> findInspectorCanvas(CanvasRenderingContext&);
+    RefPtr<InspectorCanvas> findInspectorCanvas(const CanvasRenderingContext&);
 
 protected:
     InspectorCanvasAgent(WebAgentContext&);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -621,8 +621,8 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
 
 #if USE(CA)
     if (!compositor().acceleratedDrawingEnabled() && renderer().isRenderHTMLCanvas()) {
-        const HTMLCanvasElement* canvas = downcast<HTMLCanvasElement>(renderer().element());
-        if (canvas->shouldAccelerate(canvas->size()))
+        const RefPtr canvas = downcast<HTMLCanvasElement>(renderer().element());
+        if (canvas->shouldAccelerate())
             m_graphicsLayer->setAcceleratesDrawing(true);
     }
 #endif    


### PR DESCRIPTION
#### 5c9a25ef8b204ea30c476b35272e03cc8a9f34ce
<pre>
Cherry-pick 307450@main (39eb51251d8f). <a href="https://bugs.webkit.org/show_bug.cgi?id=275100">https://bugs.webkit.org/show_bug.cgi?id=275100</a>

    CanvasBase owns a ImageBuffer that belongs to the CanvasRenderingContext
    <a href="https://bugs.webkit.org/show_bug.cgi?id=275100">https://bugs.webkit.org/show_bug.cgi?id=275100</a>
    <a href="https://rdar.apple.com/129208981">rdar://129208981</a>

    Reviewed by Simon Fraser.

    Before, CanvasBase would own a ImageBuffer that was historically the
    2d context drawing backing store. This ImageBuffer was then repurposed for
    bitmaprenderer, webgl, webgpu backing store to paint all these contexts
    to page (i.e layer) contents. This coden organization is not good,
    because this dictates that the content will exist in an ImageBuffer.
    This needs an extra draw to bitmap to be used. This in turn results
    in loss of performance and memory for all context types, and loss
    of correctness for bitmaprenderer.

    Fix by moving the ImageBuffer backing store to
    CanvasRenderingContext2DBase. Fix by introducing the paint buffer
    backing store specific to each rendering context. In subsequent commits,
    each of the context type may hold and assign the paint buffer backing
    store in efficient manner suitable for each context type.  Also in
    subsequent commits, the paint storage will be held in NativeImages,
    avoiding the need to use ImageBuffer for context types that do not
    originate their images from ImageBuffer.

    * LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
    * LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
    * Source/WebCore/dom/Document.cpp:
    (WebCore::Document::getCSSCanvasContext):
    * Source/WebCore/html/CanvasBase.cpp:
    (WebCore::CanvasBase::~CanvasBase):
    (WebCore::CanvasBase::makeRenderingResultsAvailable):
    (WebCore::CanvasBase::setSize):
    (WebCore::CanvasBase::shouldAccelerate const):
    (WebCore::CanvasBase::validateArea const):
    (WebCore::CanvasBase::buffer const): Deleted.
    (WebCore::CanvasBase::setImageBuffer const): Deleted.
    (WebCore::CanvasBase::allocateImageBuffer const): Deleted.
    * Source/WebCore/html/CanvasBase.h:
    (WebCore::CanvasBase::setImageBufferAndMarkDirty): Deleted.
    (WebCore::CanvasBase::setHasCreatedImageBuffer): Deleted.
    (WebCore::CanvasBase::hasCreatedImageBuffer const): Deleted.
    (WebCore::CanvasBase::createImageBuffer const): Deleted.
    * Source/WebCore/html/CustomPaintCanvas.cpp:
    (WebCore::CustomPaintCanvas::~CustomPaintCanvas):
    * Source/WebCore/html/CustomPaintCanvas.h:
    * Source/WebCore/html/HTMLCanvasElement.cpp:
    (WebCore::HTMLCanvasElement::~HTMLCanvasElement):
    (WebCore::HTMLCanvasElement::attributeChanged):
    (WebCore::HTMLCanvasElement::setSizeForControllingContext):
    (WebCore::HTMLCanvasElement::didUpdateSizeProperties):
    (WebCore::HTMLCanvasElement::setCSSCanvasContextSize): Deleted.
    (WebCore::HTMLCanvasElement::createImageBuffer const): Deleted.
    (WebCore::HTMLCanvasElement::setImageBufferAndMarkDirty): Deleted.
    * Source/WebCore/html/HTMLCanvasElement.h:
    * Source/WebCore/html/OffscreenCanvas.cpp:
    (WebCore::OffscreenCanvas::~OffscreenCanvas):
    (WebCore::OffscreenCanvas::setWidth):
    (WebCore::OffscreenCanvas::setHeight):
    (WebCore::OffscreenCanvas::setSizeForControllingContext):
    (WebCore::OffscreenCanvas::didUpdateSizeProperties):
    (WebCore::OffscreenCanvas::transferToImageBitmap):
    (WebCore::OffscreenCanvas::createImageBuffer const): Deleted.
    (WebCore::OffscreenCanvas::setImageBufferAndMarkDirty): Deleted.
    * Source/WebCore/html/OffscreenCanvas.h:
    * Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
    (WebCore::CanvasRenderingContext::updateMemoryCost const):
    (WebCore::CanvasRenderingContext::surfaceBufferToImageBuffer): Deleted.
    (WebCore::CanvasRenderingContext::isSurfaceBufferTransparentBlack const): Deleted.
    (WebCore::CanvasRenderingContext::updateMemoryCostOnAllocation): Deleted.
    * Source/WebCore/html/canvas/CanvasRenderingContext.h:
    * Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
    (WebCore::CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase):
    (WebCore::CanvasRenderingContext2DBase::surfaceBufferToImageBuffer):
    (WebCore::CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack const):
    (WebCore::CanvasRenderingContext2DBase::layerContentsDisplayDelegate):
    (WebCore::CanvasRenderingContext2DBase::flushDeferredOperations):
    (WebCore::CanvasRenderingContext2DBase::reset):
    (WebCore::CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties):
    (WebCore::CanvasRenderingContext2DBase::drawingContext const):
    (WebCore::CanvasRenderingContext2DBase::existingDrawingContext const):
    (WebCore::CanvasRenderingContext2DBase::baseTransform const):
    (WebCore::CanvasRenderingContext2DBase::prepareForDisplay):
    (WebCore::CanvasRenderingContext2DBase::putImageData):
    (WebCore::CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting):
    (WebCore::CanvasRenderingContext2DBase::buffer const):
    (WebCore::CanvasRenderingContext2DBase::allocateImageBuffer const):
    * Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
    (WebCore::CanvasRenderingContext2DBase::hasCreatedImageBuffer const):
    * Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
    * Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
    * Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
    (WebCore::GPUCanvasContextCocoa::didUpdateCanvasSizeProperties):
    (WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
    (WebCore::GPUCanvasContextCocoa::unconfigure):
    (WebCore::GPUCanvasContextCocoa::prepareForDisplay):
    (WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
    (WebCore::GPUCanvasContextCocoa::updateMemoryCost const):
    (WebCore::GPUCanvasContextCocoa::reshape): Deleted.
    * Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
    (WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
    (WebCore::ImageBitmapRenderingContext::transferToImageBuffer):
    (WebCore::ImageBitmapRenderingContext::surfaceBufferToImageBuffer):
    (WebCore::ImageBitmapRenderingContext::setBlank): Deleted.
    * Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
    * Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
    (WebCore::OffscreenCanvasRenderingContext2D::transferToImageBuffer):
    * Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
    (WebCore::PlaceholderRenderingContext::setContentsToLayer):
    (WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
    (WebCore::PlaceholderRenderingContext::pixelFormat const):
    (WebCore::PlaceholderRenderingContext::surfaceBufferToImageBuffer):
    (WebCore::PlaceholderRenderingContext::isSurfaceBufferTransparentBlack const):
    (WebCore::PlaceholderRenderingContext::didUpdateCanvasSizeProperties):
    * Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
    * Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
    (WebCore::WebGLRenderingContextBase::initializeNewContext):
    (WebCore::WebGLRenderingContextBase::initializeContextState):
    (WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):
    (WebCore::createImageBufferForWebGLContextReads):
    (WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
    (WebCore::WebGLRenderingContextBase::transferToImageBuffer):
    (WebCore::WebGLRenderingContextBase::didUpdateCanvasSizeProperties):
    (WebCore::WebGLRenderingContextBase::prepareForDisplay):
    (WebCore::WebGLRenderingContextBase::updateMemoryCost const):
    (WebCore::WebGLRenderingContextBase::reshape): Deleted.
    * Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
    * Source/WebCore/inspector/InspectorInstrumentation.cpp:
    (WebCore::InspectorInstrumentation::didChangeCanvasMemoryImpl):
    * Source/WebCore/inspector/InspectorInstrumentation.h:
    (WebCore::InspectorInstrumentation::didChangeCanvasMemory):
    * Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
    (WebCore::InspectorCanvasAgent::didChangeCanvasMemory):
    (WebCore::InspectorCanvasAgent::findInspectorCanvas):
    * Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
    * Source/WebCore/rendering/RenderLayerBacking.cpp:
    (WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):

    Canonical link: <a href="https://commits.webkit.org/307450@main">https://commits.webkit.org/307450@main</a>

    # Conflicts:
    #   Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
    #   Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
    #   Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
    #   Source/WebCore/rendering/RenderLayerBacking.cpp

Canonical link: <a href="https://commits.webkit.org/305877.809@webkitglib/2.52">https://commits.webkit.org/305877.809@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e3ccffb3ffc63d14c93126e749f7cfd14f805677
<pre>
Cherry-pick 306772@main (163003d0cfa2). <a href="https://bugs.webkit.org/show_bug.cgi?id=306617">https://bugs.webkit.org/show_bug.cgi?id=306617</a>

    Avoid using CanvasBase::allocateImageBuffer() in WebGL, WebGPU transferToImageBuffer()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306617">https://bugs.webkit.org/show_bug.cgi?id=306617</a>
    <a href="https://rdar.apple.com/169276497">rdar://169276497</a>

    Reviewed by Mike Wyrzykowski.

    The allocation function is related to how 2D context backing store is
    allocated. transferToImageBuffer needs a general purpose ImageBuffer,
    where the WebGL, WebGPU backing store is transferred to.

    This makes it simpler to move 2D context related ImageBuffer code to
    2D rendering context classes.

    * LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
    Example of failure being fixed here:
    Previously transferToImageBitmap of a giant WebGL context failed due to
    canvas area limitations.

    * Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
    (WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
    * Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
    (WebCore::WebGLRenderingContextBase::transferToImageBuffer):

    Canonical link: <a href="https://commits.webkit.org/306772@main">https://commits.webkit.org/306772@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.808@webkitglib/2.52">https://commits.webkit.org/305877.808@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ecfaa2e386c8b4cdac674f7cb3366401cc8981df
<pre>
Cherry-pick 306625@main (3c05c29f69e0). <a href="https://bugs.webkit.org/show_bug.cgi?id=306608">https://bugs.webkit.org/show_bug.cgi?id=306608</a>

    Move memory cost reporting to canvas rendering contexts
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306608">https://bugs.webkit.org/show_bug.cgi?id=306608</a>
    <a href="https://rdar.apple.com/169256162">rdar://169256162</a>

    Reviewed by Simon Fraser.

    Before, the canvas element or offscreen canvas object would report the
    memory cost The rendering context holds the resources and the cost is
    per rendering context type.

    This simplifies moving the ImageBuffer to CanvasRenderingContext2DBase.
    The current memory cost is bound to the image buffer size, and this is
    wildly inaccurate for WebGL and WebGPU. This will be fixed later.

    * Source/WebCore/html/CanvasBase.cpp:
    (WebCore::CanvasBase::setImageBuffer const):
    (WebCore::CanvasBase::memoryCost const): Deleted.
    (WebCore::CanvasBase::externalMemoryCost const): Deleted.
    * Source/WebCore/html/CanvasBase.h:
    * Source/WebCore/html/HTMLCanvasElement.idl:
    * Source/WebCore/html/OffscreenCanvas.idl:
    * Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
    (WebCore::CanvasRenderingContext::updateMemoryCostOnAllocation):
    (WebCore::CanvasRenderingContext::memoryCost const):
    (WebCore::CanvasRenderingContext::externalMemoryCost const):
    * Source/WebCore/html/canvas/CanvasRenderingContext.h:
    * Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:
    * Source/WebCore/html/canvas/GPUCanvasContext.idl:
    * Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl:
    * Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:
    * Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
    * Source/WebCore/html/canvas/WebGLRenderingContext.idl:
    * Source/WebCore/inspector/InspectorCanvas.cpp:
    (WebCore::InspectorCanvas::buildObjectForCanvas):
    * Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
    (WebCore::InspectorCanvasAgent::didChangeCanvasMemory):

    Canonical link: <a href="https://commits.webkit.org/306625@main">https://commits.webkit.org/306625@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.807@webkitglib/2.52">https://commits.webkit.org/305877.807@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 212940b396a875c5e81abd4abc03cde7dcfffe9c
<pre>
Cherry-pick 306511@main (8d32ab8d183e). <a href="https://bugs.webkit.org/show_bug.cgi?id=306603">https://bugs.webkit.org/show_bug.cgi?id=306603</a>

    Remove CanvasBase::m_contextStateSaver, it is not useful
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306603">https://bugs.webkit.org/show_bug.cgi?id=306603</a>
    <a href="https://rdar.apple.com/169252451">rdar://169252451</a>

    Reviewed by Simon Fraser.

    GraphicsContextStateSaver is a RAII class, it&apos;s not more useful than
    explicit save/restore useful when managed explicitly. Having the state
    saver in CanvasBase makes it harder to move the ImageBuffer from
    CanvasBase to 2DCanvasRenderingContextBase.

    * Source/WebCore/html/CanvasBase.cpp:
    (WebCore::CanvasBase::setImageBuffer const):
    (WebCore::CanvasBase::resetGraphicsContextState const): Deleted.
    * Source/WebCore/html/CanvasBase.h:
    * Source/WebCore/html/HTMLCanvasElement.cpp:
    (WebCore::HTMLCanvasElement::didUpdateSizeProperties):
    * Source/WebCore/html/OffscreenCanvas.cpp:
    (WebCore::OffscreenCanvas::didUpdateSizeProperties):
    * Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
    (WebCore::CanvasRenderingContext2DBase::unwindStateStack):
    (WebCore::CanvasRenderingContext2DBase::reset):

    Canonical link: <a href="https://commits.webkit.org/306511@main">https://commits.webkit.org/306511@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.806@webkitglib/2.52">https://commits.webkit.org/305877.806@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f7982e4cc9f859470e427c58b5402a205107b5d5
<pre>
Cherry-pick 306510@main (104d3149f3b3). <a href="https://bugs.webkit.org/show_bug.cgi?id=306606">https://bugs.webkit.org/show_bug.cgi?id=306606</a>

    Remove HTMLCanvasElement::clearImageBuffer, it is redundant
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306606">https://bugs.webkit.org/show_bug.cgi?id=306606</a>
    <a href="https://rdar.apple.com/169253510">rdar://169253510</a>

    Reviewed by Simon Fraser.

    2D context canvas is cleared in 2DCanvasRenderingContext::reset() already.
    The function makes it harder to move the ImageBuffer to
    2DCanvasRenderingContext.

    * Source/WebCore/html/HTMLCanvasElement.cpp:
    (WebCore::HTMLCanvasElement::didUpdateSizeProperties):
    (WebCore::HTMLCanvasElement::createImageBuffer const):
    (WebCore::HTMLCanvasElement::clearCopiedImage const):
    (WebCore::HTMLCanvasElement::clearImageBuffer const): Deleted.
    * Source/WebCore/html/HTMLCanvasElement.h:

    Canonical link: <a href="https://commits.webkit.org/306510@main">https://commits.webkit.org/306510@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.805@webkitglib/2.52">https://commits.webkit.org/305877.805@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c7f74f6b78d79f0db8fcc8cfaa0c952339a2e842
<pre>
Cherry-pick 306490@main (dc5403ca9f85). <a href="https://bugs.webkit.org/show_bug.cgi?id=306613">https://bugs.webkit.org/show_bug.cgi?id=306613</a>

    Remove unused code from ImageBitmapRenderingContext
    <a href="https://bugs.webkit.org/show_bug.cgi?id=306613">https://bugs.webkit.org/show_bug.cgi?id=306613</a>
    <a href="https://rdar.apple.com/169267153">rdar://169267153</a>

    Reviewed by Anne van Kesteren.

    Remove unused code and merge trivial functions that are used only once.
    Remove stale comments. The spec text has changed, and the comments
    make the trivial code more complex.

    Makes future changes moving ImageBuffer out of CanvasBase more
    reviewable.

    * Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
    (WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
    (WebCore::ImageBitmapRenderingContext::setBlank):
    (WebCore::ImageBitmapRenderingContext::setOutputBitmap): Deleted.
    * Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:

    Canonical link: <a href="https://commits.webkit.org/306490@main">https://commits.webkit.org/306490@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.804@webkitglib/2.52">https://commits.webkit.org/305877.804@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7578e9873053bf13916a09c4e40842bb9be3f834

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171897 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45814 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181200 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129451 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173762 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47100 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45454 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133734 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129451 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47100 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114205 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47100 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45454 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29950 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47100 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183868 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36484 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45454 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142438 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45481 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142329 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46161 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110811 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26090 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46161 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117849 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44679 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39232 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44079 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44311 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44138 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->