### PR TITLE
Parse @font-face metric override descriptors behind a testable flag

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides-expected.txt
@@ -1,0 +1,23 @@
+
+PASS Check that ascent-override: normal is valid
+PASS Check that ascent-override: 0% is valid
+PASS Check that ascent-override: 50% is valid
+PASS Check that ascent-override: 110% is valid
+PASS Check that ascent-override: 100000000000% is valid
+PASS Check that ascent-override: -1% is invalid
+PASS Check that ascent-override: 10px is invalid
+PASS Check that descent-override: normal is valid
+PASS Check that descent-override: 0% is valid
+PASS Check that descent-override: 50% is valid
+PASS Check that descent-override: 110% is valid
+PASS Check that descent-override: 100000000000% is valid
+PASS Check that descent-override: -1% is invalid
+PASS Check that descent-override: 10px is invalid
+PASS Check that line-gap-override: normal is valid
+PASS Check that line-gap-override: 0% is valid
+PASS Check that line-gap-override: 50% is valid
+PASS Check that line-gap-override: 110% is valid
+PASS Check that line-gap-override: 100000000000% is valid
+PASS Check that line-gap-override: -1% is invalid
+PASS Check that line-gap-override: 10px is invalid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>CSS Fonts 4 test: parsing @font-face metric override descriptors</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-metrics-override-desc">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style id="testStyle">
+</style>
+<script>
+  const sheet = testStyle.sheet;
+  const descriptors = ["ascent-override", "descent-override", "line-gap-override"];
+  const values = [
+    { value: "normal", valid: true, expected: "normal" },
+    { value: "0%", valid: true, expected: "0%" },
+    { value: "50%", valid: true, expected: "50%" },
+    { value: "110%", valid: true, expected: "110%" },
+    { value: "100000000000%", valid: true, expected: "100000000000%" },
+    { value: "-1%", valid: false },
+    { value: "10px", valid: false },
+  ];
+
+  for (const descriptor of descriptors) {
+    for (const { value, valid, expected } of values) {
+      test(() => {
+        assert_equals(sheet.cssRules.length, 0, "test sheet should initially be empty");
+        sheet.insertRule(`@font-face { ${descriptor}: ${value} }`);
+
+        try {
+          assert_equals(sheet.cssRules[0].style.getPropertyValue(descriptor), valid ? expected : "");
+        } finally {
+          sheet.deleteRule(0);
+        }
+      }, `Check that ${descriptor}: ${value} is ${valid ? "valid" : "invalid"}`);
+    }
+  }
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1156,6 +1156,20 @@ CSSFieldSizingEnabled:
     WebCore:
       default: true
 
+CSSFontFaceMetricOverrideDescriptorsEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS @font-face metric override descriptors"
+  humanReadableDescription: "Enable CSS @font-face metric override descriptors"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSFontSynthesisStyleObliqueOnlyEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -13828,6 +13828,36 @@
                     "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-src"
                 }
             },
+            "ascent-override": {
+                "codegen-properties": {
+                    "parser-grammar": "normal | <percentage [0,inf]>",
+                    "settings-flag": "cssFontFaceMetricOverrideDescriptorsEnabled"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-ascent-override"
+                }
+            },
+            "descent-override": {
+                "codegen-properties": {
+                    "parser-grammar": "normal | <percentage [0,inf]>",
+                    "settings-flag": "cssFontFaceMetricOverrideDescriptorsEnabled"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-descent-override"
+                }
+            },
+            "line-gap-override": {
+                "codegen-properties": {
+                    "parser-grammar": "normal | <percentage [0,inf]>",
+                    "settings-flag": "cssFontFaceMetricOverrideDescriptorsEnabled"
+                },
+                "specification": {
+                    "category": "css-fonts-4",
+                    "url": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-line-gap-override"
+                }
+            },
             "size-adjust": {
                 "codegen-properties": {
                     "parser-grammar": "<percentage [0,inf]>",


### PR DESCRIPTION
## Summary

Parse the CSS Fonts 4 `ascent-override`, `descent-override`, and `line-gap-override` `@font-face` descriptors behind the new testable `CSSFontFaceMetricOverrideDescriptorsEnabled` feature flag.

This is the first split from the original full implementation. It intentionally does not expose the descriptors through `FontFace` / `CSSFontFaceDescriptors` and does not apply them to font metrics yet.

Follow-up plan:

1. Expose the descriptors through `FontFace` and `CSSFontFaceDescriptors`, including getter/setter parsing.
2. Apply the descriptors to font metrics in `CSSFontFace`, `FontCreationContext`, `FontMetrics`, `Font` / `FontCache`, and remote rendering serialization.

Bug: https://bugs.webkit.org/show_bug.cgi?id=219735

## Verification

Passed locally:

- `Tools/Scripts/check-webkit-style Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml Source/WebCore/css/CSSProperties.json LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides-expected.txt`
- `Tools/Scripts/run-css-property-code-generation-tests`
- `ruby Source/WebCore/Scripts/GenerateSettings.rb ...`
- `ruby Source/WTF/Scripts/GeneratePreferences.rb ...`

Also verified:

- The updated `font-face-metric-overrides-expected.txt` now matches the actual output from the failing Mac WK2 EWS result byte-for-byte.

Not run locally:

- `Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --results-directory /private/tmp/webkit-layout-results imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-metric-overrides.html`

The local layout-test run is blocked because this checkout has no `WebKitBuild/Release/LayoutTestHelper`. EWS should run the test with build artifacts.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8731f1125b3f9b3c3757a4b47b850dc5053623e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134192 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94682 "21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114664 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36234 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34538 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30582 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3250 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184515 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33786 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142971 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154295 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142850 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46793 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31065 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111606 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37874 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118544 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45310 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9171 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44710 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->