### PR TITLE
Cherry-pick 80760a59ebe9. https://bugs.webkit.org/show_bug.cgi?id=312781

### DIFF
--- a/JSTests/stress/expression-info-multi-wide-encoding.js
+++ b/JSTests/stress/expression-info-multi-wide-encoding.js
@@ -1,0 +1,17 @@
+//@ skip if $memoryLimited
+//@ runDefault
+
+const PAD = " ".repeat(5000000);
+const src =
+  'function* gen(){var b;0+' + PAD + '(b,yield,1);null.x;} this.gen=gen;';
+(0, eval)(src);
+
+const it = gen();
+it.next();
+
+var stackStr;
+try {
+    it.next();
+} catch (e) {
+    stackStr = e.stack + 1;
+}

--- a/JSTests/stress/resizable-array-constant-folding.js
+++ b/JSTests/stress/resizable-array-constant-folding.js
@@ -1,0 +1,27 @@
+//@ runDefault("--useConcurrentJIT=false")
+const memories = [];
+
+(function() {
+    while (true) {
+        try {
+            memories.push(new WebAssembly.Memory({initial: 65535, maximum: 65536}));
+        } catch (e) {
+            break;
+        }
+    }
+})();
+
+const memory = new WebAssembly.Memory({initial: 1, maximum: 100});
+const buffer = memory.toResizableBuffer();
+const view = new Float64Array(buffer);
+
+function trigger(val) {
+    view[0] = val;
+}
+
+for (let i = 0; i < 10000; i++) {
+    trigger(13.37);
+}
+
+memory.grow(1);
+trigger(1.1);

--- a/JSTests/stress/slowputarraystorage-stale-structure-bit.js
+++ b/JSTests/stress/slowputarraystorage-stale-structure-bit.js
@@ -1,0 +1,34 @@
+Object.defineProperty(Object.prototype, 0, { get() {}, configurable: true });
+delete Object.prototype[0];
+let target = [1, 2, 3];
+Object.defineProperty(target, "length", { writable: false });
+
+let proxyGet = new Proxy(target, { 
+    get: (t, k) => k === "length" ? 999 : t[k] 
+});
+
+try {
+    let lengthLie = proxyGet.length;
+    if (lengthLie === 999) {
+        throw "\"get\" trap successfully returned a lying value (999) for a non-configurable, non-writable property!";
+    }
+} catch (e) {
+    if (!(e instanceof TypeError)) {
+        throw "Expected TypeError for \"get\" trap invariant violation, got: " + e;
+    }
+}
+
+let proxySet = new Proxy(target, { 
+    set: (t, k, v) => true 
+});
+
+try {
+    let setSuccess = Reflect.set(proxySet, "length", 999);
+    if (setSuccess === true && target.length !== 999) {
+        throw "Reflect.set returned true claiming success on a non-configurable, non-writable property!";
+    }
+} catch (e) {
+    if (!(e instanceof TypeError)) {
+        throw "Expected TypeError for \"set\" trap invariant violation, got: " + e;
+    }
+}

--- a/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race-expected.txt
+++ b/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash when toggling BiquadFilterNode.type while the channel count changes on the audio thread.
+
+PASS: did not crash.

--- a/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race.html
+++ b/LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function runTest()
+{
+    const context = new OfflineAudioContext(1, 48000 * 30, 48000);
+    const biquad = new BiquadFilterNode(context);
+    biquad.channelCountMode = 'explicit';
+    biquad.channelCount = 32;
+    biquad.connect(context.destination);
+
+    let last = biquad;
+    for (let i = 0; i < 50; ++i) {
+        const node = new BiquadFilterNode(context);
+        last.connect(node);
+        last = node;
+    }
+    last.connect(context.destination);
+
+    context.startRendering();
+
+    const types = ['lowpass', 'highpass'];
+    const counts = [31, 32];
+    let k = 0;
+    const deadline = performance.now() + 2000;
+
+    function spin()
+    {
+        for (let outer = 0; outer < 200; ++outer) {
+            biquad.channelCount = counts[k & 1];
+            ++k;
+            for (let i = 0; i < 4000; ++i)
+                biquad.type = types[i & 1];
+        }
+        if (performance.now() < deadline)
+            setTimeout(spin, 0);
+        else {
+            document.getElementById('result').textContent = 'PASS: did not crash.';
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    }
+    spin();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>This test passes if it does not crash when toggling BiquadFilterNode.type while the channel count changes on the audio thread.</p>
+<p id="result"></p>
+</body>
+</html>

--- a/LayoutTests/workers/weblock-manager-query-crash-expected.txt
+++ b/LayoutTests/workers/weblock-manager-query-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/workers/weblock-manager-query-crash.html
+++ b/LayoutTests/workers/weblock-manager-query-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+globalThis.testRunner?.dumpAsText();
+globalThis.testRunner?.waitUntilDone();
+
+const workerSrc = `
+  for (let i = 0; i < 500; i++) self.navigator.locks.query();
+  self.postMessage("ready");
+  for (let i = 0; i < 500; i++) self.navigator.locks.query();
+`;
+const blob = new Blob([workerSrc], {type: "text/javascript"});
+const url = URL.createObjectURL(blob);
+
+function log(msg) {
+    if (globalThis.$vm) $vm.print(msg);
+    console.log(msg);
+}
+
+let iterations = 0;
+function spawn() {
+    if (iterations++ > 50) {
+        globalThis.testRunner?.notifyDone();
+        return;
+    }
+    let w = new Worker(url);
+    w.onmessage = () => {
+        w.terminate();
+        w = null;
+        if (globalThis.$vm) $vm.gc();
+        setTimeout(spawn, 0);
+    };
+}
+
+window.onload = spawn;
+</script>
+</head>
+<body>
+This test passes if it doesn't crash.
+</body>
+</html>

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -59,7 +59,7 @@ namespace JSC {
       Extension: [   11111b | 1b |    offset:26                                ]
       AbsInstPC: [   11111b | 0b |     value:26                                ]
       MultiWide: [   11110b | 1b |     111b | numFields:5 | fields[6]:18       ] [ value:32 ] ...
-        DuoWide: [   11110b | 1b | field2:3 | value2:10 | field1:3 | value1:10 ]
+        DuoWide: [   11110b | 1b | field1:3 | value1:10 | field2:3 | value2:10 ]
      SingleWide: [   11110b | 0b |  field:3 | value:23                         ]
    ExtensionEnd: [   11110b | 0b |     111b |     0:23                         ]
           Basic: [ instPC:5 |   divot:7 | start:6 |  end:6 | line:3 | column:5 ]
@@ -141,7 +141,7 @@ namespace JSC {
        over to the extension island. For all encodings, this is just a single word. The only
        exception is the MultiWide encoding, which are followed by N value words. Because the
        decoder expects these words to be contiguous, we move all the value words over too. The
-       slots of the original value words will not be replaced by no-ops (SingleWide with 0).
+       slots of the original value words will now be replaced by no-ops (SingleWide with 0).
 
     AbsInstPC and Chapters
     ======================
@@ -451,6 +451,7 @@ void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDe
         // being contiguous.
         unsigned numberOfFields = (firstValue >> multiSizeShift) & multiSizeMask;
 
+        unsigned locationOfExtensionIsland = m_expressionInfoEncodedInfo.size();
         m_expressionInfoEncodedInfo.append({ firstValue }); // MultiWide header.
         for (unsigned i = 1; i < numberOfFields; ++i) {
             auto fieldValue = m_expressionInfoEncodedInfo[infoIndex + i];
@@ -460,7 +461,10 @@ void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDe
         // Save the last field in firstValue, and let the extension emitter below append it.
         firstValue = m_expressionInfoEncodedInfo[infoIndex + numberOfFields].value;
         m_expressionInfoEncodedInfo[infoIndex + numberOfFields] = encodeSingle(FieldID::InstPC, 0); // Replace with a no-op.
-        goto emitExtension;
+
+        unsigned extensionOffset = locationOfExtensionIsland - infoIndex;
+        m_expressionInfoEncodedInfo[infoIndex] = encodeExtension(extensionOffset);
+        goto emitExtensionIsland;
     }
 
     // Handle Basic.
@@ -477,9 +481,11 @@ void ExpressionInfo::Encoder::adjustInstPC(unsigned infoIndex, unsigned instPCDe
     isBasic = true;
 
 emitExtension:
-    unsigned extensionOffset = m_expressionInfoEncodedInfo.size() - infoIndex;
-    m_expressionInfoEncodedInfo[infoIndex] = encodeExtension(extensionOffset);
-
+    {
+        unsigned extensionOffset = m_expressionInfoEncodedInfo.size() - infoIndex;
+        m_expressionInfoEncodedInfo[infoIndex] = encodeExtension(extensionOffset);
+    }
+emitExtensionIsland:
     // Because the Basic word is used as a terminator for the current Entry,
     // if the firstValue is a Basic word, it needs to come last. Otherwise, we should
     // just emit firstValue first. AbsInstPC and MultiWide relies on this for correctness.
@@ -491,7 +497,7 @@ emitExtension:
     else {
         // The wides array is really only to enable us to use encodeMultiHeader. Hence,
         // we don't really need to store instPCDelta as the value here. It can be any value
-        // since it's not ued. However, to avoid confusion, we'll just populate it consistently.
+        // since it's not used. However, to avoid confusion, we'll just populate it consistently.
         Wide wides[1] = { { instPCDelta, FieldID::InstPC } };
         m_expressionInfoEncodedInfo.append(encodeMultiHeader(1, wides));
         m_expressionInfoEncodedInfo.append({ instPCDelta });
@@ -1033,7 +1039,7 @@ void ExpressionInfo::dumpEncodedInfo(ExpressionInfo::EncodedInfo* start, Express
                 out.print(" DUO ", fieldID1, " ");
                 print<duoValueBits>(out, fieldID1, value >> duoFirstValueShift);
                 out.print(" ", fieldID2, " ");
-                print<duoValueBits>(out, fieldID2, value >> duoFirstValueShift);
+                print<duoValueBits>(out, fieldID2, value >> duoSecondValueShift);
                 out.println();
 
             } else {

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -336,7 +336,13 @@ private:
                     // https://bugs.webkit.org/show_bug.cgi?id=125425
                     break;
                 }
-                
+
+                if (view->isResizableOrGrowableShared()) {
+                    // Because resizable and growable-shared views can have their backing store reallocated
+                    // by resize() / WebAssembly.Memory.grow(), a folded vector pointer would go stale.
+                    break;
+                }
+
                 m_interpreter.execute(indexInBlock);
                 eliminated = true;
                 

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -208,15 +208,16 @@ Structure::Structure(VM& vm, JSGlobalObject* globalObject, JSValue prototype, co
 {
     bool hasStaticNonEnumerableProperty = m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::DontEnum));
     bool hasStaticNonConfigurableProperty = m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::DontDelete));
+    bool isArrayStorage = hasAnyArrayStorage(indexingType);
 
     setDictionaryKind(NoneDictionaryKind);
     setIsPinnedPropertyTable(false);
     setHasAnyKindOfGetterSetterProperties(m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::AccessorOrCustomAccessorOrValue)));
     setHasReadOnlyOrGetterSetterPropertiesExcludingProto(hasAnyKindOfGetterSetterProperties() || m_classInfo->hasStaticPropertyWithAnyOfAttributes(static_cast<uint8_t>(PropertyAttribute::ReadOnly)));
-    setHasNonEnumerableProperties(hasStaticNonEnumerableProperty || typeInfo.overridesGetOwnPropertySlot());
+    setHasNonEnumerableProperties(hasStaticNonEnumerableProperty || typeInfo.overridesGetOwnPropertySlot() || isArrayStorage);
     setHasSpecialProperties(false);
-    setHasNonConfigurableProperties(hasStaticNonConfigurableProperty || typeInfo.overridesGetOwnPropertySlot());
-    setHasNonConfigurableReadOnlyOrGetterSetterProperties(hasStaticNonConfigurableProperty || (typeInfo.overridesGetOwnPropertySlot() && typeInfo.type() != ArrayType));
+    setHasNonConfigurableProperties(hasStaticNonConfigurableProperty || typeInfo.overridesGetOwnPropertySlot() || isArrayStorage);
+    setHasNonConfigurableReadOnlyOrGetterSetterProperties(hasStaticNonConfigurableProperty || (typeInfo.overridesGetOwnPropertySlot() && typeInfo.type() != ArrayType) || isArrayStorage);
     setHasUnderscoreProtoPropertyExcludingOriginalProto(false);
     setIsQuickPropertyAccessAllowedForEnumeration(true);
     setTransitionPropertyAttributes(0);

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -85,8 +85,8 @@ public:
 
     void requestLock(WebLockIdentifier, const String& name, const Options&, Function<void(bool)>&&, Function<void()>&& lockStolenHandler);
     void releaseLock(WebLockIdentifier, const String& name);
-    void abortLockRequest(WebLockIdentifier, const String& name, CompletionHandler<void(bool)>&&);
-    void query(CompletionHandler<void(Snapshot&&)>&&);
+    void abortLockRequest(WebLockIdentifier, const String& name, Function<void(bool)>&&);
+    void query(Function<void(Snapshot&&)>&&);
     void clientIsGoingAway();
 
 private:
@@ -126,23 +126,23 @@ void WebLockManager::MainThreadBridge::releaseLock(WebLockIdentifier lockIdentif
     });
 }
 
-void WebLockManager::MainThreadBridge::abortLockRequest(WebLockIdentifier lockIdentifier, const String& name, CompletionHandler<void(bool)>&& completionHandler)
+void WebLockManager::MainThreadBridge::abortLockRequest(WebLockIdentifier lockIdentifier, const String& name, Function<void(bool)>&& callback)
 {
-    callOnMainThread([this, protectedThis = Ref { *this }, lockIdentifier, name = crossThreadCopy(name), completionHandler = WTF::move(completionHandler)]() mutable {
-        WebLockRegistry::singleton().abortLockRequest(m_sessionID, m_clientOrigin, lockIdentifier, m_clientID, name, [clientID = m_clientID, completionHandler = WTF::move(completionHandler)](bool wasAborted) mutable {
-            ScriptExecutionContext::ensureOnContextThread(clientID, [completionHandler = WTF::move(completionHandler), wasAborted](auto&) mutable {
-                completionHandler(wasAborted);
+    callOnMainThread([this, protectedThis = Ref { *this }, lockIdentifier, name = crossThreadCopy(name), callback = WTF::move(callback)]() mutable {
+        WebLockRegistry::singleton().abortLockRequest(m_sessionID, m_clientOrigin, lockIdentifier, m_clientID, name, [clientID = m_clientID, callback = WTF::move(callback)](bool wasAborted) mutable {
+            ScriptExecutionContext::ensureOnContextThread(clientID, [callback = WTF::move(callback), wasAborted](auto&) mutable {
+                callback(wasAborted);
             });
         });
     });
 }
 
-void WebLockManager::MainThreadBridge::query(CompletionHandler<void(Snapshot&&)>&& completionHandler)
+void WebLockManager::MainThreadBridge::query(Function<void(Snapshot&&)>&& callback)
 {
-    callOnMainThread([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
-        WebLockRegistry::singleton().snapshot(m_sessionID, m_clientOrigin, [clientID = m_clientID, completionHandler = WTF::move(completionHandler)](Snapshot&& snapshot) mutable {
-            ScriptExecutionContext::ensureOnContextThread(clientID, [completionHandler = WTF::move(completionHandler), snapshot = crossThreadCopy(snapshot)](auto&) mutable {
-                completionHandler(WTF::move(snapshot));
+    callOnMainThread([this, protectedThis = Ref { *this }, callback = WTF::move(callback)]() mutable {
+        WebLockRegistry::singleton().snapshot(m_sessionID, m_clientOrigin, [clientID = m_clientID, callback = WTF::move(callback)](Snapshot&& snapshot) mutable {
+            ScriptExecutionContext::ensureOnContextThread(clientID, [callback = WTF::move(callback), snapshot = crossThreadCopy(snapshot)](auto&) mutable {
+                callback(WTF::move(snapshot));
             });
         });
     });
@@ -307,9 +307,15 @@ void WebLockManager::query(Ref<DeferredPromise>&& promise)
         return;
     }
 
-    m_mainThreadBridge->query([weakThis = WeakPtr { *this }, promise = WTF::move(promise)](Snapshot&& snapshot) mutable {
+    auto promiseIdentifier = WebLockIdentifier::generate();
+    m_queryPromises.add(promiseIdentifier, WTF::move(promise));
+    m_mainThreadBridge->query([weakThis = WeakPtr { *this }, promiseIdentifier](Snapshot&& snapshot) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
+            return;
+
+        auto promise = protectedThis->m_queryPromises.take(promiseIdentifier);
+        if (!promise)
             return;
 
         queueTaskKeepingObjectAlive(*protectedThis, TaskSource::DOMManipulation, [promise = WTF::move(promise), snapshot = WTF::move(snapshot)](auto&) mutable {
@@ -356,13 +362,13 @@ void WebLockManager::stop()
 
 void WebLockManager::clientIsGoingAway()
 {
-    if (m_pendingRequests.isEmpty() && m_releasePromises.isEmpty())
-        return;
-
     // Reject all pending promises before clearing
-    for (Ref promise : m_releasePromises.values())
+    auto releasePromises = std::exchange(m_releasePromises, { });
+    for (Ref promise : releasePromises.values())
         promise->reject(ExceptionCode::AbortError, "Promise was rejected because the browsing context is going away"_s);
-
+    auto queryPromises = std::exchange(m_queryPromises, { });
+    for (Ref promise : queryPromises.values())
+        promise->reject(ExceptionCode::AbortError, "Promise was rejected because the browsing context is going away"_s);
     m_pendingRequests.clear();
     m_releasePromises.clear();
 
@@ -372,7 +378,7 @@ void WebLockManager::clientIsGoingAway()
 
 bool WebLockManager::virtualHasPendingActivity() const
 {
-    return !m_pendingRequests.isEmpty() || !m_releasePromises.isEmpty();
+    return !m_pendingRequests.isEmpty() || !m_releasePromises.isEmpty() || !m_queryPromises.isEmpty();
 }
 
 void WebLockManager::suspend(ReasonForSuspension reason)

--- a/Source/WebCore/Modules/web-locks/WebLockManager.h
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.h
@@ -83,6 +83,8 @@ private:
 
     struct LockRequest;
     HashMap<WebLockIdentifier, LockRequest> m_pendingRequests;
+
+    HashMap<WebLockIdentifier, Ref<DeferredPromise>> m_queryPromises;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp
@@ -28,6 +28,8 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "BiquadFilterNode.h"
+
+#include "BaseAudioContext.h"
 #include "ExceptionOr.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -70,6 +72,11 @@ BiquadFilterType BiquadFilterNode::type() const
 
 void BiquadFilterNode::setType(BiquadFilterType type)
 {
+    ASSERT(isMainThread());
+
+    // Synchronize with any graph changes or changes to channel configuration since
+    // BiquadProcessor::setType() may iterate the processor's kernels via reset().
+    Locker contextLocker { context().graphLock() };
     checkedBiquadProcessor()->setType(type);
 }
 

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -34,7 +34,6 @@
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentPage.h"
 #include "DocumentSecurityOrigin.h"
-#include "IDLTypes.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebXRSession.h"
 #include "JSXRReferenceSpaceType.h"
@@ -49,9 +48,6 @@
 #include "WebXRSession.h"
 #include "XRReferenceSpaceType.h"
 #include "XRSessionInit.h"
-#include <JavaScriptCore/JSCJSValue.h>
-#include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/JSString.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -138,7 +134,7 @@ void WebXRSystem::ensureImmersiveXRDeviceIsSelected(CompletionHandler<void()>&& 
     });
 }
 
-void WebXRSystem::obtainCurrentDevice(XRSessionMode mode, const JSFeatureList& requiredFeatures, const JSFeatureList& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&& callback)
+void WebXRSystem::obtainCurrentDevice(XRSessionMode mode, const Vector<String>& requiredFeatures, const Vector<String>& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&& callback)
 {
     if (isImmersive(mode)) {
         ensureImmersiveXRDeviceIsSelected([this, callback = WTF::move(callback)]() mutable {
@@ -223,12 +219,11 @@ bool WebXRSystem::immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow
 // https://immersive-web.github.io/webxr/#inline-session-request-is-allowed
 bool WebXRSystem::inlineSessionRequestIsAllowedForGlobalObject(LocalDOMWindow& globalObject, Document& document, const XRSessionInit& init) const
 {
-    auto isEmptyOrViewer = [&document](const JSFeatureList& features) {
+    auto isEmptyOrViewer = [](const Vector<String>& features) {
         if (features.isEmpty())
             return true;
-        if (features.size() == 1 && document.globalObject()) {
-            auto featureString = features.first().toWTFString(document.globalObject());
-            auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(featureString);
+        if (features.size() == 1) {
+            auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(features.first());
             if (sessionFeature && *sessionFeature == PlatformXR::SessionFeature::ReferenceSpaceTypeViewer)
                 return true;
         }
@@ -333,7 +328,7 @@ bool WebXRSystem::isFeatureSupported(PlatformXR::SessionFeature feature, XRSessi
 }
 
 // https://immersive-web.github.io/webxr/#resolve-the-requested-features
-std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveRequestedFeatures(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device, JSC::JSGlobalObject& globalObject) const
+std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveRequestedFeatures(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device) const
 {
     // 1. Let consentRequired be an empty list of DOMString.
     // 2. Let consentOptional be an empty list of DOMString.
@@ -353,19 +348,16 @@ std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveReques
     //    with mode to the indicated feature list if it is not already present.
     // https://immersive-web.github.io/webxr/#default-features
     auto requiredFeaturesWithDefaultFeatures = init.requiredFeatures;
-    {
-        JSC::JSLockHolder locker(&globalObject);
-        requiredFeaturesWithDefaultFeatures.append(JSC::jsStringWithCache(globalObject.vm(), PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeViewer)));
-        if (isImmersive(mode))
-            requiredFeaturesWithDefaultFeatures.append(JSC::jsStringWithCache(globalObject.vm(), PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeLocal)));
-    }
+    requiredFeaturesWithDefaultFeatures.append(PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeViewer));
+    if (isImmersive(mode))
+        requiredFeaturesWithDefaultFeatures.append(PlatformXR::sessionFeatureDescriptor(PlatformXR::SessionFeature::ReferenceSpaceTypeLocal));
 
     // 8. For each feature in requiredFeatures|optionalFeatures perform the following steps:
     // 9. For each feature in optionalFeatures perform the following steps:
     // We're merging both loops in a single lambda. The only difference is that a failure on any required features
     // implies cancelling the whole process while failures in optional features are just skipped.
     enum class ParsingMode { Strict, Loose };
-    auto parseFeatures = [this, &device, &globalObject, mode, &resolvedFeatures, &previouslyEnabled] (const JSFeatureList& sessionFeatures, ParsingMode parsingMode) -> bool {
+    auto parseFeatures = [this, &device, mode, &resolvedFeatures, &previouslyEnabled](const Vector<String>& sessionFeatures, ParsingMode parsingMode) -> bool {
         bool returnOnFailure = parsingMode == ParsingMode::Strict;
         for (const auto& sessionFeature : sessionFeatures) {
             // 1. If the feature is null, continue to the next entry.
@@ -379,8 +371,7 @@ std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveReques
             //   2.1. Let s be the result of calling ? ToString(feature).
             //   2.2. If s is not a valid feature descriptor or is undefined, (return null|continue to next entry).
             //   2.3. Set feature to s.
-            auto featureString = sessionFeature.toWTFString(&globalObject);
-            auto feature = PlatformXR::parseSessionFeatureDescriptor(featureString);
+            auto feature = PlatformXR::parseSessionFeatureDescriptor(sessionFeature);
             if (!feature)
                 RETURN_FALSE_OR_CONTINUE(returnOnFailure);
 
@@ -432,7 +423,7 @@ std::optional<WebXRSystem::ResolvedRequestedFeatures> WebXRSystem::resolveReques
 }
 
 // https://immersive-web.github.io/webxr/#request-the-xr-permission
-void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device, JSC::JSGlobalObject& globalObject, CompletionHandler<void(std::optional<FeatureList>&&)>&& completionHandler) const
+void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionInit& init, RefPtr<PlatformXR::Device> device, CompletionHandler<void(std::optional<FeatureList>&&)>&& completionHandler) const
 {
     // 1. Set status's granted to an empty FrozenArray.
     // 2. Let requiredFeatures be descriptor's requiredFeatures.
@@ -440,7 +431,7 @@ void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionI
     // 4. Let device be the result of obtaining the current device for mode, requiredFeatures, and optionalFeatures.
 
     // 5. Let result be the result of resolving the requested features given requiredFeatures,optionalFeatures, and mode.
-    auto resolvedFeatures = resolveRequestedFeatures(mode, init, device, globalObject);
+    auto resolvedFeatures = resolveRequestedFeatures(mode, init, device);
 
     // 6. If result is null, run the following steps:
     //  6.1. Set status's state to "denied".
@@ -556,10 +547,6 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         if (!device || !device->supports(mode))
             return;
 
-        auto* globalObject = protectedDocument->globalObject();
-        if (!globalObject)
-            return;
-
         rejectPromiseWithNotSupportedError.release();
 
         // WebKit does not currently support the Permissions API. https://w3c.github.io/permissions/
@@ -571,7 +558,7 @@ void WebXRSystem::requestSession(Document& document, XRSessionMode mode, const X
         // 5.4.5 Let status be an XRPermissionStatus, initially null
         // 5.4.6 Request the xr permission with descriptor and status.
         // 5.4.7 If status' state is "denied" run the following steps: (same as above in 5.4.1)
-        resolveFeaturePermissions(mode, init, device, *globalObject, [this, weakThis = WeakPtr { *this }, protectedDocument, device, immersive, mode, promise](std::optional<FeatureList>&& requestedFeatures) mutable {
+        resolveFeaturePermissions(mode, init, device, [this, weakThis = WeakPtr { *this }, protectedDocument, device, immersive, mode, promise](std::optional<FeatureList>&& requestedFeatures) mutable {
             if (!weakThis || !requestedFeatures) {
                 promise.reject(Exception { ExceptionCode::NotSupportedError });
                 m_pendingImmersiveSession = false;

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -44,10 +44,6 @@
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
-namespace JSC {
-class JSGlobalObject;
-}
-
 namespace WebCore {
 
 class LocalDOMWindow;
@@ -101,8 +97,7 @@ private:
     explicit WebXRSystem(Navigator&);
 
     using FeatureList = PlatformXR::Device::FeatureList;
-    using JSFeatureList = Vector<JSC::JSValue>;
-    void obtainCurrentDevice(XRSessionMode, const JSFeatureList& requiredFeatures, const JSFeatureList& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&&);
+    void obtainCurrentDevice(XRSessionMode, const Vector<String>& requiredFeatures, const Vector<String>& optionalFeatures, CompletionHandler<void(ThreadSafeWeakPtr<PlatformXR::Device>)>&&);
 
     bool immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&) const;
     bool inlineSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&, const XRSessionInit&) const;
@@ -110,8 +105,8 @@ private:
     bool isFeaturePermitted(PlatformXR::SessionFeature) const;
     bool isFeatureSupported(PlatformXR::SessionFeature, XRSessionMode, const PlatformXR::Device&) const;
     struct ResolvedRequestedFeatures;
-    std::optional<ResolvedRequestedFeatures> resolveRequestedFeatures(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, JSC::JSGlobalObject&) const;
-    void resolveFeaturePermissions(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, JSC::JSGlobalObject&, CompletionHandler<void(std::optional<FeatureList>&&)>&&) const;
+    std::optional<ResolvedRequestedFeatures> resolveRequestedFeatures(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>) const;
+    void resolveFeaturePermissions(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, CompletionHandler<void(std::optional<FeatureList>&&)>&&) const;
 
     // https://immersive-web.github.io/webxr/#default-inline-xr-device
     class DummyInlineDevice final : public PlatformXR::Device, public ContextDestructionObserver {

--- a/Source/WebCore/Modules/webxr/XRSessionInit.h
+++ b/Source/WebCore/Modules/webxr/XRSessionInit.h
@@ -27,18 +27,13 @@
 
 #if ENABLE(WEBXR)
 
-#include <JavaScriptCore/Strong.h>
 #include <wtf/Forward.h>
-
-namespace JSC {
-class JSValue;
-}
 
 namespace WebCore {
 
 struct XRSessionInit {
-    Vector<JSC::JSValue> requiredFeatures;
-    Vector<JSC::JSValue> optionalFeatures;
+    Vector<String> requiredFeatures;
+    Vector<String> optionalFeatures;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRSessionInit.idl
+++ b/Source/WebCore/Modules/webxr/XRSessionInit.idl
@@ -29,6 +29,6 @@
     EnabledBySetting=WebXREnabled,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRSessionInit {
-    sequence<any> requiredFeatures;
-    sequence<any> optionalFeatures;
+    sequence<DOMString> requiredFeatures;
+    sequence<DOMString> optionalFeatures;
 };

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -299,6 +299,7 @@ template<typename T> struct IDLNullable : IDLType<typename T::NullableType> {
 };
 
 template<typename T> struct IDLSequence : IDLType<Vector<typename T::InnerParameterType>> {
+    static_assert(!std::is_same_v<T, IDLAny>, "sequence<any> is insecure; use a concrete type");
     using InnerType = T;
 
     using ParameterType = const Vector<typename T::InnerParameterType>&;
@@ -306,6 +307,7 @@ template<typename T> struct IDLSequence : IDLType<Vector<typename T::InnerParame
 };
 
 template<typename T> struct IDLFrozenArray : IDLType<Vector<typename T::InnerParameterType>> {
+    static_assert(!std::is_same_v<T, IDLAny>, "FrozenArray<any> is insecure; use a concrete type");
     using InnerType = T;
 
     using ParameterType = const Vector<typename T::InnerParameterType>&;

--- a/Source/WebCore/fileapi/AsyncFileStream.cpp
+++ b/Source/WebCore/fileapi/AsyncFileStream.cpp
@@ -164,12 +164,12 @@ void AsyncFileStream::close()
     });
 }
 
-void AsyncFileStream::read(std::span<uint8_t> buffer)
+void AsyncFileStream::read(const Box<Vector<uint8_t>>& buffer, Function<void(int bytesRead)>&& didRead)
 {
-    perform([buffer](FileStream& stream) -> Function<void(FileStreamClient&)> {
-        int bytesRead = stream.read(buffer);
-        return [bytesRead](FileStreamClient& client) {
-            client.didRead(bytesRead);
+    perform([buffer, didRead = WTF::move(didRead)](FileStream& stream) mutable -> Function<void(FileStreamClient&)> {
+        int bytesRead = stream.read(*buffer);
+        return [bytesRead, didRead = WTF::move(didRead)](FileStreamClient&) {
+            didRead(bytesRead);
         };
     });
 }

--- a/Source/WebCore/fileapi/AsyncFileStream.h
+++ b/Source/WebCore/fileapi/AsyncFileStream.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <wtf/Box.h>
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
@@ -50,7 +51,7 @@ public:
     void getSize(const String& path, std::optional<WallTime> expectedModificationTime);
     void openForRead(const String& path, long long offset, long long length);
     void close();
-    void read(std::span<uint8_t> buffer);
+    void read(const Box<Vector<uint8_t>>& outputBuffer, Function<void(int bytesRead)>&&);
 
 private:
     void start();

--- a/Source/WebCore/loader/NavigationAction.cpp
+++ b/Source/WebCore/loader/NavigationAction.cpp
@@ -35,7 +35,6 @@
 #include "HistoryItem.h"
 #include "LocalFrame.h"
 #include "MouseEvent.h"
-#include "OriginAccessPatterns.h"
 
 namespace WebCore {
 
@@ -66,16 +65,6 @@ NavigationAction::NavigationAction(NavigationAction&&) = default;
 
 NavigationAction& NavigationAction::operator=(const NavigationAction&) = default;
 NavigationAction& NavigationAction::operator=(NavigationAction&&) = default;
-
-static bool shouldTreatAsSameOriginNavigation(const Document& document, const URL& url)
-{
-    return url.protocolIsAbout() || url.protocolIsData() || (url.protocolIsBlob() && document.protectedSecurityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton()));
-}
-
-static bool shouldTreatAsSameOriginNavigation(const NavigationRequester& requester, const URL& url)
-{
-    return url.protocolIsAbout() || url.protocolIsData() || (url.protocolIsBlob() && Ref { requester.securityOrigin }->canRequest(url, OriginAccessPatternsForWebProcess::singleton()));
-}
 
 static std::optional<NavigationAction::UIEventWithKeyStateData> keyStateDataForFirstEventWithKeyState(Event* event)
 {
@@ -113,7 +102,6 @@ NavigationAction::NavigationAction(const NavigationRequester& requester, const R
     , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
     , m_type { navigationType(frameLoadType, isFormSubmission, !!event) }
 {
-    m_treatAsSameOriginNavigation = shouldTreatAsSameOriginNavigation(requester, originalRequest.url());
     setDownloadAttribute(downloadAttribute);
     setSourceElement(sourceElement);
     setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
@@ -127,7 +115,6 @@ NavigationAction::NavigationAction(Document& requester, const ResourceRequest& o
     , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
     , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
     , m_type { type }
-    , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(requester, originalRequest.url()) }
 {
     setDownloadAttribute(downloadAttribute);
     setSourceElement(sourceElement);
@@ -147,7 +134,6 @@ NavigationAction::NavigationAction(FrameLoadRequest& request, NavigationType typ
     , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
     , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
     , m_type { type }
-    , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(request.protectedRequester().get(), request.resourceRequest().url()) }
 {
 }
 

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -107,8 +107,6 @@ public:
     bool processingUserGesture() const { return m_userGestureToken ? m_userGestureToken->processingUserGesture() : false; }
     RefPtr<UserGestureToken> userGestureToken() const { return m_userGestureToken; }
 
-    bool treatAsSameOriginNavigation() const { return m_treatAsSameOriginNavigation; }
-
     bool hasOpenedFrames() const { return m_hasOpenedFrames; }
     void setHasOpenedFrames(bool value) { m_hasOpenedFrames = value; }
 
@@ -148,7 +146,6 @@ private:
     NavigationType m_type;
     std::optional<NavigationNavigationType> m_navigationAPIType;
 
-    bool m_treatAsSameOriginNavigation { false };
     bool m_hasOpenedFrames { false };
     bool m_openedByDOMWithOpener { false };
 };

--- a/Source/WebCore/platform/FileStreamClient.h
+++ b/Source/WebCore/platform/FileStreamClient.h
@@ -38,7 +38,6 @@ class FileStreamClient : public AbstractRefCountedAndCanMakeWeakPtr<FileStreamCl
 public:
     virtual void didOpen(bool) { } // false signals failure.
     virtual void didGetSize(long long) { } // -1 signals failure.
-    virtual void didRead(int) { } // -1 signals failure.
     virtual void didWrite(int) { } // -1 signals failure.
     virtual void didTruncate(bool) { } // false signals failure.
 

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -272,7 +272,7 @@ bool BlobResourceHandle::shouldAbortDispatchDidReceiveResponse()
 void BlobResourceHandle::didReceiveResponse(ResourceResponse&& response)
 {
     client()->didReceiveResponseAsync(this, WTF::move(response), [this, protectedThis = Ref { *this }] {
-        buffer().resize(bufferSize);
+        resizeBuffer(bufferSize);
         readAsync();
     });
 }

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -33,6 +33,7 @@
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include <wtf/MainThread.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -43,6 +44,7 @@ static constexpr auto httpPartialContentText = "Partial Content"_s;
 
 BlobResourceHandleBase::BlobResourceHandleBase(bool async, RefPtr<BlobData>&& blobData)
     : m_blobData(WTF::move(blobData))
+    , m_buffer(Box<Vector<uint8_t>>::create())
 {
     if (async)
         m_stream = makeUnique<AsyncFileStream>(*this);
@@ -294,12 +296,25 @@ bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
     return consumeData(data);
 }
 
+void BlobResourceHandleBase::resizeBuffer(size_t newSize)
+{
+    RELEASE_ASSERT(!m_isWritingIntoBuffer);
+    m_buffer->resize(newSize);
+}
+
 void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item)
 {
     ASSERT(isMainThread());
 
     if (m_isFileOpen) {
-        asyncStream()->read(buffer().mutableSpan());
+        m_isWritingIntoBuffer = true;
+        asyncStream()->read(m_buffer, [weakThis = WeakPtr { *this }](int bytesRead) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            protectedThis->m_isWritingIntoBuffer = false;
+            protectedThis->didRead(bytesRead);
+        });
         return;
     }
 
@@ -341,7 +356,7 @@ void BlobResourceHandleBase::didRead(int bytesRead)
         return;
     }
 
-    if (consumeData(m_buffer.subspan(0, bytesRead)))
+    if (consumeData(m_buffer->subspan(0, bytesRead)))
         readAsync();
 }
 

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.h
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.h
@@ -29,6 +29,7 @@
 #include <WebCore/BlobData.h>
 #include <WebCore/FileStreamClient.h>
 #include <WebCore/HTTPParsers.h>
+#include <wtf/Box.h>
 #include <wtf/Forward.h>
 #include <wtf/Variant.h>
 #include <wtf/Vector.h>
@@ -73,8 +74,8 @@ protected:
     WEBCORE_EXPORT BlobData* blobData() const;
     FileStream* syncStream() const;
     AsyncFileStream* asyncStream() const;
-    Vector<uint8_t>& buffer() { return m_buffer; }
-    const Vector<uint8_t>& buffer() const { return m_buffer; }
+    WEBCORE_EXPORT void resizeBuffer(size_t);
+    const Vector<uint8_t>& buffer() const LIFETIME_BOUND { return *m_buffer; }
 
 private:
     void getSizeForNext();
@@ -85,6 +86,7 @@ private:
     void readFileAsync(const BlobDataItem&);
     void dispatchDidReceiveResponse();
     void doStart();
+    void didRead(int); // -1 in case of error.
 
     virtual void didReceiveResponse(ResourceResponse&&) = 0;
     virtual void didFail(Error) = 0;
@@ -98,13 +100,13 @@ private:
     // FileStreamClient methods.
     WEBCORE_EXPORT void didOpen(bool) final;
     WEBCORE_EXPORT void didGetSize(long long) final;
-    WEBCORE_EXPORT void didRead(int) final;
 
     RefPtr<BlobData> m_blobData;
     // For Async or Sync loading.
     Variant<std::unique_ptr<AsyncFileStream>, std::unique_ptr<FileStream>> m_stream;
     std::optional<HTTPRange> m_range;
-    Vector<uint8_t> m_buffer;
+    bool m_isWritingIntoBuffer { false };
+    const Box<Vector<uint8_t>> m_buffer;
     Vector<uint64_t> m_itemLengthList;
     uint64_t m_totalSize { 0 };
     uint64_t m_totalRemainingSize { 0 };

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -46,15 +46,12 @@ WebXRTest::WebXRTest(WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData>&& syst
 
 WebXRTest::~WebXRTest() = default;
 
-static PlatformXR::Device::FeatureList parseFeatures(const Vector<JSC::JSValue>& featureList, ScriptExecutionContext& context)
+static PlatformXR::Device::FeatureList parseFeatures(const Vector<String>& featureList)
 {
     PlatformXR::Device::FeatureList features;
-    if (auto* globalObject = context.globalObject()) {
-        for (auto& feature : featureList) {
-            auto featureString = feature.toWTFString(globalObject);
-            if (auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(featureString))
-                features.append(*sessionFeature);
-        }
+    for (auto& feature : featureList) {
+        if (auto sessionFeature = PlatformXR::parseSessionFeatureDescriptor(feature))
+            features.append(*sessionFeature);
     }
     return features;
 }
@@ -62,7 +59,7 @@ static PlatformXR::Device::FeatureList parseFeatures(const Vector<JSC::JSValue>&
 void WebXRTest::simulateDeviceConnection(ScriptExecutionContext& context, const FakeXRDeviceInit& init, WebFakeXRDevicePromise&& promise)
 {
     // https://immersive-web.github.io/webxr-test-api/#dom-xrtest-simulatedeviceconnection
-    context.postTask([this, protectedThis = Ref { *this }, init, promise = WTF::move(promise)] (ScriptExecutionContext& context) mutable {
+    context.postTask([this, protectedThis = Ref { *this }, init, promise = WTF::move(promise)](ScriptExecutionContext&) mutable {
         auto device = WebFakeXRDevice::create();
         auto& simulatedDevice = device->simulatedXRDevice();
 
@@ -70,10 +67,10 @@ void WebXRTest::simulateDeviceConnection(ScriptExecutionContext& context, const 
 
         PlatformXR::Device::FeatureList supportedFeatures;
         if (init.supportedFeatures)
-            supportedFeatures = parseFeatures(init.supportedFeatures.value(), context);
+            supportedFeatures = parseFeatures(init.supportedFeatures.value());
         PlatformXR::Device::FeatureList enabledFeatures;
         if (init.enabledFeatures)
-            enabledFeatures = parseFeatures(init.enabledFeatures.value(), context);
+            enabledFeatures = parseFeatures(init.enabledFeatures.value());
 
         if (init.boundsCoordinates) {
             if (init.boundsCoordinates->size() < 3) {

--- a/Source/WebCore/testing/WebXRTest.h
+++ b/Source/WebCore/testing/WebXRTest.h
@@ -33,7 +33,6 @@
 #include "WebFakeXRDevice.h"
 #include "XRSessionMode.h"
 #include "XRSimulateUserActivationFunction.h"
-#include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
@@ -48,8 +47,8 @@ public:
         std::optional<Vector<XRSessionMode>> supportedModes;
         Vector<FakeXRViewInit> views;
 
-        std::optional<Vector<JSC::JSValue>> supportedFeatures;
-        std::optional<Vector<JSC::JSValue>> enabledFeatures;
+        std::optional<Vector<String>> supportedFeatures;
+        std::optional<Vector<String>> enabledFeatures;
 
         std::optional<Vector<FakeXRBoundsPoint>> boundsCoordinates;
 

--- a/Source/WebCore/testing/WebXRTest.idl
+++ b/Source/WebCore/testing/WebXRTest.idl
@@ -61,11 +61,11 @@
     // If not specified/empty, the device supports no features.
     // NOTE: This is meant to emulate hardware support, not whether a feature is
     // currently available (e.g. bounds not being tracked per below)
-    sequence<any> supportedFeatures;
-    
+    sequence<DOMString> supportedFeatures;
+
     // The list of features that are automatically enabled and do
     // not need further explicit consent.
-    sequence<any> enabledFeatures;
+    sequence<DOMString> enabledFeatures;
 
     // The bounds coordinates. If empty, no bounded reference space is currently tracked.
     // If not, must have at least three elements.

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -274,17 +274,14 @@ void RemoteGraphicsContextGL::getBufferSubDataInline(uint32_t target, uint64_t o
         return;
     }
 
-    MallocSpan<uint8_t> bufferStore;
-    std::span<uint8_t> bufferData;
-    bufferStore = MallocSpan<uint8_t>::tryMalloc(dataSize);
-    if (bufferStore) {
-        bufferData = bufferStore.mutableSpan();
-        if (!context->getBufferSubDataWithStatus(target, offset, bufferData))
-            bufferData = { };
+    MallocSpan<uint8_t> buffer = MallocSpan<uint8_t>::tryMalloc(dataSize);
+    if (buffer) {
+        if (!context->getBufferSubDataWithStatus(target, offset, buffer.mutableSpan()))
+            buffer = { };
     } else
         context->addError(GCGLErrorCode::OutOfMemory);
 
-    completionHandler(bufferData);
+    completionHandler(buffer.span());
 }
 
 void RemoteGraphicsContextGL::getBufferSubDataSharedMemory(uint32_t target, uint64_t offset, uint64_t dataSize, WebCore::SharedMemory::Handle handle, CompletionHandler<void(bool)>&& completionHandler)
@@ -321,25 +318,19 @@ void RemoteGraphicsContextGL::readPixelsInline(WebCore::IntRect rect, uint32_t f
         completionHandler(std::nullopt, { });
         return;
     }
-    MallocSpan<uint8_t> pixelsStore;
-    std::span<uint8_t> pixels;
-    if (replyImageBytes && replyImageBytes <= readPixelsInlineSizeLimit) {
-        pixelsStore = MallocSpan<uint8_t>::tryMalloc(replyImageBytes);
-        if (pixelsStore)
-            pixels = pixelsStore.mutableSpan();
-    }
+    MallocSpan<uint8_t> pixels;
+    if (replyImageBytes && replyImageBytes <= readPixelsInlineSizeLimit)
+        pixels = MallocSpan<uint8_t>::tryZeroedMalloc(replyImageBytes);
 
     RefPtr context = m_context;
     std::optional<WebCore::IntSize> readArea;
-    if (pixels.size() == replyImageBytes)
-        readArea = context->readPixelsWithStatus(rect, format, type, packReverseRowOrder, pixels);
+    if (pixels.sizeInBytes() == replyImageBytes)
+        readArea = context->readPixelsWithStatus(rect, format, type, packReverseRowOrder, pixels.mutableSpan());
     else
         context->addError(GCGLErrorCode::OutOfMemory);
-    if (!readArea) {
+    if (!readArea)
         pixels = { };
-        pixelsStore = { };
-    }
-    completionHandler(readArea, pixels);
+    completionHandler(readArea, pixels.span());
 }
 
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -147,7 +147,7 @@ void NetworkDataTaskBlob::didReceiveResponse(ResourceResponse&& response)
 
         switch (policyAction) {
         case PolicyAction::Use:
-            buffer().resize(bufferSize);
+            resizeBuffer(bufferSize);
             readAsync();
             break;
         case PolicyAction::LoadWillContinueInAnotherProcess:
@@ -214,7 +214,7 @@ void NetworkDataTaskBlob::download()
 
     ASSERT(!m_client);
 
-    buffer().resize(bufferSize);
+    resizeBuffer(bufferSize);
     readAsync();
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -90,7 +90,6 @@ struct NetworkResourceLoadParameters {
     WebCore::CrossOriginEmbedderPolicy parentCrossOriginEmbedderPolicy { };
     WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy { };
     WebCore::HTTPHeaderMap originalRequestHeaders { };
-    bool shouldRestrictHTTPResponseAccess { false };
     WebCore::PreflightPolicy preflightPolicy { WebCore::PreflightPolicy::Consider };
     bool shouldEnableCrossOriginResourcePolicy { false };
     Vector<Ref<WebCore::SecurityOrigin>> frameAncestorOrigins { };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -66,8 +66,6 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
     WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     WebCore::HTTPHeaderMap originalRequestHeaders;
     
-    bool shouldRestrictHTTPResponseAccess;
-    
     WebCore::PreflightPolicy preflightPolicy;
     
     bool shouldEnableCrossOriginResourcePolicy;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -154,23 +154,21 @@ NetworkResourceLoader::NetworkResourceLoader(NetworkResourceLoadParameters&& par
     if (CheckedPtr session = connection.networkProcess().networkSession(sessionID()))
         m_cache = session->cache();
 
-    if (synchronousReply || m_parameters.shouldRestrictHTTPResponseAccess || m_parameters.options.keepAlive) {
-        NetworkLoadChecker::LoadType requestLoadType = isMainFrameLoad() ? NetworkLoadChecker::LoadType::MainFrame : NetworkLoadChecker::LoadType::Other;
-        m_networkLoadChecker = NetworkLoadChecker::create(Ref { connection.networkProcess() }.get(), this,  &connection.schemeRegistry(), FetchOptions { m_parameters.options },
-            sessionID(), webPageProxyID(), HTTPHeaderMap { m_parameters.originalRequestHeaders }, URL { m_parameters.request.url() },
-            URL { m_parameters.documentURL }, m_parameters.sourceOrigin.copyRef(), m_parameters.topOrigin.copyRef(), m_parameters.parentOrigin(),
-            m_parameters.preflightPolicy, originalRequest().httpReferrer(), m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections,
-            shouldCaptureExtraNetworkLoadMetrics(), requestLoadType);
+    NetworkLoadChecker::LoadType requestLoadType = isMainFrameLoad() ? NetworkLoadChecker::LoadType::MainFrame : NetworkLoadChecker::LoadType::Other;
+    m_networkLoadChecker = NetworkLoadChecker::create(Ref { connection.networkProcess() }.get(), this,  &connection.schemeRegistry(), FetchOptions { m_parameters.options },
+        sessionID(), webPageProxyID(), HTTPHeaderMap { m_parameters.originalRequestHeaders }, URL { m_parameters.request.url() },
+        URL { m_parameters.documentURL }, m_parameters.sourceOrigin.copyRef(), m_parameters.topOrigin.copyRef(), m_parameters.parentOrigin(),
+        m_parameters.preflightPolicy, originalRequest().httpReferrer(), m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections,
+        shouldCaptureExtraNetworkLoadMetrics(), requestLoadType);
 
-        RefPtr networkLoadChecker = m_networkLoadChecker;
-        if (m_parameters.cspResponseHeaders)
-            networkLoadChecker->setCSPResponseHeaders(ContentSecurityPolicyResponseHeaders { m_parameters.cspResponseHeaders.value() });
-        networkLoadChecker->setParentCrossOriginEmbedderPolicy(m_parameters.parentCrossOriginEmbedderPolicy);
-        networkLoadChecker->setCrossOriginEmbedderPolicy(m_parameters.crossOriginEmbedderPolicy);
+    RefPtr networkLoadChecker = m_networkLoadChecker;
+    if (m_parameters.cspResponseHeaders)
+        networkLoadChecker->setCSPResponseHeaders(ContentSecurityPolicyResponseHeaders { m_parameters.cspResponseHeaders.value() });
+    networkLoadChecker->setParentCrossOriginEmbedderPolicy(m_parameters.parentCrossOriginEmbedderPolicy);
+    networkLoadChecker->setCrossOriginEmbedderPolicy(m_parameters.crossOriginEmbedderPolicy);
 #if ENABLE(CONTENT_EXTENSIONS)
-        networkLoadChecker->setContentExtensionController(URL { m_parameters.mainDocumentURL }, URL { m_parameters.frameURL }, m_parameters.userContentControllerIdentifier);
+    networkLoadChecker->setContentExtensionController(URL { m_parameters.mainDocumentURL }, URL { m_parameters.frameURL }, m_parameters.userContentControllerIdentifier);
 #endif
-    }
     if (synchronousReply)
         m_synchronousLoadData = makeUnique<SynchronousLoadData>(WTF::move(synchronousReply));
 }
@@ -1445,9 +1443,6 @@ static bool shouldSanitizeResponse(const NetworkProcess& process, std::optional<
 
 ResourceResponse NetworkResourceLoader::sanitizeResponseIfPossible(ResourceResponse&& response, ResourceResponse::SanitizationType type)
 {
-    if (!m_parameters.shouldRestrictHTTPResponseAccess)
-        return WTF::move(response);
-
     if (shouldSanitizeResponse(Ref { m_connection->networkProcess() }.get(), pageID(), parameters().options, originalRequest().url()))
         response.sanitizeHTTPHeaderFields(type);
 

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -61,7 +61,6 @@ struct NavigationActionData {
     WebCore::FloatPoint clickLocationInRootViewCoordinates;
     WebCore::ResourceResponse redirectResponse;
     bool isRequestFromClientOrUserInput { false };
-    bool treatAsSameOriginNavigation { false };
     bool hasOpenedFrames { false };
     bool openedByDOMWithOpener { false };
     bool hasOpener { false };

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -33,7 +33,6 @@ struct WebKit::NavigationActionData {
     WebCore::FloatPoint clickLocationInRootViewCoordinates;
     WebCore::ResourceResponse redirectResponse;
     bool isRequestFromClientOrUserInput;
-    bool treatAsSameOriginNavigation;
     bool hasOpenedFrames;
     bool openedByDOMWithOpener;
     bool hasOpener;

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -137,7 +137,6 @@ public:
 
     bool shouldPerformDownload() const { return m_lastNavigationAction && !m_lastNavigationAction->downloadAttribute.isNull(); }
 
-    bool treatAsSameOriginNavigation() const { return m_lastNavigationAction && m_lastNavigationAction->treatAsSameOriginNavigation; }
     bool hasOpenedFrames() const { return m_lastNavigationAction && m_lastNavigationAction->hasOpenedFrames; }
     bool openedByDOMWithOpener() const { return m_lastNavigationAction && m_lastNavigationAction->openedByDOMWithOpener; }
     bool isInitialFrameSrcLoad() const { return m_lastNavigationAction && m_lastNavigationAction->isInitialFrameSrcLoad; }

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -109,6 +109,7 @@
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
+#include <WebCore/SecurityPolicy.h>
 #include <WebCore/Site.h>
 #include <algorithm>
 #include <pal/SessionID.h>
@@ -2343,9 +2344,6 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
             return { createNewProcess(), nullptr, "Process swap because this is a first navigation in a DOM popup without opener"_s };
     }
 
-    if (navigation.treatAsSameOriginNavigation())
-        return { WTF::move(sourceProcess), nullptr, "The treatAsSameOriginNavigation flag is set"_s };
-
     URL sourceURL;
     if (page.isPageOpenedByDOMShowingInitialEmptyDocument() && !navigation.requesterOrigin().isNull())
         sourceURL = URL { navigation.requesterOrigin().toString() };
@@ -2358,6 +2356,20 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
             WEBPROCESSPOOL_RELEASE_LOG(ProcessSwapping, "processForNavigationInternal: Using related page's URL as source URL for process swap decision (page=%p)", pageConfiguration->relatedPage());
         }
     }
+
+    const bool treatAsSameOriginNavigation = [&targetURL, &sourceURL, siteIsolationEnabled] {
+        if (siteIsolationEnabled
+            && targetURL.protocolIsAbout()
+            && !SecurityPolicy::shouldInheritSecurityOriginFromOwner(targetURL))
+            return false;
+
+        return targetURL.protocolIsAbout() || targetURL.protocolIsData()
+            || (targetURL.protocolIsBlob() && sourceURL.isValid()
+                && SecurityOrigin::create(targetURL)->isSameOriginAs(SecurityOrigin::create(sourceURL).get()));
+    }();
+
+    if (treatAsSameOriginNavigation)
+        return { WTF::move(sourceProcess), nullptr, "The treatAsSameOriginNavigation flag is set"_s };
 
     // For non-HTTP(s) URLs, we only swap when navigating to a new scheme, unless processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol is set.
     if (!m_configuration->processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol() && !sourceURL.protocolIsInHTTPFamily() && sourceURL.protocol() == targetURL.protocol() && !siteIsolationEnabled)

--- a/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
@@ -75,7 +75,6 @@ void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSes
                 { }, /* clickLocationInRootViewCoordinates */
                 { }, /* redirectResponse */
                 false, /* isRequestFromClientOrUserInput */
-                false, /* treatAsSameOriginNavigation */
                 false, /* hasOpenedFrames */
                 false, /* openedByDOMWithOpener */
                 false, /* hasOpener */

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -557,8 +557,6 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         }
     }
 
-    loadParameters.shouldRestrictHTTPResponseAccess = shouldPerformSecurityChecks();
-
     loadParameters.isMainFrameNavigation = isMainFrameNavigation;
     if (loadParameters.isMainFrameNavigation && document)
         loadParameters.sourceCrossOriginOpenerPolicy = document->crossOriginOpenerPolicy();
@@ -853,7 +851,6 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     loadParameters.storedCredentialsPolicy = options.credentials == FetchOptions::Credentials::Omit ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use;
     loadParameters.clientCredentialPolicy = clientCredentialPolicy;
     loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(webFrame ? webFrame->protectedCoreLocalFrame().get() : nullptr);
-    loadParameters.shouldRestrictHTTPResponseAccess = shouldPerformSecurityChecks();
 
     loadParameters.options = options;
     loadParameters.sourceOrigin = document->securityOrigin();
@@ -935,7 +932,7 @@ void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& reques
     loadParameters.options = options;
     loadParameters.originalRequestHeaders = originalRequestHeaders;
     loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(&frame);
-    loadParameters.shouldRestrictHTTPResponseAccess = shouldPerformSecurityChecks();
+
     if (policyCheck == ContentSecurityPolicyImposition::DoPolicyCheck && !document->shouldBypassMainWorldContentSecurityPolicy()) {
         if (CheckedPtr contentSecurityPolicy = document->contentSecurityPolicy())
             loadParameters.cspResponseHeaders = contentSecurityPolicy->responseHeaders();
@@ -1015,7 +1012,7 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
     parameters.parentPID = legacyPresentingApplicationPID();
     parameters.storedCredentialsPolicy = storedCredentialsPolicy;
     parameters.shouldPreconnectOnly = PreconnectOnly::Yes;
-    parameters.shouldRestrictHTTPResponseAccess = shouldPerformSecurityChecks();
+
     // FIXME: Use the proper destination once all fetch options are passed.
     parameters.options.destination = FetchOptions::Destination::EmptyString;
 #if ENABLE(APP_BOUND_DOMAINS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -398,7 +398,6 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         mouseEventData ? mouseEventData->locationInRootViewCoordinates : FloatPoint { },
         { }, /* redirectResponse */
         navigationAction.isRequestFromClientOrUserInput(),
-        false, /* treatAsSameOriginNavigation */
         false, /* hasOpenedFrames */
         false, /* openedByDOMWithOpener */
         navigationAction.newFrameOpenerPolicy() == NewFrameOpenerPolicy::Allow, /* hasOpener */

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -148,7 +148,6 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         mouseEventData ? mouseEventData->locationInRootViewCoordinates : FloatPoint(),
         redirectResponse,
         navigationAction.isRequestFromClientOrUserInput(),
-        navigationAction.treatAsSameOriginNavigation(),
         navigationAction.hasOpenedFrames(),
         navigationAction.openedByDOMWithOpener(),
         hasOpener,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -498,7 +498,6 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         { }, /* clickLocationInRootViewCoordinates */
         { }, /* redirectResponse */
         false, /* isRequestFromClientOrUserInput */
-        true, /* treatAsSameOriginNavigation */
         false, /* hasOpenedFrames */
         false, /* openedByDOMWithOpener */
         !!localFrame->opener(), /* hasOpener */
@@ -1006,7 +1005,6 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         mouseEventData ? mouseEventData->locationInRootViewCoordinates : FloatPoint(),
         { }, /* redirectResponse */
         false, /* isRequestFromClientOrUserInput */
-        false, /* treatAsSameOriginNavigation */
         false, /* hasOpenedFrames */
         false, /* openedByDOMWithOpener */
         navigationAction.newFrameOpenerPolicy() == NewFrameOpenerPolicy::Allow, /* hasOpener */


### PR DESCRIPTION
#### e5b8f463a4a9a6994ca10db9a58d36cc82bd4947
<pre>
Cherry-pick 80760a59ebe9. <a href="https://bugs.webkit.org/show_bug.cgi?id=312781">https://bugs.webkit.org/show_bug.cgi?id=312781</a>

[JSC] Use-after-free after Wasm memory grow via stale pointer folded by DFGConstantFoldingPhase
<a href="https://bugs.webkit.org/show_bug.cgi?id=312781">https://bugs.webkit.org/show_bug.cgi?id=312781</a>
<a href="https://rdar.apple.com/174994263">rdar://174994263</a>

Reviewed by Yijia Huang.

Exempts resizable/growable-shared views from GetIndexedPropertyStorage constant folding.
Converting the vector to a constant storage pointer is invalid if the vector can be
reallocated without notice.

resizable-array-constant-folding.js tests the effects of writing to a WebAssembly
memory grown after constant folding.

* JSTests/stress/resizable-array-constant-folding.js: Added.
(trigger):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Identifier: 305413.726@safari-7624-branch

Identifier: 305413.710@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.819@webkitglib/2.52">https://commits.webkit.org/305877.819@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 15727c3012164902b132a6a21bb7f5e85f9c3c8c
<pre>
Cherry-pick dacb07e7c6bd. <a href="https://bugs.webkit.org/show_bug.cgi?id=312487">https://bugs.webkit.org/show_bug.cgi?id=312487</a>

[JSC] Stale structure bit in SlowPutArrayStorage
<a href="https://bugs.webkit.org/show_bug.cgi?id=312487">https://bugs.webkit.org/show_bug.cgi?id=312487</a>
<a href="https://rdar.apple.com/172210517">rdar://172210517</a>

Reviewed by Keith Miller.

Correctly sets HasNonConfigurableProperties and related bits during Structure construction
if the IndexingType has an array storage shape.

Test: JSTests/stress/slowputarraystorage-stale-structure-bit.js

* JSTests/stress/slowputarraystorage-stale-structure-bit.js: Added.
(get k):
(get configurable):
(set t):
(catch):
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::Structure):

Identifier: 305413.704@safari-7624-branch

Identifier: 305413.709@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.818@webkitglib/2.52">https://commits.webkit.org/305877.818@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9c1c3638d49ce5a6c0dfc36602a47f08ac79da30
<pre>
Cherry-pick 41efaeddddf2. <a href="https://bugs.webkit.org/show_bug.cgi?id=312796">https://bugs.webkit.org/show_bug.cgi?id=312796</a>

[WebCore] Take graphLock() in BiquadFilterNode::setType() to avoid race
 with audio-thread kernel reallocation
<a href="https://rdar.apple.com/174652790">rdar://174652790</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=312796">https://bugs.webkit.org/show_bug.cgi?id=312796</a>

Reviewed by Chris Dumez.

BiquadFilterNode::setType() runs on the main thread from JS bindings and calls
BiquadProcessor::setType(), which in turn calls AudioDSPKernelProcessor::reset()
to iterate m_kernels and virtual-call reset() on each kernel. This was done
without holding the context&apos;s graphLock().

Concurrently, every render quantum the audio thread runs
AudioBasicProcessorNode::checkNumberOfChannelsForInput() under graphLock() and,
when the input channel count has changed, calls uninitialize() / initialize()
on the processor, which clear()s and move-assigns m_kernels.

With the lock held only on one side, the main thread could load a kernel pointer
from a Vector slot that is being/already freed, leading to a use-after-free virtual
dispatch into a destroyed BiquadDSPKernel and writes through stale Biquad
buffer spans, or a null deref if the slot was already zeroed.

Fix by taking context().graphLock() in BiquadFilterNode::setType(), matching the
existing convention in WaveShaperNode::setOversampleForBindings() and
AudioNode::setChannelCount().

Test: webaudio/biquadfilternode-set-type-channel-count-race.html
* LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race-expected.txt: Added.
* LayoutTests/webaudio/biquadfilternode-set-type-channel-count-race.html: Added.
* Source/WebCore/Modules/webaudio/BiquadFilterNode.cpp:
(WebCore::BiquadFilterNode::setType):

Identifier: 305413.717@safari-7624-branch

Identifier: 305413.708@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.817@webkitglib/2.52">https://commits.webkit.org/305877.817@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6fc19030a5d5b4f96d5d09273669405490dc440d
<pre>
Cherry-pick 0c204da15932. <a href="https://bugs.webkit.org/show_bug.cgi?id=312564">https://bugs.webkit.org/show_bug.cgi?id=312564</a>

WebGL: Uninitialized FastMalloc heap disclosure in RemoteGraphicsContextGL::readPixelsInline
<a href="https://bugs.webkit.org/show_bug.cgi?id=312564">https://bugs.webkit.org/show_bug.cgi?id=312564</a>
<a href="https://rdar.apple.com/174640403">rdar://174640403</a>

Reviewed by Dan Glastonbury.

Allocate the read pixels area with zero init.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::readPixelsInline):

Identifier: 305413.708@safari-7624-branch

Identifier: 305413.707@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.816@webkitglib/2.52">https://commits.webkit.org/305877.816@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 752b942119d7547ed87e631d81a188111f467883
<pre>
Cherry-pick 1db91ab9400c. <a href="https://bugs.webkit.org/show_bug.cgi?id=312525">https://bugs.webkit.org/show_bug.cgi?id=312525</a>

Remove shouldRestrictHTTPResponseAccess from NetworkResourceLoadParameters
<a href="https://rdar.apple.com/174708348">rdar://174708348</a>

Reviewed by Ryosuke Niwa.

The shouldRestrictHTTPResponseAccess field in NetworkResourceLoadParameters
was sent from WebContent process to NetworkProcess via IPC with no validation.
A compromised WebContent process could set it to false to bypass response
header sanitization (Set-Cookie stripping, cross-origin header filtering).

The field was originally introduced in 2018 as a runtime-configurable flag
(RestrictedHTTPResponseAccess preference) to allow WK1 to opt out of
sanitization. After WK1 was removed, the preference was hardcoded to true
(288687@main), but the IPC parameter was never cleaned up.

Since shouldPerformSecurityChecks() unconditionally returns true, this field
always carried the value true from a legitimate WebContent process. Remove
it entirely and make sanitization unconditional on the NetworkProcess side.

No new tests (hardening, no behavior change for legitimate WebContent process).

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::sanitizeResponseIfPossible):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
(WebKit::WebLoaderStrategy::startPingLoad):
(WebKit::WebLoaderStrategy::preconnectTo):

Identifier: 305413.689@safari-7624-branch

Identifier: 305413.706@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.815@webkitglib/2.52">https://commits.webkit.org/305877.815@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8880d43cf6be2b00703bbbff275fcb0e1797b4a3
<pre>
Cherry-pick e321c398762a. <a href="https://bugs.webkit.org/show_bug.cgi?id=312525">https://bugs.webkit.org/show_bug.cgi?id=312525</a>

ExpressionInfo::Encoder computes the offset to Extension Islands incorrectly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312525">https://bugs.webkit.org/show_bug.cgi?id=312525</a>
<a href="https://rdar.apple.com/174626446">rdar://174626446</a>

Reviewed by Yijia Huang.

When an Extension ExpressionInfo is emitted, it needs to encode a displacement offset from
its location to the location of its extension island.  For a MultiWide ExpressionInfo,
parts of its island has already been emitted (from copying the MultiWide record over).  As
a result, the size of m_expressionInfoEncodedInfo is no longer the same as the starting
offset of extension island.  As a result, the offset encoded in the Extension ExpressionInfo
will be incorrect.

The fix is simply to cache the location of the extension island before we start copying the
MultiWide ExpressionInfo over.  We will use this cached location to emit the Extension
ExpressionInfo instead of using m_expressionInfoEncodedInfo.size() as we do for other cases.

Also fixed some typos and errors in comments.

Also fixed the decoding of DuoWide field2 in ExpressionInfo::dumpEncodedInfo().  This is
only used for debugging code.

Test: JSTests/stress/expression-info-multi-wide-encoding.js

* JSTests/stress/expression-info-multi-wide-encoding.js: Added.
(catch):
* Source/JavaScriptCore/bytecode/ExpressionInfo.cpp:
(JSC::ExpressionInfo::Encoder::adjustInstPC):
(JSC::ExpressionInfo::dumpEncodedInfo):

Identifier: 305413.693@safari-7624-branch

Identifier: 305413.705@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.814@webkitglib/2.52">https://commits.webkit.org/305877.814@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 81803ac44937604803142c9eceb954739807bd1c
<pre>
Cherry-pick 0b964ced2532. <a href="https://bugs.webkit.org/show_bug.cgi?id=312456">https://bugs.webkit.org/show_bug.cgi?id=312456</a>

UAF due to cross-thread destruction of worker DeferredPromise in WebLockManager::query()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312456">https://bugs.webkit.org/show_bug.cgi?id=312456</a>
<a href="https://rdar.apple.com/174652399">rdar://174652399</a>

Reviewed by Ryosuke Niwa.

WebLockManager::MainThreadBridge::query() was taking in a CompletionHandler
but it may sometimes fail to call its completion handler. This happened
when the worker thread is exiting, causing `ScriptExecutionContext::ensureOnContextThread()`
to fail. Not calling the completion handler is bad but what&apos;s worse is that
the completion handler would end up getting destroyed on the main thread.
The completion handler was capturing a promise from the worker thread,
which led to security bugs.

To address the issue:
1. Have WebLockManager::MainThreadBridge::query() take in a Function
   instead of a CompletionHandler given that it cannot always call
   its callback.
2. Have WebLockManager store the promise in a HashMap and only capture
   a promise identifier in the MainThreadBridge::query() lambda instead
   of the promise itself. This pattern was already used for other
   promises in this class.

Test: workers/weblock-manager-query-crash.html

* LayoutTests/workers/weblock-manager-query-crash-expected.txt: Added.
* LayoutTests/workers/weblock-manager-query-crash.html: Added.
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::MainThreadBridge::abortLockRequest):
(WebCore::WebLockManager::MainThreadBridge::query):
(WebCore::WebLockManager::query):
(WebCore::WebLockManager::clientIsGoingAway):
* Source/WebCore/Modules/web-locks/WebLockManager.h:

Identifier: 305413.688@safari-7624-branch

Identifier: 305413.704@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.813@webkitglib/2.52">https://commits.webkit.org/305877.813@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e2ac8db736b5f04843cd49e8df370af45478df72
<pre>
Cherry-pick 8bb359efde80. <a href="https://bugs.webkit.org/show_bug.cgi?id=312445">https://bugs.webkit.org/show_bug.cgi?id=312445</a>

Remove treatAsSameOriginNavigation from NavigationActionData IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=312445">https://bugs.webkit.org/show_bug.cgi?id=312445</a>
<a href="https://rdar.apple.com/174702490">rdar://174702490</a>

Reviewed by Rupin Mittal.

A compromised WebContent process could forge treatAsSameOriginNavigation in
DecidePolicyForNavigationAction to skip the cross-site process swap in processForNavigationInternal.

Remove the field from NavigationActionData, NavigationAction, and API::Navigation, and compute it
directly in processForNavigationInternal from the target URL protocol and the UIProcess-owned
sourceURL.

* Source/WebCore/loader/NavigationAction.cpp:
(WebCore::shouldTreatAsSameOriginNavigation): Deleted.
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::treatAsSameOriginNavigation const): Deleted.
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::treatAsSameOriginNavigation const): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp:
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):

Identifier: 305413.684@safari-7624-branch

Identifier: 305413.702@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.812@webkitglib/2.52">https://commits.webkit.org/305877.812@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 55aeb61fc70165ba52f4f3165c90142956519344
<pre>
Cherry-pick 70917758773a. <a href="https://bugs.webkit.org/show_bug.cgi?id=312449">https://bugs.webkit.org/show_bug.cgi?id=312449</a>

Cross-Thread UAF Write in AsyncFileStream::read via NetworkDataTaskBlob
<a href="https://bugs.webkit.org/show_bug.cgi?id=312449">https://bugs.webkit.org/show_bug.cgi?id=312449</a>
<a href="https://rdar.apple.com/174655475">rdar://174655475</a>

Reviewed by Ryosuke Niwa.

BlobResourceHandleBase was passing a mutable span to its m_buffer Vector
to AsyncFileStream for it to write into asynchronously on a background
thread. However, nothing guaranteed that the BlobResourceHandleBase
(and thus its m_buffer) stayed alive until AsyncFileStream was done
writing.

Address the issue by using a `Box&lt;Vector&lt;uint8_t&gt;&gt;` instead of a simple
Vector so that the buffer is now ThreadSafeRefCounted. Then update the
AsyncFileStream API to take in a `Box&lt;Vector&lt;uint8_t&gt;&gt;` instead of a
span.

For further hardening, I removed the non-const buffer getter on
BlobResourceHandleBase. This was too dangerous because any operation on
this buffer on the main thread could cause the background thread to
crash if it is currently writing to it. The non-const buffer getter was
only used to resize the buffer once we know the size of the data we
need to read. I thus added a more specific `resizeBuffer()` API to
BlobResourceHandleBase which has a RELEASE_ASSERT() to guarantee that
the background thread is NOT currently writing into the buffer. This was
not an issue with the current code but the RELEASE_ASSERT() makes sure
we cannot introduce such a security bug in the future.

* Source/WebCore/fileapi/AsyncFileStream.cpp:
(WebCore::AsyncFileStream::read):
* Source/WebCore/fileapi/AsyncFileStream.h:
* Source/WebCore/platform/FileStreamClient.h:
(WebCore::FileStreamClient::didGetSize):
(WebCore::FileStreamClient::didRead): Deleted.
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::didReceiveResponse):
* Source/WebCore/platform/network/BlobResourceHandleBase.cpp:
(WebCore::BlobResourceHandleBase::BlobResourceHandleBase):
(WebCore::BlobResourceHandleBase::resizeBuffer):
(WebCore::BlobResourceHandleBase::readFileAsync):
(WebCore::BlobResourceHandleBase::didRead):
* Source/WebCore/platform/network/BlobResourceHandleBase.h:
(WebCore::BlobResourceHandleBase::buffer): Deleted.
(WebCore::BlobResourceHandleBase::buffer const): Deleted.
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::didReceiveResponse):

Identifier: 305413.682@safari-7624-branch

Identifier: 305413.701@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.811@webkitglib/2.52">https://commits.webkit.org/305877.811@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8406a3c70f4ce9952d2ac989b8a559ae67454719
<pre>
Cherry-pick 65ba1780134a. <a href="https://bugs.webkit.org/show_bug.cgi?id=312348">https://bugs.webkit.org/show_bug.cgi?id=312348</a>

Use-after-free in XRSessionInit dictionary conversion via sequence&lt;any&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=312348">https://bugs.webkit.org/show_bug.cgi?id=312348</a>
<a href="https://rdar.apple.com/174448452">rdar://174448452</a>

Reviewed by Ryosuke Niwa.

sequence&lt;any&gt; and FrozenArray&lt;any&gt; are fundamentally unsafe as
currently implemented. Fortunately the only place where we use
sequence&lt;any&gt; can use sequence&lt;DOMString&gt;.

So adopt sequence&lt;DOMString&gt; there and add static asserts to prevent
future adoption of the unsafe constructs.

Identifier: 305413.680@safari-7624-branch

Identifier: 305413.700@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.810@webkitglib/2.52">https://commits.webkit.org/305877.810@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df76f9666832d1c4bc9b1161e05fff472bf3b7cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171906 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45823 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181210 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129460 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173771 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47109 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45463 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129460 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47109 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114212 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47109 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45463 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29959 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47109 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183877 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33165 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36493 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45463 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142445 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45490 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142336 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46170 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110823 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26092 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46170 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117858 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204584 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44688 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39241 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54628 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44088 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44320 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44147 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->