### PR TITLE
Cherry-pick f7d3c0785bb0. https://bugs.webkit.org/show_bug.cgi?id=312459

### DIFF
--- a/JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js
+++ b/JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js
@@ -1,0 +1,87 @@
+function createObject1() {
+    const tmp = {
+        toJSON: 1,
+        a: 1,
+    };
+
+    Object.create(tmp);
+
+    return tmp;
+}
+
+function createObject2() {
+    const tmp = {
+        b: 1,
+        toJSON: {}
+    };
+
+    Object.create(tmp);
+
+    return tmp;
+}
+
+function opt(container1, object2, array, thenable, flags) {
+    const promise = new Promise(() => {});
+
+    container1.x;
+    thenable.x;
+
+    const object1 = Object.getPrototypeOf(container1);
+
+    let tmp = object1;
+    object1.a;
+
+    if (flags & 1) {
+        tmp = object2;
+        tmp.b;
+
+        0[0];
+    }
+
+    +tmp.toJSON;
+    +tmp.toJSON;
+
+    array[0];
+    Promise.resolve(+tmp.toJSON === 1 ? thenable : promise);
+
+    array[0] = 2.3023e-320;
+}
+
+function main() {
+    noDFG(main);
+
+    const object1 = createObject1();
+    const object2 = createObject2();
+
+    createObject1().z = 1;
+
+    const container1 = Object.create(object1);
+
+    const thenable = {
+        x: 1
+    };
+
+    for (let i = 0; i < 100; i++) {
+        thenable['a' + i] = 1;
+    }
+
+    const array = {
+        0: 1.1
+    };
+
+    JSON.stringify(container1);
+
+    for (let i = 0; i < 200; i++) {
+        opt(container1, object2, array, thenable, i);
+    }
+
+    thenable.__defineGetter__('then', () => {
+        array[0] = {};
+    });
+
+    opt(container1, object2, array, thenable, 0);
+
+    array[0].x;
+}
+
+main();

--- a/JSTests/stress/regress-174463162.js
+++ b/JSTests/stress/regress-174463162.js
@@ -1,0 +1,13 @@
+// $vm.installStructureStubClearingWatchpointWithDeadOwner creates the IC
+// watchpoint and sets the owner as dead, simulating the state between GC
+// marking-end and CodeBlock sweep.
+
+function main() {
+    let proto = $vm.createCustomTestGetterSetterWithSharedStructure();
+    let sibling = $vm.createCustomTestGetterSetterWithSharedStructure();
+
+    $vm.installStructureStubClearingWatchpointWithDeadOwner(proto, "customAccessor");
+
+    sibling.triggerTransition = true;
+}
+main();

--- a/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display-expected.txt
+++ b/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display-expected.txt
@@ -1,0 +1,3 @@
+
+PASS RemoteImageBufferSet rejects DynamicContentScalingDisplayList during prepare-for-display
+

--- a/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html
+++ b/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html
@@ -1,0 +1,93 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>RemoteImageBufferSet rejects DynamicContentScalingDisplayList during prepare-for-display</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ipc.js"></script>
+<body>
+<script>
+promise_test(async t => {
+    if (!window.IPC)
+        return;
+    if (!IPC.messages.RemoteImageBufferSet_DynamicContentScalingDisplayList)
+        return;
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const streamConnection = CoreIPC.newStreamConnection();
+    const renderingBackendIdentifier = randomIPCID();
+
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+    const didInitializeReply = streamConnection.connection.waitForMessage(
+        renderingBackendIdentifier,
+        IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name,
+        1
+    );
+    streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+    const imageBufferSetIdentifier = randomIPCID();
+    const graphicsContextIdentifier = randomIPCID();
+
+    remoteRenderingBackend.CreateImageBufferSet({
+        identifier: imageBufferSetIdentifier,
+        contextIdentifier: graphicsContextIdentifier,
+    });
+
+    const remoteImageBufferSet = streamConnection.newInterface("RemoteImageBufferSet", imageBufferSetIdentifier);
+
+    remoteImageBufferSet.UpdateConfiguration({
+        configuration: {
+            logicalSize: { width: 128, height: 128 },
+            resolutionScale: 1.0,
+            colorSpace: {
+                serializableColorSpace: {
+                    alias: {
+                        optionalValue: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: 'WebCore::ColorSpace',
+                                    variant: 19
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            contentsFormat: 1,
+            bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+            renderingMode: 1,
+            renderingPurpose: 3,
+            includeDisplayList: 1,
+        },
+    });
+
+    // Begin prepare-for-display: this allocates the front buffer as a
+    // DynamicContentScalingBifurcatedImageBuffer and creates the
+    // RemoteImageBufferGraphicsContext receiver. We do not send EndPrepareForDisplay,
+    // so RemoteImageBufferSet::m_context (and the raw GraphicsContext& it holds via
+    // RemoteGraphicsContext::m_context) is still live for the assertion below.
+    remoteRenderingBackend.PrepareImageBufferSetsForDisplaySync({
+        swapBuffersInput: [{
+            remoteBufferSet: imageBufferSetIdentifier,
+            dirtyRegion: { data: { m_segments: [], m_spans: [] } },
+            supportsPartialRepaint: false,
+            hasEmptyDirtyRegion: false,
+            requiresClearedPixels: false,
+        }],
+    });
+
+    try {
+        assert_throws_js(TypeError,
+            () => remoteImageBufferSet.DynamicContentScalingDisplayList({}),
+            "DynamicContentScalingDisplayList during prepare-for-display must be rejected by MESSAGE_CHECK");
+    } finally {
+        streamConnection.connection.invalidate();
+    }
+}, "RemoteImageBufferSet rejects DynamicContentScalingDisplayList during prepare-for-display");
+</script>
+</body>

--- a/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change-expected.txt
+++ b/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change.html
+++ b/LayoutTests/ipc/networksindexeddb-close-connection-during-version-change.html
@@ -1,0 +1,117 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>This test passes if it does not crash.</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { ArgumentSerializer, IPCWireTap } = await import('./coreipc.js');
+
+    function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+    const origin = {
+        topOrigin: {
+            data: { variantIndex: 0, variant: { protocol: 'http', host: '127.0.0.1', port: {} } },
+        },
+        clientOrigin: {
+            data: { variantIndex: 0, variant: { protocol: 'http', host: '127.0.0.1', port: {} } },
+        },
+    };
+
+    function resId(connId, resourceNum) {
+        return {
+            m_idbConnectionIdentifier: { optionalValue: { alias: connId } },
+            m_resourceNumber: { optionalValue: resourceNum },
+        };
+    }
+
+    function mkReq(connId, resNum, reqType) {
+        return {
+            m_serverConnectionIdentifier: { alias: connId },
+            m_requestIdentifier: resId(connId, resNum),
+            m_databaseIdentifier: {
+                m_databaseName: 'crashdb',
+                m_origin: origin,
+                m_isTransient: false,
+            },
+            m_requestedVersion: 1n,
+            m_requestType: reqType,
+        };
+    }
+
+    function sendMessage(messageDesc, destinationID, args) {
+        const connection = IPC.connectionForProcessTarget('Networking');
+        const serializedArguments = ArgumentSerializer.serializeArguments(messageDesc.arguments, args);
+        connection.sendMessage(destinationID, messageDesc.name, serializedArguments);
+    }
+
+    const CONN = 42n;
+
+    // Wiretap to capture databaseConnectionIdentifier
+    let dbConnIds = [];
+    const inTap = new IPCWireTap("Networking", "Incoming");
+    inTap.tapAll((process, connID, name, typed, result) => {
+        if (!result) return;
+        const r = result.result;
+        if (!r) return;
+        if (r.m_databaseConnectionIdentifier && r.m_databaseConnectionIdentifier.optionalValue) {
+            let id = BigInt(String(r.m_databaseConnectionIdentifier.optionalValue).replace('n',''));
+            dbConnIds.push(id);
+        }
+    });
+
+    // Step 1: Open DB with version change (0 -> 1)
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDatabase, 0n, {
+        requestData: mkReq(CONN, 1n, 0),
+    });
+    await sleep(300);
+
+    let vc1ConnId = dbConnIds[0];
+    if (!vc1ConnId) { console.log('FAIL: no dbConnId captured'); return; }
+
+    // Step 2: Queue Open #2 behind VC1
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDatabase, 0n, {
+        requestData: mkReq(CONN, 2n, 0),
+    });
+    await sleep(50);
+
+    // Step 3: Establish a regular transaction on VC1's connection.
+    sendMessage(IPC.messages.NetworkStorageManager_EstablishTransaction, 0n, {
+        databaseConnectionIdentifier: vc1ConnId,
+        info: {
+            identifier: resId(CONN, 100n),
+            mode: 1, // ReadWrite
+            durability: 0,
+            newVersion: 0n,
+            objectStores: ['store1'],
+            originalDatabaseInfo: {},
+        },
+    });
+    await sleep(50);
+
+    // Step 4: Close VC1's connection via DatabaseConnectionClosed.
+    sendMessage(IPC.messages.NetworkStorageManager_DatabaseConnectionClosed, 0n, {
+        databaseConnectionIdentifier: vc1ConnId,
+    });
+    await sleep(300);
+
+    // Step 5: Cancel Open #2
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDBRequestCancelled, 0n, {
+        requestData: mkReq(CONN, 2n, 0),
+    });
+    await sleep(300);
+
+    // Cancel Open #1 in case it's still pending
+    sendMessage(IPC.messages.NetworkStorageManager_OpenDBRequestCancelled, 0n, {
+        requestData: mkReq(CONN, 1n, 0),
+    });
+    await sleep(1000);
+
+    window.testRunner?.notifyDone();
+}, 10);
+</script>

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -83,6 +83,8 @@ overlay-region [ Pass ]
 platform/visionos/transforms [ Pass ]
 fast/images/spatial-image-controls-rtl.html [ Pass ]
 
+ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html [ Pass ]
+
 imported/w3c/web-platform-tests/webxr [ Pass ]
 http/wpt/webxr [ Pass ]
 webxr [ Pass ]

--- a/LayoutTests/workers/permissions-query-crash-expected.txt
+++ b/LayoutTests/workers/permissions-query-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/workers/permissions-query-crash.html
+++ b/LayoutTests/workers/permissions-query-crash.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+const workerCode = `
+onmessage = () => {
+    for (let i = 0; i < 20; i++) {
+        navigator.permissions.query({name: i % 3 === 0 ? 'camera' : (i % 3 === 1 ? 'geolocation' : 'notifications')}).catch(()=>{});
+    }
+    postMessage('go');
+};
+`;
+
+const blob = new Blob([workerCode], {type: 'application/javascript'});
+const blobURL = URL.createObjectURL(blob);
+
+let iterations = 0;
+const maxIterations = 20;
+
+function next() {
+    iterations++;
+    if (iterations > maxIterations) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+    
+    let w = new Worker(blobURL);
+    w.onmessage = () => {
+        w.terminate();
+        setTimeout(next, 0);
+    };
+    w.postMessage(0);
+}
+
+window.onload = () => {
+    next();
+};
+</script>
+</head>
+<body>
+This test passes if it does not crash.
+</body>
+</html>

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -86,6 +86,7 @@ class AdaptiveValueStructureStubClearingWatchpoint final : public AdaptiveInferr
     WTF_MAKE_NONCOPYABLE(AdaptiveValueStructureStubClearingWatchpoint);
     WTF_MAKE_TZONE_ALLOCATED(AdaptiveValueStructureStubClearingWatchpoint);
 
+    bool isValid() const final { return !m_owner->ownerIsDead(); }
     void handleFire(VM&, const FireDetail&) final;
 
 public:

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1554,6 +1554,10 @@ ObjectPropertyConditionSet Graph::tryEnsureAbsence(JSGlobalObject* globalObject,
         return ObjectPropertyConditionSet::invalid();
 
     auto isAbsenceCacheable = [&](Structure* structure) {
+        // Absences cannot be cached on any dictionaries, including CachedDictionaryKind, because
+        // new properties can be added without structure transitions.
+        if (structure->isDictionary())
+            return false;
         if (structure->typeInfo().overridesGetOwnPropertySlot())
             return false;
         if (!structure->propertyAccessesAreCacheable())

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -58,6 +58,7 @@ class GCAwareJITStubRoutine : public JITStubRoutine {
 public:
     using Base = JITStubRoutine;
     friend class JITStubRoutine;
+    friend class JSDollarVMHelper;
     GCAwareJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, JSCell* owner, bool isCodeImmutable);
 
     static Ref<JITStubRoutine> create(VM& vm, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code, JSCell* owner, bool isCodeImmutable)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -353,6 +353,8 @@ public:
 
     bool propertyAccessesAreCacheableForAbsence()
     {
+        // FIXME: dictionaries cannot be cached for absence, so check for dictionaries here instead
+        // of at all call sites.
         return !typeInfo().getOwnPropertySlotIsImpureForPropertyAbsence();
     }
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSDollarVM.h"
 
+#include "AccessCase.h"
 #include "ArrayPrototype.h"
 #include "BuiltinNames.h"
 #include "CachedCall.h"
@@ -52,14 +53,17 @@
 #include "JSString.h"
 #include "LinkBuffer.h"
 #include "NativeCallee.h"
+#include "ObjectPropertyCondition.h"
 #include "OperationResult.h"
 #include "Options.h"
 #include "Parser.h"
 #include "ProbeContext.h"
+#include "Scribble.h"
 #include "ShadowChicken.h"
 #include "Snippet.h"
 #include "SnippetParams.h"
 #include "Strong.h"
+#include "StructureStubClearingWatchpoint.h"
 #include "TypeProfiler.h"
 #include "TypeProfilerLog.h"
 #include "VMEntryScopeInlines.h"
@@ -118,6 +122,8 @@ public:
     { }
 
     void updateVMStackLimits() { return m_vm.updateStackLimits(); };
+
+    static void setOwnerIsDead(GCAwareJITStubRoutine& stub) { stub.m_ownerIsDead = true; }
 
     VM& m_vm;
 };
@@ -2227,6 +2233,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionGlobalObjectForObject);
 static JSC_DECLARE_HOST_FUNCTION(functionGetGetterSetter);
 static JSC_DECLARE_HOST_FUNCTION(functionLoadGetterFromGetterSetter);
 static JSC_DECLARE_HOST_FUNCTION(functionCreateCustomTestGetterSetter);
+static JSC_DECLARE_HOST_FUNCTION(functionCreateCustomTestGetterSetterWithSharedStructure);
+static JSC_DECLARE_HOST_FUNCTION(functionInstallStructureStubClearingWatchpointWithDeadOwner);
 static JSC_DECLARE_HOST_FUNCTION(functionDeltaBetweenButterflies);
 static JSC_DECLARE_HOST_FUNCTION(functionCurrentCPUTime);
 static JSC_DECLARE_HOST_FUNCTION(functionTotalGCTime);
@@ -3823,6 +3831,81 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateCustomTestGetterSetter, (JSGlobalObject* 
     return JSValue::encode(JSTestCustomGetterSetter::create(vm, globalObject, JSTestCustomGetterSetter::createStructure(vm, globalObject)));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionCreateCustomTestGetterSetterWithSharedStructure, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+    auto* dollarVM = jsDynamicCast<JSDollarVM*>(callFrame->thisValue());
+    RELEASE_ASSERT(dollarVM);
+    return JSValue::encode(JSTestCustomGetterSetter::create(vm, globalObject, dollarVM->testCustomGetterSetterStructure()));
+}
+
+// Usage: $vm.installStructureStubClearingWatchpointWithDeadOwner(proto, "propertyName") Creates a
+//
+// PolymorphicAccessJITStubRoutine with an AdaptiveValueStructureStubClearingWatchpoint installed on
+// proto's Structure for the given Equivalence property condition, then simulates the dead-owner
+// state.
+JSC_DEFINE_HOST_FUNCTION(functionInstallStructureStubClearingWatchpointWithDeadOwner, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+#if ENABLE(JIT)
+    DollarVMAssertScope assertScope;
+    VM& vm = globalObject->vm();
+
+    JSObject* proto = jsDynamicCast<JSObject*>(callFrame->argument(0));
+    RELEASE_ASSERT(proto);
+    JSString* propNameStr = jsDynamicCast<JSString*>(callFrame->argument(1));
+    RELEASE_ASSERT(propNameStr);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto propertyName = propNameStr->toIdentifier(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    Structure* structure = proto->structure();
+    PropertyOffset offset = structure->get(vm, propertyName);
+    RELEASE_ASSERT(isValidOffset(offset));
+    JSValue value = proto->getDirect(offset);
+    RELEASE_ASSERT(value.isCell() && value.asCell()->type() == CustomGetterSetterType);
+
+    // Create Equivalence ObjectPropertyCondition: "property on proto equals value".
+    ObjectPropertyCondition condition = ObjectPropertyCondition::equivalence(
+        vm, proto, proto, propertyName.impl(), value);
+    RELEASE_ASSERT(condition);
+    RELEASE_ASSERT(condition.kind() == PropertyCondition::Equivalence);
+
+    // Create a PolymorphicAccessJITStubRoutine.
+    // Use isCodeImmutable=true so JITStubRoutineSet::add doesn't read the (empty) code address.
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> emptyCode;
+    auto stub = adoptRef(*new PolymorphicAccessJITStubRoutine(
+        JITStubRoutine::Type::PolymorphicAccessJITStubRoutineType, emptyCode, vm,
+        FixedVector<Ref<AccessCase>> { }, FixedVector<StructureID> { }, proto, true));
+    stub->makeGCAware(vm);
+
+    // Install the AdaptiveValueStructureStubClearingWatchpoint on proto's Structure.
+    // Must start watching property replacements first (as the IC does).
+    structure->startWatchingPropertyForReplacements(vm, offset);
+    auto& watchpointVariant = *stub->watchpoints().add(
+        WTF::InPlaceType<AdaptiveValueStructureStubClearingWatchpoint>,
+        stub.ptr(), condition, stub->watchpointSet());
+    auto& adaptiveWp = std::get<AdaptiveValueStructureStubClearingWatchpoint>(watchpointVariant);
+    adaptiveWp.install(vm);
+
+    // Store the stub on $vm and set the owner as dead, simulating the window
+    // between GC marking-end and CodeBlock sweep.
+    JSDollarVMHelper::setOwnerIsDead(stub.get());
+    auto* dollarVM = jsDynamicCast<JSDollarVM*>(callFrame->thisValue());
+    RELEASE_ASSERT(dollarVM);
+    dollarVM->m_testStubRoutine = WTF::move(stub);
+
+    // Scribble proto's cell header to simulate a swept dead cell.
+    scribble(proto, sizeof(JSCell));
+
+    return JSValue::encode(jsUndefined());
+#else
+    UNUSED_PARAM(globalObject);
+    UNUSED_PARAM(callFrame);
+    return JSValue::encode(jsUndefined());
+#endif
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionDeltaBetweenButterflies, (JSGlobalObject*, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -4483,6 +4566,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "getGetterSetter"_s, functionGetGetterSetter, 2);
     addFunction(vm, "loadGetterFromGetterSetter"_s, functionLoadGetterFromGetterSetter, 1);
     addFunction(vm, "createCustomTestGetterSetter"_s, functionCreateCustomTestGetterSetter, 1);
+    addFunction(vm, "createCustomTestGetterSetterWithSharedStructure"_s, functionCreateCustomTestGetterSetterWithSharedStructure, 0);
+    addFunction(vm, "installStructureStubClearingWatchpointWithDeadOwner"_s, functionInstallStructureStubClearingWatchpointWithDeadOwner, 2);
 
     addFunction(vm, "deltaBetweenButterflies"_s, functionDeltaBetweenButterflies, 2);
     
@@ -4551,6 +4636,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "weakCreate"_s, functionWeakCreate, 0);
 
     m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID.set(vm, this, ObjectDoingSideEffectPutWithoutCorrectSlotStatus::createStructure(vm, globalObject, jsNull()));
+    m_testCustomGetterSetterStructureID.set(vm, this, JSTestCustomGetterSetter::createStructure(vm, globalObject));
 }
 
 void JSDollarVM::addFunction(VM& vm, JSGlobalObject* globalObject, ASCIILiteral name, NativeFunction function, unsigned arguments)
@@ -4578,6 +4664,7 @@ void JSDollarVM::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     JSDollarVM* thisObject = jsCast<JSDollarVM*>(cell);
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID);
+    visitor.append(thisObject->m_testCustomGetterSetterStructureID);
 }
 
 DEFINE_VISIT_CHILDREN(JSDollarVM);

--- a/Source/JavaScriptCore/tools/JSDollarVM.h
+++ b/Source/JavaScriptCore/tools/JSDollarVM.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/GCAwareJITStubRoutine.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Options.h>
 
@@ -65,7 +66,12 @@ public:
     }
 
     Structure* objectDoingSideEffectPutWithoutCorrectSlotStatusStructure() { return m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID.get(); }
-    
+    Structure* testCustomGetterSetterStructure() { return m_testCustomGetterSetterStructureID.get(); }
+
+#if ENABLE(JIT)
+    RefPtr<PolymorphicAccessJITStubRoutine> m_testStubRoutine;
+#endif
+
 private:
     JSDollarVM(VM& vm, Structure* structure)
         : Base(vm, structure)
@@ -80,6 +86,7 @@ private:
     static void getOwnPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArrayBuilder&, DontEnumPropertiesMode);
 
     WriteBarrierStructureID m_objectDoingSideEffectPutWithoutCorrectSlotStatusStructureID;
+    WriteBarrierStructureID m_testCustomGetterSetterStructureID;
 };
 
 } // namespace JSC

--- a/Source/WTF/wtf/MappedFileData.h
+++ b/Source/WTF/wtf/MappedFileData.h
@@ -57,11 +57,19 @@ public:
     MappedFileData(MappedFileData&&) = default;
     MappedFileData& operator=(MappedFileData&&) = default;
 
+    static MappedFileData emptyFile()
+    {
+        MappedFileData result;
+        result.m_isValid = true;
+        return result;
+    }
+
+    explicit operator bool() const { return m_isValid; }
+
 #if HAVE(MMAP)
     explicit MappedFileData(MmapSpan<uint8_t>&&);
 
     [[nodiscard]] std::span<uint8_t> leakHandle() { return m_fileData.leakSpan(); }
-    explicit operator bool() const { return !!m_fileData; }
     size_t size() const { return m_fileData.span().size(); }
     std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData.span(); }
     std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData.mutableSpan(); }
@@ -69,7 +77,6 @@ public:
     MappedFileData(std::span<uint8_t>, Win32Handle&&);
 
     const Win32Handle& fileMapping() const { return m_fileMapping; }
-    explicit operator bool() const { return !!m_fileData.data(); }
     size_t size() const { return m_fileData.size(); }
     std::span<const uint8_t> span() const LIFETIME_BOUND { return m_fileData; }
     std::span<uint8_t> mutableSpan() LIFETIME_BOUND { return m_fileData; }
@@ -82,6 +89,7 @@ private:
     std::span<uint8_t> m_fileData;
     Win32Handle m_fileMapping;
 #endif
+    bool m_isValid { false };
 };
 
 } // namespace FileSystemImpl

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -113,6 +113,12 @@ public:
         ASSERT(m_ptr);
     }
 
+    template<typename X, typename WeakPtrImplType>
+    Ref(const WeakRef<X, WeakPtrImplType>& other) requires std::is_convertible_v<X*, T*>
+        : m_ptr(&RefDerefTraits::ref(other.get()))
+    {
+    }
+
     Ref& operator=(T&);
     Ref& operator=(Ref&&);
     template<typename X, typename Y, typename Z> Ref& operator=(Ref<X, Y, Z>&&);
@@ -173,6 +179,10 @@ private:
 
     typename PtrTraits::StorageType m_ptr;
 } SWIFT_ESCAPABLE;
+
+// Template deduction guide.
+template<typename X, typename Y> Ref(const WeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y> Ref(WeakRef<X, Y>&) -> Ref<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 
 template<typename T, typename _PtrTraits, typename RefDerefTraits> Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T&);
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -54,6 +54,7 @@ public:
     ALWAYS_INLINE RefPtr(RefPtr&& o) : m_ptr(o.leakRef()) { }
     template<typename X, typename Y, typename Z> RefPtr(RefPtr<X, Y, Z>&& o) : m_ptr(o.leakRef()) { }
     template<typename X, typename Y> RefPtr(Ref<X, Y>&&);
+    template<typename X, typename Y, typename Z> RefPtr(const WeakPtr<X, Y, Z>& o) requires std::is_convertible_v<X*, T*> : m_ptr(RefDerefTraits::refIfNotNull(o.get())) { }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     RefPtr(HashTableDeletedValueType) : m_ptr(PtrTraits::hashTableDeletedValue()) { }
@@ -109,6 +110,8 @@ private:
 
 // Template deduction guide.
 template<typename X, typename Y> RefPtr(Ref<X, Y>&&) -> RefPtr<X, Y, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y, typename Z> RefPtr(const WeakPtr<X, Y, Z>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
+template<typename X, typename Y, typename Z> RefPtr(WeakPtr<X, Y, Z>&) -> RefPtr<X, RawPtrTraits<X>, DefaultRefDerefTraits<X>>;
 
 template<typename T, typename U, typename V>
 template<typename X, typename Y>

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -118,6 +118,8 @@ public:
         return m_impl ? static_cast<T*>(m_impl->template get<T>()) : nullptr;
     }
 
+    operator T*() const { return get(); }
+
     WeakRef<T> releaseNonNull()
     {
         return WeakRef<T> { m_impl.releaseNonNull(), enableWeakPtrThreadingAssertions() };

--- a/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileHandlePOSIX.cpp
@@ -163,7 +163,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode mapMode, FileOpenMo
         return { };
 
     if (!size)
-        return MappedFileData { };
+        return MappedFileData::emptyFile();
 
     int pageProtection = PROT_READ;
     switch (openMode) {

--- a/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
+++ b/Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp
@@ -31,6 +31,7 @@ namespace WTF::FileSystemImpl {
 #if HAVE(MMAP)
 MappedFileData::MappedFileData(MmapSpan<uint8_t>&& fileData)
     : m_fileData(WTF::move(fileData))
+    , m_isValid(true)
 { }
 
 MappedFileData::~MappedFileData() = default;

--- a/Source/WTF/wtf/win/FileHandleWin.cpp
+++ b/Source/WTF/wtf/win/FileHandleWin.cpp
@@ -152,7 +152,7 @@ std::optional<MappedFileData> FileHandle::map(MappedFileMode, FileOpenMode openM
         return { };
 
     if (!*size)
-        return MappedFileData { };
+        return MappedFileData::emptyFile();
 
     DWORD pageProtection = PAGE_READONLY;
     DWORD desiredAccess = FILE_MAP_READ;

--- a/Source/WTF/wtf/win/MappedFileDataWin.cpp
+++ b/Source/WTF/wtf/win/MappedFileDataWin.cpp
@@ -33,6 +33,7 @@ namespace WTF::FileSystemImpl {
 MappedFileData::MappedFileData(std::span<uint8_t> fileData, Win32Handle&& fileMapping)
     : m_fileData(fileData)
     , m_fileMapping(WTF::move(fileMapping))
+    , m_isValid(true)
 {
 }
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -159,7 +159,7 @@ private:
     typedef void (IDBConnectionToServer::*ResultFunction)(const IDBResultData&);
     void callResultFunctionWithErrorLater(ResultFunction, const IDBResourceIdentifier& requestIdentifier);
 
-    Ref<IDBConnectionToServerDelegate> protectedDelegate() const { return m_delegate.get(); }
+    Ref<IDBConnectionToServerDelegate> protectedDelegate() const { return m_delegate; }
 
     WeakRef<IDBConnectionToServerDelegate> m_delegate;
     bool m_serverConnectionIsValid { true };

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp
@@ -1367,6 +1367,11 @@ void UniqueIDBDatabase::connectionClosedFromClient(UniqueIDBDatabaseConnection& 
     handleTransactions();
 }
 
+bool UniqueIDBDatabase::isVersionChangeTransactionActive(const UniqueIDBDatabaseConnection& connection) const
+{
+    return m_versionChangeDatabaseConnection == &connection && m_versionChangeTransaction;
+}
+
 void UniqueIDBDatabase::connectionClosedFromServer(UniqueIDBDatabaseConnection& connection)
 {
     ASSERT(!isMainThread());

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -115,6 +115,7 @@ public:
 
     void didFinishHandlingVersionChange(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& transactionIdentifier);
     void connectionClosedFromClient(UniqueIDBDatabaseConnection&);
+    WEBCORE_EXPORT bool isVersionChangeTransactionActive(const UniqueIDBDatabaseConnection&) const;
     void didFireVersionChangeEvent(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer);
     WEBCORE_EXPORT void openDBRequestCancelled(const IDBResourceIdentifier& requestIdentifier);
 

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -53,6 +53,7 @@
 #include "WorkerLoaderProxy.h"
 #include "WorkerThread.h"
 #include <optional>
+#include <wtf/Expected.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
@@ -60,6 +61,34 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Permissions);
+
+#if ENABLE(GEOLOCATION)
+
+static std::optional<PermissionState> determineGeolocationPermissionState(PermissionState permissionState, const Document& document)
+{
+    RefPtr window = document.window();
+    if (!window)
+        return std::nullopt;
+
+    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(window->protectedNavigator());
+
+    switch (permissionState) {
+    case PermissionState::Granted:
+        return PermissionState::Granted;
+    case PermissionState::Denied:
+        if (!geolocation || !geolocation->hasBeenRequested())
+            return PermissionState::Prompt;
+        return PermissionState::Denied;
+    case PermissionState::Prompt:
+        if (!geolocation || !geolocation->hasBeenRequested())
+            return PermissionState::Prompt;
+        return geolocation->isAllowed() ? PermissionState::Granted : PermissionState::Denied;
+    };
+
+    return std::nullopt;
+}
+
+#endif // ENABLE(GEOLOCATION)
 
 Ref<Permissions> Permissions::create(NavigatorBase& navigator)
 {
@@ -76,7 +105,12 @@ NavigatorBase* Permissions::navigator()
     return m_navigator.get();
 }
 
-Permissions::~Permissions() = default;
+Permissions::~Permissions()
+{
+    auto queryPromises = std::exchange(m_queryPromises, { });
+    for (auto& promise : queryPromises.values())
+        promise->reject(ExceptionCode::AbortError, "Promise was rejected because the browsing context is going away"_s);
+}
 
 static bool isAllowedByPermissionsPolicy(const Document& document, PermissionName name)
 {
@@ -125,24 +159,46 @@ std::optional<PermissionName> Permissions::toPermissionName(const String& name)
     return std::nullopt;
 }
 
-void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DOMPromiseDeferred<IDLInterface<PermissionStatus>>&& promise)
+static Expected<PermissionState, Exception> processPermissionQueryResult(std::optional<PermissionState> permissionState, const PermissionDescriptor& permissionDescriptor, const Document& document)
+{
+    if (!permissionState)
+        return makeUnexpected(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
+
+#if ENABLE(GEOLOCATION)
+    if (permissionDescriptor.name == PermissionName::Geolocation) {
+        if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))
+            permissionState = geolocationPermissionState;
+        else
+            return makeUnexpected(Exception { ExceptionCode::InvalidStateError, "The Document does not have a Geolocation object"_s });
+    }
+#endif
+
+#if ENABLE(MEDIA_STREAM)
+    if (document.quirks().shouldEnableCameraAndMicrophonePermissionStateQuirk() && (permissionDescriptor.name == PermissionName::Camera || permissionDescriptor.name == PermissionName::Microphone) && *permissionState == PermissionState::Prompt)
+        permissionState = PermissionState::Granted;
+#endif
+
+    return *permissionState;
+}
+
+void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, Ref<DeferredPromise>&& promise)
 {
     RefPtr context = m_navigator ? m_navigator->scriptExecutionContext() : nullptr;
     if (!context || !context->globalObject()) {
-        promise.reject(Exception { ExceptionCode::InvalidStateError, "The context is invalid"_s });
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The context is invalid"_s });
         return;
     }
 
     auto source = sourceFromContext(*context);
     if (!source) {
-        promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query is not supported in this context"_s  });
+        promise->reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query is not supported in this context"_s  });
         return;
     }
 
     RefPtr document = dynamicDowncast<Document>(*context);
     if (document && !document->isFullyActive()) {
-        promise.reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active"_s });
-        return; 
+        promise->reject(Exception { ExceptionCode::InvalidStateError, "The document is not fully active"_s });
+        return;
     }
 
     auto& vm = context->globalObject()->vm();
@@ -150,7 +206,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
 
     auto permissionDescriptorConversionResult = convert<IDLDictionary<PermissionDescriptor>>(*context->globalObject(), permissionDescriptorValue.get());
     if (permissionDescriptorConversionResult.hasException(scope)) [[unlikely]] {
-        promise.reject(Exception { ExceptionCode::ExistingExceptionError });
+        promise->reject(Exception { ExceptionCode::ExistingExceptionError });
         return;
     }
 
@@ -159,119 +215,71 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
     RefPtr origin = context->securityOrigin();
     auto originData = origin ? origin->data() : SecurityOriginData { };
 
-    if (document) {
-        WeakPtr page = document->page();
-        if (!page) {
-            promise.reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
-            return;
-        }
+    auto contextIdentifier = context->identifier();
 
-        if (!isAllowedByPermissionsPolicy(*document, permissionDescriptor.name)) {
-            promise.resolve(PermissionStatus::create(*context, PermissionState::Denied, permissionDescriptor, PermissionQuerySource::Window, *page));
-            return;
-        }
+    auto promiseIdentifier = PromiseIdentifier::generate();
+    m_queryPromises.add(promiseIdentifier, WTF::move(promise));
 
-        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTF::move(originData) }, permissionDescriptor, *page, *source, [document = Ref { *document }, page, permissionDescriptor, promise = WTF::move(promise)](auto permissionState) mutable {
-            if (!permissionState) {
-                promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
-                return;
-            }
-
-#if ENABLE(GEOLOCATION)
-            if (permissionDescriptor.name == PermissionName::Geolocation) {
-                if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))
-                    permissionState = geolocationPermissionState;
-                else {
-                    promise.reject(Exception { ExceptionCode::InvalidStateError, "The Document does not have a Geolocation object"_s });
-                    return;
-                }
-            }
-#endif
-
-#if ENABLE(MEDIA_STREAM)
-            if (document->quirks().shouldEnableCameraAndMicrophonePermissionStateQuirk() && (permissionDescriptor.name == PermissionName::Camera || permissionDescriptor.name == PermissionName::Microphone) && *permissionState == PermissionState::Prompt)
-                permissionState = PermissionState::Granted;
-#endif
-            promise.resolve(PermissionStatus::create(document, *permissionState, permissionDescriptor, PermissionQuerySource::Window, WTF::move(page)));
-        });
-        return;
-    }
-
-    Ref workerGlobalScope = downcast<WorkerGlobalScope>(*context);
-    auto completionHandler = [originData = WTF::move(originData).isolatedCopy(), permissionDescriptor, contextIdentifier = workerGlobalScope->identifier(), source = *source, promise = WTF::move(promise)] (auto& context) mutable {
+    auto queryPermissionOnMainThread = [originData = WTF::move(originData).isolatedCopy(), permissionDescriptor, contextIdentifier, source = *source, promiseIdentifier, weakThis = WeakPtr { *this }] (ScriptExecutionContext& mainThreadContext) mutable {
         ASSERT(isMainThread());
 
-        Ref document = downcast<Document>(context);
-        if (!document->page()) {
-            ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise)](auto&) mutable {
-                promise.reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
+        auto& document = downcast<Document>(mainThreadContext);
+        if (!document.page()) {
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier](auto&) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis)
+                    return;
+                if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                    promise->reject(Exception { ExceptionCode::InvalidStateError, "The page does not exist"_s });
             });
             return;
         }
 
-        auto page = source == PermissionQuerySource::DedicatedWorker ? WeakPtr { *document->page() } : nullptr;
+        if (source == PermissionQuerySource::Window && !isAllowedByPermissionsPolicy(document, permissionDescriptor.name)) {
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, permissionDescriptor, page = WeakPtr { *document.page() }](auto& context) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis)
+                    return;
+                if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                    promise->resolve<IDLInterface<PermissionStatus>>(PermissionStatus::create(context, PermissionState::Denied, permissionDescriptor, PermissionQuerySource::Window, WTF::move(page)));
+            });
+            return;
+        }
 
-        PermissionController::singleton().query(ClientOrigin { document->topOrigin().data(), WTF::move(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, promise = WTF::move(promise), source, page, document](auto permissionState) mutable {
+        auto page = source == PermissionQuerySource::DedicatedWorker || source == PermissionQuerySource::Window ? WeakPtr { *document.page() } : nullptr;
+
+        PermissionController::singleton().query(ClientOrigin { document.topOrigin().data(), WTF::move(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, weakThis = WTF::move(weakThis), promiseIdentifier, source, page, document = Ref { document }](auto permissionState) mutable {
             ASSERT(isMainThread());
 
-            if (!permissionState) {
-                ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise)](auto&) mutable {
-                    promise.reject(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
+            auto result = processPermissionQueryResult(permissionState, permissionDescriptor, document);
+            if (!result) {
+                ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, exception = result.error()](auto&) mutable {
+                    RefPtr protectedThis = weakThis;
+                    if (!protectedThis)
+                        return;
+                    if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                        promise->reject(WTF::move(exception));
                 });
-
                 return;
             }
 
-#if ENABLE(GEOLOCATION)
-            if (permissionDescriptor.name == PermissionName::Geolocation) {
-                if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))
-                    permissionState = geolocationPermissionState;
-                else {
-                    ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise)](auto&) mutable {
-                        promise.reject(Exception { ExceptionCode::InvalidStateError, "The Document does not have a Geolocation object"_s });
-                    });
-
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, permissionState = *result, permissionDescriptor, source, page = WTF::move(page)](auto& context) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis)
                     return;
-                }
-            }
-#endif
-
-            ScriptExecutionContext::postTaskTo(contextIdentifier, [promise = WTF::move(promise), permissionState, permissionDescriptor, source, page = WTF::move(page)](auto& context) mutable {
-                promise.resolve(PermissionStatus::create(context, *permissionState, permissionDescriptor, source, WTF::move(page)));
+                if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
+                    promise->resolve<IDLInterface<PermissionStatus>>(PermissionStatus::create(context, permissionState, permissionDescriptor, source, WTF::move(page)));
             });
         });
     };
 
-    if (CheckedPtr workerLoaderProxy = workerGlobalScope->thread()->workerLoaderProxy())
-        workerLoaderProxy->postTaskToLoader(WTF::move(completionHandler));
+    if (document)
+        queryPermissionOnMainThread(*document);
+    else {
+        Ref workerGlobalScope = downcast<WorkerGlobalScope>(*context);
+        if (CheckedPtr workerLoaderProxy = workerGlobalScope->thread()->workerLoaderProxy())
+            workerLoaderProxy->postTaskToLoader(WTF::move(queryPermissionOnMainThread));
+    }
 }
-
-#if ENABLE(GEOLOCATION)
-
-static std::optional<PermissionState> determineGeolocationPermissionState(PermissionState permissionState, const Document& document)
-{
-    RefPtr window = document.window();
-    if (!window)
-        return std::nullopt;
-
-    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(window->protectedNavigator());
-
-    switch (permissionState) {
-    case PermissionState::Granted:
-        return PermissionState::Granted;
-    case PermissionState::Denied:
-        if (!geolocation || !geolocation->hasBeenRequested())
-            return PermissionState::Prompt;
-        return PermissionState::Denied;
-    case PermissionState::Prompt:
-        if (!geolocation || !geolocation->hasBeenRequested())
-            return PermissionState::Prompt;
-        return geolocation->isAllowed() ? PermissionState::Granted : PermissionState::Denied;
-    };
-
-    return std::nullopt;
-}
-
-#endif // ENABLE(GEOLOCATION)
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/Permissions.h
+++ b/Source/WebCore/Modules/permissions/Permissions.h
@@ -27,6 +27,9 @@
 
 #include <JavaScriptCore/Strong.h>
 #include <WebCore/IDLTypes.h>
+#include <WebCore/JSDOMPromiseDeferredForward.h>
+#include <wtf/ObjectIdentifier.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -50,14 +53,14 @@ enum class PermissionState : uint8_t;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
-class Permissions : public RefCounted<Permissions> {
+class Permissions : public RefCountedAndCanMakeWeakPtr<Permissions> {
     WTF_MAKE_TZONE_ALLOCATED(Permissions);
 public:
     static Ref<Permissions> create(NavigatorBase&);
     ~Permissions();
 
     NavigatorBase* navigator();
-    void query(JSC::Strong<JSC::JSObject>, DOMPromiseDeferred<IDLInterface<PermissionStatus>>&&);
+    void query(JSC::Strong<JSC::JSObject>, Ref<DeferredPromise>&&);
     WEBCORE_EXPORT static std::optional<PermissionQuerySource> sourceFromContext(const ScriptExecutionContext&);
     WEBCORE_EXPORT static std::optional<PermissionName> toPermissionName(const String&);
 
@@ -65,6 +68,10 @@ private:
     explicit Permissions(NavigatorBase&);
 
     WeakPtr<NavigatorBase> m_navigator;
+
+    enum class PromiseIdentifierType { };
+    using PromiseIdentifier = AtomicObjectIdentifier<PromiseIdentifierType>;
+    HashMap<PromiseIdentifier, Ref<DeferredPromise>> m_queryPromises;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
@@ -49,8 +49,8 @@ private:
 
     RefPtr<NativeImage> copyNativeImage() final;
     RefPtr<NativeImage> createNativeImageReference() final { return copyNativeImage(); }
-    void getPixelBuffer(const IntRect&, PixelBuffer&) final { ASSERT_NOT_REACHED(); }
-    void putPixelBuffer(const PixelBufferSourceView&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { ASSERT_NOT_REACHED(); }
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final { RELEASE_ASSERT_NOT_REACHED(); }
+    void putPixelBuffer(const PixelBufferSourceView&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { RELEASE_ASSERT_NOT_REACHED(); }
 
     RefPtr<SharedBuffer> sinkIntoPDFDocument() final;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
@@ -54,8 +54,8 @@ private:
     RefPtr<NativeImage> copyNativeImage() final { return createNativeImageReference(); }
     RefPtr<NativeImage> createNativeImageReference() final { return nullptr; }
 
-    void getPixelBuffer(const IntRect&, PixelBuffer&) final { ASSERT_NOT_REACHED(); }
-    void putPixelBuffer(const PixelBufferSourceView&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { ASSERT_NOT_REACHED(); }
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final { RELEASE_ASSERT_NOT_REACHED(); }
+    void putPixelBuffer(const PixelBufferSourceView&, const IntRect&, const IntPoint&, AlphaPremultiplication) final { RELEASE_ASSERT_NOT_REACHED(); }
 
     RefPtr<SharedBuffer> sinkIntoPDFDocument() final;
 

--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -39,6 +39,7 @@ namespace WebCore {
 BlobData::BlobData(const String& contentType)
     : m_contentType(contentType)
 {
+    ASSERT(isMainThread());
 }
 
 const long long BlobDataItem::toEndOfFile = -1;

--- a/Source/WebCore/platform/network/BlobData.h
+++ b/Source/WebCore/platform/network/BlobData.h
@@ -106,7 +106,7 @@ private:
 
 typedef Vector<BlobDataItem> BlobDataItemList;
 
-class BlobData : public ThreadSafeRefCounted<BlobData> {
+class BlobData : public ThreadSafeRefCounted<BlobData, WTF::DestructionThread::Main> {
 public:
     static Ref<BlobData> create(const String& contentType)
     {

--- a/Source/WebCore/platform/network/BlobDataFileReference.cpp
+++ b/Source/WebCore/platform/network/BlobDataFileReference.cpp
@@ -35,6 +35,7 @@ BlobDataFileReference::BlobDataFileReference(const String& path, const String& r
     : m_path(path)
     , m_replacementPath(replacementPath)
 {
+    ASSERT(isMainThread());
 }
 
 BlobDataFileReference::~BlobDataFileReference()

--- a/Source/WebCore/platform/network/BlobDataFileReference.h
+++ b/Source/WebCore/platform/network/BlobDataFileReference.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT BlobDataFileReference : public RefCounted<BlobDataFileReference> {
+class WEBCORE_EXPORT BlobDataFileReference : public ThreadSafeRefCounted<BlobDataFileReference, WTF::DestructionThread::Main> {
 public:
     static Ref<BlobDataFileReference> create(const String& path, const String& replacementPath = { })
     {

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -109,6 +109,7 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
     auto memory = m_renderingBackend->sharedMemoryForGetPixelBuffer();
     MESSAGE_CHECK(memory, "No shared memory for getPixelBufferForImageBuffer");
     MESSAGE_CHECK(WebCore::PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat), "Pixel format not supported");
+    MESSAGE_CHECK(m_imageBuffer->renderingMode() != RenderingMode::PDFDocument && m_imageBuffer->renderingMode() != RenderingMode::DisplayList, "Backend does not hold pixels");
     WebCore::IntRect srcRect(srcPoint, srcSize);
     if (auto pixelBuffer = m_imageBuffer->getPixelBuffer(destinationFormat, srcRect)) {
         MESSAGE_CHECK(pixelBuffer->bytes().size() <= memory->size(), "Shmem for return of getPixelBuffer is too small");
@@ -133,6 +134,7 @@ void RemoteImageBuffer::putPixelBuffer(const WebCore::PixelBufferSourceView& pix
     assertIsCurrent(workQueue());
 
     MESSAGE_CHECK(m_imageBuffer->resolutionScale() == 1, "putPixelBuffer() should not be called if (resolutionScale() != 1)");
+    MESSAGE_CHECK(m_imageBuffer->renderingMode() != RenderingMode::PDFDocument && m_imageBuffer->renderingMode() != RenderingMode::DisplayList, "Backend does not hold pixels");
 
     WebCore::IntRect srcRect(srcPoint, srcSize);
     m_imageBuffer->putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -195,6 +195,7 @@ bool RemoteImageBufferSet::makeBuffersVolatile(OptionSet<BufferInSetType> reques
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 void RemoteImageBufferSet::dynamicContentScalingDisplayList(CompletionHandler<void(std::optional<WebCore::DynamicContentScalingDisplayList>&&)>&& completionHandler)
 {
+    MESSAGE_CHECK(!isPreparingForDisplay(), "DynamicContentScalingDisplayList requested while preparing for display");
     std::optional<WebCore::DynamicContentScalingDisplayList> displayList;
     if (m_frontBuffer)
         displayList = m_frontBuffer->dynamicContentScalingDisplayList();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -78,8 +78,8 @@ private:
     RemoteAdapter& operator=(RemoteAdapter&&) = delete;
 
     WebCore::WebGPU::Adapter& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -76,7 +76,7 @@ private:
     WebCore::WebGPU::BindGroup& backing() { return m_backing; }
     Ref<WebCore::WebGPU::BindGroup> protectedBacking();
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -86,8 +86,8 @@ private:
     WebCore::WebGPU::CommandEncoder& backing() { return m_backing; }
     Ref<WebCore::WebGPU::CommandEncoder> protectedBacking();
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -94,8 +94,8 @@ private:
 
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -141,7 +141,7 @@ Ref<IPC::StreamServerConnection> RemoteComputePassEncoder::protectedStreamConnec
 
 Ref<WebGPU::ObjectHeap> RemoteComputePassEncoder::protectedObjectHeap() const
 {
-    return m_objectHeap.get();
+    return m_objectHeap;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -78,8 +78,8 @@ private:
 
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -444,7 +444,7 @@ void RemoteDevice::setLabel(String&& label)
 
 Ref<WebGPU::ObjectHeap> RemoteDevice::protectedObjectHeap() const
 {
-    return m_objectHeap.get();
+    return m_objectHeap;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -116,7 +116,7 @@ private:
 
     WebCore::WebGPU::Device& backing() { return m_backing; }
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -109,7 +109,7 @@ Ref<WebCore::WebGPU::PresentationContext> RemotePresentationContext::protectedBa
 
 Ref<WebGPU::ObjectHeap> RemotePresentationContext::protectedObjectHeap() const
 {
-    return m_objectHeap.get();
+    return m_objectHeap;
 }
 
 Ref<IPC::StreamServerConnection> RemotePresentationContext::protectedStreamConnection() const

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -80,7 +80,7 @@ private:
     Ref<WebCore::WebGPU::PresentationContext> protectedBacking();
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -188,7 +188,7 @@ Ref<WebCore::WebGPU::Queue> RemoteQueue::protectedBacking()
 
 Ref<WebGPU::ObjectHeap> RemoteQueue::protectedObjectHeap() const
 {
-    return m_objectHeap.get();
+    return m_objectHeap;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -199,7 +199,7 @@ Ref<IPC::StreamServerConnection> RemoteRenderBundleEncoder::protectedStreamConne
 
 Ref<WebGPU::ObjectHeap> RemoteRenderBundleEncoder::protectedObjectHeap() const
 {
-    return m_objectHeap.get();
+    return m_objectHeap;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -83,7 +83,7 @@ private:
     Ref<WebCore::WebGPU::RenderBundleEncoder> protectedBacking() const;
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -233,7 +233,7 @@ Ref<WebCore::WebGPU::RenderPassEncoder> RemoteRenderPassEncoder::protectedBackin
 
 Ref<WebGPU::ObjectHeap> RemoteRenderPassEncoder::protectedObjectHeap() const
 {
-    return m_objectHeap.get();
+    return m_objectHeap;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -80,7 +80,7 @@ private:
     Ref<WebCore::WebGPU::RenderPassEncoder> protectedBacking();
 
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -78,8 +78,8 @@ private:
 
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -79,8 +79,8 @@ private:
     WebCore::WebGPU::ShaderModule& backing() { return m_backing; }
     Ref<WebCore::WebGPU::ShaderModule> protectedBacking();
     Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap.get(); }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu.get(); }
+    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
+    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1751,8 +1751,16 @@ void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const We
 
 void NetworkStorageManager::establishTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
 {
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
-        connection->establishTransaction(transactionInfo);
+    RefPtr databaseConnection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection);
+    if (!databaseConnection)
+        return;
+
+    // FIXME: consider converting this early return to MESSAGE_CHECK.
+    CheckedPtr database = databaseConnection->database();
+    if (database && database->isVersionChangeTransactionActive(*databaseConnection))
+        return;
+
+    databaseConnection->establishTransaction(transactionInfo);
 }
 
 void NetworkStorageManager::databaseConnectionPendingClose(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -78,8 +78,8 @@ public:
 
     virtual ~PaymentAuthorizationPresenter() = default;
 
-    Client* client() { return m_client.get(); }
-    RefPtr<Client> protectedClient() { return m_client.get(); }
+    Client* client() { return m_client; }
+    RefPtr<Client> protectedClient() { return m_client; }
 
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&);
     void completePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&&);

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp
@@ -126,10 +126,10 @@ void WebExtensionRegisteredScriptsSQLiteStore::deleteScriptsWithIDs(Vector<Strin
 void WebExtensionRegisteredScriptsSQLiteStore::addScripts(Vector<Ref<JSON::Object>> scripts, CompletionHandler<void(const String& errorMessage)>&& completionHandler)
 {
     // Only save persistent scripts to storage
-    Vector<Ref<JSON::Object>> persistentScripts;
+    Vector<std::pair<String, String>> persistentScripts;
     for (Ref script : scripts) {
         if (auto persistent = script->getBoolean(persistAcrossSessionsKey); persistent && persistent.value())
-            persistentScripts.append(script);
+            persistentScripts.append({ script->getString(idKey), script->toJSONString() });
     }
 
     if (persistentScripts.isEmpty()) {
@@ -137,7 +137,7 @@ void WebExtensionRegisteredScriptsSQLiteStore::addScripts(Vector<Ref<JSON::Objec
         return;
     }
 
-    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, persistentScripts, completionHandler = WTF::move(completionHandler)]() mutable {
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, persistentScripts = crossThreadCopy(persistentScripts), completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler({ });
@@ -154,8 +154,8 @@ void WebExtensionRegisteredScriptsSQLiteStore::addScripts(Vector<Ref<JSON::Objec
 
         ASSERT(errorMessage.isEmpty());
 
-        for (Ref script : persistentScripts)
-            protectedThis->insertScript(script, *(protectedThis->database()), errorMessage);
+        for (auto& [scriptID, scriptData] : persistentScripts)
+            protectedThis->insertScript(scriptID, scriptData, *(protectedThis->database()), errorMessage);
 
         WorkQueue::mainSingleton().dispatch([errorMessage = crossThreadCopy(errorMessage), completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(errorMessage);
@@ -216,14 +216,11 @@ Vector<Ref<JSON::Object>> WebExtensionRegisteredScriptsSQLiteStore::getKeysAndVa
     return results;
 }
 
-void WebExtensionRegisteredScriptsSQLiteStore::insertScript(const JSON::Object& script, Ref<WebExtensionSQLiteDatabase> database, String& errorMessage)
+void WebExtensionRegisteredScriptsSQLiteStore::insertScript(const String& scriptID, const String& scriptData, Ref<WebExtensionSQLiteDatabase> database, String& errorMessage)
 {
     assertIsCurrent(queue());
-
-    auto scriptID = script.getString(idKey);
     ASSERT(!scriptID.isEmpty());
 
-    auto scriptData = script.toJSONString();
     DatabaseResult result = SQLiteDatabaseExecute(database, "INSERT INTO registered_scripts (key, script) VALUES (?, ?)"_s, scriptID, scriptData);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Extensions, "Failed to insert registered content script for extension %s.", uniqueIdentifier().utf8().data());

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.h
@@ -62,7 +62,7 @@ private:
 
     Vector<Ref<JSON::Object>> getScriptsWithErrorMessage(String& errorMessage);
     Vector<Ref<JSON::Object>> getKeysAndValuesFromRowIterator(Ref<WebExtensionSQLiteRowEnumerator> rows);
-    void insertScript(const JSON::Object& script, Ref<WebExtensionSQLiteDatabase>, String& errorMessage);
+    void insertScript(const String& scriptID, const String& scriptData, Ref<WebExtensionSQLiteDatabase>, String& errorMessage);
 
     void migrateData();
 };

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -53,8 +53,8 @@ public:
     WebCore::BackForwardFrameItemIdentifier identifier() const { return m_identifier; }
     const String& url() const;
 
-    WebBackForwardListFrameItem* parent() const { return m_parent.get(); }
-    RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent.get(); }
+    WebBackForwardListFrameItem* parent() const { return m_parent; }
+    RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent; }
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
     bool sharesAncestor(WebBackForwardListFrameItem&) const;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -44,6 +44,7 @@
 #import "WebExtensionMessageTargetParameters.h"
 #import "WebExtensionUtilities.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/Box.h>
 #import <wtf/CallbackAggregator.h>
 #import <wtf/darwin/DispatchExtras.h>
 
@@ -204,11 +205,11 @@ void WebExtensionContext::runtimeConnect(const String& extensionID, WebExtension
             return;
         }
 
-        size_t handledCount = 0;
+        auto handledCount = Box<size_t>::create(0);
         size_t totalExpected = mainWorldProcesses.size();
 
         for (auto& process : mainWorldProcesses) {
-            process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, std::nullopt, completeSenderParameters), [=, this, protectedThis = Ref { *this }, &handledCount](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
+            process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, std::nullopt, completeSenderParameters), [=, this, protectedThis = Ref { *this }](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
                 // Flip target and source worlds since we're adding the opposite side of the port connection, sending from target back to source.
                 addPorts(targetContentWorldType, sourceContentWorldType, channelIdentifier, WTF::move(addedPortCounts));
 
@@ -217,7 +218,7 @@ void WebExtensionContext::runtimeConnect(const String& extensionID, WebExtension
 
                 firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
 
-                if (++handledCount < totalExpected)
+                if (++*handledCount < totalExpected)
                     return;
 
                 clearQueuedPortMessages(targetContentWorldType, channelIdentifier);
@@ -539,11 +540,11 @@ void WebExtensionContext::runtimeWebPageConnect(const String& extensionID, WebEx
             return;
         }
 
-        size_t handledCount = 0;
+        auto handledCount = Box<size_t>::create(0);
         size_t totalExpected = mainWorldProcesses.size();
 
         for (auto& process : mainWorldProcesses) {
-            process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, std::nullopt, completeSenderParameters), [=, this, protectedThis = Ref { *this }, &handledCount](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
+            process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, std::nullopt, completeSenderParameters), [=, this, protectedThis = Ref { *this }](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
                 // Flip target and source worlds since we're adding the opposite side of the port connection, sending from target back to source.
                 addPorts(targetContentWorldType, sourceContentWorldType, channelIdentifier, WTF::move(addedPortCounts));
 
@@ -552,7 +553,7 @@ void WebExtensionContext::runtimeWebPageConnect(const String& extensionID, WebEx
 
                 firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
 
-                if (++handledCount < totalExpected)
+                if (++*handledCount < totalExpected)
                     return;
 
                 clearQueuedPortMessages(targetContentWorldType, channelIdentifier);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -47,6 +47,7 @@
 #import "WebExtensionWindowIdentifier.h"
 #import "WebPageProxy.h"
 #import <WebCore/ImageBufferUtilitiesCG.h>
+#import <wtf/Box.h>
 #import <wtf/CallbackAggregator.h>
 
 namespace WebKit {
@@ -521,11 +522,11 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
         return;
     }
 
-    size_t handledCount = 0;
+    auto handledCount = Box<size_t>::create(0);
     size_t totalExpected = processes.size();
 
     for (Ref process : processes) {
-        process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, targetParameters, senderParameters), [=, this, protectedThis = Ref { *this }, &handledCount](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
+        process->sendWithAsyncReply(Messages::WebExtensionContextProxy::DispatchRuntimeConnectEvent(targetContentWorldType, channelIdentifier, name, targetParameters, senderParameters), [=, this, protectedThis = Ref { *this }](HashCountedSet<WebPageProxyIdentifier>&& addedPortCounts) mutable {
             // Flip target and source worlds since we're adding the opposite side of the port connection, sending from target back to source.
             addPorts(targetContentWorldType, sourceContentWorldType, channelIdentifier, WTF::move(addedPortCounts));
 
@@ -534,7 +535,7 @@ void WebExtensionContext::tabsConnect(WebExtensionTabIdentifier tabIdentifier, W
 
             firePortDisconnectEventIfNeeded(sourceContentWorldType, targetContentWorldType, channelIdentifier);
 
-            if (++handledCount < totalExpected)
+            if (++*handledCount < totalExpected)
                 return;
 
             clearQueuedPortMessages(targetContentWorldType, channelIdentifier);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -261,7 +261,7 @@ private:
             // FIXME: <https://webkit.org/b/267514> Add support for changeInfo.
 
 #if PLATFORM(COCOA)
-            if (RefPtr extensionController = m_extensionController.get())
+            if (RefPtr extensionController = m_extensionController)
                 extensionController->cookiesDidChange(cookieStore);
 #endif
         }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp
@@ -76,7 +76,20 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
         return;
     }
 
-    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, rules = WTF::move(rules), completionHandler = WTF::move(completionHandler)]() mutable {
+    Vector<std::pair<double, String>> serializedRules;
+    for (Ref ruleValue : rules.get()) {
+        RefPtr rule = ruleValue->asObject();
+        if (!rule || !rule->size()) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+
+        auto ruleID = rule->getInteger("id"_s);
+        ASSERT(ruleID);
+        serializedRules.append({ *ruleID, rule->toJSONString() });
+    }
+
+    queue().dispatch([weakThis = ThreadSafeWeakPtr { *this }, serializedRules = crossThreadCopy(serializedRules), completionHandler = WTF::move(completionHandler)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completionHandler({ });
@@ -94,17 +107,8 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
         ASSERT(errorMessage.isEmpty());
 
         Vector<double> rulesIDs;
-        for (Ref ruleValue : rules.get()) {
-            RefPtr rule = ruleValue->asObject();
-            if (!rule || !rule->size()) {
-                ASSERT_NOT_REACHED();
-                continue;
-            }
-
-            auto ruleID = rule->getInteger("id"_s);
-            ASSERT(ruleID);
-            rulesIDs.append(*ruleID);
-        }
+        for (auto& [ruleID, ruleData] : serializedRules)
+            rulesIDs.append(ruleID);
 
         ASSERT(rulesIDs.size());
 
@@ -130,14 +134,8 @@ void WebExtensionDeclarativeNetRequestSQLiteStore::addRules(Ref<JSON::Array> rul
             }
         }
 
-        for (Ref ruleValue : rules.get()) {
-            RefPtr rule = ruleValue->asObject();
-            if (!rule || !rule->size()) {
-                ASSERT_NOT_REACHED();
-                continue;
-            }
-
-            errorMessage = protectedThis->insertRule(*rule, *(protectedThis->database()));
+        for (auto& [ruleID, ruleData] : serializedRules) {
+            errorMessage = protectedThis->insertRule(ruleID, ruleData, *(protectedThis->database()));
             if (!errorMessage.isEmpty())
                 break;
         }
@@ -259,15 +257,11 @@ Ref<JSON::Array> WebExtensionDeclarativeNetRequestSQLiteStore::getKeysAndValuesF
     return results;
 }
 
-String WebExtensionDeclarativeNetRequestSQLiteStore::insertRule(const JSON::Object& rule, Ref<WebExtensionSQLiteDatabase> database)
+String WebExtensionDeclarativeNetRequestSQLiteStore::insertRule(double ruleID, const String& ruleData, Ref<WebExtensionSQLiteDatabase> database)
 {
     assertIsCurrent(queue());
 
-    auto ruleData = rule.toJSONString();
-    auto ruleID = rule.getInteger("id"_s);
-    ASSERT(ruleID);
-
-    DatabaseResult result = SQLiteDatabaseExecute(database, makeString("INSERT INTO "_s, m_tableName, " (id, rule) VALUES (?, ?)"_s), *ruleID, ruleData);
+    DatabaseResult result = SQLiteDatabaseExecute(database, makeString("INSERT INTO "_s, m_tableName, " (id, rule) VALUES (?, ?)"_s), ruleID, ruleData);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Extensions, "Failed to insert dynamic declarative net request rule for extension %s", uniqueIdentifier().utf8().data());
         return makeString("Failed to add "_s, m_storageType, " rule."_s);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h
@@ -74,7 +74,7 @@ private:
 
     RefPtr<JSON::Array> getRulesWithRuleIDsInternal(Vector<double> ruleIDs, String& errorMessage);
     Ref<JSON::Array> getKeysAndValuesFromRowIterator(Ref<WebExtensionSQLiteRowEnumerator> rows);
-    String insertRule(const JSON::Object& rule, Ref<WebExtensionSQLiteDatabase>);
+    String insertRule(double ruleID, const String& ruleData, Ref<WebExtensionSQLiteDatabase>);
 
     WebExtensionDeclarativeNetRequestStorageType m_storageType;
     String m_tableName;

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -120,10 +120,10 @@ public:
     void setInspectorClient(std::unique_ptr<API::InspectorClient>&&);
 
     // Public APIs
-    WebPageProxy* inspectedPage() const { return m_inspectedPage.get(); }
-    RefPtr<WebPageProxy> protectedInspectedPage() const { return m_inspectedPage.get(); }
-    WebPageProxy* inspectorPage() const { return m_inspectorPage.get(); }
-    RefPtr<WebPageProxy> protectedInspectorPage() const { return m_inspectorPage.get(); }
+    WebPageProxy* inspectedPage() const { return m_inspectedPage; }
+    RefPtr<WebPageProxy> protectedInspectedPage() const { return m_inspectedPage; }
+    WebPageProxy* inspectorPage() const { return m_inspectorPage; }
+    RefPtr<WebPageProxy> protectedInspectorPage() const { return m_inspectorPage; }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WebInspectorUIExtensionControllerProxy* extensionController() const { return m_extensionController.get(); }

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -43,7 +43,7 @@ public:
     }
     ~RemotePageVisitedLinkStoreRegistration()
     {
-        if (RefPtr page = m_page.get())
+        if (RefPtr page = m_page)
             m_process->removeVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());
     }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -223,7 +223,7 @@ public:
     void getFrameInfo(CompletionHandler<void(std::optional<FrameInfoData>&&)>&&);
     FrameTreeCreationParameters frameTreeCreationParameters() const;
 
-    WebFrameProxy* parentFrame() const { return m_parentFrame.get(); }
+    WebFrameProxy* parentFrame() const { return m_parentFrame; }
     Ref<WebFrameProxy> rootFrame();
     RefPtr<WebFrameProxy> childFrame(uint64_t index) const;
 
@@ -278,9 +278,9 @@ public:
     void updateScrollingMode(WebCore::ScrollbarMode);
 
     void updateOpener(std::optional<WebCore::FrameIdentifier>);
-    WebFrameProxy* opener() const { return m_opener.get(); }
+    WebFrameProxy* opener() const { return m_opener; }
     void disownOpener() { m_opener = nullptr; }
-    WebFrameProxy* disownedOpener() const { return m_disownedOpener.get(); }
+    WebFrameProxy* disownedOpener() const { return m_disownedOpener; }
 
     std::optional<WebCore::IntRect> remoteFrameRect() const { return m_remoteFrameRect; }
     void setRemoteFrameRect(WebCore::IntRect rect) { m_remoteFrameRect = rect; }

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -204,11 +204,11 @@ protected:
 
     template<typename T> bool send(T&& message)
     {
-        Ref webPage = m_webPage.get();
+        Ref webPage = m_webPage;
         return webPage->send(std::forward<T>(message), m_identifier.toUInt64(), { });
     }
 
-    Ref<WebPage> protectedWebPage() const { return m_webPage.get(); }
+    Ref<WebPage> protectedWebPage() const { return m_webPage; }
 
     DrawingAreaIdentifier m_identifier;
     WeakRef<WebPage> m_webPage;

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -130,7 +130,8 @@ TEST_F(FileSystemTest, MappingExistingEmptyFile)
 {
     auto mappedFileData = FileSystem::mapFile(tempEmptyFilePath(), FileSystem::MappedFileMode::Shared);
     EXPECT_TRUE(!!mappedFileData);
-    EXPECT_TRUE(!*mappedFileData);
+    EXPECT_TRUE(!!*mappedFileData);
+    EXPECT_EQ(mappedFileData->size(), 0u);
 }
 
 TEST_F(FileSystemTest, FilesHaveSameVolume)


### PR DESCRIPTION
#### a7a45186ece2fda8ef5e8a8a0918febb8c6b416e
<pre>
Cherry-pick f7d3c0785bb0. <a href="https://bugs.webkit.org/show_bug.cgi?id=312459">https://bugs.webkit.org/show_bug.cgi?id=312459</a>

UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=312459">https://bugs.webkit.org/show_bug.cgi?id=312459</a>
<a href="https://rdar.apple.com/174651133">rdar://174651133</a>

Reviewed by Ryosuke Niwa.

When Permissions::query() is called in a worker, we would dispatch a lambda
to the main thread, get the information and then try to go back to the
worker thread using ScriptExecutionContext::postTaskTo() in order to
call the promise with the result. However, in case of worker termination,
ScriptExecutionContext::postTaskTo() would fail and the lambda would get
destroyed on the main thread, without getting called. This would lead to
a security bug because the lambda was capturing the promise object which
is a worker object and thus should not get destroyed on the main thread.

To address the issue, we now store the promise in a HashMap on the
Permissions object. We then capture a promise identifier in the lambda
instead of the promise. In the ~Permissions() destructor, if there are
pending promises, we reject them.

I made the following changes also:
1. I used `Ref&lt;DeferredPromise&gt;` type for the promise instead of
   `DOMPromiseDeferred&lt;IDLInterface&lt;PermissionStatus&gt;&gt;` so that I could
   store the promise in a HashMap.
2. There was a LOT of code duplication in Permissions::query() for the
   main thread code path and the worker code path. I merged them so we
   now have a single code path for both. This simplifies things a lot.

Test: workers/permissions-query-crash.html

* LayoutTests/workers/permissions-query-crash-expected.txt: Added.
* LayoutTests/workers/permissions-query-crash.html: Added.
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::determineGeolocationPermissionState):
(WebCore::Permissions::~Permissions):
(WebCore::processPermissionQueryResult):
(WebCore::Permissions::query):
* Source/WebCore/Modules/permissions/Permissions.h:

Identifier: 305413.686@safari-7624-branch

Identifier: 305413.703@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.829@webkitglib/2.52">https://commits.webkit.org/305877.829@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### adfe8abddbda0c7889f1db74b953afdfabddbb26
<pre>
Cherry-pick 305907@main (0a2324667740). <a href="https://bugs.webkit.org/show_bug.cgi?id=305822">https://bugs.webkit.org/show_bug.cgi?id=305822</a>

Allow constructing a Ref / RefPtr from a WeakRef / WeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=305822">https://bugs.webkit.org/show_bug.cgi?id=305822</a>

Reviewed by Anne van Kesteren.

Allow constructing a Ref / RefPtr from a WeakRef / WeakPtr, without
requiring calling `.get()`. Also allow silencing converting a WeakPtr&lt;T&gt;
to a T* for consistency with other smart pointer types.

Also simplify code in Source/WebKit/ as a result. If this is approved,
I&apos;ll simplify the rest of the codebase.

* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/WeakPtr.h:
(WTF::WeakPtr::operator T* const):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::protectedObjectHeap const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
(WebKit::PaymentAuthorizationPresenter::client):
(WebKit::PaymentAuthorizationPresenter::protectedClient):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::parent const):
(WebKit::WebBackForwardListFrameItem::protectedParent const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::inspectedPage const):
(WebKit::WebInspectorUIProxy::protectedInspectedPage const):
(WebKit::WebInspectorUIProxy::inspectorPage const):
(WebKit::WebInspectorUIProxy::protectedInspectorPage const):
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h:
(WebKit::RemotePageVisitedLinkStoreRegistration::~RemotePageVisitedLinkStoreRegistration):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::parentFrame const):
(WebKit::WebFrameProxy::opener const):
(WebKit::WebFrameProxy::disownedOpener const):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::send):
(WebKit::DrawingArea::protectedWebPage const):

Canonical link: <a href="https://commits.webkit.org/305877.828@webkitglib/2.52">https://commits.webkit.org/305877.828@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8f4ad594b473a76375f785d44d993a7300344700
<pre>
Cherry-pick c85584f296ce. <a href="https://bugs.webkit.org/show_bug.cgi?id=312319">https://bugs.webkit.org/show_bug.cgi?id=312319</a>

heap-use-after-free in WebExtensionRegisteredScriptsSQLiteStore::addScripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=312319">https://bugs.webkit.org/show_bug.cgi?id=312319</a>
<a href="https://rdar.apple.com/174530074">rdar://174530074</a>

Reviewed by Timothy Hatcher.

WebExtensionRegisteredScriptsSQLiteStore::addScripts and WebExtensionDeclarativeNetRequestSQLiteStore::addRules
both captured Ref&lt;JSON::Value&gt; into lambdas dispatched to a background WorkQueue, while the main
thread still held live references to the same objects. Concurrent increments and decrements from the
two threads cause a lost update on the m_refCount. When the object is freed prematurely on the main
thread, the WorkQueue is left holding with a dangling reference, causing a heap-use-after-free on
the WorkQueue.

Fix this by serializing the data before dispatching it to the WorkQueue.

* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.cpp:
(WebKit::WebExtensionRegisteredScriptsSQLiteStore::addScripts):
(WebKit::WebExtensionRegisteredScriptsSQLiteStore::insertScript):
* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptsSQLiteStore.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.cpp:
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::addRules):
(WebKit::WebExtensionDeclarativeNetRequestSQLiteStore::insertRule):
* Source/WebKit/UIProcess/Extensions/WebExtensionDeclarativeNetRequestSQLiteStore.h:

Identifier: 305413.675@safari-7624-branch

Identifier: 305413.720@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.827@webkitglib/2.52">https://commits.webkit.org/305877.827@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1d5b9c09d536c7b4860dc5ba7c9bdc4e19d14caa
<pre>
Cherry-pick 5364d0966d20. <a href="https://bugs.webkit.org/show_bug.cgi?id=313460">https://bugs.webkit.org/show_bug.cgi?id=313460</a>

Dynamic content scaling display lists should not be requested while preparing for display
<a href="https://bugs.webkit.org/show_bug.cgi?id=313460">https://bugs.webkit.org/show_bug.cgi?id=313460</a>
<a href="https://rdar.apple.com/174414109">rdar://174414109</a>

Reviewed by Simon Fraser.

The WebProcess can send DynamicContentScalingDisplayList while prepareBufferForDisplay
is still active on the GPU Process. This is semantically invalid.

DynamicContentScalingDisplayList calls dynamicContentScalingDisplayList() on the
front buffer, which calls releaseGraphicsContext() — destroying the graphics context
that prepareBufferForDisplay is actively using through m_context. This leads to a
dangling reference.

This is a variant of <a href="https://rdar.apple.com/167565825">rdar://167565825</a> (939a2f7876f3) that survives the existing
MESSAGE_CHECK on markSurfacesVolatile. Only reachable on PLATFORM(VISION) where
ENABLE(RE_DYNAMIC_CONTENT_SCALING) is defined.

To fix, we add a MESSAGE_CHECK to reject when dynamicContentScalingDisplayList is
called while drawing is ongoing, mirroring the existing guard on markSurfacesVolatile.

Test: ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html

* LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display-expected.txt: Added.
* LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html: Added.
* LayoutTests/platform/visionos/TestExpectations:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::dynamicContentScalingDisplayList):

Identifier: 305413.743@safari-7624-branch

Identifier: 305413.719@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.826@webkitglib/2.52">https://commits.webkit.org/305877.826@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fe9df9caf70ae452871ee17002675eda762b5706
<pre>
Cherry-pick 343f135c4791. <a href="https://bugs.webkit.org/show_bug.cgi?id=313465">https://bugs.webkit.org/show_bug.cgi?id=313465</a>

Web Extensions: stack-use-after-return of &amp;handledCount in WebExtensionContext async-reply lambdas.
<a href="https://webkit.org/b/313465">https://webkit.org/b/313465</a>
<a href="https://rdar.apple.com/175672573">rdar://175672573</a>

Reviewed by Brian Weinstein.

Fix use-after-return of handledCount in runtimeConnect, runtimeWebPageConnect, and tabsConnect. The stack-local
counter was captured by reference into async-reply lambdas that execute after the enclosing frame returns.
Use Box&lt;size_t&gt; to heap-allocate the shared counter instead.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeConnect):
(WebKit::WebExtensionContext::runtimeWebPageConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsConnect):

Identifier: 305413.749@safari-7624-branch

Identifier: 305413.718@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.825@webkitglib/2.52">https://commits.webkit.org/305877.825@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f158c0f7a99cc57c2e970e7e0fc253ac848ea870
<pre>
Cherry-pick acb3c0834c1a. <a href="https://bugs.webkit.org/show_bug.cgi?id=312835">https://bugs.webkit.org/show_bug.cgi?id=312835</a>

putPixelBuffer() and getPixelBuffer() should never be called for PDF and DisplayList ImageBufferBackends
<a href="https://bugs.webkit.org/show_bug.cgi?id=312835">https://bugs.webkit.org/show_bug.cgi?id=312835</a>
<a href="https://rdar.apple.com/174740190">rdar://174740190</a>

Reviewed by Simon Fraser.

Currently these functions debug ASSERT only. In the release build, getPixelBuffer()
returns without filling the PixelBuffer with zeros. If the ImageBuffer is remote,
the returned PixelBuffer will be serialized uninitialized to the WebProcess.

RemoteImageBuffer should MESSAGE_CHECK, the backend has pixels. The calls to
putPixelBuffer() and getPixelBuffer() should not be made in normal snapshotting
scenarios.

* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getPixelBuffer):
(WebKit::RemoteImageBuffer::putPixelBuffer):

Identifier: 305413.751@safari-7624-branch

Identifier: 305413.717@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.824@webkitglib/2.52">https://commits.webkit.org/305877.824@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6e418f9536458b073e50f895f7f9d9065a293765
<pre>
Cherry-pick 343b8326d944. <a href="https://bugs.webkit.org/show_bug.cgi?id=313265">https://bugs.webkit.org/show_bug.cgi?id=313265</a>

[JSC] Do not cache property absence on dictionaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=313265">https://bugs.webkit.org/show_bug.cgi?id=313265</a>
<a href="https://rdar.apple.com/175520268">rdar://175520268</a>

Reviewed by Yusuke Suzuki.

Structures with CachedDictionaryKind can add new properties without
transitioning structures. Therefore, property absences are not cacheable. This
PR fixes a bug in DFG which incorrectly caches property absences on structures
with CachedDictionaryKind.

Test: JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js

* JSTests/stress/dfg-ensure-absence-cached-dictionary-then.js: Added.
(createObject1):
(createObject2):
(opt):
(main):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::tryEnsureAbsence):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::propertyAccessesAreCacheableForAbsence):

Identifier: 305413.731@safari-7624-branch

Identifier: 305413.716@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.823@webkitglib/2.52">https://commits.webkit.org/305877.823@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c58fda5a7d9f5aef70ba4064177c668b873f6106
<pre>
Cherry-pick 6b2393e40648. <a href="https://bugs.webkit.org/show_bug.cgi?id=312391">https://bugs.webkit.org/show_bug.cgi?id=312391</a>

Reject IndexedDB transactions during version change operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=312391">https://bugs.webkit.org/show_bug.cgi?id=312391</a>
<a href="https://rdar.apple.com/173799670">rdar://173799670</a>

Reviewed by Sihui Liu.

When an IndexedDB connection is closed while a version
change transaction is active, UniqueIDBDatabase::connectionClosedFromClient
successfully closes the version change transaction however it does
not clear any other pending transactions due to an early return
when clearing version change transactions.

Instead of being defensive and clearing the pending transaciton
in the case of the early return, we should reject any incoming
transactions which come on a version change connection.

Only whenever a version change operation completes, can
a new transaction be established. So, this patch rejects any
incoming transactions which come while a version change operation
is active.

The IndexedDB spec describes the steps for starting a new transaction:

        The transaction(storeNames, mode, options) method steps are:
        1. If a live upgrade transaction is associated with the connection, throw an &quot;InvalidStateError&quot; DOMException.

<a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction">https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction</a>

This check already happens in the web process during
IDBDatabase::transaction where it returns an &quot;InvalidStateError&quot;
in this state.

However, this doesn&apos;t account for a compromised web process
who avoids this client side check and makes it across IPC
to invoke transaction creation in the NetworkProcess.

This patch adds a check for this scenario of a comprimised web
process who manages to start a new transaction during a
version change, if this is detected, we return early and
don&apos;t move forward with creating the transaction

This patch checks that the current connection isn&apos;t the
stored UniqueIDBDatabase::m_versionChangeDatabaseConnection.
That member variable will point to the active version change connection,
if any, and it is cleared when the version change completes.
It also checks if m_versionChangeTransaction is non-null
since it will only be null once the version change transaction
is completed.

* LayoutTests/ipc/networksindexeddb-close-connection-during-version-change-expected.txt: Added.
* LayoutTests/ipc/networksindexeddb-close-connection-during-version-change.html: Added.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::isVersionChangeTransactionActive const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::establishTransaction):
(WebKit::NetworkStorageManager::databaseConnectionPendingClose):

Identifier: 305413.734@safari-7624-branch

Identifier: 305413.714@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.822@webkitglib/2.52">https://commits.webkit.org/305877.822@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 2e12e62ce9ba37724cebb854d5acea3b1a65f6ee
<pre>
Cherry-pick d577d4001218. <a href="https://bugs.webkit.org/show_bug.cgi?id=312610">https://bugs.webkit.org/show_bug.cgi?id=312610</a>

[JSC] Override isValid() on AdaptiveValueStructureStubClearingWatchpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=312610">https://bugs.webkit.org/show_bug.cgi?id=312610</a>
<a href="https://rdar.apple.com/174463162">rdar://174463162</a>

Reviewed by Keith Miller.

AdaptiveValueStructureStubClearingWatchpoint doesn&apos;t override isValid().
The base class fire() calls isValid() before dereferencing m_key.object()
via m_key.isWatchable() and install(). The default isValid() returns true,
allowing fire() to dereference a potentially dead m_key.object() when the
owning stub routine&apos;s CodeBlock has been collected.

The IC code paths that exercise this are not directly exercisable from vanilla
JS, so a $vm.installStructureStubClearingWatchpointWithDeadOwner is added to
simulate the conditions that would trigger this bug.

Test: JSTests/stress/regress-174463162.js
* JSTests/stress/regress-174463162.js: Added.
(main):
* Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSDollarVMHelper::setOwnerIsDead):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
(JSC::JSDollarVM::visitChildrenImpl):
* Source/JavaScriptCore/tools/JSDollarVM.h:

Identifier: 305413.706@safari-7624-branch

Identifier: 305413.712@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.821@webkitglib/2.52">https://commits.webkit.org/305877.821@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 992e017dca6787c34e526328675c2ddd658469fd
<pre>
Cherry-pick 5b1739a247ed. <a href="https://bugs.webkit.org/show_bug.cgi?id=312734">https://bugs.webkit.org/show_bug.cgi?id=312734</a>

Cross-Thread Destruction of BlobData Races Non-Thread-Safe RefCounted&lt;BlobDataFileReference&gt; Leads to UAF
<a href="https://bugs.webkit.org/show_bug.cgi?id=312734">https://bugs.webkit.org/show_bug.cgi?id=312734</a>
<a href="https://rdar.apple.com/174674094">rdar://174674094</a>

Reviewed by Ryosuke Niwa.

BlobData was ThreadSafeRefCounted but contained data members that were
not safe to destroy on other threads like a String and a
`RefPtr&lt;BlobDataFileReference&gt;` (BlobDataFileReference only subclasses
RefCounted). For thread safety, both BlobData and BlobDataFileReference
now subclass `ThreadSafeRefCounted&lt;T, WTF::DestructionThread::Main&gt;` so
that not only their ref-counting is atomic but also to guarantee that
they get destroyed on the main thread (since they are always constructed
on the main thread). This is important given that they have String
data members.

Also, as further hardening recommended by the AI, update MappedFileData
to be able to distinguish empty data and invalid data.

* Source/WTF/wtf/MappedFileData.h:
(WTF::FileSystemImpl::MappedFileData::emptyFile):
(WTF::FileSystemImpl::MappedFileData::operator bool const):
(WTF::FileSystemImpl::MappedFileData::leakHandle):
(WTF::FileSystemImpl::MappedFileData::fileMapping const):
* Source/WTF/wtf/posix/FileHandlePOSIX.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/posix/MappedFileDataPOSIX.cpp:
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
* Source/WTF/wtf/win/FileHandleWin.cpp:
(WTF::FileSystemImpl::FileHandle::map):
* Source/WTF/wtf/win/MappedFileDataWin.cpp:
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
* Source/WebCore/platform/network/BlobData.cpp:
(WebCore::BlobData::BlobData):
* Source/WebCore/platform/network/BlobData.h:
* Source/WebCore/platform/network/BlobDataFileReference.cpp:
(WebCore::BlobDataFileReference::BlobDataFileReference):
* Source/WebCore/platform/network/BlobDataFileReference.h:

Identifier: 305413.709@safari-7624-branch

Identifier: 305413.711@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.820@webkitglib/2.52">https://commits.webkit.org/305877.820@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f9e7b7dd4610bae8d3c15d65c5cce404ca919a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171953 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45870 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181257 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129507 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173818 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47156 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45510 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133777 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129507 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174911 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47156 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114249 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47156 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45510 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30006 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47156 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183925 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33212 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36540 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45510 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142485 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45537 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142376 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46217 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110877 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26104 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46217 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117905 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204631 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44735 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39288 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54637 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44135 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44367 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44194 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->