### PR TITLE
Rebase WPT webrtc encoded transform tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7712,6 +7712,7 @@ imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-flattened
 
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https.html [ Failure ]
 
 # https://bugs.webkit.org/show_bug.cgi?id=276663
 inspector/css/getMatchedStylesForNodeNestingStyleGrouping.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/webrtc-encoded-transform.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/webrtc-encoded-transform.idl
@@ -3,20 +3,16 @@
 // (https://github.com/w3c/webref)
 // Source: WebRTC Encoded Transform (https://w3c.github.io/webrtc-encoded-transform/)
 
-typedef (SFrameTransform or RTCRtpScriptTransform) RTCRtpTransform;
+typedef (RTCSFrameSenderTransform or RTCRtpScriptTransform) RTCRtpSenderTransform;
+typedef (RTCSFrameReceiverTransform or RTCRtpScriptTransform) RTCRtpReceiverTransform;
 
 // New methods for RTCRtpSender and RTCRtpReceiver
 partial interface RTCRtpSender {
-    attribute RTCRtpTransform? transform;
+    attribute RTCRtpSenderTransform? transform;
 };
 
 partial interface RTCRtpReceiver {
-    attribute RTCRtpTransform? transform;
-};
-
-enum SFrameTransformRole {
-    "encrypt",
-    "decrypt"
+    attribute RTCRtpReceiverTransform? transform;
 };
 
 // List of supported cipher suites, as defined in [[RFC9605]] section 4.5.
@@ -29,20 +25,47 @@ enum SFrameCipherSuite {
 };
 
 dictionary SFrameTransformOptions {
-    SFrameTransformRole role = "encrypt";
     required SFrameCipherSuite cipherSuite;
 };
 
 typedef [EnforceRange] unsigned long long SmallCryptoKeyID;
 typedef (SmallCryptoKeyID or bigint) CryptoKeyID;
 
-[Exposed=(Window,DedicatedWorker)]
-interface SFrameTransform : EventTarget {
-    constructor(optional SFrameTransformOptions options = {});
-    Promise<undefined> setEncryptionKey(CryptoKey key, optional CryptoKeyID keyID);
+interface mixin SFrameEncrypterManager {
+    Promise<undefined> setEncryptionKey(CryptoKey key, CryptoKeyID keyId);
+};
+
+interface mixin SFrameDecrypterManager {
+    Promise<undefined> addDecryptionKey(CryptoKey key, CryptoKeyID keyId);
+    Promise<undefined> removeDecryptionKey(CryptoKeyID keyId);
     attribute EventHandler onerror;
 };
-SFrameTransform includes GenericTransformStream;
+
+[Exposed=Window]
+interface RTCSFrameSenderTransform {
+    constructor(optional SFrameTransformOptions options = {});
+};
+RTCSFrameSenderTransform includes SFrameEncrypterManager;
+
+[Exposed=Window]
+interface RTCSFrameReceiverTransform : EventTarget {
+    constructor(optional SFrameTransformOptions options = {});
+};
+RTCSFrameReceiverTransform includes SFrameDecrypterManager;
+
+[Exposed=(Window,DedicatedWorker)]
+interface SFrameEncrypterStream : EventTarget {
+    constructor(optional SFrameTransformOptions options = {});
+};
+SFrameEncrypterStream includes GenericTransformStream;
+SFrameEncrypterStream includes SFrameEncrypterManager;
+
+[Exposed=(Window,DedicatedWorker)]
+interface SFrameDecrypterStream : EventTarget {
+    constructor(optional SFrameTransformOptions options = {});
+};
+SFrameDecrypterStream includes GenericTransformStream;
+SFrameDecrypterStream includes SFrameDecrypterManager;
 
 enum SFrameTransformErrorEventType {
     "authentication",
@@ -76,14 +99,6 @@ dictionary RTCEncodedFrameMetadata {
     DOMString mimeType;
 };
 
-// New enum for video frame types. Will eventually re-use the equivalent defined
-// by WebCodecs.
-enum RTCEncodedVideoFrameType {
-    "empty",
-    "key",
-    "delta",
-};
-
 dictionary RTCEncodedVideoFrameMetadata : RTCEncodedFrameMetadata {
     unsigned long long frameId;
     sequence<unsigned long long> dependencies;
@@ -98,12 +113,11 @@ dictionary RTCEncodedVideoFrameOptions {
     RTCEncodedVideoFrameMetadata metadata;
 };
 
-// New interfaces to define encoded video and audio frames. Will eventually
-// re-use or extend the equivalent defined in WebCodecs.
+// New interfaces to define RTC specific encoded video and audio frames used by RTCRtpScriptTransform.
 [Exposed=(Window,DedicatedWorker), Serializable]
 interface RTCEncodedVideoFrame {
     constructor(RTCEncodedVideoFrame originalFrame, optional RTCEncodedVideoFrameOptions options = {});
-    readonly attribute RTCEncodedVideoFrameType type;
+    readonly attribute EncodedVideoChunkType type;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
 };
@@ -124,13 +138,9 @@ interface RTCEncodedAudioFrame {
     RTCEncodedAudioFrameMetadata getMetadata();
 };
 
-[Exposed=DedicatedWorker]
-interface RTCTransformEvent : Event {
-    readonly attribute RTCRtpScriptTransformer transformer;
-};
-
-partial interface DedicatedWorkerGlobalScope {
-    attribute EventHandler onrtctransform;
+[Exposed=Window]
+interface RTCRtpScriptTransform {
+    constructor(Worker worker, optional any options, optional sequence<object> transfer);
 };
 
 [Exposed=DedicatedWorker]
@@ -146,9 +156,13 @@ interface RTCRtpScriptTransformer : EventTarget {
     readonly attribute any options;
 };
 
-[Exposed=Window]
-interface RTCRtpScriptTransform {
-    constructor(Worker worker, optional any options, optional sequence<object> transfer);
+[Exposed=DedicatedWorker]
+interface RTCTransformEvent : Event {
+    readonly attribute RTCRtpScriptTransformer transformer;
+};
+
+partial interface DedicatedWorkerGlobalScope {
+    attribute EventHandler onrtctransform;
 };
 
 [Exposed=DedicatedWorker]

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS RTCEncodedVideoFrame copy construction on main thread.
+PASS RTCEncodedAudioFrame copy construction on main thread.
+FAIL RTCEncodedVideoFrame copy construction metadata override on main thread. assert_equals: expected "{\"contributingSources\":[2],\"dependencies\":[],\"frameId\":1,\"height\":480,\"mimeType\":\"video/H264\",\"payloadType\":96,\"rtpTimestamp\":1700513326,\"spatialIndex\":0,\"synchronizationSource\":1379895005,\"temporalIndex\":0,\"width\":640}" but got "{\"contributingSources\":[],\"dependencies\":[],\"frameId\":1,\"height\":480,\"mimeType\":\"video/H264\",\"payloadType\":96,\"rtpTimestamp\":1700513326,\"spatialIndex\":0,\"synchronizationSource\":1379895005,\"temporalIndex\":0,\"width\":640}"
+PASS RTCEncodedVideoFrame structuredClone on main thread.
+FAIL RTCEncodedVideoFrame structuredClone transfer on main thread. assert_equals: expected 214 but got 0
+FAIL RTCEncodedAudioFrame copy construction metadata override on main thread. assert_equals: expected "{\"contributingSources\":[2],\"mimeType\":\"audio/opus\",\"payloadType\":111,\"rtpTimestamp\":1257486326,\"synchronizationSource\":8300854}" but got "{\"contributingSources\":[],\"mimeType\":\"audio/opus\",\"payloadType\":111,\"rtpTimestamp\":1257486326,\"synchronizationSource\":8300854}"
+PASS RTCEncodedAudioFrame structuredClone on main thread.
+FAIL RTCEncodedAudioFrame structuredClone transfer on main thread. assert_equals: expected 99 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name='timeout' content='long'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src="../webrtc/RTCPeerConnection-helper.js"></script>
+<script src="helper.js"></script>
+</head>
+<body>
+<script>
+
+const assert_json_equals = (a, b) => assert_equals(JSON.stringify(a), JSON.stringify(b));
+const assert_json_not_equals = (a, b) => assert_not_equals(JSON.stringify(a), JSON.stringify(b));
+
+const reuse = {}; // speed up tests
+
+promise_test(async t => {
+   const frame = await createRTCEncodedFrameFromScratch("video");
+   reuse["video"] = frame;
+   assert_true(frame instanceof RTCEncodedVideoFrame);
+   assert_equals(frame.type, "key"); // first frame is key
+
+   const clone = new RTCEncodedVideoFrame(frame);
+   assert_true(clone instanceof RTCEncodedVideoFrame);
+   assert_equals(clone.type, frame.type);
+   assert_true(areArrayBuffersEqual(clone.data, frame.data));
+   assert_json_equals(clone.getMetadata(), frame.getMetadata());
+}, "RTCEncodedVideoFrame copy construction on main thread.");
+
+promise_test(async t => {
+   const frame = await createRTCEncodedFrameFromScratch("audio");
+   reuse["audio"] = frame;
+   assert_true(frame instanceof RTCEncodedAudioFrame);
+
+   const clone = new RTCEncodedAudioFrame(frame);
+   assert_true(clone instanceof RTCEncodedAudioFrame);
+   assert_equals(clone.type, frame.type);
+   assert_true(areArrayBuffersEqual(clone.data, frame.data));
+   assert_json_equals(clone.getMetadata(), frame.getMetadata());
+}, "RTCEncodedAudioFrame copy construction on main thread.");
+
+function different(value) {
+   switch (typeof value) {
+     case "number": return value + 1;
+     case "string": return value + "2";
+     case "object": return Array.isArray(value) ? value.concat([2]) : {};
+     default: assert_unreached(`unexpected type ${typeof value}`);
+   }
+}
+
+["RTCEncodedVideoFrame", "RTCEncodedAudioFrame"].forEach(constr => {
+  const kind = constr.includes("Video")? "video" : "audio";
+
+  promise_test(async t => {
+    const frame = reuse[kind];
+    const oldData = frame.getMetadata();
+    // test single key replacement
+    for (const key of Object.keys(oldData)) {
+      const metadata = {[key]: different(oldData[key])};
+      // Spec says "The new frame’s [[metadata]] is a deep copy
+      // of originalFrame.[[metadata]], with fields replaced with
+      // deep copies of the fields present in options.[metadata]."
+      // This compares well to how Object.assign() works
+      const expected = Object.assign(structuredClone(oldData), metadata);
+      const clone = new window[constr](frame, {metadata});
+      assert_json_equals(clone.getMetadata(), expected);
+      assert_json_not_equals(clone.getMetadata(), oldData);
+    }
+    // test cumulative key replacement
+    let metadata = {};
+    for (const key of Object.keys(oldData)) {
+      Object.assign(metadata, {[key]: different(oldData[key])});
+      const expected = Object.assign(structuredClone(oldData), metadata);
+      const clone = new window[constr](frame, {metadata});
+      assert_json_equals(clone.getMetadata(), expected);
+      assert_json_not_equals(clone.getMetadata(), oldData);
+    }
+  }, `${constr} copy construction metadata override on main thread.`);
+
+  promise_test(async t => {
+    const frame = reuse[kind];
+    assert_greater_than(frame.data.byteLength, 0);
+    const length = frame.data.byteLength;
+    const clone = structuredClone(frame);
+    assert_equals(frame.data.byteLength, length, "not transferred");
+    assert_true(areArrayBuffersEqual(clone.data, frame.data));
+    assert_json_equals(clone.getMetadata(), frame.getMetadata());
+  }, `${constr} structuredClone on main thread.`);
+
+  promise_test(async t => {
+    const frame = reuse[kind];
+    assert_greater_than(frame.data.byteLength, 0);
+    const length = frame.data.byteLength;
+    const clone = structuredClone(frame, {transfer: [frame.data]});
+    assert_equals(frame.data.byteLength, 0, "was transferred");
+    assert_equals(clone.data.byteLength, length);
+  }, `${constr} structuredClone transfer on main thread.`);
+
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform-worker.js
@@ -18,15 +18,14 @@ function RestoreAndWrite(chunk, transformer) {
     chunk.value.data = chunk.value.data.slice(0, chunk.value.data.byteLength - 1);
     let frameData = chunk.value.data;
     transformer.writer.write(chunk.value);
-    if (lastByte === modification && !chunk.value.getMetadata().rtpTimestamp && frameData.byteLength == 0) {
+    if (lastByte === modification && frameData.byteLength == 0) {
         self.postMessage("got expected");
     }
     else {
         self.postMessage("unexpected value: lastByte (got " + lastByte +
             ", expected " + modification +
             "),  frame data length (got " + frameData.byteLength +
-            ", expected 0), rtpTimestamp (got " +
-             chunk.value.getMetadata().rtpTimestamp + ", expected null)");
+            ", expected 0))");
     }
 }
 onrtctransform = (event) => {

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src=/resources/testdriver.js></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-sender-worker-single-frame.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-sender-worker-single-frame.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="timeout" content="long">
 <title>RTCRtpScriptTransform Insertable Streams - Worker</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,25 +9,10 @@
 <script src=/resources/testdriver-vendor.js></script>
 <script src='../../mediacapture-streams/permission-helper.js'></script>
 <script src="../../webrtc/RTCPeerConnection-helper.js"></script>
+<script src="helper.js"></script>
 </head>
 <body>
 <script>
-
-function areArrayBuffersEqual(buffer1, buffer2)
-{
-  if (buffer1.byteLength !== buffer2.byteLength) {
-    return false;
-  }
-  let array1 = new Int8Array(buffer1);
-  var array2 = new Int8Array(buffer2);
-  for (let i = 0 ; i < buffer1.byteLength ; ++i) {
-    if (array1[i] !== array2[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 
 promise_test(async t => {
   const caller = new RTCPeerConnection();

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/helper.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 async function setupLoopbackWithCodecAndGetReader(t, codec) {
   const caller = new RTCPeerConnection({encodedInsertableStreams:true});
@@ -23,4 +23,44 @@ async function setupLoopbackWithCodecAndGetReader(t, codec) {
   exchangeIceCandidates(caller, callee);
   await exchangeOfferAnswer(caller, callee);
   return senderStreams.readable.getReader();
+}
+
+// Returns an RTCEncodedVideoFrame or RTCEncodedAudioFrame
+// on main thread. Spins up a peer connection and worker.
+// Relies on serialization being implemented.
+
+async function createRTCEncodedFrameFromScratch(kind) {
+  function work() {
+    onrtctransform = async ({transformer: {readable}}) => {
+      try {
+        const reader = readable.getReader();
+        const {value, done} = await reader.read();
+        if (done) throw {name: "done"};
+        self.postMessage(value);
+      } catch (e) {
+        self.postMessage(e.name);
+      }
+    }
+  }
+  const worker = new Worker(`data:text/javascript,(${work.toString()})()`);
+  const pc1 = new RTCPeerConnection(), pc2 = new RTCPeerConnection();
+  pc1.onicecandidate = e => pc2.addIceCandidate(e.candidate);
+  pc2.onicecandidate = e => pc1.addIceCandidate(e.candidate);
+  pc1.onnegotiationneeded = async () => {
+    await pc1.setLocalDescription(); await pc2.setRemoteDescription(pc1.localDescription);
+    await pc2.setLocalDescription(); await pc1.setRemoteDescription(pc2.localDescription);
+  }
+  const stream = await getNoiseStream({[kind]: true});
+  const sender = pc1.addTrack(stream.getTracks()[0], stream);
+  sender.transform = new RTCRtpScriptTransform(worker);
+  const {data} = await new Promise(r => worker.onmessage = r);
+  return data;
+}
+
+function areArrayBuffersEqual(a, b) {
+  if (a.byteLength != b.byteLength) {
+    return false;
+  }
+  const ui8b = new Uint8Array(b);
+  return new Uint8Array(a).every((val, i) => val === ui8b[i]);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window-expected.txt
@@ -10,18 +10,47 @@ PASS Partial interface RTCRtpReceiver: member names are unique
 PASS Partial interface DedicatedWorkerGlobalScope: original interface defined
 PASS Partial interface DedicatedWorkerGlobalScope: member names are unique
 PASS Partial interface RTCRtpSender[2]: member names are unique
-PASS SFrameTransform includes GenericTransformStream: member names are unique
+PASS RTCSFrameSenderTransform includes SFrameEncrypterManager: member names are unique
+PASS RTCSFrameReceiverTransform includes SFrameDecrypterManager: member names are unique
+PASS SFrameEncrypterStream includes GenericTransformStream: member names are unique
+PASS SFrameEncrypterStream includes SFrameEncrypterManager: member names are unique
+PASS SFrameDecrypterStream includes GenericTransformStream: member names are unique
+PASS SFrameDecrypterStream includes SFrameDecrypterManager: member names are unique
 PASS WorkerGlobalScope includes WindowOrWorkerGlobalScope: member names are unique
 PASS DedicatedWorkerGlobalScope includes AnimationFrameProvider: member names are unique
 PASS DedicatedWorkerGlobalScope includes MessageEventTarget: member names are unique
-PASS SFrameTransform interface: existence and properties of interface object
-PASS SFrameTransform interface object length
-PASS SFrameTransform interface object name
-PASS SFrameTransform interface: existence and properties of interface prototype object
-PASS SFrameTransform interface: existence and properties of interface prototype object's "constructor" property
-PASS SFrameTransform interface: existence and properties of interface prototype object's @@unscopables property
-PASS SFrameTransform interface: operation setEncryptionKey(CryptoKey, optional CryptoKeyID)
-PASS SFrameTransform interface: attribute onerror
+FAIL RTCSFrameSenderTransform interface: existence and properties of interface object assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameSenderTransform interface object length assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameSenderTransform interface object name assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameSenderTransform interface: existence and properties of interface prototype object assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameSenderTransform interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameSenderTransform interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameSenderTransform interface: operation setEncryptionKey(CryptoKey, CryptoKeyID) assert_own_property: self does not have own property "RTCSFrameSenderTransform" expected property "RTCSFrameSenderTransform" missing
+FAIL RTCSFrameReceiverTransform interface: existence and properties of interface object assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface object length assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface object name assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface: existence and properties of interface prototype object assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface: operation addDecryptionKey(CryptoKey, CryptoKeyID) assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface: operation removeDecryptionKey(CryptoKeyID) assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL RTCSFrameReceiverTransform interface: attribute onerror assert_own_property: self does not have own property "RTCSFrameReceiverTransform" expected property "RTCSFrameReceiverTransform" missing
+FAIL SFrameEncrypterStream interface: existence and properties of interface object assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameEncrypterStream interface object length assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameEncrypterStream interface object name assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameEncrypterStream interface: existence and properties of interface prototype object assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameEncrypterStream interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameEncrypterStream interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameEncrypterStream interface: operation setEncryptionKey(CryptoKey, CryptoKeyID) assert_own_property: self does not have own property "SFrameEncrypterStream" expected property "SFrameEncrypterStream" missing
+FAIL SFrameDecrypterStream interface: existence and properties of interface object assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface object length assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface object name assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface: existence and properties of interface prototype object assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface: operation addDecryptionKey(CryptoKey, CryptoKeyID) assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface: operation removeDecryptionKey(CryptoKeyID) assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
+FAIL SFrameDecrypterStream interface: attribute onerror assert_own_property: self does not have own property "SFrameDecrypterStream" expected property "SFrameDecrypterStream" missing
 PASS SFrameTransformErrorEvent interface: existence and properties of interface object
 PASS SFrameTransformErrorEvent interface object length
 PASS SFrameTransformErrorEvent interface object name
@@ -40,6 +69,11 @@ PASS RTCEncodedVideoFrame interface: existence and properties of interface proto
 PASS RTCEncodedVideoFrame interface: attribute type
 PASS RTCEncodedVideoFrame interface: attribute data
 PASS RTCEncodedVideoFrame interface: operation getMetadata()
+PASS RTCEncodedVideoFrame must be primary interface of idlTestObjects.videoFrame
+PASS Stringification of idlTestObjects.videoFrame
+FAIL RTCEncodedVideoFrame interface: idlTestObjects.videoFrame must inherit property "type" with the proper type Right hand side of instanceof is not an object
+PASS RTCEncodedVideoFrame interface: idlTestObjects.videoFrame must inherit property "data" with the proper type
+PASS RTCEncodedVideoFrame interface: idlTestObjects.videoFrame must inherit property "getMetadata()" with the proper type
 PASS RTCEncodedAudioFrame interface: existence and properties of interface object
 PASS RTCEncodedAudioFrame interface object length
 PASS RTCEncodedAudioFrame interface object name
@@ -48,14 +82,18 @@ PASS RTCEncodedAudioFrame interface: existence and properties of interface proto
 PASS RTCEncodedAudioFrame interface: existence and properties of interface prototype object's @@unscopables property
 PASS RTCEncodedAudioFrame interface: attribute data
 PASS RTCEncodedAudioFrame interface: operation getMetadata()
-PASS RTCTransformEvent interface: existence and properties of interface object
-PASS RTCRtpScriptTransformer interface: existence and properties of interface object
+PASS RTCEncodedAudioFrame must be primary interface of idlTestObjects.audioFrame
+PASS Stringification of idlTestObjects.audioFrame
+PASS RTCEncodedAudioFrame interface: idlTestObjects.audioFrame must inherit property "data" with the proper type
+PASS RTCEncodedAudioFrame interface: idlTestObjects.audioFrame must inherit property "getMetadata()" with the proper type
 PASS RTCRtpScriptTransform interface: existence and properties of interface object
 PASS RTCRtpScriptTransform interface object length
 PASS RTCRtpScriptTransform interface object name
 PASS RTCRtpScriptTransform interface: existence and properties of interface prototype object
 PASS RTCRtpScriptTransform interface: existence and properties of interface prototype object's "constructor" property
 PASS RTCRtpScriptTransform interface: existence and properties of interface prototype object's @@unscopables property
+PASS RTCRtpScriptTransformer interface: existence and properties of interface object
+PASS RTCTransformEvent interface: existence and properties of interface object
 PASS KeyFrameRequestEvent interface: existence and properties of interface object
 PASS RTCRtpSender interface: attribute transform
 PASS RTCRtpSender interface: new RTCPeerConnection().addTransceiver('audio').sender must inherit property "transform" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window.js
@@ -1,21 +1,27 @@
-// META: variant=?exclude=SFrameTransform.*
-// META: variant=?include=SFrameTransform.*
+// META: variant=?exclude=.*SFrame.*
+// META: variant=?include=.*SFrame.*
 // META: script=/common/subset-tests-by-key.js
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
-// META: script=./RTCPeerConnection-helper.js
+// META: script=../webrtc/RTCPeerConnection-helper.js
+// META: script=helper.js
+// META: timeout=long
 
 'use strict';
+
+const idlTestObjects = {};
 
 idl_test(
   ['webrtc-encoded-transform'],
   ['webrtc', 'streams', 'html', 'dom'],
   async idlArray => {
     idlArray.add_objects({
-      // TODO: RTCEncodedVideoFrame
-      // TODO: RTCEncodedAudioFrame
       RTCRtpSender: [`new RTCPeerConnection().addTransceiver('audio').sender`],
       RTCRtpReceiver: [`new RTCPeerConnection().addTransceiver('audio').receiver`],
+      RTCEncodedVideoFrame: [`idlTestObjects.videoFrame`],
+      RTCEncodedAudioFrame: [`idlTestObjects.audioFrame`],
     });
+    idlTestObjects.videoFrame = await createRTCEncodedFrameFromScratch("video");
+    idlTestObjects.audioFrame = await createRTCEncodedFrameFromScratch("audio");
   }
 );

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS video exchange with late receiver transform
+FAIL video exchange with late receiver transform promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: RTCRtpSFrameEncrypter"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https.html
@@ -49,11 +49,11 @@ async function checkVideoIsUpdated(test, shouldBeUpdated, count, referenceData)
 promise_test(async (test) => {
     await setMediaPermission("granted", ["camera"]);
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
-    const senderTransform = new SFrameTransform({ compatibilityMode: "H264" });
-    const receiverTransform = new SFrameTransform({ compatibilityMode: "H264" });
+    const senderTransform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const receiverTransform = new RTCRtpSFrameDecrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => {
        senderTransform.setEncryptionKey(key);
-       receiverTransform.setEncryptionKey(key);
+       receiverTransform.addDecryptionKey(key);
     });
 
     let sender, receiver;

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt
@@ -1,16 +1,28 @@
 
 
-PASS audio metadata: timestamp
 PASS audio metadata: synchronizationSource
 PASS audio metadata: payloadType
 PASS audio metadata: contributingSources
+PASS audio metadata: rtpTimestamp
+FAIL audio metadata: receiveTime assert_equals: expected "number" but got "undefined"
+FAIL audio metadata: captureTime assert_equals: expected "number" but got "undefined"
+FAIL audio metadata: senderCaptureTimeOffset assert_equals: expected "number" but got "undefined"
+PASS audio metadata: mimeType
+PASS video metadata: synchronizationSource
+PASS video metadata: payloadType
+PASS video metadata: contributingSources
+PASS video metadata: rtpTimestamp
+FAIL video metadata: receiveTime assert_equals: expected "number" but got "undefined"
+FAIL video metadata: captureTime assert_equals: expected "number" but got "undefined"
+FAIL video metadata: senderCaptureTimeOffset assert_equals: expected "number" but got "undefined"
+PASS video metadata: mimeType
 PASS audio metadata: sequenceNumber
-PASS video metadata: timestamp
-PASS video metadata: ssrc
-PASS video metadata: csrcs
+FAIL audio metadata: audioLevel assert_equals: expected "number" but got "undefined"
+FAIL video metadata: frameId assert_equals: frameId matches (for sender and receiver) expected (undefined) undefined but got (number) 1
+PASS video metadata: dependencies
 PASS video metadata: width and height
 PASS video metadata: spatial and temporal index
-PASS video metadata: dependencies
-PASS video metadata: frameId
-PASS video metadata: type
+PASS video frame: type
+PASS audio frame: timestamp (renamed to metadata.rtpTimestamp
+PASS video frame: timestamp (renamed to metadata.rtpTimestamp
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html
@@ -22,30 +22,39 @@ async function waitForMessage(worker, data)
     }
 }
 
-async function gatherMetadata(test, kind)
+async function gatherMetadata(test, kind, neededExtensions = [])
 {
     worker = new Worker('script-metadata-transform-worker.js');
     const data = await new Promise(resolve => worker.onmessage = (event) => resolve(event.data));
     assert_equals(data, 'registered');
 
     // Both audio and vido are needed at one time or another
-    // so asking for both permissions
+    // so asking for both permissions.
     await setMediaPermission();
     const localStream = await navigator.mediaDevices.getUserMedia({[kind]: true});
 
-    let sender, receiver;
     const senderTransform = new RTCRtpScriptTransform(worker, {name:'sender'});
     const receiverTransform = new RTCRtpScriptTransform(worker, {name:'receiver'});
 
     await new Promise((resolve, reject) => {
         createConnections(test, (firstConnection) => {
             pc1 = firstConnection;
-            sender = firstConnection.addTrack(localStream.getTracks()[0], localStream);
+            const sender = firstConnection.addTrack(localStream.getTracks()[0], localStream);
             sender.transform = senderTransform;
+            if ('getHeaderExtensionsToNegotiate' in RTCRtpTransceiver.prototype) {
+                const transceiver = pc1.getTransceivers()[0];
+                const extensions = transceiver.getHeaderExtensionsToNegotiate();
+                extensions.forEach(ext => {
+                    if (neededExtensions.includes(ext.uri)) {
+                        ext.direction = 'sendrecv';
+                    }
+                });
+                transceiver.setHeaderExtensionsToNegotiate(extensions);
+            }
         }, (secondConnection) => {
             pc2 = secondConnection;
             secondConnection.ontrack = (trackEvent) => {
-                receiver = trackEvent.receiver;
+                const receiver = trackEvent.receiver;
                 receiver.transform = receiverTransform;
                 resolve(trackEvent.streams[0]);
             };
@@ -79,179 +88,124 @@ async function gatherMetadata(test, kind)
     }
 }
 
+function checkSendReceive(data, propertyName, propertyType) {
+    assert_equals(typeof data.senderBeforeWrite.metadata[propertyName], propertyType);
+    assert_equals(data.senderBeforeWrite.metadata[propertyName],
+      data.senderAfterWrite.metadata[propertyName],
+      propertyName + ' matches (for sender before and after write)');
+    assert_equals(data.senderBeforeWrite.metadata[propertyName],
+      data.receiverBeforeWrite.metadata[propertyName],
+      propertyName + ' matches (for sender and receiver)');
+    assert_equals(data.senderBeforeWrite.metadata[propertyName],
+      data.receiverAfterWrite.metadata[propertyName],
+      propertyName + ' matches (for receiver before and after write)');
+}
+
+function checkReceiveOnly(data, propertyName, propertyType) {
+    assert_equals(data.senderBeforeWrite.metadata[propertyName], undefined);
+    assert_equals(data.senderBeforeWrite.metadata[propertyName],
+      data.senderAfterWrite.metadata[propertyName],
+      propertyName + ' matches (for sender before and after write)');
+    assert_equals(typeof data.receiverBeforeWrite.metadata[propertyName], propertyType);
+    assert_equals(data.receiverBeforeWrite.metadata[propertyName],
+      data.receiverAfterWrite.metadata[propertyName],
+      propertyName + ' matches (for receiver before and after write)');
+}
+
+function checkSendOnly(data, propertyName, propertyType) {
+    assert_equals(typeof data.senderBeforeWrite.metadata[propertyName], propertyType);
+    assert_equals(data.senderBeforeWrite.metadata[propertyName],
+      data.senderAfterWrite.metadata[propertyName],
+      propertyName + ' matches (for sender before and after write)');
+    assert_equals(data.receiverBeforeWrite.metadata[propertyName], undefined);
+    assert_equals(data.receiverBeforeWrite.metadata[propertyName],
+      data.receiverAfterWrite.metadata[propertyName],
+      propertyName + ' matches (for receiver before and after write)');
+}
+
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedFrameMetadata
+['audio', 'video'].forEach(kind => {
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+        checkSendReceive(data, 'synchronizationSource', 'number');
+    }, kind + ' metadata: synchronizationSource');
+
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+        checkSendReceive(data, 'payloadType', 'number');
+    }, kind + ' metadata: payloadType');
+
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+
+        assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
+          data.senderAfterWrite.metadata.contributingSources,
+          'csrcs are arrays, and match (for sender before and after write)');
+        assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
+          data.receiverBeforeWrite.metadata.contributingSources,
+          'csrcs are arrays, and match');
+        assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
+          data.receiverAfterWrite.metadata.contributingSources,
+          'csrcs are arrays, and match (for receiver before and after write)');
+    }, kind + ' metadata: contributingSources');
+
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+        checkSendReceive(data, 'rtpTimestamp', 'number');
+    }, kind + ' metadata: rtpTimestamp');
+
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+        checkReceiveOnly(data, 'receiveTime', 'number');
+    }, kind + ' metadata: receiveTime');
+
+    // Requires abs-capture-time header extension.
+    promise_test(async (test) => {
+        // TODO: crbug.com/391114797 - should negotiate the extension
+        //   and checkSendReceive.
+        const data = await gatherMetadata(test, kind, [
+            // 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+        ]);
+        checkSendOnly(data, 'captureTime', 'number');
+    }, kind + ' metadata: captureTime');
+
+    // Requires abs-capture-time header extension.
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind, [
+            'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+        ]);
+        checkReceiveOnly(data, 'senderCaptureTimeOffset', 'number');
+    }, kind + ' metadata: senderCaptureTimeOffset');
+
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+        checkSendReceive(data, 'mimeType', 'string');
+    }, kind + ' metadata: mimeType');
+});
+
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrameMetadata
 promise_test(async (test) => {
     const data = await gatherMetadata(test, 'audio');
-
-    assert_equals(typeof data.senderBeforeWrite.timestamp, 'number');
-    assert_not_equals(data.senderBeforeWrite.timestamp, 0);
-    assert_equals(data.senderBeforeWrite.timestamp,
-      data.senderAfterWrite.timestamp,
-      'timestamp matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.timestamp,
-      data.receiverBeforeWrite.timestamp,
-      'timestamp matches (for sender and receiver)');
-    assert_equals(data.receiverBeforeWrite.timestamp,
-      data.receiverAfterWrite.timestamp,
-      'timestamp matches (for receiver before and after write)');
-}, 'audio metadata: timestamp');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'audio');
-
-    assert_equals(typeof data.senderBeforeWrite.metadata.synchronizationSource, 'number');
-    assert_not_equals(data.senderBeforeWrite.metadata.synchronizationSource, 0);
-    assert_equals(data.senderBeforeWrite.metadata.synchronizationSource,
-      data.senderAfterWrite.metadata.synchronizationSource,
-      'ssrc matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.synchronizationSource,
-      data.receiverBeforeWrite.metadata.synchronizationSource,
-      'ssrc matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.synchronizationSource,
-      data.receiverAfterWrite.metadata.synchronizationSource,
-      'ssrc matches (for receiver before and after write)');
-}, 'audio metadata: synchronizationSource');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'audio');
-
-    assert_equals(typeof data.senderBeforeWrite.metadata.payloadType, 'number');
-    assert_equals(data.senderBeforeWrite.metadata.payloadType,
-      data.senderAfterWrite.metadata.payloadType,
-      'payload type matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.payloadType,
-      data.receiverBeforeWrite.metadata.payloadType,
-      'payload type matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.payloadType,
-      data.receiverAfterWrite.metadata.payloadType,
-      'payload type matches (for receiver before and after write)');
-}, 'audio metadata: payloadType');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'audio');
-
-    assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
-      data.senderAfterWrite.metadata.contributingSources,
-      'csrcs are arrays, and match (for sender before and after write)');
-    assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
-      data.receiverBeforeWrite.metadata.contributingSources,
-      'csrcs are arrays, and match');
-    assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
-      data.receiverAfterWrite.metadata.contributingSources,
-      'csrcs are arrays, and match (for receiver before and after write)');
-}, 'audio metadata: contributingSources');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'audio');
-
-    assert_equals(typeof data.receiverBeforeWrite.metadata.sequenceNumber,
-      'number');
-    assert_equals(data.receiverBeforeWrite.metadata.sequenceNumber,
-      data.receiverAfterWrite.metadata.sequenceNumber,
-      'sequenceNumber matches (for receiver before and after write)');
-    // spec says sequenceNumber exists only for incoming audio frames
-    assert_equals(data.senderBeforeWrite.metadata.sequenceNumber, undefined);
-    assert_equals(data.senderAfterWrite.metadata.sequenceNumber, undefined);
+    checkReceiveOnly(data, 'sequenceNumber', 'number');
 }, 'audio metadata: sequenceNumber');
 
 promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'video');
+    const data = await gatherMetadata(test, 'audio');
+    checkSendReceive(data, 'audioLevel', 'number');
+}, 'audio metadata: audioLevel');
 
-    assert_equals(typeof data.senderBeforeWrite.timestamp, 'number');
-    assert_equals(data.senderBeforeWrite.timestamp,
-      data.senderAfterWrite.timestamp,
-      'timestamp matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.timestamp,
-      data.receiverBeforeWrite.timestamp,
-      'timestamp matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.timestamp,
-      data.receiverAfterWrite.timestamp,
-      'timestamp matches (for receiver before and after write)');
-}, 'video metadata: timestamp');
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface
+promise_test(async (test) => {
+    const data = await gatherMetadata(test, 'video', [
+        'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+    ]);
+    checkSendReceive(data, 'frameId', 'number');
+}, 'video metadata: frameId');
 
 promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'video');
-
-    assert_equals(typeof data.senderBeforeWrite.metadata.synchronizationSource,
-      'number');
-    assert_equals(data.senderBeforeWrite.metadata.synchronizationSource,
-      data.senderAfterWrite.metadata.synchronizationSource,
-      'ssrc matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.synchronizationSource,
-      data.receiverBeforeWrite.metadata.synchronizationSource,
-      'ssrc matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.synchronizationSource,
-      data.receiverAfterWrite.metadata.synchronizationSource,
-      'ssrc matches (for receiver before and after write)');
-}, 'video metadata: ssrc');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'video');
-
-    assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
-      data.senderAfterWrite.metadata.contributingSources,
-      'csrcs are arrays, and match (for sender before and after write)');
-    assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
-      data.receiverBeforeWrite.metadata.contributingSources,
-      'csrcs are arrays, and match');
-    assert_array_equals(data.senderBeforeWrite.metadata.contributingSources,
-      data.receiverAfterWrite.metadata.contributingSources,
-      'csrcs are arrays, and match (for receiver before and after write)');
-}, 'video metadata: csrcs');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'video');
-
-    assert_equals(typeof data.senderBeforeWrite.metadata.height, 'number');
-    assert_equals(data.senderBeforeWrite.metadata.height,
-      data.senderAfterWrite.metadata.height,
-      'height matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.height,
-      data.receiverBeforeWrite.metadata.height,
-      'height matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.height,
-      data.receiverAfterWrite.metadata.height,
-      'height matches (for receiver before and after write)');
-    assert_equals(typeof data.senderBeforeWrite.metadata.width, 'number');
-    assert_equals(data.senderBeforeWrite.metadata.width,
-      data.senderAfterWrite.metadata.width,
-      'width matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.width,
-      data.receiverBeforeWrite.metadata.width,
-      'width matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.width,
-      data.receiverAfterWrite.metadata.width,
-      'width matches (for receiver before and after write)');
-}, 'video metadata: width and height');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'video');
-
-    assert_equals(typeof data.senderBeforeWrite.metadata.spatialIndex,
-      'number');
-    assert_equals(data.senderBeforeWrite.metadata.spatialIndex,
-      data.senderAfterWrite.metadata.spatialIndex,
-      'spatialIndex matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.spatialIndex,
-      data.receiverBeforeWrite.metadata.spatialIndex,
-      'spatialIndex matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.spatialIndex,
-      data.receiverAfterWrite.metadata.spatialIndex,
-      'spatialIndex matches (for receiver before and after write)');
-    assert_equals(typeof data.senderBeforeWrite.metadata.temporalIndex,
-      'number');
-    assert_equals(data.senderBeforeWrite.metadata.temporalIndex,
-      data.senderAfterWrite.metadata.temporalIndex,
-      'temporalIndex matches (for sender before and after write)');
-    assert_equals(data.senderBeforeWrite.metadata.temporalIndex,
-      data.receiverBeforeWrite.metadata.temporalIndex,
-      'temporalIndex matches (for sender and receiver)');
-    assert_equals(data.senderBeforeWrite.metadata.temporalIndex,
-      data.receiverAfterWrite.metadata.temporalIndex,
-      'temporalIndex matches (for receiver before and after write)');
-}, 'video metadata: spatial and temporal index');
-
-promise_test(async (test) => {
-    const data = await gatherMetadata(test, 'video');
+    const data = await gatherMetadata(test, 'video', [
+        'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+    ]);
 
     assert_array_equals(data.senderBeforeWrite.metadata.dependencies,
       data.senderAfterWrite.metadata.dependencies,
@@ -266,20 +220,17 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const data = await gatherMetadata(test, 'video');
+    checkSendReceive(data, 'width', 'number');
+    checkSendReceive(data, 'height', 'number');
+}, 'video metadata: width and height');
 
-    assert_equals(typeof data.senderBeforeWrite.metadata.frameId, 'number');
-    assert_equals(data.senderBeforeWrite.metadata.frameId,
-      data.senderAfterWrite.metadata.frameId,
-      'frameId matches (for sender before and after write)');
+promise_test(async (test) => {
+    const data = await gatherMetadata(test, 'video');
+    checkSendReceive(data, 'spatialIndex', 'number');
+    checkSendReceive(data, 'temporalIndex', 'number');
+}, 'video metadata: spatial and temporal index');
 
-    assert_true(data.senderBeforeWrite.metadata.frameId == data.receiverBeforeWrite.metadata.frameId ||
-      data.receiverBeforeWrite.metadata.frameId == undefined,
-      'frameId matches (for sender and receiver)');
-    assert_equals(data.receiverBeforeWrite.metadata.frameId,
-      data.receiverAfterWrite.metadata.frameId,
-      'frameId matches (for receiver before and after write)');
-}, 'video metadata: frameId');
-
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-members
 promise_test(async (test) => {
     const data = await gatherMetadata(test, 'video');
 
@@ -294,8 +245,25 @@ promise_test(async (test) => {
     assert_equals(data.senderBeforeWrite.type,
       data.receiverAfterWrite.type,
       'type matches (for receiver before and after write)');
-}, 'video metadata: type');
+}, 'video frame: type');
 
+// Legacy timestamp, moved to metadata.rtpTimestamp.
+['audio', 'video'].forEach(kind => {
+    promise_test(async (test) => {
+        const data = await gatherMetadata(test, kind);
+
+        assert_equals(typeof data.senderBeforeWrite.timestamp, 'number');
+        assert_equals(data.senderBeforeWrite.timestamp,
+          data.senderAfterWrite.timestamp,
+          'timestamp matches (for sender before and after write)');
+        assert_equals(data.senderBeforeWrite.timestamp,
+          data.receiverBeforeWrite.timestamp,
+          'timestamp matches (for sender and receiver)');
+        assert_equals(data.senderBeforeWrite.timestamp,
+          data.receiverAfterWrite.timestamp,
+          'timestamp matches (for receiver before and after write)');
+    }, kind + ' frame: timestamp (renamed to metadata.rtpTimestamp');
+});
         </script>
     </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.js
@@ -1,7 +1,7 @@
 onrtctransform = event => {
   const transformer = event.transformer;
   let keyFrameCount = 0;
-  let gotFrame;
+  let gotFrameCallback;
 
   transformer.options.port.onmessage = event => {
     const {method, rid} = event.data;
@@ -33,7 +33,7 @@ onrtctransform = event => {
 
   async function generateKeyFrame(rid) {
     try {
-      const timestamp = await Promise.race([transformer.generateKeyFrame(rid), rejectInMs(8000)]);
+      const timestamp = await Promise.race([transformer.generateKeyFrame(rid), rejectInMs(16000)]);
       transformer.options.port.postMessage({result: 'success', value: timestamp, count: keyFrameCount});
     } catch (e) {
       // TODO: This does not work if we send e.name, why?
@@ -53,7 +53,7 @@ onrtctransform = event => {
 
   async function waitForFrame() {
     try {
-      await Promise.race([new Promise(r => gotFrameCallback = r), rejectInMs(8000)]);
+      await Promise.race([new Promise(r => gotFrameCallback = r), rejectInMs(16000)]);
       transformer.options.port.postMessage('got frame');
     } catch (e) {
       // TODO: This does not work if we send e.name, why?

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.js
@@ -1,6 +1,6 @@
 onrtctransform = event => {
   const transformer = event.transformer;
-  let gotFrame;
+  let gotFrameCallback;
 
   transformer.options.port.onmessage = event => {
     const {method} = event.data;
@@ -31,7 +31,7 @@ onrtctransform = event => {
 
   async function sendKeyFrameRequest() {
     try {
-      await Promise.race([transformer.sendKeyFrameRequest(), rejectInMs(8000)]);;
+      await Promise.race([transformer.sendKeyFrameRequest(), rejectInMs(16000)]);;
       transformer.options.port.postMessage('success');
     } catch (e) {
       // TODO: This does not work if we send e.name, why?
@@ -51,7 +51,7 @@ onrtctransform = event => {
 
   async function waitForFrame() {
     try {
-      await Promise.race([new Promise(r => gotFrameCallback = r), rejectInMs(8000)]);
+      await Promise.race([new Promise(r => gotFrameCallback = r), rejectInMs(16000)]);
       transformer.options.port.postMessage('got frame');
     } catch (e) {
       // TODO: This does not work if we send e.name, why?

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
+        <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src=/resources/testdriver.js></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https-expected.txt
@@ -1,5 +1,7 @@
 
 
-PASS Passing various key IDs
-PASS Audio exchange with SFrame setup
+Harness Error (FAIL), message = Unhandled rejection: Can't find variable: RTCRtpSFrameEncrypter
+
+FAIL Passing various key IDs promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: RTCRtpSFrameEncrypter"
+FAIL Audio exchange with SFrame setup promise_test: Unhandled rejection with value: "Test timed out"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https.html
@@ -17,7 +17,7 @@ let key1, key2, key3, key4;
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
-    const transform = new SFrameTransform;
+    const transform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
 
     await transform.setEncryptionKey(key);
     await transform.setEncryptionKey(key, 1);
@@ -42,16 +42,16 @@ promise_test(async (test) => {
     const stream = await new Promise((resolve, reject) => {
         const connections = createConnections(test, (firstConnection) => {
             sender = firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
-            let transform = new SFrameTransform;
+            let transform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
             transform.setEncryptionKey(key1);
             sender.transform = transform;
         }, (secondConnection) => {
             secondConnection.ontrack = (trackEvent) => {
-                let transform = new SFrameTransform;
-                transform.setEncryptionKey(key1);
-                transform.setEncryptionKey(key2);
-                transform.setEncryptionKey(key3, 1000);
-                transform.setEncryptionKey(key4, BigInt('18446744073709551615'));
+                let transform = new RTCRtpSFrameDecrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+                transform.addDecryptionKey(key1);
+                transform.addDecryptionKey(key2);
+                transform.addDecryptionKey(key3, 1000);
+                transform.addDecryptionKey(key4, BigInt('18446744073709551615'));
                 receiver = trackEvent.receiver;
                 receiver.transform = transform;
                 resolve(trackEvent.streams[0]);

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Uint8Array as input to SFrameTransform promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'crypto.subtle.importKey')"
+FAIL Uint8Array as input to SFrameEncrypterStream promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'crypto.subtle.importKey')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source.html
@@ -17,9 +17,9 @@ async function getEncryptedData(transform)
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
-    const transform1 = new SFrameTransform;
-    const transform2 = new SFrameTransform;
-    const transform3 = new SFrameTransform;
+    const transform1 = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const transform2 = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const transform3 = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
 
     await transform1.setEncryptionKey(key);
     await transform2.setEncryptionKey(key);
@@ -44,7 +44,7 @@ promise_test(async (test) => {
 
     assert_array_equals(result1, result2, "result2");
     assert_array_equals(result1, result3, "result3");
-}, "Uint8Array as input to SFrameTransform");
+}, "Uint8Array as input to SFrameEncrypterStream");
         </script>
     </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-expected.txt
@@ -1,8 +1,7 @@
 
-PASS Cannot reuse attached transforms
-PASS SFrameTransform exposes readable and writable
-PASS readable/writable are locked when attached and after being attached
-FAIL SFrame with array buffer - authentication size 10 promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'crypto.subtle.importKey')"
+FAIL Cannot reuse attached transforms promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: RTCRtpSFrameEncrypter"
+FAIL SFrameEncrypterStream exposes readable and writable Can't find variable: SFrameEncrypterStream
+FAIL SFrame with array buffer - AES_128_CTR_HMAC_SHA256_80 promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'crypto.subtle.importKey')"
 FAIL SFrame decryption with array buffer that is too small promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'crypto.subtle.importKey')"
 FAIL SFrame transform gets errored if trying to process unexpected value types promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'crypto.subtle.importKey')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS video exchange with SFrame transform in worker
+FAIL video exchange with SFrame transform in worker promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: RTCRtpSFrameEncrypter"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html
@@ -29,7 +29,7 @@ promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({ video: true });
 
     let sender, receiver;
-    const senderTransform = new SFrameTransform({ compatibilityMode: "H264" });
+    const senderTransform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const receiverTransform = new RTCRtpScriptTransform(worker, "SFrameRTCRtpTransform");
 
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-readable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-readable-expected.txt
@@ -1,3 +1,4 @@
 
-PASS sframe-transform-readable
+
+FAIL sframe-transform-readable promise_test: Unhandled rejection with value: object "TypeError: undefined is not a constructor (evaluating 'new frame.contentWindow.SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" })')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-readable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-readable.html
@@ -10,7 +10,7 @@
         <script>
 promise_test(async (test) => {
     const frameDOMException = frame.contentWindow.DOMException;
-    const transform = new frame.contentWindow.SFrameTransform;
+    const transform = new frame.contentWindow.SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     frame.remove();
     assert_throws_dom("InvalidStateError", frameDOMException, () => transform.readable);
 });

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-worker.js
@@ -1,6 +1,6 @@
 onrtctransform = (event) => {
-    const sframeTransform = new SFrameTransform({ role : "decrypt", authenticationSize: "10", compatibilityMode: "H264" });
-    crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => sframeTransform.setEncryptionKey(key));
+    const sframeTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_32" });
+    crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]).then(key => sframeTransform.addDecryptionKey(key));
     const transformer = event.transformer;
     transformer.readable.pipeThrough(sframeTransform).pipeTo(transformer.writable);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform.html
@@ -10,8 +10,8 @@
 
 promise_test(async (test) => {
     const pc = new RTCPeerConnection();
-    const senderTransform = new SFrameTransform();
-    const receiverTransform = new SFrameTransform();
+    const senderTransform = new RTCRtpSFrameEncrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    const receiverTransform = new RTCRtpSFrameDecrypter({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const sender1 = pc.addTransceiver('audio').sender;
     const sender2 = pc.addTransceiver('video').sender;
     const receiver1 = pc.getReceivers()[0];
@@ -30,51 +30,20 @@ promise_test(async (test) => {
 }, "Cannot reuse attached transforms");
 
 test(() => {
-    const senderTransform = new SFrameTransform();
+    const stream = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
 
-    assert_true(senderTransform.readable instanceof ReadableStream);
-    assert_true(senderTransform.writable instanceof WritableStream);
-}, "SFrameTransform exposes readable and writable");
-
-promise_test(async (test) => {
-    const pc = new RTCPeerConnection();
-    const senderTransform = new SFrameTransform();
-    const receiverTransform = new SFrameTransform();
-    const sender1 = pc.addTransceiver('audio').sender;
-    const sender2 = pc.addTransceiver('video').sender;
-    const receiver1 = pc.getReceivers()[0];
-    const receiver2 = pc.getReceivers()[1];
-
-    assert_false(senderTransform.readable.locked, "sender readable before");
-    assert_false(senderTransform.writable.locked, "sender writable before");
-    assert_false(receiverTransform.readable.locked, "receiver readable before");
-    assert_false(receiverTransform.writable.locked, "receiver writable before");
-
-    sender1.transform = senderTransform;
-    receiver1.transform = receiverTransform;
-
-    assert_true(senderTransform.readable.locked, "sender readable during");
-    assert_true(senderTransform.writable.locked, "sender writable during");
-    assert_true(receiverTransform.readable.locked, "receiver readable during");
-    assert_true(receiverTransform.writable.locked, "receiver writable during");
-
-    sender1.transform = null;
-    receiver1.transform = null;
-
-    assert_true(senderTransform.readable.locked, "sender readable after");
-    assert_true(senderTransform.writable.locked, "sender writable after");
-    assert_true(receiverTransform.readable.locked, "receiver readable after");
-    assert_true(receiverTransform.writable.locked, "receiver writable after");
-}, "readable/writable are locked when attached and after being attached");
+    assert_true(stream.readable instanceof ReadableStream);
+    assert_true(stream.writable instanceof WritableStream);
+}, "SFrameEncrypterStream exposes readable and writable");
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
-    const senderTransform = new SFrameTransform({ role : 'encrypt', authenticationSize: 10 });
+    const senderTransform = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     senderTransform.setEncryptionKey(key);
 
-    const receiverTransform = new SFrameTransform({ role : 'decrypt', authenticationSize: 10 });
-    receiverTransform.setEncryptionKey(key);
+    const receiverTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
+    receiverTransform.addDecryptionKey(key);
 
     const writer = senderTransform.writable.getWriter();
     const reader = receiverTransform.readable.getReader();
@@ -93,21 +62,21 @@ promise_test(async (test) => {
     const view2 = new Int8Array(received.value);
     for (let cptr = 0; cptr < sent.byteLength; ++cptr)
         assert_equals(view2[cptr], view[cptr]);
-}, "SFrame with array buffer - authentication size 10");
+}, "SFrame with array buffer - AES_128_CTR_HMAC_SHA256_80");
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
-    const senderTransform = new SFrameTransform({ role : 'encrypt', authenticationSize: 10 });
+    const senderTransform = new SFrameEncrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const senderWriter = senderTransform.writable.getWriter();
     const senderReader = senderTransform.readable.getReader();
 
-    const receiverTransform = new SFrameTransform({ role : 'decrypt', authenticationSize: 10 });
+    const receiverTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const receiverWriter = receiverTransform.writable.getWriter();
     const receiverReader = receiverTransform.readable.getReader();
 
     senderTransform.setEncryptionKey(key);
-    receiverTransform.setEncryptionKey(key);
+    receiverTransform.addDecryptionKey(key);
 
     const chunk = new ArrayBuffer(8);
 
@@ -127,9 +96,9 @@ promise_test(async (test) => {
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
-    const receiverTransform = new SFrameTransform({ role : 'decrypt', authenticationSize: 10 });
+    const receiverTransform = new SFrameDecrypterStream({ cipherSuite: "AES_128_CTR_HMAC_SHA256_80" });
     const receiverWriter = receiverTransform.writable.getWriter();
-    receiverTransform.setEncryptionKey(key);
+    receiverTransform.addDecryptionKey(key);
 
     // decryption should fail, leading to erroring the transform.
     await promise_rejects_js(test, TypeError, receiverWriter.write({ }));

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/w3c-import.log
@@ -10,11 +10,10 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https.html
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-bad-chunk-worker.js
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-bad-chunk.https.html
 /LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform-drop-frames-worker.js

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2927,6 +2927,7 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/scr
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-sender-worker-single-frame.https.html  [ Skip ]
+imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/tentative/RTCEncodedAudioFrame-audiolevel.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/tentative/RTCEncodedFrame-timestamps.html [ Skip ]
 webrtc/audio-sframe.html [ Failure ]

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -6818,6 +6818,15 @@
     "imported/w3c/web-platform-tests/webmessaging/broadcastchannel/opaque-origin.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-sender-worker-single-frame.https.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html": [
         "slow"
     ],
@@ -6828,6 +6837,9 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpEncodingParameters-scaleResolutionDownTo.https.html": [


### PR DESCRIPTION
#### f9cedae9fb4f654e97942a35ddcf6177d01536f8
<pre>
Rebase WPT webrtc encoded transform tests
<a href="https://rdar.apple.com/181104430">rdar://181104430</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318318">https://bugs.webkit.org/show_bug.cgi?id=318318</a>

Reviewed by Jean-Yves Avenard.

Rebasing up to 6ddb6700d1e60aac3b09e53ead34dbe86db7a712.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/webrtc-encoded-transform.idl:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCEncodedFrame-copy-construction.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform-worker.js:
(RestoreAndWrite):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-sender-worker-single-frame.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/helper.js:
(async createRTCEncodedFrameFromScratch.work.async try):
(async createRTCEncodedFrameFromScratch.work):
(areArrayBuffersEqual):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window.js:
(async idlArray):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-late-transform.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-metadata-transform.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame.js:
(onrtctransform.event.async generateKeyFrame):
(onrtctransform.event.async waitForFrame):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-sendKeyFrameRequest.js:
(onrtctransform.event.async sendKeyFrameRequest):
(onrtctransform.event.async waitForFrame):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-keys.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-buffer-source.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-in-worker.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-readable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-readable.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform-worker.js:
(onrtctransform):
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/sframe-transform.html:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/w3c-import.log:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/316396@main">https://commits.webkit.org/316396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f939ec69715fc3a73a0b469a9dcd084dc0a1ca13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46138 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181668 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24e06dc8-a0e0-404b-8a94-5ea3cd76ea1b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45778 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3206c0ff-b05b-4a3f-a53b-c7fa1f767ea9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37383 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e016e8e1-2449-4e78-ab5a-85d877e9061f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30277 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184206 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45805 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38494 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46485 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111194 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37674 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45003 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44403 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->