### PR TITLE
[css-mixins-1] Unwrap braces in function arguments

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
@@ -60,12 +60,12 @@ PASS IACVT argument shadows outer scope, typed
 PASS IACVT argument shadows outer scope, type mismatch
 PASS Missing only argument
 PASS Missing one argument of several
-FAIL Passing list as only argument assert_equals: expected "1px,2px" but got "{1px,2px}"
-FAIL Passing list as first argument assert_equals: expected "1px, 2px | 3px" but got "{1px, 2px} | 3px"
-FAIL Passing list as second argument assert_equals: expected "1px | 2px, 3px" but got "1px | {2px, 3px}"
-FAIL Passing comma as argument assert_equals: expected "," but got "{,}"
-FAIL Passing {} as argument assert_equals: expected "{}" but got "{{}}"
-FAIL Passing non-whole-value {} as argument assert_equals: expected "foo{}" but got "{foo{}}"
+PASS Passing list as only argument
+PASS Passing list as first argument
+PASS Passing list as second argument
+PASS Passing comma as argument
+PASS Passing {} as argument
+PASS Passing non-whole-value {} as argument
 PASS Local variable with initial keyword
 PASS Local variable with initial keyword, defaulted
 PASS Local variable with initial keyword, no value via IACVT-capture

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -76,6 +76,20 @@ static bool containsURLTokens(std::span<const CSSParserToken> tokens)
     return false;
 }
 
+// A comma-containing value can be passed as a single free-form-production argument by wrapping it in
+// curly braces. The braces are syntactic and the argument is the block's contents.
+// https://drafts.csswg.org/css-values-5/#component-function-commas
+static CSSParserTokenRange unwrapArgumentBraces(CSSParserTokenRange argument)
+{
+    auto range = argument;
+    range.consumeWhitespace();
+    if (range.peek().type() != LeftBraceToken)
+        return argument;
+    auto contents = range.consumeBlock();
+    range.consumeWhitespace();
+    return range.atEnd() ? contents : argument;
+}
+
 static Ref<CSSVariableData> createFirstValidVariableData(std::span<const std::span<const CSSParserToken>> candidates, const CSSParserContext& context)
 {
     // Uses the internal -internal-first-valid name rather than the public first-valid(). The public
@@ -362,7 +376,7 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
             auto argumentRange = CSSPropertyParserHelpers::consumeArgument(range, i);
             if (!argumentRange)
                 break;
-            auto substituted = substituteTokenRange(*argumentRange, m_substitutionValue->context());
+            auto substituted = substituteTokenRange(unwrapArgumentBraces(*argumentRange), m_substitutionValue->context());
             // A failed substitution leaves the argument guaranteed-invalid (empty) so it defaults via
             // first-valid(), rather than aborting. https://drafts.csswg.org/css-mixins/#replace-a-dashed-function
             result.append(substituted.value_or(Vector<CSSParserToken> { }));
@@ -736,12 +750,7 @@ bool SubstitutionResolver::substituteInternalAutoBaseFunction(CSSParserTokenRang
 
     auto selectedRange = isBaseAppearance() ? *secondArgRange : *firstArgRange;
 
-    // Strip outer braces if present, allowing comma-containing values like:
-    // -internal-auto-base({value1, value2}, {value3, value4})
-    if (!selectedRange.atEnd() && selectedRange.peek().type() == LeftBraceToken)
-        selectedRange = selectedRange.consumeBlock();
-
-    auto selectedTokens = substituteTokenRange(selectedRange, context);
+    auto selectedTokens = substituteTokenRange(unwrapArgumentBraces(selectedRange), context);
     if (!selectedTokens)
         return false;
 


### PR DESCRIPTION
#### 95091b3ea725d9c6caaee71f76221bc36a6e26b6
<pre>
[css-mixins-1] Unwrap braces in function arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=318332">https://bugs.webkit.org/show_bug.cgi?id=318332</a>
<a href="https://rdar.apple.com/181118666">rdar://181118666</a>

Reviewed by Alan Baradlay.

Comma-containing values can be used in arguments using braces like --f({1px,2px}).

<a href="https://drafts.csswg.org/css-values-5/#component-function-commas">https://drafts.csswg.org/css-values-5/#component-function-commas</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::unwrapArgumentBraces):

Add a helper.

(WebCore::Style::SubstitutionResolver::substituteDashedFunction):
(WebCore::Style::SubstitutionResolver::substituteInternalAutoBaseFunction):

Also use for -internal-auto-base which already had unwrap code.

Canonical link: <a href="https://commits.webkit.org/316265@main">https://commits.webkit.org/316265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb14545fe280fff083cfa8c1219d940fdb66a8a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181220 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce7d2ae7-6318-49d6-b493-cfcae730e2fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e31f9ab-94f2-42b9-b091-a86793f68262) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a4e81e3-f8fc-456f-a145-f006050ddd5b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29969 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183887 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142455 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45500 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38379 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46180 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110838 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37443 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44698 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44157 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->