### PR TITLE
[YARR] EOL string list optimization produces incorrect matches with multiline flag

### DIFF
--- a/JSTests/stress/regexp-stringlist-eol-multiline.js
+++ b/JSTests/stress/regexp-stringlist-eol-multiline.js
@@ -1,0 +1,18 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ', expected: ' + expected);
+}
+
+// Alternation must prefer the earlier alternative "a", which matches because
+// multiline $ succeeds before the line terminator.
+shouldBe(/^(?:a|a\nx)$/m.exec("a\nx")[0], "a");
+shouldBe(/^(?:a|a\nx)$/m.test("a\nx"), true);
+
+// "a\nb" matches the text but fails $ (next char is "Q"); the later
+// alternative "a" must then be tried and succeeds before the "\n".
+shouldBe(/^(?:a\nb|a)$/m.exec("a\nbQ")[0], "a");
+
+shouldBe(/^(?:foo|bar|f)$/m.exec("foo")[0], "foo");
+shouldBe(/^(?:foo|bar|f)$/m.exec("bar\nzzz")[0], "bar");
+shouldBe(/^(?:foo|bar|f)$/m.exec("f\nbar")[0], "f");
+shouldBe(/^(?:foo|bar|f)$/m.exec("fo"), null);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -2084,7 +2084,7 @@ public:
                 && terms[1].quantityMaxCount == 1
                 && !terms[1].parentheses.isCopy
                 && (terms.size() == 2
-                    || (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL))) {
+                    || (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL && !m_pattern.multiline()))) {
                 // We start assuming this is a string list and then prove the negative.
                 isStringList = true;
 


### PR DESCRIPTION
#### 630d6be8962a1cc6f8158ade1ea590bd5397129e
<pre>
[YARR] EOL string list optimization produces incorrect matches with multiline flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=318333">https://bugs.webkit.org/show_bug.cgi?id=318333</a>

Reviewed by Yusuke Suzuki.

When the multiline flag is set, the EOL string list optimization produces
incorrect matches:

    /^(?:a|a\nx)$/m.exec(&quot;a\nx&quot;)   // actual(JIT): &quot;a\nx&quot;, expected: &quot;a&quot;
    /^(?:a\nb|a)$/m.exec(&quot;a\nbQ&quot;)  // actual(JIT): null,   expected: &quot;a&quot;

This patch fixes the bug by disabling the optimization when the multiline
flag is set.

Test: JSTests/stress/regexp-stringlist-eol-multiline.js

* JSTests/stress/regexp-stringlist-eol-multiline.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::checkForTerminalParentheses):

Canonical link: <a href="https://commits.webkit.org/316345@main">https://commits.webkit.org/316345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a8ec40f93df3de28b2618deed480201776d296f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129471 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133748 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114219 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35767 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29970 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2791 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183888 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33176 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36504 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142456 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45501 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142346 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46181 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110839 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37442 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204595 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44699 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8699 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54630 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->