### PR TITLE
[JSC] Use direct 3-character append for `"%XY"` escapes in `encode()`

### DIFF
--- a/JSTests/microbenchmarks/encode-uri-component-query-string.js
+++ b/JSTests/microbenchmarks/encode-uri-component-query-string.js
@@ -1,0 +1,18 @@
+// Tests encodeURIComponent on query-string payloads full of spaces, quotes,
+// ampersands and percent signs, mimicking building fetch URLs from JSON values.
+
+const values = [];
+for (let j = 0; j < 16; j++)
+    values.push('user query ' + j + ': {"name":"Alice & Bob","tags":["a b","c=d"],"note":"100% legit, really?","page":' + j + '}');
+
+let expected = 0;
+for (let j = 0; j < 16; j++)
+    expected += encodeURIComponent(values[j]).length;
+
+const iterations = 200000;
+let sum = 0;
+for (let i = 0; i < iterations; i++)
+    sum += encodeURIComponent(values[i & 15]).length;
+
+if (sum !== expected * (iterations / 16))
+    throw new Error("bad result: " + sum);

--- a/JSTests/microbenchmarks/encode-uri-component-unicode.js
+++ b/JSTests/microbenchmarks/encode-uri-component-unicode.js
@@ -1,0 +1,18 @@
+// Tests encodeURIComponent on non-ASCII text where every character expands to
+// multiple %XY escape sequences.
+
+const values = [];
+for (let j = 0; j < 16; j++)
+    values.push('検索クエリ' + j + ': 東京都渋谷区の天気予報と交通情報を教えてください \u{1F600}\u{1F680}');
+
+let expected = 0;
+for (let j = 0; j < 16; j++)
+    expected += encodeURIComponent(values[j]).length;
+
+const iterations = 100000;
+let sum = 0;
+for (let i = 0; i < iterations; i++)
+    sum += encodeURIComponent(values[i & 15]).length;
+
+if (sum !== expected * (iterations / 16))
+    throw new Error("bad result: " + sum);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -126,8 +126,9 @@ static JSValue encode(JSGlobalObject* globalObject, const WTF::BitSet<256>& doNo
             // 4-d-vi-1. Let jOctet be the value at index j within Octets.
             // 4-d-vi-2. Let S be a String containing three code units "%XY" where XY are two uppercase hexadecimal digits encoding the value of jOctet.
             // 4-d-vi-3. Let R be a new String value computed by concatenating the previous value of R and S.
-            builder.append('%');
-            builder.append(hex(utf8OctetsBuffer[index], 2));
+            auto octet = utf8OctetsBuffer[index];
+            std::array<Latin1Character, 3> escaped { '%', static_cast<Latin1Character>(upperNibbleToASCIIHexDigit(octet)), static_cast<Latin1Character>(lowerNibbleToASCIIHexDigit(octet)) };
+            builder.append(std::span<const Latin1Character> { escaped });
         }
     }
 


### PR DESCRIPTION
#### c96c07c35cc49de658a762231a6f984545f714ce
<pre>
[JSC] Use direct 3-character append for `&quot;%XY&quot;` escapes in `encode()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318334">https://bugs.webkit.org/show_bug.cgi?id=318334</a>

Reviewed by Yusuke Suzuki.

encode() (shared by encodeURIComponent / encodeURI / escape) emits each
escaped octet with two StringBuilder appends, where the second one goes
through the generic hex() adapter: it constructs a HexNumberBuffer and
runs the out-of-line arbitrary-width hex loop plus string-adapter
dispatch per octet. This dominates the profile on escape-heavy inputs.

Build the &quot;%XY&quot; triple on the stack with the constexpr nibble helpers
from wtf/ASCIICType.h and append it once. The output is byte-identical.

                                            Baseline                  Patched

encode-uri-component-unicode            71.1958+-1.1739     ^     52.1049+-1.0046        ^ definitely 1.3664x faster
encode-uri-component-query-string       78.8259+-2.7355     ^     61.2906+-1.1368        ^ definitely 1.2861x faster

Tests: JSTests/microbenchmarks/encode-uri-component-query-string.js
       JSTests/microbenchmarks/encode-uri-component-unicode.js

* JSTests/microbenchmarks/encode-uri-component-query-string.js: Added.
* JSTests/microbenchmarks/encode-uri-component-unicode.js: Added.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::encode):

Canonical link: <a href="https://commits.webkit.org/316343@main">https://commits.webkit.org/316343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f369c9e44e14cbbef2ffbfd48148a140314699ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129474 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133749 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154256 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35770 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29973 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2798 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183891 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33179 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36507 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142457 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45504 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142347 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38444 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46184 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110842 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37444 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44702 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8706 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54631 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->