### PR TITLE
SVGLength.value returns raw negative numbers for r/rx/ry/width/height/textLength after setAttribute, disagreeing with getComputedStyle()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-invalid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS cx="auto" should be an invalid attribute value (ignored)
+PASS cx="none" should be an invalid attribute value (ignored)
+PASS cx="10px 20px" should be an invalid attribute value (ignored)
+PASS cx="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cx presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cx presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("cx", "auto", 0, "0px");
+test_invalid_attribute_value("cx", "none", 0, "0px");
+test_invalid_attribute_value("cx", "10px 20px", 0, "0px");
+test_invalid_attribute_value("cx", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-valid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS cx="0" should be a valid attribute value
+PASS cx="5" should be a valid attribute value
+PASS cx="-10" should be a valid attribute value
+PASS cx="5px" should be a valid attribute value
+PASS cx="-10px" should be a valid attribute value
+PASS cx="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cx presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cx presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;' (unlike the cx CSS property, which does not accept a bare number)."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("cx", "0", 0);
+test_valid_attribute_value("cx", "5", 5);
+test_valid_attribute_value("cx", "-10", -10);
+test_valid_attribute_value("cx", "5px", 5);
+test_valid_attribute_value("cx", "-10px", -10);
+test_valid_attribute_value("cx", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-invalid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS cy="auto" should be an invalid attribute value (ignored)
+PASS cy="none" should be an invalid attribute value (ignored)
+PASS cy="10px 20px" should be an invalid attribute value (ignored)
+PASS cy="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cy presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cy presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("cy", "auto", 0, "0px");
+test_invalid_attribute_value("cy", "none", 0, "0px");
+test_invalid_attribute_value("cy", "10px 20px", 0, "0px");
+test_invalid_attribute_value("cy", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-valid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS cy="0" should be a valid attribute value
+PASS cy="5" should be a valid attribute value
+PASS cy="-10" should be a valid attribute value
+PASS cy="5px" should be a valid attribute value
+PASS cy="-10px" should be a valid attribute value
+PASS cy="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the cy presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the cy presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;' (unlike the cy CSS property, which does not accept a bare number)."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("cy", "0", 0);
+test_valid_attribute_value("cy", "5", 5);
+test_valid_attribute_value("cy", "-10", -10);
+test_valid_attribute_value("cy", "5px", 5);
+test_valid_attribute_value("cy", "-10px", -10);
+test_valid_attribute_value("cy", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-invalid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS rx="-10" should be an invalid attribute value (ignored)
+PASS rx="-10px" should be an invalid attribute value (ignored)
+PASS rx="-10%" should be an invalid attribute value (ignored)
+PASS rx="none" should be an invalid attribute value (ignored)
+PASS rx="10px 20px" should be an invalid attribute value (ignored)
+PASS rx="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute on ellipse with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute on ellipse rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for rx is invalid and must be ignored per SVG2 geometry.html#RX."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("rx", "-10", 0, "auto");
+test_invalid_attribute_value("rx", "-10px", 0, "auto");
+test_invalid_attribute_value("rx", "-10%", 0, "auto");
+test_invalid_attribute_value("rx", "none", 0, "auto");
+test_invalid_attribute_value("rx", "10px 20px", 0, "auto");
+test_invalid_attribute_value("rx", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-valid-expected.txt
@@ -1,0 +1,7 @@
+
+PASS rx="auto" should be a valid attribute value
+PASS rx="0" should be a valid attribute value
+PASS rx="5" should be a valid attribute value
+PASS rx="5px" should be a valid attribute value
+PASS rx="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute on ellipse with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute on ellipse supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("rx", "auto", 0, "auto");
+test_valid_attribute_value("rx", "0", 0);
+test_valid_attribute_value("rx", "5", 5);
+test_valid_attribute_value("rx", "5px", 5);
+test_valid_attribute_value("rx", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-invalid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS ry="-10" should be an invalid attribute value (ignored)
+PASS ry="-10px" should be an invalid attribute value (ignored)
+PASS ry="-10%" should be an invalid attribute value (ignored)
+PASS ry="none" should be an invalid attribute value (ignored)
+PASS ry="10px 20px" should be an invalid attribute value (ignored)
+PASS ry="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute on ellipse with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute on ellipse rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for ry is invalid and must be ignored per SVG2 geometry.html#RY."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("ry", "-10", 0, "auto");
+test_invalid_attribute_value("ry", "-10px", 0, "auto");
+test_invalid_attribute_value("ry", "-10%", 0, "auto");
+test_invalid_attribute_value("ry", "none", 0, "auto");
+test_invalid_attribute_value("ry", "10px 20px", 0, "auto");
+test_invalid_attribute_value("ry", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-valid-expected.txt
@@ -1,0 +1,7 @@
+
+PASS ry="auto" should be a valid attribute value
+PASS ry="0" should be a valid attribute value
+PASS ry="5" should be a valid attribute value
+PASS ry="5px" should be a valid attribute value
+PASS ry="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute on ellipse with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute on ellipse supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <ellipse id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("ry", "auto", 0, "auto");
+test_valid_attribute_value("ry", "0", 0);
+test_valid_attribute_value("ry", "5", 5);
+test_valid_attribute_value("ry", "5px", 5);
+test_valid_attribute_value("ry", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-invalid-expected.txt
@@ -1,0 +1,9 @@
+
+PASS height="-10" should be an invalid attribute value (ignored)
+PASS height="-10px" should be an invalid attribute value (ignored)
+PASS height="-10%" should be an invalid attribute value (ignored)
+PASS height="auto" should be an invalid attribute value (ignored)
+PASS height="none" should be an invalid attribute value (ignored)
+PASS height="10px 20px" should be an invalid attribute value (ignored)
+PASS height="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-invalid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the height presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the height presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt;', keeping the initial computed value of 0."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("height", "-10", 0, "0px");
+test_invalid_attribute_value("height", "-10px", 0, "0px");
+test_invalid_attribute_value("height", "-10%", 0, "0px");
+test_invalid_attribute_value("height", "auto", 0, "0px");
+test_invalid_attribute_value("height", "none", 0, "0px");
+test_invalid_attribute_value("height", "10px 20px", 0, "0px");
+test_invalid_attribute_value("height", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-valid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS height="0" should be a valid attribute value
+PASS height="5" should be a valid attribute value
+PASS height="5px" should be a valid attribute value
+PASS height="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the height presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the height presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("height", "0", 0);
+test_valid_attribute_value("height", "5", 5);
+test_valid_attribute_value("height", "5px", 5);
+test_valid_attribute_value("height", "5%", 40, "40px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-invalid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS r="-10" should be an invalid attribute value (ignored)
+PASS r="-10px" should be an invalid attribute value (ignored)
+PASS r="-10%" should be an invalid attribute value (ignored)
+PASS r="auto" should be an invalid attribute value (ignored)
+PASS r="10px 20px" should be an invalid attribute value (ignored)
+PASS r="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the r presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the r presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt;', keeping the initial computed value of 0. A negative value for r is invalid and must be ignored per SVG2 geometry.html#R."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("r", "-10", 0, "0px");
+test_invalid_attribute_value("r", "-10px", 0, "0px");
+test_invalid_attribute_value("r", "-10%", 0, "0px");
+test_invalid_attribute_value("r", "auto", 0, "0px");
+test_invalid_attribute_value("r", "10px 20px", 0, "0px");
+test_invalid_attribute_value("r", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-valid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS r="0" should be a valid attribute value
+PASS r="5" should be a valid attribute value
+PASS r="5px" should be a valid attribute value
+PASS r="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the r presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the r presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;'."/>
+  </metadata>
+  <circle id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("r", "0", 0);
+test_valid_attribute_value("r", "5", 5);
+test_valid_attribute_value("r", "5px", 5);
+test_valid_attribute_value("r", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-invalid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS rx="-10" should be an invalid attribute value (ignored)
+PASS rx="-10px" should be an invalid attribute value (ignored)
+PASS rx="-10%" should be an invalid attribute value (ignored)
+PASS rx="none" should be an invalid attribute value (ignored)
+PASS rx="10px 20px" should be an invalid attribute value (ignored)
+PASS rx="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for rx is invalid and must be ignored per SVG2 geometry.html#RX."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("rx", "-10", 0, "auto");
+test_invalid_attribute_value("rx", "-10px", 0, "auto");
+test_invalid_attribute_value("rx", "-10%", 0, "auto");
+test_invalid_attribute_value("rx", "none", 0, "auto");
+test_invalid_attribute_value("rx", "10px 20px", 0, "auto");
+test_invalid_attribute_value("rx", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-valid-expected.txt
@@ -1,0 +1,7 @@
+
+PASS rx="auto" should be a valid attribute value
+PASS rx="0" should be a valid attribute value
+PASS rx="5" should be a valid attribute value
+PASS rx="5px" should be a valid attribute value
+PASS rx="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the rx presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the rx presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("rx", "auto", 0, "auto");
+test_valid_attribute_value("rx", "0", 0);
+test_valid_attribute_value("rx", "5", 5);
+test_valid_attribute_value("rx", "5px", 5);
+test_valid_attribute_value("rx", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-invalid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS ry="-10" should be an invalid attribute value (ignored)
+PASS ry="-10px" should be an invalid attribute value (ignored)
+PASS ry="-10%" should be an invalid attribute value (ignored)
+PASS ry="none" should be an invalid attribute value (ignored)
+PASS ry="10px 20px" should be an invalid attribute value (ignored)
+PASS ry="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-invalid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt; | auto', keeping the initial computed value of auto. A negative value for ry is invalid and must be ignored per SVG2 geometry.html#RY."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("ry", "-10", 0, "auto");
+test_invalid_attribute_value("ry", "-10px", 0, "auto");
+test_invalid_attribute_value("ry", "-10%", 0, "auto");
+test_invalid_attribute_value("ry", "none", 0, "auto");
+test_invalid_attribute_value("ry", "10px 20px", 0, "auto");
+test_invalid_attribute_value("ry", "garbage", 0, "auto");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-valid-expected.txt
@@ -1,0 +1,7 @@
+
+PASS ry="auto" should be a valid attribute value
+PASS ry="0" should be a valid attribute value
+PASS ry="5" should be a valid attribute value
+PASS ry="5px" should be a valid attribute value
+PASS ry="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the ry presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the ry presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt; | auto'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("ry", "auto", 0, "auto");
+test_valid_attribute_value("ry", "0", 0);
+test_valid_attribute_value("ry", "5", 5);
+test_valid_attribute_value("ry", "5px", 5);
+test_valid_attribute_value("ry", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/support/attribute-testcommon.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/support/attribute-testcommon.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Create a test that a SVG geometry-property presentation attribute
+ * (https://w3c.github.io/svgwg/svg2-draft/geometry.html) parses a value
+ * correctly when set via the SVG-attribute syntax (setAttribute), as
+ * distinct from the CSS-property syntax already covered by
+ * /css/support/parsing-testcommon.js.
+ *
+ * Per https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value,
+ * presentation attributes for <length-percentage>-typed geometry properties
+ * also accept a bare unitless <number> (treated as a length in user units),
+ * which the CSS-property grammar rejects — so the two syntaxes need
+ * independent valid/invalid value sets, not a shared one.
+ *
+ * The document element #target is used to perform the test; it must be an
+ * element that supports the given attribute (e.g. <rect> for rx/ry,
+ * <circle> for r, <circle>/<ellipse> for cx/cy).
+ *
+ * @param {string} attribute  The name of the presentation attribute.
+ * @param {string} value      A specified attribute value.
+ * @param {number} expected   The expected SVGAnimatedLength.baseVal.value.
+ * @param {string} computed   The expected getComputedStyle() serialization.
+ *                            Defaults to `${expected}px` when omitted.
+ */
+function test_valid_attribute_value(attribute, value, expected, computed) {
+  if (computed === undefined)
+    computed = `${expected}px`;
+
+  test(() => {
+    const target = document.getElementById('target');
+    target.removeAttribute(attribute);
+    target.setAttribute(attribute, value);
+    assert_equals(target.getAttribute(attribute), value,
+      'attribute should round-trip in the DOM');
+    assert_equals(target[attribute].baseVal.value, expected,
+      'SVGAnimatedLength.baseVal.value');
+    assert_equals(getComputedStyle(target)[attribute], computed,
+      'getComputedStyle()');
+  }, `${attribute}="${value}" should be a valid attribute value`);
+}
+
+/**
+ * Create a test that an invalid presentation-attribute value for a SVG
+ * geometry property is ignored — the attribute keeps the initial computed
+ * value (per https://w3c.github.io/svgwg/svg2-draft/geometry.html, "invalid
+ * and must be ignored").
+ *
+ * @param {string} attribute       The name of the presentation attribute.
+ * @param {string} value           An invalid specified attribute value.
+ * @param {number} initialValue    The expected initial baseVal.value.
+ * @param {string} initialComputed The expected initial getComputedStyle()
+ *                                 serialization.
+ */
+function test_invalid_attribute_value(attribute, value, initialValue, initialComputed) {
+  test(() => {
+    const target = document.getElementById('target');
+    target.removeAttribute(attribute);
+    assert_equals(target[attribute].baseVal.value, initialValue,
+      'sanity check: initial baseVal.value before setAttribute');
+    target.setAttribute(attribute, value);
+    assert_equals(target.getAttribute(attribute), value,
+      'invalid value is still reflected in the DOM attribute string');
+    assert_equals(target[attribute].baseVal.value, initialValue,
+      'SVGAnimatedLength.baseVal.value should keep the initial value');
+    assert_equals(getComputedStyle(target)[attribute], initialComputed,
+      'getComputedStyle() should keep the initial value');
+  }, `${attribute}="${value}" should be an invalid attribute value (ignored)`);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-invalid-expected.txt
@@ -1,0 +1,9 @@
+
+PASS width="-10" should be an invalid attribute value (ignored)
+PASS width="-10px" should be an invalid attribute value (ignored)
+PASS width="-10%" should be an invalid attribute value (ignored)
+PASS width="auto" should be an invalid attribute value (ignored)
+PASS width="none" should be an invalid attribute value (ignored)
+PASS width="10px 20px" should be an invalid attribute value (ignored)
+PASS width="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-invalid.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the width presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the width presentation attribute rejects negative values and values outside '&lt;length-percentage&gt; | &lt;number&gt;', keeping the initial computed value of 0."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("width", "-10", 0, "0px");
+test_invalid_attribute_value("width", "-10px", 0, "0px");
+test_invalid_attribute_value("width", "-10%", 0, "0px");
+test_invalid_attribute_value("width", "auto", 0, "0px");
+test_invalid_attribute_value("width", "none", 0, "0px");
+test_invalid_attribute_value("width", "10px 20px", 0, "0px");
+test_invalid_attribute_value("width", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-valid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS width="0" should be a valid attribute value
+PASS width="5" should be a valid attribute value
+PASS width="5px" should be a valid attribute value
+PASS width="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-valid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the width presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the width presentation attribute supports '&lt;length-percentage [0,inf]&gt; | &lt;number [0,inf]&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("width", "0", 0);
+test_valid_attribute_value("width", "5", 5);
+test_valid_attribute_value("width", "5px", 5);
+test_valid_attribute_value("width", "5%", 40, "40px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-invalid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS x="auto" should be an invalid attribute value (ignored)
+PASS x="none" should be an invalid attribute value (ignored)
+PASS x="10px 20px" should be an invalid attribute value (ignored)
+PASS x="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the x presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the x presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("x", "auto", 0, "0px");
+test_invalid_attribute_value("x", "none", 0, "0px");
+test_invalid_attribute_value("x", "10px 20px", 0, "0px");
+test_invalid_attribute_value("x", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-valid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS x="0" should be a valid attribute value
+PASS x="5" should be a valid attribute value
+PASS x="-10" should be a valid attribute value
+PASS x="5px" should be a valid attribute value
+PASS x="-10px" should be a valid attribute value
+PASS x="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the x presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#X"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the x presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("x", "0", 0);
+test_valid_attribute_value("x", "5", 5);
+test_valid_attribute_value("x", "-10", -10);
+test_valid_attribute_value("x", "5px", 5);
+test_valid_attribute_value("x", "-10px", -10);
+test_valid_attribute_value("x", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-invalid-expected.txt
@@ -1,0 +1,6 @@
+
+PASS y="auto" should be an invalid attribute value (ignored)
+PASS y="none" should be an invalid attribute value (ignored)
+PASS y="10px 20px" should be an invalid attribute value (ignored)
+PASS y="garbage" should be an invalid attribute value (ignored)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-invalid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-invalid.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the y presentation attribute with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the y presentation attribute rejects values outside '&lt;length-percentage&gt; | &lt;number&gt;' and keeps the initial computed value."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_attribute_value("y", "auto", 0, "0px");
+test_invalid_attribute_value("y", "none", 0, "0px");
+test_invalid_attribute_value("y", "10px 20px", 0, "0px");
+test_invalid_attribute_value("y", "garbage", 0, "0px");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-valid-expected.txt
@@ -1,0 +1,8 @@
+
+PASS y="0" should be a valid attribute value
+PASS y="5" should be a valid attribute value
+PASS y="-10" should be a valid attribute value
+PASS y="5px" should be a valid attribute value
+PASS y="-10px" should be a valid attribute value
+PASS y="5%" should be a valid attribute value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-valid.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-valid.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Geometry Properties: parsing the y presentation attribute with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y"/>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#presentation-attribute-css-value"/>
+    <h:link rel="help" href="https://github.com/web-platform-tests/wpt/issues/61017"/>
+    <h:meta name="assert" content="the y presentation attribute supports '&lt;length-percentage&gt; | &lt;number&gt;'."/>
+  </metadata>
+  <rect id="target"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <h:script src="support/attribute-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_attribute_value("y", "0", 0);
+test_valid_attribute_value("y", "5", 5);
+test_valid_attribute_value("y", "-10", -10);
+test_valid_attribute_value("y", "5px", 5);
+test_valid_attribute_value("y", "-10px", -10);
+test_valid_attribute_value("y", "5%", 40, "5%");
+
+  ]]></script>
+</svg>

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/error/007-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/hixie/error/007-expected.txt
@@ -6,5 +6,5 @@ layer at (0,0) size 800x600
     RenderSVGViewportContainer at (0,0) size 800x600
       RenderSVGRect {rect} at (0,0) size 200x100 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=200.00] [height=100.00]
       RenderSVGRect {rect} at (0,100) size 200x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=100.00] [width=200.00] [height=100.00]
-      RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#FF0000]}] [x=50.00] [y=0.00] [width=-200.00] [height=200.00]
+      RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#FF0000]}] [x=50.00] [y=0.00] [width=0.00] [height=200.00]
       RenderSVGRect {rect} at (0,0) size 200x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=200.00] [height=100.00]

--- a/LayoutTests/svg/hixie/error/007-expected.txt
+++ b/LayoutTests/svg/hixie/error/007-expected.txt
@@ -5,5 +5,5 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 200x200
     RenderSVGRect {rect} at (0,0) size 200x100 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=200.00] [height=100.00]
     RenderSVGRect {rect} at (0,100) size 200x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=100.00] [width=200.00] [height=100.00]
-    RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#FF0000]}] [x=50.00] [y=0.00] [width=-200.00] [height=200.00]
+    RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#FF0000]}] [x=50.00] [y=0.00] [width=0.00] [height=200.00]
     RenderSVGRect {rect} at (0,0) size 200x100 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=200.00] [height=100.00]

--- a/Source/WebCore/svg/SVGLengthValue.cpp
+++ b/Source/WebCore/svg/SVGLengthValue.cpp
@@ -138,6 +138,10 @@ SVGLengthValue SVGLengthValue::construct(SVGLengthMode lengthMode, StringView va
     if (!fallbackValue.isNull() && parseError != SVGParsingError::None)
         return SVGLengthValue(lengthMode, fallbackValue);
 
+    // A forbidden negative value must be ignored even without an explicit fallback.
+    if (parseError == SVGParsingError::ForbiddenNegativeValue)
+        return SVGLengthValue(lengthMode);
+
     return length;
 }
 


### PR DESCRIPTION
#### 81156f087d4a7f806965e361402a8d55cc6f64ac
<pre>
SVGLength.value returns raw negative numbers for r/rx/ry/width/height/textLength after setAttribute, disagreeing with getComputedStyle()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318324">https://bugs.webkit.org/show_bug.cgi?id=318324</a>
<a href="https://rdar.apple.com/181108927">rdar://181108927</a>

Reviewed by Taher Ali.

SVG 2 says a negative value for &apos;r&apos;, &apos;rx&apos;, or &apos;ry&apos; is invalid and must be
ignored, e.g. <a href="https://w3c.github.io/svgwg/svg2-draft/geometry.html#R.">https://w3c.github.io/svgwg/svg2-draft/geometry.html#R.</a> Before
this change, getComputedStyle() correctly fell back to the initial value, but
SVGAnimatedLength.baseVal.value leaked the raw negative number through:

    &lt;svg xmlns=&quot;<a href="http://www.w3.org/2000/svg&quot">http://www.w3.org/2000/svg&quot</a>;&gt;
    &lt;circle id=&quot;c&quot; r=&quot;5&quot;/&gt;
    &lt;/svg&gt;
    &lt;script&gt;
    c.setAttribute(&quot;r&quot;, &quot;-10&quot;);
    getComputedStyle(c).r;   // &quot;0px&quot; (correct)
    c.r.baseVal.value;       // -10 (wrong; now 0)
    &lt;/script&gt;

The bug was in SVGLengthValue::construct(): when a negative value is
forbidden, it only reset the parsed length to a fallback value if the call
site explicitly passed one (via the `fallbackValue` parameter). Most call
sites don&apos;t pass one, so the negative value survived into baseVal.

The same shape of bug also affects width/height on &lt;rect&gt;, &lt;image&gt;,
&lt;pattern&gt;, and &lt;use&gt;, and textLength on &lt;text&gt;, which all pass
`SVGLengthNegativeValuesMode::Forbid` without a fallback. A cross-engine
probe confirmed a single fix in SVGLengthValue::construct() is correct
for all of them, rather than only patching the three call sites named
in this bug.

Added ellipse rx/ry coverage to the existing WPT attribute-syntax tests,
which previously only covered rect for those two attributes.

* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cx-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/cy-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-rx-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ellipse-ry-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/height-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/r-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/rx-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/ry-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/support/attribute-testcommon.js: Added.
(test_valid_attribute_value):
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/width-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/x-attribute-valid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-invalid.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/geometry/parsing/y-attribute-valid.svg: Added.
* LayoutTests/svg/hixie/error/007-expected.txt
* Source/WebCore/svg/SVGLengthValue.cpp:
(WebCore::SVGLengthValue::construct):

Canonical link: <a href="https://commits.webkit.org/317963@main">https://commits.webkit.org/317963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572124ad54167f362b0325a9e533bf2c8399a4d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186484 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18681eec-cca5-497a-acaa-4d802a9cfa52) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137800 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9544c2dc-89b7-4d6e-98b1-339cf06cb694) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118274 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95f6f011-2093-401e-97f7-2411bf79526e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38332 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38087 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34951 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188907 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50485 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158131 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Passed layout tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146875 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39488 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51168 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146676 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41438 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123376 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117610 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49673 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13068 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Uploaded test results") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49072 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->