### PR TITLE
[cleanup] Rename RenderBox::frameRect()/setFrameRect() to borderBoxRectInContainer()/setBorderBoxRectInContainer()

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -3220,7 +3220,7 @@ FloatRect AccessibilityRenderObject::localRect() const
 {
     CheckedPtr renderer = this->renderer();
     if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer.get()))
-        return box ? convertFrameToSpace(box->frameRect(), AccessibilityConversionSpace::Page) : FloatRect();
+        return box ? convertFrameToSpace(box->borderBoxRectInContainer(), AccessibilityConversionSpace::Page) : FloatRect();
 
     CheckedPtr renderText = dynamicDowncast<RenderText>(renderer.get());
     return renderText ? renderText->linesBoundingBox() : FloatRect();

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -2271,7 +2271,7 @@ std::optional<InspectorOverlay::Highlight::FlexHighlightOverlay> InspectorOverla
     for (CheckedPtr renderChild : renderChildrenInFlexOrder) {
         // Build bounds for each child and collect children on the same logical line.
         {
-            auto childRect = renderChild->frameRect();
+            auto childRect = renderChild->borderBoxRectInContainer();
             renderFlex->flipForWritingMode(childRect);
             childRect.expand(renderChild->marginBox());
 

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -219,7 +219,7 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
     };
 
     // rendering does not offset for relative positioned boxes.
-    auto frameRect = renderer.frameRect();
+    auto frameRect = renderer.borderBoxRectInContainer();
     if (renderer.isInFlowPositioned())
         frameRect.move(renderer.offsetForInFlowPosition());
 
@@ -245,7 +245,7 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
             return false;
     }
     if (!areEssentiallyEqual(frameRect, BoxGeometry::borderBoxRect(boxGeometry))) {
-        outputRect("frameBox"_s, renderer.frameRect(), BoxGeometry::borderBoxRect(boxGeometry));
+        outputRect("frameBox"_s, renderer.borderBoxRectInContainer(), BoxGeometry::borderBoxRect(boxGeometry));
         return true;
     }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -634,7 +634,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
             floatingObject.setMarginOffset({ borderBoxVisualRect.x() - marginBoxVisualRect.x(), borderBoxVisualRect.y() - marginBoxVisualRect.y() });
             floatingObject.setIsPlaced(true);
 
-            auto oldRect = renderer->frameRect();
+            auto oldRect = renderer->borderBoxRectInContainer();
             renderer->setLocation(borderBoxVisualRect.location());
 
             if (renderer->checkForRepaintDuringLayout()) {

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2130,7 +2130,7 @@ std::optional<LayoutRect> LocalFrameView::visibleRectOfChild(const Frame& child)
     ASSERT(childOwnerRenderer->frame().frameID() == m_frame->frameID());
 
     auto rects = childOwnerRenderer->computeVisibleRectsInContainer(
-        { childOwnerRenderer->frameRect() },
+        { childOwnerRenderer->borderBoxRectInContainer() },
         &childOwnerRenderer->view(),
         {
             .hasPositionFixedDescendant = false,

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1182,7 +1182,7 @@ void RenderBlockFlow::layoutBlockChild(RenderBox& child, MarginInfo& marginInfo,
     LayoutUnit logicalTopEstimate = estimateLogicalTopPosition(child, marginInfo, estimateWithoutPagination);
 
     // Cache our old rect so that we can dirty the proper repaint rects if the child moves.
-    LayoutRect oldRect = child.frameRect();
+    LayoutRect oldRect = child.borderBoxRectInContainer();
     LayoutUnit oldLogicalTop = logicalTopForChild(child);
 
 #if ASSERT_ENABLED
@@ -2972,7 +2972,7 @@ bool RenderBlockFlow::positionNewFloats()
         if (childBox.containingBlock() != this)
             continue;
 
-        LayoutRect oldRect = childBox.frameRect();
+        LayoutRect oldRect = childBox.borderBoxRectInContainer();
         auto childBoxUsedClear = Style::ComputedStyle::usedClear(childBox);
         if (childBoxUsedClear == UsedClear::Left || childBoxUsedClear == UsedClear::Both)
             logicalTop = std::max(lowestFloatLogicalBottom(FloatingObject::FloatLeft), logicalTop);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -119,7 +119,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderBox);
 
 struct SameSizeAsRenderBox : public RenderBoxModelObject {
     virtual ~SameSizeAsRenderBox() = default;
-    LayoutRect frameRect;
+    LayoutRect borderBoxRectInContainer;
     LayoutBoxExtent marginBox;
     LayoutUnit preferredLogicalWidths[2];
     void* pointers[1];
@@ -2754,14 +2754,14 @@ auto RenderBox::computeVisibleRectsInContainer(const RepaintRects& rects, const 
 
 void RenderBox::repaintDuringLayoutIfMoved(const LayoutRect& oldRect)
 {
-    if (oldRect.location() != m_frameRect.location()) {
-        LayoutRect newRect = m_frameRect;
+    if (oldRect.location() != m_borderBoxRectInContainer.location()) {
+        LayoutRect newRect = m_borderBoxRectInContainer;
         // The child moved.  Invalidate the object's old and new positions.  We have to do this
         // since the object may not have gotten a layout.
-        m_frameRect = oldRect;
+        m_borderBoxRectInContainer = oldRect;
         repaint();
         repaintOverhangingFloats(true);
-        m_frameRect = newRect;
+        m_borderBoxRectInContainer = newRect;
         repaint();
         repaintOverhangingFloats(true);
     }

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -62,20 +62,18 @@ public:
     bool NODELETE requiresLayerWithScrollableArea() const;
     bool backgroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect) const override;
 
-    LayoutUnit x() const { return m_frameRect.x(); }
-    LayoutUnit y() const { return m_frameRect.y(); }
-    LayoutUnit borderBoxWidth() const { return m_frameRect.width(); }
-    LayoutUnit borderBoxHeight() const { return m_frameRect.height(); }
+    LayoutUnit x() const { return m_borderBoxRectInContainer.x(); }
+    LayoutUnit y() const { return m_borderBoxRectInContainer.y(); }
 
     // These represent your location relative to your container as a physical offset.
     // In layout related methods you almost always want the logical location (e.g. x() and y()).
     LayoutUnit top() const { return topLeftLocation().y(); }
     LayoutUnit left() const { return topLeftLocation().x(); }
 
-    template<typename T> void setX(T x) { m_frameRect.setX(x); }
-    template<typename T> void setY(T y) { m_frameRect.setY(y); }
-    template<typename T> void setBorderBoxWidth(T width) { m_frameRect.setWidth(width); }
-    template<typename T> void setBorderBoxHeight(T height) { m_frameRect.setHeight(height); }
+    template<typename T> void setX(T x) { m_borderBoxRectInContainer.setX(x); }
+    template<typename T> void setY(T y) { m_borderBoxRectInContainer.setY(y); }
+    template<typename T> void setBorderBoxWidth(T width) { m_borderBoxRectInContainer.setWidth(width); }
+    template<typename T> void setBorderBoxHeight(T height) { m_borderBoxRectInContainer.setHeight(height); }
 
     inline LayoutUnit logicalLeft() const;
     inline LayoutUnit logicalRight() const;
@@ -96,28 +94,22 @@ public:
     inline void setLogicalHeight(LayoutUnit);
     inline void setLogicalSize(LayoutSize);
 
-    LayoutPoint location() const { return m_frameRect.location(); }
+    LayoutPoint location() const { return m_borderBoxRectInContainer.location(); }
     LayoutSize locationOffset() const { return LayoutSize(x(), y()); }
-    LayoutSize borderBoxSize() const { return m_frameRect.size(); }
     inline LayoutSize logicalSize() const;
 
-    void setLocation(const LayoutPoint& location) { m_frameRect.setLocation(location); }
+    void setLocation(const LayoutPoint& location) { m_borderBoxRectInContainer.setLocation(location); }
     
-    void setBorderBoxSize(const LayoutSize& size) { m_frameRect.setSize(size); }
-    void move(LayoutUnit dx, LayoutUnit dy) { m_frameRect.move(dx, dy); }
+    void setBorderBoxSize(const LayoutSize& size) { m_borderBoxRectInContainer.setSize(size); }
+    void move(LayoutUnit dx, LayoutUnit dy) { m_borderBoxRectInContainer.move(dx, dy); }
 
-    LayoutRect frameRect() const { return m_frameRect; }
-    void setFrameRect(const LayoutRect& rect) { m_frameRect = rect; }
-
-    inline LayoutRect marginBoxRect() const;
-    LayoutRect borderBoxRect() const { return LayoutRect(LayoutPoint(), borderBoxSize()); }
-    LayoutRect borderBoundingBox() const final { return borderBoxRect(); }
+    LayoutRect borderBoxRectInContainer() const { return m_borderBoxRectInContainer; }
+    void setBorderBoxInContainer(const LayoutRect& rect) { m_borderBoxRectInContainer = rect; }
 
     // Don't use this; it doesn't make sense in a future world with corner-shape. Use BorderShape instead.
     WEBCORE_EXPORT LayoutRoundedRectRadii borderRadii() const;
 
     // The content area of the box (excludes padding - and intrinsic padding for table cells, etc... - and border).
-    inline LayoutRect contentBoxRect() const;
     LayoutPoint contentBoxLocation() const;
     inline LayoutRect flippedContentBoxRect() const;
 
@@ -196,6 +188,12 @@ public:
 
     void applyTransform(TransformationMatrix&, const Style::ComputedStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const override;
 
+    // margin, border, padding and content box rects are relative to border box.
+    inline LayoutRect marginBoxRect() const;
+    LayoutRect borderBoxRect() const { return { { }, borderBoxSize() }; }
+    LayoutRect paddingBoxRect() const;
+    inline LayoutRect contentBoxRect() const;
+
     inline LayoutSize contentBoxSize() const;
     inline LayoutUnit contentBoxWidth() const;
     inline LayoutUnit contentBoxHeight() const;
@@ -210,8 +208,13 @@ public:
     inline LayoutUnit paddingBoxLogicalWidth() const;
     inline LayoutUnit paddingBoxLogicalHeight() const;
     inline LayoutUnit paddingBoxLogicalBottom() const;
-    LayoutRect paddingBoxRect() const;
     inline LayoutRect paddingBoxRectIncludingScrollbar() const;
+
+    LayoutUnit borderBoxWidth() const { return m_borderBoxRectInContainer.width(); }
+    LayoutUnit borderBoxHeight() const { return m_borderBoxRectInContainer.height(); }
+    LayoutSize borderBoxSize() const { return m_borderBoxRectInContainer.size(); }
+
+    LayoutRect borderBoundingBox() const final { return borderBoxRect(); }
 
     // IE extensions. Used to calculate offsetWidth/Height.  Overridden by inlines (RenderFlow)
     // to return the remaining width on a given line (and the height of a single line).
@@ -758,7 +761,7 @@ private:
     // These include tables, positioned objects, floats and flexible boxes.
     virtual void computeIntrinsicLogicalWidthContributions();
 
-    LayoutRect frameRectForStickyPositioning() const override { return frameRect(); }
+    LayoutRect frameRectForStickyPositioning() const override { return borderBoxRectInContainer(); }
 
     RepaintRects computeVisibleRectsUsingPaintOffset(const RepaintRects&) const;
     
@@ -768,8 +771,8 @@ private:
     void removeShapeOutsideInfo();
 
 private:
-    // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).
-    LayoutRect m_frameRect;
+    // Relative to our container.
+    LayoutRect m_borderBoxRectInContainer;
 
 protected:
     LayoutBoxExtent m_marginBox;

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -62,7 +62,7 @@ inline LayoutUnit RenderBox::logicalLeftVisualOverflow() const { return writingM
 inline LayoutUnit RenderBox::logicalRight() const { return logicalLeft() + logicalWidth(); }
 inline LayoutUnit RenderBox::logicalRightLayoutOverflow() const { return writingMode().isHorizontal() ? layoutOverflowRect().maxX() : layoutOverflowRect().maxY(); }
 inline LayoutUnit RenderBox::logicalRightVisualOverflow() const { return writingMode().isHorizontal() ? visualOverflowRect().maxX() : visualOverflowRect().maxY(); }
-inline LayoutSize RenderBox::logicalSize() const { return writingMode().isHorizontal() ? m_frameRect.size() : m_frameRect.size().transposedSize(); }
+inline LayoutSize RenderBox::logicalSize() const { return writingMode().isHorizontal() ? m_borderBoxRectInContainer.size() : m_borderBoxRectInContainer.size().transposedSize(); }
 inline LayoutUnit RenderBox::logicalTop() const { return writingMode().isHorizontal() ? y() : x(); }
 inline LayoutUnit RenderBox::logicalWidth() const { return writingMode().isHorizontal() ? borderBoxWidth() : borderBoxHeight(); }
 inline LayoutUnit RenderBox::paddingBoxHeight() const { return std::max(0_lu, borderBoxHeight() - borderTop() - borderBottom() - horizontalScrollbarHeight()); }

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -281,15 +281,15 @@ void RenderDeprecatedFlexibleBox::computeIntrinsicLogicalWidthContributions()
 }
 
 // Use an inline capacity of 8, since flexbox containers usually have less than 8 children.
-typedef Vector<LayoutRect, 8> ChildFrameRects;
+typedef Vector<LayoutRect, 8> ChildBorderBoxRects;
 typedef Vector<LayoutSize, 8> ChildLayoutDeltas;
 
-static void appendChildFrameRects(RenderDeprecatedFlexibleBox* box, ChildFrameRects& childFrameRects)
+static void appendChildBorderBoxRects(RenderDeprecatedFlexibleBox* box, ChildBorderBoxRects& childBorderBoxRects)
 {
     FlexBoxIterator iterator(box);
     for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
         if (!child->isOutOfFlowPositioned())
-            childFrameRects.append(child->frameRect());
+            childBorderBoxRects.append(child->borderBoxRectInContainer());
     }
 }
 
@@ -302,7 +302,7 @@ static void appendChildLayoutDeltas(RenderDeprecatedFlexibleBox* box, ChildLayou
     }
 }
 
-static void repaintChildrenDuringLayoutIfMoved(RenderDeprecatedFlexibleBox* box, const ChildFrameRects& oldChildRects)
+static void repaintChildrenDuringLayoutIfMoved(RenderDeprecatedFlexibleBox* box, const ChildBorderBoxRects& oldChildRects)
 {
     size_t childIndex = 0;
     FlexBoxIterator iterator(box);
@@ -383,8 +383,8 @@ void RenderDeprecatedFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren,
         // It doesn't get included in the normal layout process but is instead skipped.
         layoutExcludedChildren(relayoutChildren);
 
-        ChildFrameRects oldChildRects;
-        appendChildFrameRects(this, oldChildRects);
+        ChildBorderBoxRects oldChildRects;
+        appendChildBorderBoxRects(this, oldChildRects);
 
         if (isHorizontal())
             layoutHorizontalBox(relayoutChildren);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2158,7 +2158,7 @@ bool RenderElement::getTrailingCorner(FloatPoint& point, bool& insideFixed) cons
                     continue;
                 point.moveBy(linesBox.maxXMaxYCorner());
             } else
-                point.moveBy(downcast<RenderBox>(*o).frameRect().maxXMaxYCorner());
+                point.moveBy(downcast<RenderBox>(*o).borderBoxRectInContainer().maxXMaxYCorner());
             point = o->container()->localToAbsolute(point, MapCoordinatesMode::UseTransforms, &insideFixed);
             return true;
         }

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -474,8 +474,8 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
         // It doesn't get included in the normal layout process but is instead skipped.
         layoutExcludedChildren(relayoutChildren);
 
-        FlexItemFrameRects oldFlexItemRects;
-        appendFlexItemFrameRects(oldFlexItemRects);
+        FlexItemBorderBoxRects oldFlexItemRects;
+        appendFlexItemBorderBoxRects(oldFlexItemRects);
 
         performFlexLayout(relayoutChildren);
 
@@ -510,15 +510,15 @@ void RenderFlexibleBox::layoutBlock(RelayoutChildren relayoutChildren, LayoutUni
     m_inLayout = oldInLayout;
 }
 
-void RenderFlexibleBox::appendFlexItemFrameRects(FlexItemFrameRects& flexItemFrameRects)
+void RenderFlexibleBox::appendFlexItemBorderBoxRects(FlexItemBorderBoxRects& flexItemBorderBoxRects)
 {
     for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {
         if (!flexItem->isOutOfFlowPositioned())
-            flexItemFrameRects.append(flexItem->frameRect());
+            flexItemBorderBoxRects.append(flexItem->borderBoxRectInContainer());
     }
 }
 
-void RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved(const FlexItemFrameRects& oldFlexItemRects)
+void RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved(const FlexItemBorderBoxRects& oldFlexItemRects)
 {
     size_t index = 0;
     for (RenderBox* flexItem = m_orderIterator.first(); flexItem; flexItem = m_orderIterator.next()) {

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -186,7 +186,7 @@ private:
     enum class SizeDefiniteness : uint8_t { Definite, Indefinite, Unknown };
     
     static constexpr unsigned s_flexLayoutItemsInitialCapacity = 4;
-    using FlexItemFrameRects = Vector<LayoutRect, s_flexLayoutItemsInitialCapacity>;
+    using FlexItemBorderBoxRects = Vector<LayoutRect, s_flexLayoutItemsInitialCapacity>;
     using FlexLayoutItems = Vector<FlexLayoutItem, s_flexLayoutItemsInitialCapacity>;
 
     struct LineState;
@@ -327,8 +327,8 @@ private:
     void flipForRightToLeftColumn(const FlexLineStates& linesState);
     void flipForWrapReverse(const FlexLineStates&, LayoutUnit crossAxisStartEdge);
     
-    void appendFlexItemFrameRects(FlexItemFrameRects&);
-    void repaintFlexItemsDuringLayoutIfMoved(const FlexItemFrameRects&);
+    void appendFlexItemBorderBoxRects(FlexItemBorderBoxRects&);
+    void repaintFlexItemsDuringLayoutIfMoved(const FlexItemBorderBoxRects&);
 
     bool flexItemHasPercentHeightDescendants(const RenderBox&) const;
     void dirtyPercentHeightDescendantsWithinFlexItem(RenderBox&);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1605,7 +1605,7 @@ void RenderGrid::layoutGridItems(RenderGridLayoutState& gridLayoutState)
         // used during the track sizing algorithm.
         updateGridAreaIncludingAlignment(gridItem);
 
-        LayoutRect oldGridItemRect = gridItem.frameRect();
+        LayoutRect oldGridItemRect = gridItem.borderBoxRectInContainer();
 
         // Stretching logic might force a grid item layout, so we need to run it before the layoutIfNeeded
         // call to avoid unnecessary relayouts. This might imply that grid item margins, needed to correctly

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2086,8 +2086,8 @@ static LayoutRect computeLayerPositionAndIntegralSize(const RenderLayerModelObje
         return { LayoutPoint(), inlineRenderer->linesBoundingBox().size() };
 
     if (auto* boxRenderer = dynamicDowncast<RenderBox>(renderer)) {
-        const auto& frameRect = boxRenderer->frameRect();
-        return { boxRenderer->topLeftLocation(), snappedIntSize(frameRect.size(), frameRect.location()) };
+        const auto& borderBox = boxRenderer->borderBoxRectInContainer();
+        return { boxRenderer->topLeftLocation(), snappedIntSize(borderBox.size(), borderBox.location()) };
     }
 
     if (auto* svgModelObjectRenderer = dynamicDowncast<RenderSVGModelObject>(renderer)) {

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -342,8 +342,8 @@ RenderLayerBacking::RenderLayerBacking(RenderLayer& layer)
         if (!fullscreenElement || !fullscreenElement->renderer() || fullscreenElement->renderer()->pseudoElementRenderer(PseudoElementType::Backdrop) != &renderer)
             return false;
 
-        auto rendererRect = box->frameRect();
-        return rendererRect == box->view().frameRect();
+        auto rendererRect = box->borderBoxRectInContainer();
+        return rendererRect == box->view().borderBoxRectInContainer();
     };
     setRequiresBackgroundLayer(isFullsizeBackdrop(layer.renderer()));
 #endif

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1121,13 +1121,13 @@ bool RenderLayerScrollableArea::positionOverflowControls(const IntSize& offsetFr
         }
     }
 
-    if (m_scrollCorner && m_scrollCorner->frameRect() != rects.scrollCorner) {
-        m_scrollCorner->setFrameRect(rects.scrollCorner);
+    if (m_scrollCorner && m_scrollCorner->borderBoxRectInContainer() != rects.scrollCorner) {
+        m_scrollCorner->setBorderBoxInContainer(rects.scrollCorner);
         changed = true;
     }
 
-    if (m_resizer && m_resizer->frameRect() != rects.resizer) {
-        m_resizer->setFrameRect(rects.resizer);
+    if (m_resizer && m_resizer->borderBoxRectInContainer() != rects.resizer) {
+        m_resizer->setBorderBoxInContainer(rects.resizer);
         changed = true;
     }
     return changed;

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -138,7 +138,7 @@ private:
     // Repaint needs those positions relative to the repaint container (e.g. the RenderView), and a repaint rect is built by walking up
     // the containing-block chain to that container, accumulating each ancestor's position.
     // During layout, though, some of those ancestors may have already moved, so their current positions can no longer be used to recover the _old_ rect.
-    // (We don't retain previous paint positions; the closest we have is each renderer's m_frameRect, and that is overwritten during layout.)
+    // (We don't retain previous paint positions; the closest we have is each renderer's m_borderBoxRectInContainer, and that is overwritten during layout.)
     // This delta helps to recover the last layout's (paint) position by keeping track of position changes during _this_ layout.
     LayoutSize m_layoutDeltaForRepaint;
 

--- a/Source/WebCore/rendering/RenderMeter.cpp
+++ b/Source/WebCore/rendering/RenderMeter.cpp
@@ -57,14 +57,14 @@ void RenderMeter::updateLogicalWidth()
 {
     RenderBox::updateLogicalWidth();
 
-    auto frameSize = theme().meterSizeForBounds(*this, snappedIntRect(frameRect()));
+    auto frameSize = theme().meterSizeForBounds(*this, snappedIntRect(borderBoxRectInContainer()));
     setLogicalWidth(LayoutUnit(isHorizontalWritingMode() ? frameSize.width() : frameSize.height()));
 }
 
 RenderBox::LogicalExtentComputedValues RenderMeter::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const
 {
     auto computedValues = RenderBox::computeLogicalHeight(logicalHeight, logicalTop);
-    LayoutRect frame = frameRect();
+    LayoutRect frame = borderBoxRectInContainer();
     if (isHorizontalWritingMode())
         frame.setHeight(computedValues.extent);
     else

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -823,7 +823,7 @@ void RenderMultiColumnSet::collectLayerFragments(LayerFragments& fragments, cons
     //
     // All other rectangles in this method are slightly less physical, when it comes to how they are
     // used with different writing modes, but they aren't really logical either. They are just like
-    // RenderBox::frameRect(). More precisely, the sizes are physical, and the inline direction
+    // RenderBox::borderBoxRectInContainer(). More precisely, the sizes are physical, and the inline direction
     // coordinate is too, but the block direction coordinate is always "logical top". These
     // rectangles also pretend that there's only one long column, i.e. they are for the flow thread.
     //

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1363,7 +1363,7 @@ void RenderObject::outputRenderObject(TextStream& stream, bool mark, int depth) 
         stream << " (::" << *style().pseudoElementType() << ")";
 
     if (auto* renderBox = dynamicDowncast<RenderBox>(*this)) {
-        FloatRect boxRect = renderBox->frameRect();
+        FloatRect boxRect = renderBox->borderBoxRectInContainer();
         if (renderBox->isInFlowPositioned())
             boxRect.move(renderBox->offsetForInFlowPosition());
         stream << " " << boxRect;

--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -64,7 +64,7 @@ void RenderProgress::updateFromElement()
 RenderBox::LogicalExtentComputedValues RenderProgress::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const
 {
     auto computedValues = RenderBox::computeLogicalHeight(logicalHeight, logicalTop);
-    LayoutRect frame = frameRect();
+    LayoutRect frame = borderBoxRectInContainer();
     if (isHorizontalWritingMode())
         frame.setHeight(computedValues.extent);
     else

--- a/Source/WebCore/rendering/RenderReplica.cpp
+++ b/Source/WebCore/rendering/RenderReplica.cpp
@@ -55,7 +55,7 @@ RenderReplica::~RenderReplica() = default;
 void RenderReplica::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
-    setFrameRect(parentBox()->borderBoxRect());
+    setBorderBoxInContainer(parentBox()->borderBoxRect());
     updateLayerTransform();
     clearNeedsLayout();
 }

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -286,7 +286,7 @@ IntRect RenderScrollbar::buttonRect(ScrollbarPart partType) const
     partRenderer->layout();
     
     bool isHorizontal = orientation() == ScrollbarOrientation::Horizontal;
-    IntSize pixelSnappedIntSize = snappedIntRect(partRenderer->frameRect()).size();
+    IntSize pixelSnappedIntSize = snappedIntRect(partRenderer->borderBoxRectInContainer()).size();
     if (partType == BackButtonStartPart)
         return IntRect(location(), IntSize(isHorizontal ? pixelSnappedIntSize.width() : width(), isHorizontal ? height() : pixelSnappedIntSize.height()));
     if (partType == ForwardButtonEndPart)

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -382,7 +382,7 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToC
 
 void RenderTable::layoutCaption(RenderTableCaption& caption)
 {
-    LayoutRect captionRect(caption.frameRect());
+    LayoutRect captionRect(caption.borderBoxRectInContainer());
 
     if (caption.needsLayout()) {
         // The margins may not be available but ensure the caption is at least located beneath any previous sibling caption

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1486,9 +1486,9 @@ void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPo
 
 static LayoutRect NODELETE backgroundRectForRow(const RenderBox& tableRow, const RenderTable& table)
 {
-    LayoutRect rect = tableRow.frameRect();
+    LayoutRect rect = tableRow.borderBoxRectInContainer();
     if (!table.collapseBorders()) {
-        // Row frameRects include unwanted hSpacing on both inline ends.
+        // Row border boxes include unwanted hSpacing on both inline ends.
         auto hSpacing = table.hBorderSpacing();
         LayoutUnit vSpacing = 0_lu;
         if (table.writingMode().isHorizontal())

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -641,7 +641,7 @@ void RenderTableSection::layoutRows()
                     cell->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);
                 }
 
-                LayoutRect oldCellRect = cell->frameRect();
+                LayoutRect oldCellRect = cell->borderBoxRectInContainer();
 
                 setLogicalPositionForCell(cell, columnIndex);
 
@@ -690,7 +690,7 @@ void RenderTableSection::layoutRows()
         if (CheckedPtr rowRenderer = m_grid[rowIndex].rowRenderer) {
             // FIXME: the x() position of the row should be table()->hBorderSpacing() so that it can
             // report the correct offsetLeft. However, that will require a lot of rebaselining of test results.
-            auto oldRowRect = rowRenderer->frameRect();
+            auto oldRowRect = rowRenderer->borderBoxRectInContainer();
             rowRenderer->setLogicalLocation({ 0_lu, m_rowPos[rowIndex] });
             rowRenderer->setLogicalWidth(logicalWidth());
 
@@ -703,7 +703,7 @@ void RenderTableSection::layoutRows()
             rowRenderer->setLogicalHeight(rowLogicalHeight);
             rowRenderer->updateLayerTransform();
 
-            if (rowRenderer->frameRect() != oldRowRect && !table()->selfNeedsLayout() && rowRenderer->checkForRepaintDuringLayout())
+            if (rowRenderer->borderBoxRectInContainer() != oldRowRect && !table()->selfNeedsLayout() && rowRenderer->checkForRepaintDuringLayout())
                 rowRenderer->repaintDuringLayoutIfMoved(oldRowRect);
 
             // Push the row's offset onto the layout state so that pagination offsets
@@ -1368,7 +1368,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
     CellSpan dirtiedRows { 0, 0 };
     CellSpan dirtiedColumns { 0, 0 };
 
-    if (localRepaintRect.contains(frameRect())) {
+    if (localRepaintRect.contains(borderBoxRectInContainer())) {
         dirtiedRows = fullTableRowSpan();
         dirtiedColumns = fullTableColumnSpan();
     } else {

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -357,7 +357,7 @@ LayoutRect RenderTextControlSingleLine::controlClipRect(const LayoutPoint& addit
     ASSERT(hasControlClip());
     auto clipRect = paddingBoxRect();
     if (auto* containerElementRenderer = containerElement() ? containerElement()->renderBox() : nullptr)
-        clipRect = unionRect(clipRect, containerElementRenderer->frameRect());
+        clipRect = unionRect(clipRect, containerElementRenderer->borderBoxRectInContainer());
     clipRect.moveBy(additionalOffset);
     return clipRect;
 }

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -232,7 +232,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         auto rowOffset = cell->parent() ? downcast<RenderBox>(*cell->parent()).location() : LayoutPoint();
         r = LayoutRect(cell->x() + rowOffset.x(), cell->y() + rowOffset.y() + cell->intrinsicPaddingBefore(), cell->borderBoxWidth(), cell->borderBoxHeight() - cell->intrinsicPaddingBefore() - cell->intrinsicPaddingAfter());
     } else if (auto* box = dynamicDowncast<RenderBox>(o))
-        r = box->frameRect();
+        r = box->borderBoxRectInContainer();
     else if (auto* svgModelObject = dynamicDowncast<RenderSVGModelObject>(o)) {
         r = svgModelObject->frameRectEquivalent();
         ASSERT(r.location() == svgModelObject->currentSVGLayoutLocation());

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
@@ -58,10 +58,10 @@ void RenderMathMLMath::centerChildren(LayoutUnit contentWidth)
     if (!style().writingMode().deprecatedIsLeftToRightDirection())
         centerBlockOffset = -centerBlockOffset;
     for (CheckedPtr child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox()) {
-        auto repaintRect = child->checkForRepaintDuringLayout() ? std::make_optional(child->frameRect()) : std::nullopt;
+        auto repaintRect = child->checkForRepaintDuringLayout() ? std::make_optional(child->borderBoxRectInContainer()) : std::nullopt;
         child->move(centerBlockOffset, { });
         if (repaintRect) {
-            repaintRect->uniteEvenIfEmpty(child->frameRect());
+            repaintRect->uniteEvenIfEmpty(child->borderBoxRectInContainer());
             repaintRectangle(*repaintRect);
         }
     }

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -178,10 +178,10 @@ void RenderMathMLRow::layoutRowItems(LayoutUnit width, LayoutUnit ascent)
         LayoutUnit childVerticalOffset = ascent - ascentForChild(*child);
         LayoutUnit childWidth = child->logicalWidth();
         LayoutUnit childHorizontalOffset = writingMode().isBidiLTR() ? horizontalOffset : width - horizontalOffset - childWidth;
-        auto repaintRect = child->checkForRepaintDuringLayout() ? std::make_optional(child->frameRect()) : std::nullopt;
+        auto repaintRect = child->checkForRepaintDuringLayout() ? std::make_optional(child->borderBoxRectInContainer()) : std::nullopt;
         child->setLocation(LayoutPoint(childHorizontalOffset, childVerticalOffset));
         if (repaintRect) {
-            repaintRect->uniteEvenIfEmpty(child->frameRect());
+            repaintRect->uniteEvenIfEmpty(child->borderBoxRectInContainer());
             repaintRectangle(*repaintRect);
         }
         horizontalOffset += childWidth + child->marginEnd();

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -1033,7 +1033,7 @@ void RenderSVGText::updatePositionAndOverflow(const FloatRect& boundaries)
     setLocation(boundingRect.location());
     setBorderBoxSize(boundingRect.size());
     m_objectBoundingBox = boundingRect;
-    ASSERT(m_objectBoundingBox == frameRect());
+    ASSERT(m_objectBoundingBox == borderBoxRectInContainer());
 }
 
 void RenderSVGText::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -276,7 +276,7 @@ static TextStream& writePositionAndStyle(TextStream& ts, const RenderElement& re
 {
     if (behavior.contains(RenderAsTextFlag::ShowSVGGeometry)) {
         if (auto* box = dynamicDowncast<RenderBox>(renderer))
-            ts << ' ' << enclosingIntRect(box->frameRect());
+            ts << ' ' << enclosingIntRect(box->borderBoxRectInContainer());
         ts << " clipped"_s;
     }
 


### PR DESCRIPTION
#### ebf470598457240abd83094a80f79411ef1c9115
<pre>
[cleanup] Rename RenderBox::frameRect()/setFrameRect() to borderBoxRectInContainer()/setBorderBoxRectInContainer()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318048">https://bugs.webkit.org/show_bug.cgi?id=318048</a>
&lt;<a href="https://rdar.apple.com/problem/181125416">rdar://problem/181125416</a>&gt;

Reviewed by Antti Koivisto.

m_frameRect and its frameRect()/setFrameRect() accessors hold the border box
positioned in the container&apos;s coordinate space, but &quot;frame&quot; was vague and collided
with Frame/LocalFrame. Rename them to m_borderBoxRectInContainer /
borderBoxRectInContainer() / setBorderBoxRectInContainer(), naming the thing for what
it is and pairing directly with the existing borderBoxRect() (the same rect in the
renderer&apos;s own coordinates, { 0, 0, size }) -- the only difference is the coordinate
space. &quot;container&quot; matches RenderBox.h&apos;s own description of the location (&quot;relative to
your container&quot;) and the mapLocalToContainer/offsetFromContainer vocabulary.

Also fixes the stale &quot;frame rect&quot; comments left behind and renames the flex
repaint-snapshot helpers (ChildFrameRects/FlexItemFrameRects and their append*
functions) to ...BorderBoxRects to match. No behavior change.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(AccessibilityRenderObject::localRect):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(InspectorOverlay::buildFlexOverlay):
* Source/WebCore/layout/Verification.cpp:
(outputMismatchingBlockBoxInformationIfNeeded):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(LineLayout::updateRenderTreePositions):
* Source/WebCore/page/LocalFrameView.cpp:
(LocalFrameView::visibleRectOfChild):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::layoutBlockChild):
(RenderBlockFlow::positionNewFloats):
* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::repaintDuringLayoutIfMoved):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxInlines.h:
(RenderBox::logicalSize):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(appendChildBorderBoxRects):
(repaintChildrenDuringLayoutIfMoved):
(RenderDeprecatedFlexibleBox::layoutBlock):
* Source/WebCore/rendering/RenderElement.cpp:
(RenderElement::getTrailingCorner):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(RenderFlexibleBox::appendFlexItemBorderBoxRects):
(RenderFlexibleBox::repaintFlexItemsDuringLayoutIfMoved):
(RenderFlexibleBox::layoutBlock):
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(RenderGrid::layoutGridItems):
* Source/WebCore/rendering/RenderLayer.cpp:
(computeLayerPositionAndIntegralSize):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(RenderLayerBacking::RenderLayerBacking):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(RenderLayerScrollableArea::positionOverflowControls):
* Source/WebCore/rendering/RenderLayoutState.h:
* Source/WebCore/rendering/RenderMeter.cpp:
(RenderMeter::updateLogicalWidth):
(RenderMeter::computeLogicalHeight):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(RenderMultiColumnSet::collectLayerFragments):
* Source/WebCore/rendering/RenderObject.cpp:
(RenderObject::outputRenderObject):
* Source/WebCore/rendering/RenderProgress.cpp:
(RenderProgress::updateFromElement):
* Source/WebCore/rendering/RenderReplica.cpp:
(RenderReplica::layout):
* Source/WebCore/rendering/RenderScrollbar.cpp:
(RenderScrollbar::buttonRect):
* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::layoutCaption):
* Source/WebCore/rendering/RenderTableCell.cpp:
(backgroundRectForRow):
* Source/WebCore/rendering/RenderTableSection.cpp:
(RenderTableSection::layoutRows):
(RenderTableSection::paintObject):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(RenderTextControlSingleLine::controlClipRect):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(RenderTreeAsText::writeRenderObject):
* Source/WebCore/rendering/mathml/RenderMathMLMath.cpp:
(RenderMathMLMath::centerChildren):
* Source/WebCore/rendering/mathml/RenderMathMLRow.cpp:
(RenderMathMLRow::layoutRowItems):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(RenderSVGText::updatePositionAndOverflow):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(writePositionAndStyle):

Canonical link: <a href="https://commits.webkit.org/316286@main">https://commits.webkit.org/316286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45cfa57c7ac37cbad74b75d2d07f78e8fd9c969a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181237 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9869592e-472a-419b-bf69-76602a9beb16) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133760 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0445cb89-16ab-473f-92e9-c274209356f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174891 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114231 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1e4c83c-253f-40e3-beb1-a44de7aeeb5e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29986 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183905 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142468 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45517 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46197 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110855 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37458 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44715 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44115 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44347 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->