### PR TITLE
Elements with `filter: drop-shadow()` are not fully repainted on child resize

### DIFF
--- a/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 200 200 100 100)
+  (rect 172 174 156 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-change-full-repaint.html
+++ b/LayoutTests/fast/repaint/drop-shadow-change-full-repaint.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+    <style>
+        #box {
+            position: absolute;
+            top: 200px;
+            left: 200px;
+            filter: drop-shadow(0 2px 10px black);
+        }
+
+        #child {
+            height: 100px;
+            width: 100px;
+            background-color: green;
+        }
+
+        #child.hidden {
+            display: none;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when a box with drop-shadow changes size");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+
+            document.getElementById('child').classList.add('hidden');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="box">
+        <div id="child"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4663,20 +4663,6 @@ bool RenderBox::avoidsFloats() const
     return false;
 }
 
-IntBoxExtent RenderBox::computeFilterOutsets() const
-{
-    if (!hasFilter())
-        return { };
-
-    auto zoom = style().usedZoomForLength();
-
-    if (auto outsets = style().filter().calculateOutsets(zoom))
-        return *outsets;
-
-    // FIXME: Need to compute outsets for reference filters: webkit.org/b/237538.
-    return { };
-}
-
 void RenderBox::addVisualEffectOverflow()
 {
     bool hasBoxShadow = !style().boxShadow().isNone();

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -233,8 +233,6 @@ public:
     void clearOverflow();
     RenderOverflow& ensureOverflow();
 
-    IntBoxExtent computeFilterOutsets() const;
-
     void addVisualEffectOverflow();
     LayoutRect applyVisualEffectOverflow(const LayoutRect&, EnumSet<VisualEffectOverflowOption> = { }) const;
     virtual void addOverflowFromInFlowChildren(OptionSet<ComputeOverflowOptions> = { });

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1431,6 +1431,20 @@ void RenderElement::layout()
     clearNeedsLayout();
 }
 
+IntBoxExtent RenderElement::computeFilterOutsets() const
+{
+    if (!hasFilter())
+        return { };
+
+    auto zoom = style().usedZoomForLength();
+
+    if (auto outsets = style().filter().calculateOutsets(zoom))
+        return *outsets;
+
+    // FIXME: Need to compute outsets for reference filters: webkit.org/b/237538.
+    return { };
+}
+
 template<typename FillLayers> static bool mustRepaintFillLayers(const RenderElement& renderer, const FillLayers& layers)
 {
     // Nobody will use multiple layers without wanting fancy positioning.
@@ -1477,8 +1491,11 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
     if (oldClippedOverflowRect.isEmpty() && newClippedOverflowRect.isEmpty())
         return true;
 
-    auto mustRepaintBackgroundOrBorderOnSizeChange = [&](LayoutRect oldOutlineBounds, LayoutRect newOutlineBounds) {
+    auto mustFullRepaintOnSizeChange = [&](LayoutRect oldOutlineBounds, LayoutRect newOutlineBounds) {
         if (hasMask() && mustRepaintFillLayers(*this, style().maskLayers()))
+            return true;
+
+        if (hasFilter() && !computeFilterOutsets().isZero())
             return true;
 
         if (style().border().hasBorderRadius()) {
@@ -1524,7 +1541,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
 
         // If our outline bounds rect resized (as a proxy for a border box resize),
         // we have to repaint if we paint content that scales with the size.
-        if (oldRects.outlineBoundsRect->size() != newRects.outlineBoundsRect->size() && mustRepaintBackgroundOrBorderOnSizeChange(*oldRects.outlineBoundsRect, *newRects.outlineBoundsRect))
+        if (oldRects.outlineBoundsRect->size() != newRects.outlineBoundsRect->size() && mustFullRepaintOnSizeChange(*oldRects.outlineBoundsRect, *newRects.outlineBoundsRect))
             return true;
 
         return false;

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <WebCore/BoxExtents.h>
 #include <WebCore/HitTestRequest.h>
 #include <WebCore/RenderObject.h>
 #include <WebCore/RenderPtr.h>
@@ -223,6 +224,8 @@ public:
     inline bool hasBackdropFilter() const; // Defined in RenderElementStyleInlines.h.
     inline bool hasBlendMode() const; // Defined in RenderElementStyleInlines.h.
     inline bool hasShapeOutside() const; // Defined in RenderElementStyleInlines.h.
+
+    IntBoxExtent computeFilterOutsets() const;
 
 #if HAVE(CORE_MATERIAL)
     inline bool hasAppleVisualEffect() const; // Defined in RenderElementStyleInlines.h.


### PR DESCRIPTION
#### f1d39ab9d6ce9378a6199cedac6be906e53cafd0
<pre>
Elements with `filter: drop-shadow()` are not fully repainted on child resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=318337">https://bugs.webkit.org/show_bug.cgi?id=318337</a>

Reviewed by Simon Fraser.

After a layout caused by one of its children&apos;s size change, an element
with a `drop-shadow()` filter can be not fully repainted, leaving a
ghost of the shadow.

Fix the issue by ensuring that the element is fully repainted after
layout on size change if it has a filter with outsets applied.

Test: fast/repaint/drop-shadow-change-full-repaint.html

* LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-change-full-repaint.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::computeFilterOutsets const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::computeFilterOutsets const):
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
* Source/WebCore/rendering/RenderElement.h:

Canonical link: <a href="https://commits.webkit.org/316450@main">https://commits.webkit.org/316450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c474dab8b35a71f3ea81d58b9561430cf8c98e64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181629 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34266 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30239 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184165 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142676 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142560 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38534 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46448 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111138 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37652 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118203 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44966 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8921 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->