### PR TITLE
[GLib] Add per-navigation custom User-Agent to WebKitWebsitePolicies

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp
@@ -22,7 +22,6 @@
 
 #include "APIWebsitePolicies.h"
 #include "WebKitEnumTypes.h"
-#include "WebsitePoliciesData.h"
 #include <glib/gi18n-lib.h>
 #include <wtf/glib/WTFGType.h>
 
@@ -35,7 +34,7 @@ using namespace WebKit;
  * View specific website policies.
  *
  * WebKitWebsitePolicies allows you to configure per-page policies,
- * currently only autoplay policies are supported.
+ * currently only autoplay and custom user agent policies are supported.
  *
  * Since: 2.30
  */
@@ -45,7 +44,8 @@ using namespace WebKit;
 enum {
     PROP_0,
 
-    PROP_AUTOPLAY_POLICY
+    PROP_AUTOPLAY_POLICY,
+    PROP_CUSTOM_USER_AGENT,
 };
 
 struct _WebKitWebsitePoliciesPrivate {
@@ -54,6 +54,7 @@ struct _WebKitWebsitePoliciesPrivate {
     {
     }
     RefPtr<API::WebsitePolicies> websitePolicies;
+    CString customUserAgent;
 };
 
 WEBKIT_DEFINE_FINAL_TYPE(WebKitWebsitePolicies, webkit_website_policies, G_TYPE_OBJECT, GObject)
@@ -63,27 +64,6 @@ API::WebsitePolicies& webkitWebsitePoliciesGetWebsitePolicies(WebKitWebsitePolic
     return *policies->priv->websitePolicies.get();
 }
 
-WebsitePoliciesData webkitWebsitePoliciesGetPoliciesData(WebKitWebsitePolicies* policies)
-{
-    WebsitePoliciesData policiesData;
-
-    switch (webkit_website_policies_get_autoplay_policy(policies)) {
-    case WEBKIT_AUTOPLAY_ALLOW:
-        policiesData.autoplayPolicy = WebsiteAutoplayPolicy::Allow;
-        break;
-    case WEBKIT_AUTOPLAY_ALLOW_WITHOUT_SOUND:
-        policiesData.autoplayPolicy = WebsiteAutoplayPolicy::AllowWithoutSound;
-        break;
-    case WEBKIT_AUTOPLAY_DENY:
-        policiesData.autoplayPolicy = WebsiteAutoplayPolicy::Deny;
-        break;
-    default:
-        policiesData.autoplayPolicy = WebsiteAutoplayPolicy::Default;
-    }
-
-    return policiesData;
-}
-
 static void webkitWebsitePoliciesGetProperty(GObject* object, guint propID, GValue* value, GParamSpec* paramSpec)
 {
     WebKitWebsitePolicies* policies = WEBKIT_WEBSITE_POLICIES(object);
@@ -91,6 +71,9 @@ static void webkitWebsitePoliciesGetProperty(GObject* object, guint propID, GVal
     switch (propID) {
     case PROP_AUTOPLAY_POLICY:
         g_value_set_enum(value, webkit_website_policies_get_autoplay_policy(policies));
+        break;
+    case PROP_CUSTOM_USER_AGENT:
+        g_value_set_string(value, webkit_website_policies_get_custom_user_agent(policies));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
@@ -122,6 +105,10 @@ static void webkitWebsitePoliciesSetProperty(GObject* object, guint propID, cons
     case PROP_AUTOPLAY_POLICY:
         webkitWebsitePoliciesSetAutoplayPolicy(policies, static_cast<WebKitAutoplayPolicy>(g_value_get_enum(value)));
         break;
+    case PROP_CUSTOM_USER_AGENT:
+        if (const auto* customUserAgent = g_value_get_string(value))
+            policies->priv->websitePolicies->setCustomUserAgent(String::fromUTF8(customUserAgent));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propID, paramSpec);
     }
@@ -149,6 +136,23 @@ static void webkit_website_policies_class_init(WebKitWebsitePoliciesClass* findC
             nullptr, nullptr,
             WEBKIT_TYPE_AUTOPLAY_POLICY,
             WEBKIT_AUTOPLAY_ALLOW_WITHOUT_SOUND,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
+
+    /**
+     * WebKitWebsitePolicies:custom-user-agent: (getter get_custom_user_agent) (attributes org.gtk.Property.get=webkit_website_policies_get_custom_user_agent):
+     *
+     * The custom user agent string to send for navigations governed by these
+     * #WebKitWebsitePolicies, or %NULL to use the default user agent.
+     *
+     * Since: 2.54
+     */
+    g_object_class_install_property(
+        gObjectClass,
+        PROP_CUSTOM_USER_AGENT,
+        g_param_spec_string(
+            "custom-user-agent",
+            nullptr, nullptr,
+            nullptr,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY)));
 }
 
@@ -181,6 +185,7 @@ WebKitWebsitePolicies* webkit_website_policies_new(void)
  * ```c
  * WebKitWebsitePolicies *default_website_policies = webkit_website_policies_new_with_policies(
  *     "autoplay", WEBKIT_AUTOPLAY_DENY,
+ *     "custom-user-agent", "Foo/1.0 (custom)",
  *     NULL);
  *
  * // ...
@@ -234,3 +239,24 @@ WebKitAutoplayPolicy webkit_website_policies_get_autoplay_policy(WebKitWebsitePo
     }
 }
 
+/**
+ * webkit_website_policies_get_custom_user_agent: (get-property custom-user-agent):
+ * @policies: a #WebKitWebsitePolicies
+ *
+ * Get the #WebKitWebsitePolicies:custom-user-agent property.
+ *
+ * Returns: (transfer none) (nullable): the custom user agent string, or %NULL if the default
+ *    user agent is used
+ *
+ * Since: 2.54
+ */
+const gchar* webkit_website_policies_get_custom_user_agent(WebKitWebsitePolicies* policies)
+{
+    g_return_val_if_fail(WEBKIT_IS_WEBSITE_POLICIES(policies), nullptr);
+
+    if (policies->priv->customUserAgent.isNull()) {
+        const auto& newCustomUserAgent = policies->priv->websitePolicies->customUserAgent();
+        policies->priv->customUserAgent = newCustomUserAgent.isEmpty() ? CString() : newCustomUserAgent.utf8();
+    }
+    return policies->priv->customUserAgent.data();
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in
@@ -74,4 +74,7 @@ webkit_website_policies_new_with_policies                     (const gchar      
 WEBKIT_API WebKitAutoplayPolicy
 webkit_website_policies_get_autoplay_policy                   (WebKitWebsitePolicies *policies);
 
+WEBKIT_API const gchar *
+webkit_website_policies_get_custom_user_agent                 (WebKitWebsitePolicies *policies);
+
 G_END_DECLS

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsitePoliciesPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsitePoliciesPrivate.h
@@ -21,7 +21,5 @@
 
 #include "APIWebsitePolicies.h"
 #include "WebKitWebsitePolicies.h"
-#include "WebsitePoliciesData.h"
 
 API::WebsitePolicies* webkitWebsitePoliciesGetWebsitePolicies(WebKitWebsitePolicies*);
-WebKit::WebsitePoliciesData webkitWebsitePoliciesGetPoliciesData(WebKitWebsitePolicies*);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitPolicyClient.cpp
@@ -24,9 +24,12 @@
 #include "WebKitTestServer.h"
 #include "WebKitWebsitePolicies.h"
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/CString.h>
 
 static WebKitTestServer* kServer;
+
+static GUniquePtr<char> gLastRequestUserAgent;
 
 class PolicyClientTest: public LoadTrackingTest {
 public:
@@ -143,6 +146,17 @@ public:
             g_main_loop_run(m_mainLoop);
 
         return *m_autoplayed;
+    }
+
+    // Load a URI (responding to the navigation policy decision with whatever
+    // m_policyDecisionResponse/m_websitePolicies are currently set to) and return
+    // the User-Agent the server received for the main resource request.
+    CString loadAndGetServerUserAgent(const char* uri)
+    {
+        gLastRequestUserAgent = nullptr;
+        loadURI(uri);
+        waitUntilLoadFinished();
+        return CString(gLastRequestUserAgent ? gLastRequestUserAgent.get() : "");
     }
 
     PolicyDecisionResponse m_policyDecisionResponse { None };
@@ -317,6 +331,15 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
     } else if (g_str_equal(path, "/redirect")) {
         soup_server_message_set_status(message, SOUP_STATUS_MOVED_PERMANENTLY, nullptr);
         soup_message_headers_append(soup_server_message_get_response_headers(message), "Location", "/");
+    } else if (g_str_equal(path, "/echo-user-agent")) {
+        const char* userAgent = soup_message_headers_get_one(soup_server_message_get_request_headers(message), "User-Agent");
+        gLastRequestUserAgent.reset(g_strdup(userAgent ? userAgent : ""));
+        GUniquePtr<char> responseString(g_strdup_printf("<html><body>%s</body></html>", gLastRequestUserAgent.get()));
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+        auto* responseBody = soup_server_message_get_response_body(message);
+        auto responseLength = strlen(responseString.get());
+        soup_message_body_append(responseBody, SOUP_MEMORY_TAKE, responseString.release(), responseLength);
+        soup_message_body_complete(responseBody);
     } else
         soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
 }
@@ -356,6 +379,46 @@ static void testAutoplayPolicy(PolicyClientTest* test, gconstpointer)
     g_assert_true(test->loadURIAndWaitForAutoPlayed(resourceURL.get(), WEBKIT_AUTOPLAY_ALLOW_WITHOUT_SOUND));
 }
 
+static void testCustomUserAgentPolicy(PolicyClientTest* test, gconstpointer)
+{
+    test->m_policyDecisionTypeFilter = WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION;
+
+    static const char* kSiteYUserAgent = "MyLauncher/1.0 (custom UA for site Y)";
+    static const char* kSiteZUserAgent = "MyLauncher/1.0 (different UA for site Z)";
+
+    GRefPtr<WebKitWebsitePolicies> defaultPolicies = adoptGRef(webkit_website_policies_new());
+    g_assert_null(webkit_website_policies_get_custom_user_agent(defaultPolicies.get()));
+
+    // (1) Navigate with a per-navigation custom UA attached to the policy decision.
+    test->m_websitePolicies = adoptGRef(webkit_website_policies_new_with_policies("custom-user-agent", kSiteYUserAgent, nullptr));
+
+    const char* customUserAgent = webkit_website_policies_get_custom_user_agent(test->m_websitePolicies.get());
+    g_assert_cmpstr(customUserAgent, ==, kSiteYUserAgent);
+    g_assert_true(webkit_website_policies_get_custom_user_agent(test->m_websitePolicies.get()) == customUserAgent);
+
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    CString seenUserAgent = test->loadAndGetServerUserAgent(kServer->getURIForPath("/echo-user-agent").data());
+
+    g_assert_cmpstr(seenUserAgent.data(), ==, kSiteYUserAgent);
+
+    GUniquePtr<char> navigatorUserAgent(WebViewTest::javascriptResultToCString(test->runJavaScriptAndWaitUntilFinished("navigator.userAgent", nullptr)));
+    g_assert_cmpstr(navigatorUserAgent.get(), ==, kSiteYUserAgent);
+
+    // (2) Reusing the SAME web view, navigate again WITHOUT policies: the override
+    //     must not persist (the UA is bound to the navigation, not to the view).
+    test->m_websitePolicies = nullptr;
+    test->m_policyDecisionResponse = PolicyClientTest::Use;
+    CString defaultUserAgent = test->loadAndGetServerUserAgent(kServer->getURIForPath("/echo-user-agent").data());
+    g_assert_cmpstr(defaultUserAgent.data(), !=, kSiteYUserAgent);
+    g_assert_nonnull(g_strstr_len(defaultUserAgent.data(), -1, "AppleWebKit"));
+
+    // (3) Navigate once more with a DIFFERENT custom UA: the new value is used.
+    test->m_websitePolicies = adoptGRef(webkit_website_policies_new_with_policies("custom-user-agent", kSiteZUserAgent, nullptr));
+    test->m_policyDecisionResponse = PolicyClientTest::UseWithPolicy;
+    CString secondSeenUserAgent = test->loadAndGetServerUserAgent(kServer->getURIForPath("/echo-user-agent").data());
+    g_assert_cmpstr(secondSeenUserAgent.data(), ==, kSiteZUserAgent);
+}
+
 void beforeAll()
 {
     kServer = new WebKitTestServer();
@@ -364,6 +427,7 @@ void beforeAll()
     PolicyClientTest::add("WebKitPolicyClient", "navigation-policy", testNavigationPolicy);
     PolicyClientTest::add("WebKitPolicyClient", "response-policy", testResponsePolicy);
     PolicyClientTest::add("WebKitPolicyClient", "autoplay-policy", testAutoplayPolicy);
+    PolicyClientTest::add("WebKitPolicyClient", "custom-user-agent-policy", testCustomUserAgentPolicy);
     // WARNING: This test must come last, it uses racey constructs that
     // interfere nondeterminisically with any test running after it.
     // https://bugs.webkit.org/show_bug.cgi?id=213190


### PR DESCRIPTION
#### 718b0d312579fd8b1141a2e65e0616e2ce3bcd20
<pre>
[GLib] Add per-navigation custom User-Agent to WebKitWebsitePolicies
<a href="https://bugs.webkit.org/show_bug.cgi?id=318352">https://bugs.webkit.org/show_bug.cgi?id=318352</a>

Reviewed by Carlos Garcia Campos and Alejandro G. Castro.

The Cocoa API already lets an embedder choose the User Agent per
top-level navigation, applied through the navigation policy decision.
This expands the GLib public API for the same feature, driven with
webkit_policy_decision_use_with_policies(). This also removes
webkitWebSitePoliciesGetPoliciesData(), as it had no callers and, if
used, would have dropped the new User Agent property.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitPolicyClient.cpp

* Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.cpp:
(webkitWebsitePoliciesGetProperty):
(webkitWebsitePoliciesSetProperty):
(webkit_website_policies_class_init):
(webkit_website_policies_get_custom_user_agent):
(webkitWebsitePoliciesGetPoliciesData): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebsitePolicies.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebsitePoliciesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitPolicyClient.cpp:
(serverCallback):
(testCustomUserAgentPolicy):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/316808@main">https://commits.webkit.org/316808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6751e72ea07d8e2f9f2a4c14ba39258b05addeb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47407 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183048 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115366 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35314 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185473 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143761 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47075 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143623 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38760 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47754 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112882 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38561 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46260 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10022 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45662 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->