### PR TITLE
[WPE] Do not show the on-screen keyboard when an element is focused programmatically

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -207,6 +207,10 @@ static std::optional<InputMethodState> inputMethodStateForElement(Element* eleme
 void WebPage::setInputMethodState(Element* element)
 {
     auto state = inputMethodStateForElement(element);
+
+    if (state && !m_userIsInteracting)
+        state->hints.add(InputMethodState::Hint::InhibitOnScreenKeyboard);
+
     if (m_inputMethodState == state)
         return;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestInputMethodContext.cpp
@@ -975,119 +975,119 @@ static void testWebKitInputMethodContextContentType(InputMethodTest* test, gcons
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='number' spellcheck='false'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_NUMBER);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='number' spellcheck='false' pattern='[0-9]*'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_DIGITS);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='text' spellcheck='false' pattern='\\d*'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_DIGITS);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='tel' spellcheck='false'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_PHONE);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='url' spellcheck='false'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_URL);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='email' spellcheck='false'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_EMAIL);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='password' spellcheck='false'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_PASSWORD);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='search' spellcheck='false'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_SEARCH);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<input id='editable' type='search' spellcheck='true'>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_SEARCH);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='text' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='decimal' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_NUMBER);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='numeric' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_DIGITS);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='tel' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_PHONE);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='email' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_EMAIL);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='url' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_URL);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='search' spellcheck='false'></div>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_SEARCH);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_NONE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<div contenteditable id='editable' inputmode='none' spellcheck='false'></div>", nullptr);
@@ -1101,35 +1101,35 @@ static void testWebKitInputMethodContextContentType(InputMethodTest* test, gcons
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<textarea id='editable' autocapitalize='none'></textarea>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_LOWERCASE);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_LOWERCASE | WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<textarea id='editable' autocapitalize='sentences'></textarea>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_UPPERCASE_SENTENCES);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_UPPERCASE_SENTENCES | WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<textarea id='editable' autocapitalize='words'></textarea>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_UPPERCASE_WORDS);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_UPPERCASE_WORDS | WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 
     test->loadHtml("<textarea id='editable' autocapitalize='characters'></textarea>", nullptr);
     test->waitUntilLoadFinished();
     test->focusEditableAndWaitUntilInputMethodEnabled();
     g_assert_cmpuint(test->purpose(), ==, WEBKIT_INPUT_PURPOSE_FREE_FORM);
-    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_UPPERCASE_CHARS);
+    g_assert_cmpuint(test->hints(), ==, WEBKIT_INPUT_HINT_SPELLCHECK | WEBKIT_INPUT_HINT_UPPERCASE_CHARS | WEBKIT_INPUT_HINT_INHIBIT_OSK);
     test->unfocusEditableAndWaitUntilInputMethodDisabled();
 }
 


### PR DESCRIPTION
#### 824d8965832ac280b6a10458cd8592217f3ce517
<pre>
[WPE] Do not show the on-screen keyboard when an element is focused programmatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=318353">https://bugs.webkit.org/show_bug.cgi?id=318353</a>

Reviewed by Carlos Alberto Lopez Perez.

When an editable element becomes focused, the GLib ports activate the platform
input method. On a Wayland compositor that provides an on-screen keyboard, this
raises the OSK. It currently happens for every focus change, including focus
driven by script (element.focus()) without any user interaction. Web content
commonly focuses a field programmatically, on load via autofocus, on client-
side navigation, or when a component mounts, so the on-screen keyboard is
raised unexpectedly, covering content, even though the user never indicated an
intent to type.

Other engines, and WebKit&apos;s own iOS port, only present the keyboard when the
focus is the result of a user interaction (iOS gates this in
[WKContentView _elementDidFocus:userIsInteracting:...]). The GLib ports have no
equivalent gate: the view forwards the focused element to the input method
unconditionally, which activates the Wayland text-input protocol and lets the
compositor raise the OSK.

Modified the API tests checking this.

* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::setInputMethodState):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestInputMethodContext.cpp:
(testWebKitInputMethodContextContentType):

Canonical link: <a href="https://commits.webkit.org/316375@main">https://commits.webkit.org/316375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bc18b3e417ab43ad5ed4b9df80ab787d9c68be9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133798 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34100 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183969 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36584 "Failed to build and analyze WebKit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142521 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45581 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142412 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46261 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110924 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37511 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44779 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8759 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->