### PR TITLE
[GFC] Modern grid layout may incorrectly run when content mutates

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-formatting-context-fallback-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-formatting-context-fallback-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#layout-algorithm">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: 100px;
+    width: 50px;
+    height: 50px;
+}
+.item {
+    grid-row: 1 / 2;
+}
+.item.max {
+    max-width: 100%;
+}
+</style>
+<div class="grid"><div class="item"></div></div>
+<script>
+document.body.offsetHeight;
+
+document.querySelector(".item").classList.add("max");
+document.body.offsetHeight;
+</script>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -190,6 +190,15 @@ void GridLayout::updateFormattingContextRootRenderer(const Layout::GridLayoutCon
         orderIteratorPopulator.collectChild(CheckedRef { downcast<RenderBox>(*layoutBox->rendererForIntegration()) });
 }
 
+// updateFormattingContextRootRenderer may mutate bits of RenderGrid to properly reflect
+// the state and result of layout since certain clients may query this information
+// (see RenderGrid::paintChildren). Undo this state if we are falling back to legacy
+// so that we run a full layout.
+void GridLayout::invalidateFormattingContextRootRenderer(RenderGrid& renderGrid)
+{
+    renderGrid.currentGrid().setNeedsItemsPlacement(true);
+}
+
 std::pair<LayoutUnit, LayoutUnit> GridLayout::computeIntrinsicWidths()
 {
     auto gridFormattingContext = Layout::GridFormattingContext { gridBox(), layoutState() };

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -53,6 +53,11 @@ public:
 
     void layout();
 
+    // A GFC layout marks the legacy grid as placed without populating it, since the GFC path does not
+    // rely on the legacy grid state. Reverts that stale state so a subsequent legacy (non-GFC) layout
+    // treats the grid as needing a fresh layout, for example re-placing items to rebuild its tracks.
+    static void invalidateFormattingContextRootRenderer(RenderGrid&);
+
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicWidths();
 
     friend WTF::TextStream& operator<<(WTF::TextStream&, const GridLayout&);

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -567,11 +567,17 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
 bool RenderGrid::layoutUsingGridFormattingContext()
 {
-    if (!m_hasGridFormattingContextLayout.has_value())
-        m_hasGridFormattingContextLayout = LayoutIntegration::canUseForGridLayout(*this);
-
-    if (!*m_hasGridFormattingContextLayout)
+    if (m_hasGridFormattingContextLayout && !*m_hasGridFormattingContextLayout) {
+        // FIXME: Avoid continous content checking on (potentially) unsupported content. This ensures no pref impact on cases like resize etc.
+        // Remove when canUseForGridLayout becomes less expensive.
         return false;
+    }
+
+    m_hasGridFormattingContextLayout = LayoutIntegration::canUseForGridLayout(*this);
+    if (!*m_hasGridFormattingContextLayout) {
+        LayoutIntegration::GridLayout::invalidateFormattingContextRootRenderer(*this);
+        return false;
+    }
 
     auto gridLayout = LayoutIntegration::GridLayout { *this };
     gridLayout.updateFormattingContextGeometries();


### PR DESCRIPTION
#### 0768bc0b4089e320b1132cdba41c2240bbe56f37
<pre>
[GFC] Modern grid layout may incorrectly run when content mutates
<a href="https://bugs.webkit.org/show_bug.cgi?id=318358">https://bugs.webkit.org/show_bug.cgi?id=318358</a>
<a href="https://rdar.apple.com/problem/181150143">rdar://problem/181150143</a>

Reviewed by Alan Baradlay.

RenderGrid cached the grid formatting context (GFC) coverage decision in
m_hasGridFormattingContextLayout and only computed it once, when the optional
had no value. A positive decision was therefore never re-evaluated, so a grid
that qualified for the GFC path on its first layout kept using it even after its
content mutated into something the GFC path does not support (for example a grid
item gaining a max-width). That eventually reached unfinished GFC code and
crashed.

Match what RenderFlexibleBox::layoutUsingFlexFormattingContext already does:
only make a negative decision sticky (a perf guard, since unsupported content
stays unsupported) and re-run canUseForGridLayout whenever the grid previously
used, or has not yet evaluated, the GFC path.

Re-checking coverage exposed a second crash. At the end of a GFC layout,
GridLayout::updateFormattingContextRootRenderer marks the legacy grid as placed
without populating it, since the GFC path does not rely on the legacy grid
state. When we then fall back to the legacy layout, placeItemsOnGrid saw the
grid as already placed and returned early, leaving the track lists empty and
crashing in gridAreaBreadthForGridItemIncludingAlignmentOffsets. Add
GridLayout::invalidateFormattingContextRootRenderer to revert that stale state
on fallback so the legacy path re-places the items and rebuilds its tracks.

Canonical link: <a href="https://commits.webkit.org/316392@main">https://commits.webkit.org/316392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98b56b68e825222f9ef637fa54b2d321bd3077dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171991 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45908 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129545 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/671f03b6-ee13-4977-bd7c-0f34906e83e5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133795 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f397d37-3635-42e7-9949-48209ab336cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114267 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dc7dddb-d09f-4969-ae44-e3d1e9d1e2c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34092 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30044 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183963 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142517 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45575 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142408 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38491 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46255 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110918 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37501 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117943 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44773 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44173 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->