### PR TITLE
[CoreIPC][GPU] Queue::writeTexture() 1D replaceRegion fast-path should return early when copyExtent.height is zero

### DIFF
--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -926,7 +926,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
 
     switch (textureDimension) {
     case WGPUTextureDimension_1D:
-        if (!widthForMetal)
+        if (!widthForMetal || !heightForMetal)
             return;
         break;
     case WGPUTextureDimension_2D:
@@ -1029,7 +1029,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
             {
                 switch (textureDimension) {
                 case WGPUTextureDimension_1D: {
-                    if (!widthForMetal)
+                    if (!widthForMetal || !heightForMetal)
                         return;
 
                     auto region = MTLRegionMake1D(destination.origin.x, widthForMetal);
@@ -1136,7 +1136,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         // https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400771-copyfrombuffer?language=objc
         // "When you copy to a 1D texture, height and depth must be 1."
         auto sourceSize = MTLSizeMake(widthForMetal, 1, 1);
-        if (!widthForMetal)
+        if (!widthForMetal || !heightForMetal)
             return;
 
         auto destinationOrigin = MTLOriginMake(destination.origin.x, 0, 0);


### PR DESCRIPTION
#### 81aff7380e1907262e8e174dd6954d9785569b8d
<pre>
[CoreIPC][GPU] Queue::writeTexture() 1D replaceRegion fast-path should return early when copyExtent.height is zero
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312372">https://bugs.webkit.org/show_bug.cgi?id=312372</a>&gt;
&lt;<a href="https://rdar.apple.com/174662761">rdar://174662761</a>&gt;

Reviewed by Mike Wyrzykowski.

Add `!heightForMetal` check to the three 1D early-out guards in
`Queue::writeTexture()`, consistent with the 2D and 3D cases
that already check both dimensions.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):

Originally-landed-as: 305413.694@safari-7624-branch (22b1d50fc728). <a href="https://rdar.apple.com/180437434">rdar://180437434</a>
Canonical link: <a href="https://commits.webkit.org/316374@main">https://commits.webkit.org/316374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6392366580d6b5c8077b86a8bda3e3257e732784

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129543 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c60e3f21-5f47-4ff0-807f-45cb302ed8c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133794 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61476440-e54b-4465-8fd4-b5d7a1406d52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f3ec47a-4b4c-420c-a01e-be686863a5da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35825 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34090 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30042 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183961 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142513 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45573 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142404 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38474 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46253 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30659 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110916 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37500 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117941 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44771 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8753 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44403 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->