### PR TITLE
[LBSE] Cache the resolved SVG fill and stroke paint server

### DIFF
--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "ReferencedSVGResources.h"
 
+#include "ContainerNodeInlines.h"
 #include "DocumentView.h"
 #include "LegacyRenderSVGResourceClipper.h"
 #include "LegacyRenderSVGResourceContainerInlines.h"
@@ -35,6 +36,9 @@
 #include "RenderLayerModelObject.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGPath.h"
+#include "RenderSVGResourceGradient.h"
+#include "RenderSVGResourcePaintServer.h"
+#include "RenderSVGResourcePattern.h"
 #include "SVGClipPathElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGFilterElement.h"
@@ -83,6 +87,14 @@ void CSSSVGResourceElementClient::resourceChanged(SVGElement& element)
     if (!m_clientRenderer->document().settings().layerBasedSVGEngineEnabled()) {
         m_clientRenderer->repaint();
         return;
+    }
+
+    // A gradient or pattern change can leave the cached fill or stroke paint server stale, so drop
+    // it before the needsLayout() return below, because layout never touches the cache. Other
+    // resource types are not paint servers, so they leave it alone.
+    if (is<RenderSVGResourceGradient>(element.renderer()) || is<RenderSVGResourcePattern>(element.renderer())) {
+        if (CheckedPtr layerModelObject = dynamicDowncast<RenderLayerModelObject>(m_clientRenderer.get()))
+            layerModelObject->invalidateSVGPaintServerCache();
     }
 
     if (m_clientRenderer->needsLayout())
@@ -143,6 +155,25 @@ void ReferencedSVGResources::removeClientForTarget(const AtomString& targetID)
     auto entry = m_elementClients.take(targetID);
     if (RefPtr targetElement = entry.targetElement)
         targetElement->removeReferencingCSSClient(protect(*entry.client));
+}
+
+RenderSVGResourcePaintServer* ReferencedSVGResources::cachedFillPaintServer() const
+{
+    return m_cachedFillPaintServer.get();
+}
+
+RenderSVGResourcePaintServer* ReferencedSVGResources::cachedStrokePaintServer() const
+{
+    return m_cachedStrokePaintServer.get();
+}
+
+void ReferencedSVGResources::setCachedPaintServer(SVGPaintType paintType, RenderSVGResourcePaintServer& paintServer)
+{
+    ASSERT(paintType == SVGPaintType::Fill || paintType == SVGPaintType::Stroke);
+    if (paintType == SVGPaintType::Fill)
+        m_cachedFillPaintServer = paintServer;
+    else
+        m_cachedStrokePaintServer = paintServer;
 }
 
 ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::referencedSVGResourceIDs(const Style::ComputedStyle& style, const Document& document)

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SVGNames.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -42,12 +43,14 @@ class LegacyRenderSVGResourceContainer;
 class QualifiedName;
 class RenderElement;
 class RenderSVGResourceFilter;
+class RenderSVGResourcePaintServer;
 class SVGClipPathElement;
 class SVGElement;
 class SVGFilterElement;
 class SVGMarkerElement;
 class SVGMaskElement;
 class TreeScope;
+enum class SVGPaintType : bool;
 
 namespace Style {
 class ComputedStyle;
@@ -57,8 +60,9 @@ struct ReferencePath;
 struct URL;
 }
 
-class ReferencedSVGResources {
+class ReferencedSVGResources : public CanMakeCheckedPtr<ReferencedSVGResources> {
     WTF_MAKE_TZONE_ALLOCATED(ReferencedSVGResources);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ReferencedSVGResources);
 public:
     ReferencedSVGResources(RenderElement&);
     ~ReferencedSVGResources();
@@ -83,6 +87,18 @@ public:
     static RefPtr<SVGMaskElement> referencedMaskElement(TreeScope&, const AtomString&);
     static RefPtr<SVGElement> referencedPaintServerElement(TreeScope&, const Style::URL&);
 
+    // Cached fill and stroke paint server, filled in by RenderLayerModelObject. The weak pointer
+    // clears itself if the paint server dies, so a live pointer is a hit and a null one re-resolves.
+    // Defined out of line, they need the complete RenderSVGResourcePaintServer type for the weak pointer.
+    RenderSVGResourcePaintServer* cachedFillPaintServer() const;
+    RenderSVGResourcePaintServer* cachedStrokePaintServer() const;
+    void setCachedPaintServer(SVGPaintType, RenderSVGResourcePaintServer&);
+    void invalidatePaintServerCache()
+    {
+        m_cachedFillPaintServer = nullptr;
+        m_cachedStrokePaintServer = nullptr;
+    }
+
 private:
     static RefPtr<SVGElement> elementForResourceID(TreeScope&, const AtomString& resourceID, const SVGQualifiedName& tagName);
     static RefPtr<SVGElement> elementForResourceIDs(TreeScope&, const AtomString& resourceID, const SVGQualifiedNames& tagNames);
@@ -96,6 +112,9 @@ private:
         WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> targetElement;
     };
     MemoryCompactRobinHoodHashMap<AtomString, ClientEntry> m_elementClients;
+
+    SingleThreadWeakPtr<RenderSVGResourcePaintServer> m_cachedFillPaintServer;
+    SingleThreadWeakPtr<RenderSVGResourcePaintServer> m_cachedStrokePaintServer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2504,6 +2504,14 @@ ReferencedSVGResources& RenderElement::ensureReferencedSVGResources()
     return *rareData.referencedSVGResources;
 }
 
+ReferencedSVGResources* RenderElement::referencedSVGResources() const
+{
+    if (!hasRareData())
+        return nullptr;
+
+    return rareData().referencedSVGResources.get();
+}
+
 void RenderElement::clearReferencedSVGResources()
 {
     if (!hasRareData())

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -294,6 +294,7 @@ public:
     void setPseudoElementRenderer(PseudoElementType, RenderBlockFlow&);
 
     ReferencedSVGResources& ensureReferencedSVGResources();
+    ReferencedSVGResources* referencedSVGResources() const;
 
     Overflow NODELETE effectiveOverflowX() const;
     Overflow NODELETE effectiveOverflowY() const;

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -177,6 +177,12 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Style:
     updateFromStyle();
     RenderElement::styleDidChange(diff, oldStyle);
 
+    // Drop the cached paint-server resolution only when fill/stroke actually changed. SVG animation
+    // restyles the element every frame (e.g. the transform presentation attribute) without touching
+    // fill/stroke, and the cache must survive those to be worthwhile.
+    if (!oldStyle || oldStyle->fill() != style().fill() || oldStyle->stroke() != style().stroke())
+        invalidateSVGPaintServerCache();
+
     // When an out-of-flow-positioned element changes its display between block and inline-block,
     // then an incremental layout on the element's containing block lays out the element through
     // LayoutPositionedObjects, which skips laying out the element's parent.
@@ -634,44 +640,52 @@ RenderSVGResourceMarker* RenderLayerModelObject::svgMarkerResourceFromStyle(cons
     return nullptr;
 }
 
-RenderSVGResourcePaintServer* RenderLayerModelObject::svgFillPaintServerResourceFromStyle(const Style::ComputedStyle& style) const
+RenderSVGResourcePaintServer* RenderLayerModelObject::svgPaintServerResourceFromStyle(const Style::SVGPaint& paint, const Style::ComputedStyle& style, SVGPaintType paintType) const
 {
     if (!document().settings().layerBasedSVGEngineEnabled())
         return nullptr;
 
-    auto fillURL = style.fill().tryAnyURL();
-    if (!fillURL)
+    // Only the renderer's own style is cached. A foreign style from the text selection or
+    // decoration painters resolves fresh. The cache lives on ReferencedSVGResources, which exists
+    // whenever this renderer references a paint server.
+    CheckedPtr resources = &style == &this->style() ? referencedSVGResources() : nullptr;
+    if (resources) {
+        if (auto* cached = paintType == SVGPaintType::Fill ? resources->cachedFillPaintServer() : resources->cachedStrokePaintServer())
+            return cached;
+    }
+
+    auto paintURL = paint.tryAnyURL();
+    if (!paintURL)
         return nullptr;
 
-    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), *fillURL)) {
-        if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer()))
+    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), *paintURL)) {
+        if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer())) {
+            if (resources)
+                resources->setCachedPaintServer(paintType, *referencedPaintServerRenderer);
             return referencedPaintServerRenderer;
+        }
     }
 
     if (RefPtr element = this->element())
-        document().addPendingSVGResource(AtomString(fillURL->resolved.string()), downcast<SVGElement>(*element));
+        document().addPendingSVGResource(AtomString(paintURL->resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;
 }
 
+RenderSVGResourcePaintServer* RenderLayerModelObject::svgFillPaintServerResourceFromStyle(const Style::ComputedStyle& style) const
+{
+    return svgPaintServerResourceFromStyle(style.fill(), style, SVGPaintType::Fill);
+}
+
 RenderSVGResourcePaintServer* RenderLayerModelObject::svgStrokePaintServerResourceFromStyle(const Style::ComputedStyle& style) const
 {
-    if (!document().settings().layerBasedSVGEngineEnabled())
-        return nullptr;
+    return svgPaintServerResourceFromStyle(style.stroke(), style, SVGPaintType::Stroke);
+}
 
-    auto strokeURL = style.stroke().tryAnyURL();
-    if (!strokeURL)
-        return nullptr;
-
-    if (RefPtr referencedElement = ReferencedSVGResources::referencedPaintServerElement(treeScopeForSVGReferences(), *strokeURL)) {
-        if (auto* referencedPaintServerRenderer = dynamicDowncast<RenderSVGResourcePaintServer>(referencedElement->renderer()))
-            return referencedPaintServerRenderer;
-    }
-
-    if (RefPtr element = this->element())
-        document().addPendingSVGResource(AtomString(strokeURL->resolved.string()), downcast<SVGElement>(*element));
-
-    return nullptr;
+void RenderLayerModelObject::invalidateSVGPaintServerCache() const
+{
+    if (CheckedPtr resources = referencedSVGResources())
+        resources->invalidatePaintServerCache();
 }
 
 LegacyRenderSVGResourceClipper* RenderLayerModelObject::legacySVGClipperResourceFromStyle() const

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -42,6 +42,7 @@ class SVGGraphicsElement;
 
 namespace Style {
 struct SVGMarkerResource;
+struct SVGPaint;
 enum class TransformResolverOption : uint8_t;
 }
 
@@ -56,6 +57,8 @@ enum class ContentChangeType : uint8_t {
     FullScreen,
     Model
 };
+
+enum class SVGPaintType : bool { Fill, Stroke };
 
 class RenderLayerModelObject : public RenderElement {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerModelObject);
@@ -125,6 +128,8 @@ public:
     RenderSVGResourcePaintServer* svgFillPaintServerResourceFromStyle(const Style::ComputedStyle&) const;
     RenderSVGResourcePaintServer* svgStrokePaintServerResourceFromStyle(const Style::ComputedStyle&) const;
 
+    void invalidateSVGPaintServerCache() const;
+
     RenderSVGResourceClipper* svgClipperResourceFromStyle() const;
     RenderSVGResourceFilter* svgFilterResourceFromStyle() const;
     RenderSVGResourceMasker* svgMaskerResourceFromStyle() const;
@@ -180,6 +185,8 @@ private:
     void removeOnlyThisLayerWithRepaint();
 
     RenderSVGResourceMarker* svgMarkerResourceFromStyle(const Style::SVGMarkerResource&) const;
+
+    RenderSVGResourcePaintServer* svgPaintServerResourceFromStyle(const Style::SVGPaint&, const Style::ComputedStyle&, SVGPaintType) const;
 
     UniquelyOwnedPtr<RenderLayer> m_layer;
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -71,6 +71,10 @@ void RenderSVGResourceContainer::styleDidChange(Style::Difference diff, const St
 
 void RenderSVGResourceContainer::idChanged()
 {
+    // Clients resolved this resource under the old id and may now resolve elsewhere or to nothing.
+    // Notify them to drop any cached resolution and repaint.
+    repaintAllClients();
+
     // Remove old id, that is guaranteed to be present in cache.
     m_id = element().getIdAttribute();
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -1073,6 +1073,8 @@ void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
         // Notify resources about id changes, this is important as we cache resources by id in SVGDocumentExtensions
         if (CheckedPtr container = dynamicDowncast<LegacyRenderSVGResourceContainer>(renderer()))
             container->idChanged();
+        else if (CheckedPtr container = dynamicDowncast<RenderSVGResourceContainer>(renderer()))
+            container->idChanged();
         if (isConnected())
             buildPendingResourcesIfNeeded();
         invalidateInstances();


### PR DESCRIPTION
#### a36097add8b01a89a6cac53320fb09eec72f24ff
<pre>
[LBSE] Cache the resolved SVG fill and stroke paint server
<a href="https://bugs.webkit.org/show_bug.cgi?id=318363">https://bugs.webkit.org/show_bug.cgi?id=318363</a>

Reviewed by Rob Buis.

Resolving the url(#id) fill or stroke paint server from style on every paint
re-parses the URL string and looks the element up by id, which is not cheap.

Cache the resolved RenderSVGResourcePaintServer on ReferencedSVGResources, the
SVG-only object in rare data that already tracks a renderer&apos;s fill and stroke
references. It exists whenever a paint server is referenced and the weak pointer
clears itself if the paint server is destroyed. Only the renderer&apos;s own style
is cached. A foreign style passed by the text selection or decoration painters
points at a different paint server, so it resolves fresh and never reads or
writes the cache.

Drop the cache whenever it can go stale. styleDidChange clears it when fill or
stroke changes. resourceChanged clears it when the referenced gradient or
pattern changes. To make that work under the layer-based engine, dispatch
idChanged to RenderSVGResourceContainer, which was previously only wired up
for the legacy containers, and have it notify existing clients so a renamed
resource repaints properly.

Covered by existing tests.

* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::CSSSVGResourceElementClient::resourceChanged):
(WebCore::ReferencedSVGResources::cachedFillPaintServer const):
(WebCore::ReferencedSVGResources::cachedStrokePaintServer const):
(WebCore::ReferencedSVGResources::setCachedPaintServer):
* Source/WebCore/rendering/ReferencedSVGResources.h:
(WebCore::ReferencedSVGResources::invalidatePaintServerCache):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::referencedSVGResources const):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::styleDidChange):
(WebCore::RenderLayerModelObject::svgPaintServerResourceFromStyle const):
(WebCore::RenderLayerModelObject::svgFillPaintServerResourceFromStyle const):
(WebCore::RenderLayerModelObject::svgStrokePaintServerResourceFromStyle const):
(WebCore::RenderLayerModelObject::invalidateSVGPaintServerCache const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::idChanged):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/316428@main">https://commits.webkit.org/316428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e8c2f15bf64b4ea076656f5e87b98dd3b6b4a83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45840 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37426 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114474 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36060 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30337 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184265 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142759 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45870 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38506 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46548 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111274 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37712 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45065 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8994 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->