### PR TITLE
SVGProperty::contextElement after stopAnimation drops m_animVal without detach()

### DIFF
--- a/LayoutTests/svg/animations/animVal-detach-after-stopAnimation-crash-expected.txt
+++ b/LayoutTests/svg/animations/animVal-detach-after-stopAnimation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/svg/animations/animVal-detach-after-stopAnimation-crash.html
+++ b/LayoutTests/svg/animations/animVal-detach-after-stopAnimation-crash.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg id="s">
+  <rect id="r" x="10" width="50" height="50">
+    <animate id="a" attributeName="x" from="0" to="100" dur="1s" begin="0s"/>
+  </rect>
+</svg>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+let len;
+
+function grab()
+{
+    // Separate frame so intermediate wrappers are not pinned by a conservative stack scan.
+    return document.getElementById("r").x.animVal;
+}
+
+function step1()
+{
+    let s = document.getElementById("s");
+    let a = document.getElementById("a");
+    let r = document.getElementById("r");
+
+    // Enter the active interval so stopAnimation() takes the m_animVal = nullptr branch.
+    s.pauseAnimations();
+    s.setCurrentTime(0.5);
+
+    len = grab();
+
+    // Reaches SVGAnimatedValueProperty::stopAnimation().
+    a.remove();
+    r.remove();
+    s.remove();
+}
+
+function step2()
+{
+    if (window.GCController)
+        GCController.collect();
+    // SVGLength::valueForBindings -> SVGProperty::contextElement; m_owner must not dangle.
+    len.value;
+    document.body.textContent = "PASS if no crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.onload = () => {
+    // Defer past Document::implicitClose so svgExtensions->startAnimations() has run.
+    setTimeout(() => {
+        step1();
+        setTimeout(step2, 0);
+    }, 0);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyList.h
@@ -94,7 +94,7 @@ public:
     {
         Base::stopAnimation(animator);
         if (!this->isAnimating())
-            m_animVal = nullptr;
+            detachAnimVal();
         else if (m_animVal)
             *m_animVal = m_baseVal;
     }
@@ -102,8 +102,10 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimationImpl(SVGAttributeAnimator& animator, SVGAnimatedPropertyList& animated) override
     {
-        if (!this->isAnimating())
+        if (!this->isAnimating()) {
+            detachAnimVal();
             m_animVal = animated.animVal();
+        }
         Base::startAnimation(animator);
     }
 
@@ -111,7 +113,7 @@ public:
     {
         Base::stopAnimation(animator);
         if (!this->isAnimating())
-            m_animVal = nullptr;
+            detachAnimVal();
     }
 
 protected:
@@ -127,6 +129,14 @@ protected:
         if (!m_animVal)
             m_animVal = ListType::create(m_baseVal, SVGPropertyAccess::ReadOnly);
         return *m_animVal;
+    }
+
+    void detachAnimVal()
+    {
+        // m_animVal may be retained by the bindings after we drop it. Detach it now so its
+        // raw SVGProperty::m_owner back-pointer cannot dangle once |this| is destroyed.
+        if (RefPtr animVal = std::exchange(m_animVal, nullptr))
+            animVal->detach();
     }
 
     // Called when m_baseVal changes or an item in m_baseVal changes.

--- a/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedValueProperty.h
@@ -110,7 +110,7 @@ public:
     {
         Base::stopAnimation(animator);
         if (!this->isAnimating())
-            m_animVal = nullptr;
+            detachAnimVal();
         else if (m_animVal)
             m_animVal->setValue(m_baseVal->value());
     }
@@ -118,8 +118,10 @@ public:
     // Controlling the instance animation.
     void instanceStartAnimationImpl(SVGAttributeAnimator& animator, SVGAnimatedValueProperty& animated) override
     {
-        if (!this->isAnimating())
+        if (!this->isAnimating()) {
+            detachAnimVal();
             m_animVal = animated.animVal();
+        }
         Base::startAnimation(animator);
     }
 
@@ -127,7 +129,7 @@ public:
     {
         Base::stopAnimation(animator);
         if (!this->isAnimating())
-            m_animVal = nullptr;
+            detachAnimVal();
     }
 
 protected:
@@ -152,6 +154,14 @@ protected:
         if (!m_animVal)
             m_animVal = PropertyType::create(this, SVGPropertyAccess::ReadOnly, m_baseVal->value());
         return *m_animVal;
+    }
+
+    void detachAnimVal()
+    {
+        // m_animVal may be retained by the bindings after we drop it. Detach it now so its
+        // raw SVGProperty::m_owner back-pointer cannot dangle once |this| is destroyed.
+        if (RefPtr animVal = std::exchange(m_animVal, nullptr))
+            animVal->detach();
     }
 
     // Called when m_baseVal changes.


### PR DESCRIPTION
#### eb617fc2899ad5c540d73f03d27f00963203b843
<pre>
SVGProperty::contextElement after stopAnimation drops m_animVal without detach()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318365">https://bugs.webkit.org/show_bug.cgi?id=318365</a>
<a href="https://rdar.apple.com/177599904">rdar://177599904</a>

Reviewed by Simon Fraser.

SVGAnimatedValueProperty&lt;T&gt;::ensureAnimVal() creates the animVal SVGProperty
with |this| as the raw SVGProperty::m_owner back-pointer. The destructor clears
it via detach(), but stopAnimation() and instanceStopAnimationImpl() set
m_animVal = nullptr without detaching first. Since the animVal is exposed to script via
SVGAnimatedLength.animVal and the JS wrapper holds an independent Ref, it can
outlive the SVGAnimatedValueProperty, leaving m_owner dangling. A later
len.value read reaches SVGProperty::contextElement() through freed memory.

SVGAnimatedPropertyList&lt;T&gt; has the identical pattern and is fixed the same way.

Detach m_animVal before releasing or overwriting it, via a detachAnimVal()
helper that mirrors the destructor.

Test: svg/animations/animVal-detach-after-stopAnimation-crash.html

* LayoutTests/svg/animations/animVal-detach-after-stopAnimation-crash-expected.txt: Added.
* LayoutTests/svg/animations/animVal-detach-after-stopAnimation-crash.html: Added.
* Source/WebCore/svg/properties/SVGAnimatedPropertyList.h:
(WebCore::SVGAnimatedPropertyList::detachAnimVal):
* Source/WebCore/svg/properties/SVGAnimatedValueProperty.h:
(WebCore::SVGAnimatedValueProperty::detachAnimVal):

Canonical link: <a href="https://commits.webkit.org/316557@main">https://commits.webkit.org/316557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/548eab4afe47b232a6c600058692763f704b5901

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181439 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129554 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7f87bca-e30e-4ed2-851e-acccd6acc882) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133800 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94387 "2 flakes 20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/711c25c2-a4e7-4265-bc71-0b22019d2a29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/067d2270-0a68-4641-be6a-a8b1022c871c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35837 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34102 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30053 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183972 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142526 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/153905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38620 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46264 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30670 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37508 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117952 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44782 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8764 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44182 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44241 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->