### PR TITLE
Cherry-pick(s) 8e2784fd0807. rdar://180429216

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1066,6 +1066,22 @@ struct WebCore::ClientOrigin {
 
 enum class WebCore::AdjustViewSize : bool;
 
+<<<<<<< HEAD
+=======
+enum class WebCore::UseLosslessCompression : bool;
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ImageBufferFormat {
+    WebCore::PixelFormat pixelFormat;
+    WebCore::UseLosslessCompression useLosslessCompression;
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PixelBufferFormat {
+    WebCore::AlphaPremultiplication alphaFormat;
+    WebCore::PixelFormat pixelFormat;
+    [Validator='colorSpace->usesRGBColorModel()'] WebCore::DestinationColorSpace colorSpace;
+};
+
+>>>>>>> 8e2784fd0807 (GetPixelBuffer should zeroFill the destination if any error happens)
 [RefCounted] class WebCore::TextIndicator {
     WebCore::TextIndicatorData data();
 };

--- a/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp
@@ -326,8 +326,11 @@ INSTANTIATE_TEST_SUITE_P(ImageBufferTests,
         testing::Values(RenderingMode::Unaccelerated, RenderingMode::Accelerated)),
     TestParametersToStringFormatter());
 
+<<<<<<< HEAD
 #if USE(CG)
 
+=======
+>>>>>>> 8e2784fd0807 (GetPixelBuffer should zeroFill the destination if any error happens)
 TEST(ImageBufferTests, GetPixelBufferAllZeros)
 {
     auto sourceColorSpace = DestinationColorSpace::SRGB();
@@ -361,6 +364,9 @@ TEST(ImageBufferTests, GetPixelBufferAllZeros)
     EXPECT_TRUE(getPixelBufferAllZeros({ FloatPoint { size - size / 10 }, size / 10 }));
 }
 
+<<<<<<< HEAD
 #endif
 
+=======
+>>>>>>> 8e2784fd0807 (GetPixelBuffer should zeroFill the destination if any error happens)
 }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180429216 to main. [8e2784fd0807] caused a merge conflict. 

```
GetPixelBuffer should zeroFill the destination if any error happens
https://bugs.webkit.org/show_bug.cgi?id=312945
rdar://174640273

Reviewed by Kimmo Kinnunen.

RemoteImageBuffer fails to GetPixelBuffer if the destination colorSpace is non-RGB
model (e.g. kCGColorSpaceGenericCMYK). In this case the PixelBuffer is allocated
but never be initialized. So stale heap can be exposed to callers.

To fix this an IPC validator is needed to ensure the colorSpace is indeed RGB model.
And to handle other possible unknown failures, the destination PixelBuffer will
be zero-filled if vImage fails to do the conversion the colorSpace conversion.

* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::usesRGBColorModel const):
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertImagePixelsAccelerated):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/ImageBufferTests.cpp:
(TestWebKitAPI::TEST(ImageBufferTests, GetPixelBufferAllZeros)):

Originally-landed-as: 305413.874@safari-7624-branch (8e2784fd0807). rdar://180429216


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12f0646b9824d17c6ec6669abe9432a57accd39f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172001 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45918 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181440 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173866 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47204 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45558 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181440 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174959 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47204 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181440 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47204 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45558 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30054 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47204 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183973 "") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45558 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/183973 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45585 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/183973 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46265 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110928 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46265 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44783 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39336 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44183 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44415 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44242 "") | | | 
<!--EWS-Status-Bubble-End-->