### PR TITLE
[WPE] Fix broken Vivante super-tiled rendering with the Skia compositor

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -100,7 +100,7 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
             continue;
 
         tilePaint.setAntiAlias(paint.isAntiAlias() && allTileEdgesExposed(layerRect, tile.rect()));
-        canvas.drawImageRect(image, SkRect::MakeWH(image->width(), image->height()), tile.rect(), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
+        canvas.drawImageRect(image, tile.imageSourceRect(), tile.rect(), SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &tilePaint, SkCanvas::kFast_SrcRectConstraint);
     }
 }
 
@@ -125,7 +125,7 @@ Vector<SkCanvas::ImageSetEntry> SkiaBackingStore::buildImageSet(SkCanvas& canvas
 
         // FIXME: implement per edge antialiasing.
         unsigned aaFlags = enableAntialias && allTileEdgesExposed(layerRect, tile.rect()) ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
-        images.append(SkCanvas::ImageSetEntry(image, SkRect::MakeWH(image->width(), image->height()), SkRect(tile.rect()), matrixIndex, opacity, aaFlags, false));
+        images.append(SkCanvas::ImageSetEntry(image, tile.imageSourceRect(), SkRect(tile.rect()), matrixIndex, opacity, aaFlags, false));
     }
     return images;
 }
@@ -243,10 +243,33 @@ sk_sp<SkImage> SkiaBackingStore::Tile::image() const
         externalTexture.fTarget = GL_TEXTURE_2D;
         externalTexture.fID = m_texture->id();
         externalTexture.fFormat = colorType == kBGRA_8888_SkColorType ? GL_BGRA8_EXT : GL_RGBA8;
-        auto backendTexture = GrBackendTextures::MakeGL(m_texture->size().width(), m_texture->size().height(), skgpu::Mipmapped::kNo, externalTexture);
+        // Use the physical allocatedSize(): super-tiled textures are padded past the logical
+        // size(), and sizing the image to size() would map u=1.0 to the padded edge, stretching
+        // content and bleeding in padding. imageSourceRect() then restricts sampling to the
+        // logical region, mirroring the uvMax clamp on the TextureMapper path.
+        auto allocatedSize = m_texture->allocatedSize();
+        auto backendTexture = GrBackendTextures::MakeGL(allocatedSize.width(), allocatedSize.height(), skgpu::Mipmapped::kNo, externalTexture);
         m_cachedImage = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     }
     return m_cachedImage;
+}
+
+SkRect SkiaBackingStore::Tile::imageSourceRect() const
+{
+    // The surface snapshot is sized to the logical tile, so all of it is valid.
+    if (m_surface)
+        return SkRect::MakeWH(m_surface->width(), m_surface->height());
+
+    // The texture image spans allocatedSize() - only the top-left size() region is real content.
+    if (m_texture) {
+        auto size = m_texture->size();
+        return SkRect::MakeWH(size.width(), size.height());
+    }
+
+    // Callers only reach imageSourceRect() after image() returned a valid image, which requires
+    // one of m_surface or m_texture to be set, so this fallback is never taken in practice.
+    ASSERT_NOT_REACHED();
+    return SkRect::MakeEmpty();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -76,6 +76,9 @@ private:
         const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
         sk_sp<SkImage> image() const;
 
+        // Logical region to sample from image() - smaller than the image for padded super-tiled textures.
+        SkRect imageSourceRect() const;
+
     private:
         void ensureTexture(const IntSize&, CoordinatedTileBuffer&);
         void update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);


### PR DESCRIPTION
#### f58a8697d2f8667a948fc0e4b69bd5760fd33a29
<pre>
[WPE] Fix broken Vivante super-tiled rendering with the Skia compositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=318369">https://bugs.webkit.org/show_bug.cgi?id=318369</a>

Reviewed by Carlos Garcia Campos.

With WEBKIT_SKIA_USE_VIVANTE_SUPER_TILED_TILE_TEXTURES=1 on Vivante GPUs,
super-tiled tile buffers are allocated padded up to 64-pixel multiples, so
BitmapTexture::allocatedSize() exceeds the logical size(). SkiaBackingStore
built the borrowed GL image from size() and sampled it using the image&apos;s own
dimensions, so Skia&apos;s normalized u=1.0/v=1.0 mapped to the padded edge of the
physical texture rather than the logical edge. The content was stretched and
the garbage padding columns/rows bled in, producing the observed glitches.
The TextureMapper compositor avoids this with its uvMax clamp - the Skia path
had no equivalent (linear tiles are unaffected since allocatedSize == size).

Describe the borrowed image at the physical allocatedSize() and restrict
sampling to the logical region via the new Tile::imageSourceRect(), mirroring
the uvMax clamp. The accelerated display-list path is unchanged as its surface
snapshot is already sized to the logical tile.

* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::paintToCanvas):
(WebCore::SkiaBackingStore::buildImageSet const):
(WebCore::SkiaBackingStore::Tile::image const):
(WebCore::SkiaBackingStore::Tile::imageSourceRect const):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:

Canonical link: <a href="https://commits.webkit.org/316716@main">https://commits.webkit.org/316716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fec6bd4fee985e31baaf752c58dd578b45d62684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134611 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115080 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36665 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31173 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185110 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143455 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46715 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143327 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47394 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112467 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26301 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Carlos Garcia Campos; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38287 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119143 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45900 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9787 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->