### PR TITLE
Cherry-pick 62a1052dd1fe. https://bugs.webkit.org/show_bug.cgi?id=313252

### DIFF
--- a/JSTests/stress/array-indexof-ensure-still-alive.js
+++ b/JSTests/stress/array-indexof-ensure-still-alive.js
@@ -1,0 +1,15 @@
+//@ runDefault("--useFTLJIT=1", "--jitPolicyScale=0.1", "--useConcurrentJIT=0", "--useConcurrentGC=0", "--sweepSynchronously=1", "--collectContinuously=1")
+
+function opt(s, needle) {
+    return [s + "A", s + "B", s + "C", s + "D", s + "E", s + "F", s + "G", s + "H"].indexOf(needle);
+}
+noInline(opt);
+
+let big = "Q".repeat(1024 * 1024);
+let needleStr = "Z".repeat(big.length + 1);
+
+for (let i = 0; i < 2000; i++)
+    opt(big, (i & 1) ? needleStr : 1234);
+
+for (let i = 0; i < 10000; i++)
+    opt(big, needleStr);

--- a/JSTests/stress/regress-174630697.js
+++ b/JSTests/stress/regress-174630697.js
@@ -1,0 +1,25 @@
+const icCount = 100;
+const structCount = 16;
+
+let body = "var x = 0;\n";
+for (let i = 0; i < icCount; i++)
+    body += "x += o.p;\n";
+body += "return x;\n";
+
+let objs = [];
+for (let i = 0; i < structCount; i++) {
+    let o = {};
+    o["k" + i] = i;
+    o.p = 1;
+    objs.push(o);
+}
+
+let f = new Function("o", body);
+
+for (let j = 0; j < 130; j++)
+    f(objs[j % structCount]);
+
+for (let j = 0; j < 100000; j++)
+    f(objs[j % structCount]);
+
+f(42);

--- a/JSTests/stress/spread-with-OnlyAtomStringsStructure.js
+++ b/JSTests/stress/spread-with-OnlyAtomStringsStructure.js
@@ -1,0 +1,6 @@
+//@ runDefault("--forceEagerCompilation=1", "--validateAbstractInterpreterState=1")
+
+const array = [""];
+
+for (let index = 0; index < testLoopCount; index++)
+    (() => {})(...array);

--- a/LayoutTests/fast/canvas/canvas-getContext-reentrant-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-getContext-reentrant-expected.txt
@@ -1,0 +1,33 @@
+getContext("2d") with reentrant getContext("2d"): outer=CanvasRenderingContext2D inner=CanvasRenderingContext2D
+getContext("2d") with reentrant getContext("bitmaprenderer"): outer=null inner=ImageBitmapRenderingContext
+getContext("2d") with reentrant getContext("webgl"): outer=null inner=WebGLRenderingContext
+getContext("2d") with reentrant getContext("webgl2"): outer=null inner=WebGL2RenderingContext
+getContext("bitmaprenderer") with reentrant getContext("2d"): outer=null inner=CanvasRenderingContext2D
+getContext("bitmaprenderer") with reentrant getContext("bitmaprenderer"): outer=ImageBitmapRenderingContext inner=ImageBitmapRenderingContext
+getContext("bitmaprenderer") with reentrant getContext("webgl"): outer=null inner=WebGLRenderingContext
+getContext("bitmaprenderer") with reentrant getContext("webgl2"): outer=null inner=WebGL2RenderingContext
+getContext("webgl") with reentrant getContext("2d"): outer=null inner=CanvasRenderingContext2D
+getContext("webgl") with reentrant getContext("bitmaprenderer"): outer=null inner=ImageBitmapRenderingContext
+getContext("webgl") with reentrant getContext("webgl"): outer=WebGLRenderingContext inner=WebGLRenderingContext
+getContext("webgl") with reentrant getContext("webgl2"): outer=null inner=WebGL2RenderingContext
+getContext("webgl2") with reentrant getContext("2d"): outer=null inner=CanvasRenderingContext2D
+getContext("webgl2") with reentrant getContext("bitmaprenderer"): outer=null inner=ImageBitmapRenderingContext
+getContext("webgl2") with reentrant getContext("webgl"): outer=null inner=WebGLRenderingContext
+getContext("webgl2") with reentrant getContext("webgl2"): outer=WebGL2RenderingContext inner=WebGL2RenderingContext
+OffscreenCanvas getContext("2d") with reentrant getContext("2d"): outer=OffscreenCanvasRenderingContext2D inner=OffscreenCanvasRenderingContext2D
+OffscreenCanvas getContext("2d") with reentrant getContext("bitmaprenderer"): outer=null inner=ImageBitmapRenderingContext
+OffscreenCanvas getContext("2d") with reentrant getContext("webgl"): outer=null inner=WebGLRenderingContext
+OffscreenCanvas getContext("2d") with reentrant getContext("webgl2"): outer=null inner=WebGL2RenderingContext
+OffscreenCanvas getContext("bitmaprenderer") with reentrant getContext("2d"): outer=null inner=OffscreenCanvasRenderingContext2D
+OffscreenCanvas getContext("bitmaprenderer") with reentrant getContext("bitmaprenderer"): outer=ImageBitmapRenderingContext inner=ImageBitmapRenderingContext
+OffscreenCanvas getContext("bitmaprenderer") with reentrant getContext("webgl"): outer=null inner=WebGLRenderingContext
+OffscreenCanvas getContext("bitmaprenderer") with reentrant getContext("webgl2"): outer=null inner=WebGL2RenderingContext
+OffscreenCanvas getContext("webgl") with reentrant getContext("2d"): outer=null inner=OffscreenCanvasRenderingContext2D
+OffscreenCanvas getContext("webgl") with reentrant getContext("bitmaprenderer"): outer=null inner=ImageBitmapRenderingContext
+OffscreenCanvas getContext("webgl") with reentrant getContext("webgl"): outer=WebGLRenderingContext inner=WebGLRenderingContext
+OffscreenCanvas getContext("webgl") with reentrant getContext("webgl2"): outer=null inner=WebGL2RenderingContext
+OffscreenCanvas getContext("webgl2") with reentrant getContext("2d"): outer=null inner=OffscreenCanvasRenderingContext2D
+OffscreenCanvas getContext("webgl2") with reentrant getContext("bitmaprenderer"): outer=null inner=ImageBitmapRenderingContext
+OffscreenCanvas getContext("webgl2") with reentrant getContext("webgl"): outer=null inner=WebGLRenderingContext
+OffscreenCanvas getContext("webgl2") with reentrant getContext("webgl2"): outer=WebGL2RenderingContext inner=WebGL2RenderingContext
+PASS if no crash.

--- a/LayoutTests/fast/canvas/canvas-getContext-reentrant.html
+++ b/LayoutTests/fast/canvas/canvas-getContext-reentrant.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function gc() {
+    if (window.GCController)
+        return GCController.collect();
+    for (let i = 0; i < 10000; i++)
+        new String("abc");
+}
+
+function reenter(outer, inner) {
+    let canvas = document.createElement("canvas");
+    let innerCtx;
+    let outerCtx = canvas.getContext(outer, {
+        get colorSpace() { innerCtx = canvas.getContext(inner); return "srgb"; },
+        get alpha() { innerCtx = canvas.getContext(inner); return true; },
+    });
+    document.write(`getContext("${outer}") with reentrant getContext("${inner}"): outer=${name(outerCtx)} inner=${name(innerCtx)}<br>`);
+}
+
+function reenterOffscreen(outer, inner) {
+    let canvas = new OffscreenCanvas(10, 10);
+    let innerCtx;
+    let outerCtx = canvas.getContext(outer, {
+        get colorSpace() { innerCtx = canvas.getContext(inner); return "srgb"; },
+        get alpha() { innerCtx = canvas.getContext(inner); return true; },
+    });
+    document.write(`OffscreenCanvas getContext("${outer}") with reentrant getContext("${inner}"): outer=${name(outerCtx)} inner=${name(innerCtx)}<br>`);
+}
+
+function name(ctx) {
+    return ctx ? ctx.constructor.name : "null";
+}
+
+for (let outer of ["2d", "bitmaprenderer", "webgl", "webgl2"])
+    for (let inner of ["2d", "bitmaprenderer", "webgl", "webgl2"])
+        reenter(outer, inner);
+
+for (let outer of ["2d", "bitmaprenderer", "webgl", "webgl2"])
+    for (let inner of ["2d", "bitmaprenderer", "webgl", "webgl2"])
+        reenterOffscreen(outer, inner);
+
+gc();
+document.write("PASS if no crash.");
+</script>

--- a/LayoutTests/fast/dom/CloseWatcher-watcher-crash-expected.txt
+++ b/LayoutTests/fast/dom/CloseWatcher-watcher-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/dom/CloseWatcher-watcher-crash.html
+++ b/LayoutTests/fast/dom/CloseWatcher-watcher-crash.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<body>
+This test passes if it does not crash.
+<script>
+globalThis.testRunner?.waitUntilDone();
+globalThis.testRunner?.dumpAsText();
+
+function gc() {
+    if (globalThis.GCController) GCController.collect();
+    else if (globalThis.$vm) $vm.gc();
+    else for (let i = 0; i < 10000; i++) new ArrayBuffer(0x1000);
+}
+
+const ac = new AbortController();
+
+// Create the CloseWatcher in a nested call frame so its wrapper
+// pointer doesn't linger on the conservative-scanned stack.
+(function () {
+    new CloseWatcher({ signal: ac.signal }); // no listeners, result discarded
+})();
+
+// Churn stack and force full GC so JSCloseWatcher is finalized and
+// the C++ CloseWatcher's refcount drops to 1 (held only by CloseWatcherManager).
+for (let i = 0; i < 100; i++) new Uint8Array(0x100);
+gc(); gc(); gc();
+
+// Trigger: AbortSignal::runAbortSteps -> lambda(weakWatcher) -> destroy()
+// -> manager->remove(*this) deletes `this` -> m_active=false (UAF write)
+// -> RefPtr signal = m_signal (UAF read).
+ac.abort();
+
+globalThis.testRunner?.notifyDone();
+</script>
+</body>

--- a/LayoutTests/fast/history/popstate-add-iframes-during-history-back-expected.txt
+++ b/LayoutTests/fast/history/popstate-add-iframes-during-history-back-expected.txt
@@ -1,0 +1,5 @@
+This test verifies that adding many iframes during a popstate event triggered by history.back() does not cause a crash.
+
+PASS: Did not crash.
+
+

--- a/LayoutTests/fast/history/popstate-add-iframes-during-history-back.html
+++ b/LayoutTests/fast/history/popstate-add-iframes-during-history-back.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function gc() {
+    if (typeof GCController !== 'undefined')
+        GCController.collect();
+    else {
+        for (let i = 0; i < 10000; i++)
+            new String("A".repeat(10000));
+    }
+}
+
+function step1() {
+    const childA = document.getElementById('childA').contentWindow;
+    childA.addEventListener('popstate', () => {
+        for (let i = 0; i < 40; i++) {
+            const f = document.createElement('iframe');
+            f.src = 'about:blank';
+            document.body.appendChild(f);
+        }
+        gc();
+    }, { once: true });
+
+    childA.history.pushState({k: 1}, '', '#x');
+
+    setTimeout(step2, 0);
+}
+
+function step2() {
+    history.back();
+    setTimeout(() => {
+        document.getElementById('result').textContent = 'PASS: Did not crash.';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 1000);
+}
+
+window.onload = () => {
+    setTimeout(step1, 0);
+};
+</script>
+</head>
+<body>
+<p>This test verifies that adding many iframes during a popstate event triggered by history.back() does not cause a crash.</p>
+<p id="result"></p>
+<iframe id="childA" src="resources/dummy.html"></iframe>
+<iframe id="childB" src="resources/dummy.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash-expected.txt
+++ b/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash.html
+++ b/LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useDollarVM=true ] -->
+<html>
+<head>
+    <script>
+        if (globalThis.testRunner) {
+            globalThis.testRunner.waitUntilDone();
+            globalThis.testRunner.dumpAsText();
+        }
+
+        let delays = [10, 50, 100];
+        let iteration = 0;
+        let innerBase64 = 'A'.repeat(64 * 1024);
+        let inner = 'data:image/png;base64,' + innerBase64;
+
+        function armNext() {
+            if (iteration >= delays.length) {
+                setTimeout(() => {
+                    if (globalThis.testRunner)
+                        globalThis.testRunner.notifyDone();
+                }, 500);
+                return;
+            }
+
+            let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">` +
+                      `<image href="${inner}" width="200" height="200"/>`.repeat(4) +
+                      `</svg>`;
+            let outer = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+
+            let m = new MediaMetadata({ artwork: [{ src: outer, sizes: 'any', type: 'image/svg+xml' }] });
+            navigator.mediaSession.metadata = m;
+
+            setTimeout(() => {
+                navigator.mediaSession.metadata = null;
+                m = null;
+                if (globalThis.$vm)
+                    $vm.gc();
+
+                setTimeout(armNext, 500);
+            }, delays[iteration++]);
+        }
+
+        window.onload = armNext;
+    </script>
+</head>
+<body>
+This test passes if it doesn't crash.
+</body>
+</html>

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -723,6 +723,7 @@ void repatchGetBy(JSGlobalObject* globalObject, CodeBlock* codeBlock, JSValue ba
 // Mainly used to transition from megamorphic case to generic case.
 void repatchGetBySlowPathCall(CodeBlock* codeBlock, StructureStubInfo& stubInfo, GetByKind kind)
 {
+    ConcurrentJSLocker locker(codeBlock->m_lock);
     resetGetBy(codeBlock, stubInfo, kind);
     repatchSlowPathCall(codeBlock, stubInfo, appropriateGetByGaveUpFunction(kind));
 }
@@ -927,6 +928,7 @@ static CodePtr<CFunctionPtrTag> appropriatePutByGaveUpFunction(PutByKind putByKi
 // Mainly used to transition from megamorphic case to generic case.
 void repatchPutBySlowPathCall(CodeBlock* codeBlock, StructureStubInfo& stubInfo, PutByKind kind)
 {
+    ConcurrentJSLocker locker(codeBlock->m_lock);
     resetPutBy(codeBlock, stubInfo, kind);
     repatchSlowPathCall(codeBlock, stubInfo, appropriatePutByGaveUpFunction(kind));
 }
@@ -1533,6 +1535,7 @@ inline CodePtr<CFunctionPtrTag> appropriateInByGaveUpFunction(InByKind kind)
 // Mainly used to transition from megamorphic case to generic case.
 void repatchInBySlowPathCall(CodeBlock* codeBlock, StructureStubInfo& stubInfo, InByKind kind)
 {
+    ConcurrentJSLocker locker(codeBlock->m_lock);
     resetInBy(codeBlock, stubInfo, kind);
     repatchSlowPathCall(codeBlock, stubInfo, appropriateInByGaveUpFunction(kind));
 }

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3680,7 +3680,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         }
 
-        setForNode(node, m_vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous));
+        {
+            RegisteredStructureSet structureSet;
+            structureSet.add(m_graph.registerStructure(m_vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous)));
+            structureSet.add(m_graph.registerStructure(m_vm.cellButterflyOnlyAtomStringsStructure.get()));
+            setForNode(node, structureSet);
+        }
         break;
         
     case NewArrayBuffer:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8646,12 +8646,12 @@ IGNORE_CLANG_WARNINGS_END
                     setInt32(vmCall(Int32, operationArrayIndexOfValueDouble, storage, lowJSValue(searchElementEdge), startIndex));
                 return;
             case Array::Contiguous:
-                // We have to keep base alive since that keeps content of storage alive.
-                ensureStillAliveHere(base);
                 if (isArrayIncludes)
                     setBoolean(vmCall(Int32, operationArrayIncludesValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
                 else
                     setInt32(vmCall(Int32, operationArrayIndexOfValueInt32OrContiguous, weakPointer(globalObject), storage, lowJSValue(searchElementEdge), startIndex));
+                // We have to keep base alive since that keeps content of storage alive.
+                ensureStillAliveHere(base);
                 return;
             case Array::Int32:
                 if (isArrayIncludes)

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -268,14 +268,17 @@ void MediaMetadata::tryNextArtworkImage(uint32_t index, Vector<Pair>&& artworks)
 
     String artworkImageSrc = artworks[index].src;
 
-    m_artworkLoader = ArtworkImageLoader::create(*document, artworkImageSrc, [this, index, artworkImageSrc, artworks = WTF::move(artworks)](Image* image) mutable {
+    m_artworkLoader = ArtworkImageLoader::create(*document, artworkImageSrc, [weakThis = WeakPtr { *this }, index, artworkImageSrc, artworks = WTF::move(artworks)](Image* image) mutable {
+        RefPtr strongThis = weakThis;
+        if (!strongThis)
+            return;
         if (image && image->data() && image->width() && image->height()) {
             IntSize size { int(image->width()), int(image->height()) };
             float imageScore = imageDimensionsScore(size.width(), size.height(), s_minimumSize, s_idealSize);
-            if (!index || (m_artworkImage && (imageDimensionsScore(m_artworkImage->width(), m_artworkImage->height(), s_minimumSize, s_idealSize) < imageScore))) {
-                m_artworkImageSrc = artworkImageSrc;
-                setArtworkImage(image);
-                metadataUpdated();
+            if (!index || (strongThis->m_artworkImage && (imageDimensionsScore(strongThis->m_artworkImage->width(), strongThis->m_artworkImage->height(), s_minimumSize, s_idealSize) < imageScore))) {
+                strongThis->m_artworkImageSrc = artworkImageSrc;
+                strongThis->setArtworkImage(image);
+                strongThis->metadataUpdated();
             }
             // If selection from `sizes` attribute yielded a valid image, or we have downloaded an image bigger than the ideal size we stop.
             if (artworks[index].score >= 0 || size.maxDimension() >= s_idealSize)
@@ -283,7 +286,7 @@ void MediaMetadata::tryNextArtworkImage(uint32_t index, Vector<Pair>&& artworks)
         }
 
         if (++index < artworks.size())
-            tryNextArtworkImage(index, WTF::move(artworks));
+            strongThis->tryNextArtworkImage(index, WTF::move(artworks));
     });
     m_artworkLoader->requestImageResource();
 }

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.h
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.h
@@ -75,7 +75,7 @@ private:
     CachedResourceHandle<CachedImage> m_cachedImage;
 };
 
-class MediaMetadata final : public RefCounted<MediaMetadata> {
+class MediaMetadata final : public RefCountedAndCanMakeWeakPtr<MediaMetadata> {
 public:
     static ExceptionOr<Ref<MediaMetadata>> create(ScriptExecutionContext&, std::optional<MediaMetadataInit>&&);
     static Ref<MediaMetadata> create(MediaSession&, Vector<URL>&&);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -232,7 +232,8 @@ void HTMLCanvasElement::setSizeForControllingContext(IntSize newSize)
 
 ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::JSGlobalObject& state, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments)
 {
-    if (m_context) {
+    auto getExistingContext = [&]() -> ExceptionOr<std::optional<RenderingContext>> {
+        ASSERT(m_context);
         if (m_context->isPlaceholder())
             return Exception { ExceptionCode::InvalidStateError };
 
@@ -269,7 +270,10 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
 
         ASSERT_NOT_REACHED();
         return std::optional<RenderingContext> { std::nullopt };
-    }
+    };
+
+    if (m_context)
+        return getExistingContext();
 
     if (is2dType(contextId)) {
         Ref vm = state.vm();
@@ -278,6 +282,10 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         auto settings = convert<IDLDictionary<CanvasRenderingContext2DSettings>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
         if (settings.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
+
+        // Dictionary conversion may run script, which may have set m_context via a re-entrant getContext().
+        if (m_context) [[unlikely]]
+            return getExistingContext();
 
         RefPtr context = createContext2d(contextId, settings.releaseReturnValue());
         if (!context)
@@ -293,6 +301,10 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         if (settings.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
 
+        // Dictionary conversion may run script, which may have set m_context via a re-entrant getContext().
+        if (m_context) [[unlikely]]
+            return getExistingContext();
+
         RefPtr context = createContextBitmapRenderer(contextId, settings.releaseReturnValue());
         if (!context)
             return std::optional<RenderingContext> { std::nullopt };
@@ -307,6 +319,10 @@ ExceptionOr<std::optional<RenderingContext>> HTMLCanvasElement::getContext(JSC::
         auto attributes = convert<IDLDictionary<WebGLContextAttributes>>(state, arguments.isEmpty() ? JSC::jsUndefined() : (arguments[0].isObject() ? arguments[0].get() : JSC::jsNull()));
         if (attributes.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };
+
+        // Dictionary conversion may run script, which may have set m_context via a re-entrant getContext().
+        if (m_context) [[unlikely]]
+            return getExistingContext();
 
         RefPtr context = createContextWebGL(toWebGLVersion(contextId), attributes.releaseReturnValue());
         if (!context)
@@ -361,7 +377,7 @@ bool HTMLCanvasElement::is2dType(const String& type)
 CanvasRenderingContext2D* HTMLCanvasElement::createContext2d(const String& type, CanvasRenderingContext2DSettings&& settings)
 {
     ASSERT_UNUSED(HTMLCanvasElement::is2dType(type), type);
-    ASSERT(!m_context);
+    ASSERT_WITH_SECURITY_IMPLICATION(!m_context);
 
     m_context = CanvasRenderingContext2D::create(*this, WTF::move(settings), document().inQuirksMode());
     if (!m_context)
@@ -429,7 +445,7 @@ WebGLVersion HTMLCanvasElement::toWebGLVersion(const String& type)
 
 WebGLRenderingContextBase* HTMLCanvasElement::createContextWebGL(WebGLVersion type, WebGLContextAttributes&& attrs)
 {
-    ASSERT(!m_context);
+    ASSERT_WITH_SECURITY_IMPLICATION(!m_context);
 
     if (!shouldEnableWebGL(document().settings()))
         return nullptr;
@@ -496,7 +512,7 @@ bool HTMLCanvasElement::isBitmapRendererType(const String& type)
 ImageBitmapRenderingContext* HTMLCanvasElement::createContextBitmapRenderer(const String& type, ImageBitmapRenderingContextSettings&& settings)
 {
     ASSERT_UNUSED(type, HTMLCanvasElement::isBitmapRendererType(type));
-    ASSERT(!m_context);
+    ASSERT_WITH_SECURITY_IMPLICATION(!m_context);
 
     auto context = ImageBitmapRenderingContext::create(*this, WTF::move(settings));
     WeakPtr weakContext = *context;
@@ -528,7 +544,7 @@ bool HTMLCanvasElement::isWebGPUType(const String& type)
 GPUCanvasContext* HTMLCanvasElement::createContextWebGPU(const String& type, GPU* gpu)
 {
     ASSERT_UNUSED(type, HTMLCanvasElement::isWebGPUType(type));
-    ASSERT(!m_context);
+    ASSERT_WITH_SECURITY_IMPLICATION(!m_context);
 
     if (!document().settings().webGPUEnabled() || !gpu)
         return nullptr;

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -211,6 +211,13 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
     if (m_detached)
         return Exception { ExceptionCode::InvalidStateError };
 
+    // Dictionary conversion may run script, which may have detached this canvas.
+    auto shouldThrowForDetachedCanvas = [&]() -> ExceptionOr<void> {
+        if (m_detached) [[unlikely]]
+            return Exception { ExceptionCode::InvalidStateError };
+        return { };
+    };
+
     if (contextType == RenderingContextType::_2d) {
         if (!m_context) {
             auto scope = DECLARE_THROW_SCOPE(state.vm());
@@ -219,7 +226,10 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             if (settings.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
 
-            m_context = OffscreenCanvasRenderingContext2D::create(*this, settings.releaseReturnValue());
+            if (auto result = shouldThrowForDetachedCanvas(); result.hasException())
+                return result.releaseException();
+            if (!m_context)
+                m_context = OffscreenCanvasRenderingContext2D::create(*this, settings.releaseReturnValue());
         }
         if (RefPtr context = dynamicDowncast<OffscreenCanvasRenderingContext2D>(m_context.get()))
             return { { WTF::move(context) } };
@@ -233,8 +243,12 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             if (settings.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
 
-            m_context = ImageBitmapRenderingContext::create(*this, settings.releaseReturnValue());
-            downcast<ImageBitmapRenderingContext>(m_context.get())->transferFromImageBitmap(nullptr);
+            if (auto result = shouldThrowForDetachedCanvas(); result.hasException())
+                return result.releaseException();
+            if (!m_context) {
+                m_context = ImageBitmapRenderingContext::create(*this, settings.releaseReturnValue());
+                downcast<ImageBitmapRenderingContext>(m_context.get())->transferFromImageBitmap(nullptr);
+            }
         }
         if (RefPtr context = dynamicDowncast<ImageBitmapRenderingContext>(m_context.get()))
             return { { WTF::move(context) } };
@@ -271,8 +285,10 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             if (attributes.hasException(scope)) [[unlikely]]
                 return Exception { ExceptionCode::ExistingExceptionError };
 
+            if (auto result = shouldThrowForDetachedCanvas(); result.hasException())
+                return result.releaseException();
             RefPtr scriptExecutionContext = this->scriptExecutionContext();
-            if (shouldEnableWebGL(scriptExecutionContext->settingsValues(), is<WorkerGlobalScope>(scriptExecutionContext)))
+            if (!m_context && shouldEnableWebGL(scriptExecutionContext->settingsValues(), is<WorkerGlobalScope>(scriptExecutionContext)))
                 m_context = WebGLRenderingContextBase::create(*this, attributes.releaseReturnValue(), webGLVersion);
         }
         if (webGLVersion == WebGLVersion::WebGL1) {

--- a/Source/WebCore/html/closewatcher/CloseWatcher.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.cpp
@@ -59,8 +59,8 @@ ExceptionOr<Ref<CloseWatcher>> CloseWatcher::create(ScriptExecutionContext& cont
         } else {
             watcher->m_signal = signal;
             watcher->m_signalAlgorithm = signal->addAlgorithm([weakWatcher = WeakPtr { watcher.get() }](JSC::JSValue) mutable {
-                if (weakWatcher)
-                    weakWatcher->destroy();
+                if (RefPtr watcher = weakWatcher.get())
+                    watcher->destroy();
             });
         }
     }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -941,7 +941,7 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
         m_provisionalItem = item;
     }
 
-    for (Ref childItem : item.children()) {
+    for (Ref childItem : copyToVector(item.children())) {
         auto frameID = childItem->frameID();
         if (!frameID)
             continue;
@@ -963,7 +963,7 @@ void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromIt
         return m_frame->loader().loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
 
     // Just iterate over the rest, looking for frames to navigate.
-    for (Ref childItem : item.children()) {
+    for (Ref childItem : copyToVector(item.children())) {
         auto frameID = childItem->frameID();
         if (!frameID)
             continue;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1544,9 +1544,12 @@ size_t NetworkConnectionToWebProcess::findNetworkActivityTracker(WebCore::Resour
 void NetworkConnectionToWebProcess::establishSharedWorkerContextConnection(WebPageProxyIdentifier, WebCore::Site&& site, CompletionHandler<void()>&& completionHandler)
 {
     CONNECTION_RELEASE_LOG(SharedWorker, "establishSharedWorkerContextConnection:");
-    CheckedPtr session = networkSession();
-    if (CheckedPtr swServer = session ? session->sharedWorkerServer() : nullptr)
-        m_sharedWorkerContextConnection = WebSharedWorkerServerToContextConnection::create(*this, WTF::move(site), *swServer);
+    if (CheckedPtr session = networkSession()) {
+        auto allowCookieAccess = session->networkProcess().allowsFirstPartyForCookies(webProcessIdentifier(), site.domain());
+        MESSAGE_CHECK_COMPLETION(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate, completionHandler());
+        if (CheckedPtr swServer = session->sharedWorkerServer())
+            m_sharedWorkerContextConnection = WebSharedWorkerServerToContextConnection::create(*this, WTF::move(site), *swServer);
+    }
     completionHandler();
 }
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -179,9 +179,9 @@ void WebSharedWorkerServer::addContextConnection(WebSharedWorkerServerToContextC
 {
     RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::addContextConnection(%p) webProcessIdentifier=%" PRIu64, &contextConnection, contextConnection.webProcessIdentifier() ? contextConnection.webProcessIdentifier()->toUInt64() : 0);
 
-    ASSERT(!m_contextConnections.contains(contextConnection.registrableDomain()));
-
-    m_contextConnections.add(contextConnection.registrableDomain(), contextConnection);
+    auto result = m_contextConnections.add(contextConnection.registrableDomain(), contextConnection);
+    if (!result.isNewEntry)
+        return;
 
     contextConnectionCreated(contextConnection);
 }

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -477,7 +477,8 @@ void Connection::setDidCloseOnConnectionWorkQueueCallback(DidCloseOnConnectionWo
 
 void Connection::setOutgoingMessageQueueIsGrowingLargeCallback(OutgoingMessageQueueIsGrowingLargeCallback&& callback)
 {
-    m_outgoingMessageQueueIsGrowingLargeCallback = WTF::move(callback);
+    Locker locker { m_outgoingMessagesLock };
+    m_outgoingMessageQueueIsGrowingLargeCallback = Box<OutgoingMessageQueueIsGrowingLargeCallback>::create(WTF::move(callback));
 }
 
 bool Connection::open(Client& client, SerialFunctionDispatcher& dispatcher)
@@ -519,7 +520,10 @@ void Connection::invalidate()
         return;
     assertIsCurrent(dispatcher());
     m_client = nullptr;
-    m_outgoingMessageQueueIsGrowingLargeCallback = nullptr;
+    {
+        Locker locker { m_outgoingMessagesLock };
+        m_outgoingMessageQueueIsGrowingLargeCallback = nullptr;
+    }
     {
         Locker locker { m_incomingMessagesLock };
         m_syncState = nullptr;
@@ -634,6 +638,7 @@ Error Connection::sendMessageImpl(UniqueRef<Encoder>&& encoder, OptionSet<SendOp
     bool shouldDispatchMessageSend;
     size_t outgoingMessagesCount;
     bool shouldNotifyOfQueueGrowingLarge;
+    Box<OutgoingMessageQueueIsGrowingLargeCallback> outgoingMessageQueueIsGrowingLargeCallback;
     unsigned maxOutgoingMessageNameCount = 0;
     ASCIILiteral maxOutgoingMessageName;
     {
@@ -643,6 +648,7 @@ Error Connection::sendMessageImpl(UniqueRef<Encoder>&& encoder, OptionSet<SendOp
         outgoingMessagesCount = m_outgoingMessages.size();
         shouldNotifyOfQueueGrowingLarge = m_outgoingMessageQueueIsGrowingLargeCallback && outgoingMessagesCount > largeOutgoingMessageQueueCountThreshold && (MonotonicTime::now() - m_lastOutgoingMessageQueueIsGrowingLargeCallbackCallTime) >= largeOutgoingMessageQueueTimeThreshold;
         if (shouldNotifyOfQueueGrowingLarge) {
+            outgoingMessageQueueIsGrowingLargeCallback = m_outgoingMessageQueueIsGrowingLargeCallback;
             HashCountedSet<ASCIILiteral> outgoingMessageNameCounts;
             for (auto& encoder : m_outgoingMessages) {
                 auto name = description(encoder->messageName());
@@ -663,7 +669,7 @@ Error Connection::sendMessageImpl(UniqueRef<Encoder>&& encoder, OptionSet<SendOp
 #else
         RELEASE_LOG_ERROR(IPC, "Connection::sendMessage(): Too many messages (%zu) in the queue, notifying client (most common: %u %" PUBLIC_LOG_STRING " messages)", outgoingMessagesCount, maxOutgoingMessageNameCount, maxOutgoingMessageName.characters());
 #endif
-        m_outgoingMessageQueueIsGrowingLargeCallback();
+        (*outgoingMessageQueueIsGrowingLargeCallback)();
     }
 
     // It's not clear if calling dispatchWithQOS() will do anything if Connection::sendOutgoingMessages() is already running.

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -38,6 +38,7 @@
 #include <new>
 #include <tuple>
 #include <wtf/Assertions.h>
+#include <wtf/Box.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -689,7 +690,7 @@ private:
     bool m_onlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage { false };
     bool m_shouldExitOnSyncMessageSendFailure { false };
     DidCloseOnConnectionWorkQueueCallback m_didCloseOnConnectionWorkQueueCallback { nullptr };
-    OutgoingMessageQueueIsGrowingLargeCallback m_outgoingMessageQueueIsGrowingLargeCallback;
+    Box<OutgoingMessageQueueIsGrowingLargeCallback> m_outgoingMessageQueueIsGrowingLargeCallback WTF_GUARDED_BY_LOCK(m_outgoingMessagesLock);
     MonotonicTime m_lastOutgoingMessageQueueIsGrowingLargeCallbackCallTime WTF_GUARDED_BY_LOCK(m_outgoingMessagesLock);
 
     const Ref<WorkQueue> m_connectionQueue;

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.c
@@ -210,23 +210,22 @@ struct pas_mar_exported_allocation_record pas_mar_get_allocation_record(pas_mar_
 
     void* base_object_address = NULL;
     for (unsigned i = 0; i < PAS_MAR_TRACKED_ALLOCATIONS; ++i) {
-        unsigned index = (pas_mar_allocation_table_head_index(registry) + i) % PAS_MAR_TRACKED_ALLOCATIONS;
-        if ((registry->allocation_record_table_head + i) % MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS == registry->allocation_record_table_tail)
+        struct pas_mar_memory_action_record* art_entry = pas_mar_registry_get_memory_action(registry, i);
+        if (!art_entry)
             break;
-        struct pas_mar_memory_action_record* art_entry = &registry->allocation_record_table[index];
         if (art_entry->is_allocation) {
             // Check if the allocation was within the range
             if ((uintptr_t) address >= (uintptr_t) pas_mar_canonicalize_address(art_entry->address) && (uintptr_t) address < ((uintptr_t) pas_mar_canonicalize_address(art_entry->address)) + art_entry->allocation_size_bytes) {
                 // Check that we have a valid backtrace
                 unsigned registry_index = art_entry->backtrace_registry_index;
-                if (registry->backtrace_registry[registry_index].hash != art_entry->backtrace_hash)
+                pas_mar_backtrace_record* backtrace = pas_mar_registry_get_backtrace(registry, registry_index);
+                if (backtrace->hash != art_entry->backtrace_hash)
                     continue;
-
-                pas_mar_backtrace_record* backtrace = &registry->backtrace_registry[registry_index];
 
                 result.allocation_size_bytes = art_entry->allocation_size_bytes;
                 result.is_valid = true;
-                result.allocation_trace.num_frames= backtrace->num_frames;
+                result.allocation_trace.num_frames = backtrace->num_frames;
+                PAS_ASSERT(backtrace->num_frames < PAS_MAR_BACKTRACE_MAX_SIZE);
                 memcpy(result.allocation_trace.backtrace_buffer, backtrace->backtrace_buffer, backtrace->num_frames * sizeof(void*));
 
                 base_object_address = art_entry->address;
@@ -235,12 +234,12 @@ struct pas_mar_exported_allocation_record pas_mar_get_allocation_record(pas_mar_
         if (result.is_valid && !art_entry->is_allocation && art_entry->address == base_object_address) {
             // Check that we have a valid backtrace
             unsigned registry_index = art_entry->backtrace_registry_index;
-            if (registry->backtrace_registry[registry_index].hash != art_entry->backtrace_hash)
+            pas_mar_backtrace_record* backtrace = pas_mar_registry_get_backtrace(registry, registry_index);
+            if (backtrace->hash != art_entry->backtrace_hash)
                 continue;
 
-            pas_mar_backtrace_record* backtrace = &registry->backtrace_registry[registry_index];
-
-            result.deallocation_trace.num_frames= backtrace->num_frames;
+            result.deallocation_trace.num_frames = backtrace->num_frames;
+            PAS_ASSERT(backtrace->num_frames < PAS_MAR_BACKTRACE_MAX_SIZE);
             memcpy(result.deallocation_trace.backtrace_buffer, backtrace->backtrace_buffer, backtrace->num_frames * sizeof(void*));
 
             base_object_address = NULL;

--- a/Source/bmalloc/libpas/src/libpas/pas_mar_registry.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mar_registry.h
@@ -138,6 +138,29 @@ PAS_ALWAYS_INLINE static void pas_mar_increment_allocation_record_table_tail(pas
     registry->allocation_record_table_tail %= MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS;
 }
 
+/* Bounds-checking accessors */
+PAS_ALWAYS_INLINE static pas_mar_memory_action_record* pas_mar_registry_get_memory_action(pas_mar_registry* registry, unsigned i)
+{
+    PAS_ASSERT(registry);
+    unsigned index = (pas_mar_allocation_table_head_index(registry) + i) % PAS_MAR_TRACKED_ALLOCATIONS;
+    if ((registry->allocation_record_table_head + i) % MAR_ALLOCATION_RECORD_TABLE_FIFO_MODULUS == registry->allocation_record_table_tail)
+        return NULL;
+
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN;
+    return &registry->allocation_record_table[index];
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
+}
+
+PAS_ALWAYS_INLINE static pas_mar_backtrace_record* pas_mar_registry_get_backtrace(pas_mar_registry* registry, size_t idx)
+{
+    PAS_ASSERT(registry);
+    PAS_ASSERT(idx < PAS_MAR_TRACKED_BACKTRACES);
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN;
+    return &registry->backtrace_registry[idx];
+    PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
+}
+
+
 PAS_BEGIN_EXTERN_C;
 
 void* pas_mar_record_allocation(pas_mar_registry*, void* address, size_t allocation_size_bytes, unsigned num_stack_frames, void** backtrace);


### PR DESCRIPTION
#### d4581721a2eacefa9e48613323524d92e619389f
<pre>
Cherry-pick 62a1052dd1fe. <a href="https://bugs.webkit.org/show_bug.cgi?id=313252">https://bugs.webkit.org/show_bug.cgi?id=313252</a>

[JSC] Spread operator doesn&apos;t account for cellButterflyOnlyAtomStringsStructure in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=313252">https://bugs.webkit.org/show_bug.cgi?id=313252</a>
<a href="https://rdar.apple.com/175498631">rdar://175498631</a>

Reviewed by Yijia Huang.

This patch fixes the abstract interpreter&apos;s structure prediction for the spread operator.
Instead of only cellButterflyStructure(CopyOnWriteArrayWithContiguous), it now also takes
cellButterflyOnlyAtomStringsStructure into account.

Test: JSTests/stress/spread-with-OnlyAtomStringsStructure.js

* JSTests/stress/spread-with-OnlyAtomStringsStructure.js: Added.
(index):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Identifier: 305413.768@safari-7624-branch

Identifier: 305413.735@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.843@webkitglib/2.52">https://commits.webkit.org/305877.843@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 95ef4019680b649d6930ecf60bd746106a24321f
<pre>
Cherry-pick a2cb3a724645. <a href="https://bugs.webkit.org/show_bug.cgi?id=313626">https://bugs.webkit.org/show_bug.cgi?id=313626</a>

use-after-free in CloseWatcher::destroy(): abort-signal algorithm calls destroy() via WeakPtr while CloseWatcherManager holds the last Ref
<a href="https://bugs.webkit.org/show_bug.cgi?id=313626">https://bugs.webkit.org/show_bug.cgi?id=313626</a>
<a href="https://rdar.apple.com/175672431">rdar://175672431</a>

Reviewed by Ryosuke Niwa.

Protect the watcher before calling destroy() on it.

Test: fast/dom/CloseWatcher-watcher-crash.html

* LayoutTests/fast/dom/CloseWatcher-watcher-crash-expected.txt: Added.
* LayoutTests/fast/dom/CloseWatcher-watcher-crash.html: Added.
* Source/WebCore/html/closewatcher/CloseWatcher.cpp:
(WebCore::CloseWatcher::create):

Identifier: 305413.770@safari-7624-branch

Identifier: 305413.734@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.842@webkitglib/2.52">https://commits.webkit.org/305877.842@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e17194482bacb2a8c69eb7abdd4df05ac8a8a5a3
<pre>
Cherry-pick db99db96e504. <a href="https://bugs.webkit.org/show_bug.cgi?id=313490">https://bugs.webkit.org/show_bug.cgi?id=313490</a>

[JSC][FTL] compileArrayIndexOfOrArrayIncludes (UntypedUse + Array::Contiguous): ensureStillAliveHere(base) placed before GC-capable vmCall
<a href="https://bugs.webkit.org/show_bug.cgi?id=313490">https://bugs.webkit.org/show_bug.cgi?id=313490</a>
<a href="https://rdar.apple.com/175674067">rdar://175674067</a>

Reviewed by Yusuke Suzuki.

Delays an ensureStillAliveHere call until after a GC-capable function invocation.

Test: JSTests/stress/array-indexof-ensure-still-alive.js

* JSTests/stress/array-indexof-ensure-still-alive.js: Added.
(opt):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):

Identifier: 305413.767@safari-7624-branch

Identifier: 305413.731@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.841@webkitglib/2.52">https://commits.webkit.org/305877.841@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 29f4e4d3ca4df95b99381ccec875461fe385472c
<pre>
Cherry-pick 153d034e52b2. <a href="https://bugs.webkit.org/show_bug.cgi?id=313533">https://bugs.webkit.org/show_bug.cgi?id=313533</a>

Fix data race on m_outgoingMessageQueueIsGrowingLargeCallback in IPC::Connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=313533">https://bugs.webkit.org/show_bug.cgi?id=313533</a>
<a href="https://rdar.apple.com/175743852">rdar://175743852</a>

Reviewed by Kimmo Kinnunen.

sendMessageImpl() is thread-safe but was reading and invoking
m_outgoingMessageQueueIsGrowingLargeCallback outside m_outgoingMessagesLock,
while invalidate() was clearing it on the dispatcher thread without holding
the lock. This is a data race on the Function object.

Wrap the callback in a Box&lt;&gt; (ThreadSafeRefCounted) so it can be safely copied under
the lock and invoked outside it. Guard all accesses to the member with
m_outgoingMessagesLock.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::setOutgoingMessageQueueIsGrowingLargeCallback):
(IPC::Connection::invalidate):
(IPC::Connection::sendMessageImpl):
* Source/WebKit/Platform/IPC/Connection.h:

Identifier: 305413.761@safari-7624-branch

Identifier: 305413.730@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.840@webkitglib/2.52">https://commits.webkit.org/305877.840@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 143e59252f0db9745e521835de3cb3f0b3c01340
<pre>
Cherry-pick 40941e46f2d4. <a href="https://bugs.webkit.org/show_bug.cgi?id=313175">https://bugs.webkit.org/show_bug.cgi?id=313175</a>

Crash in CanvasRenderingContext::deref after reentrant getContext()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313175">https://bugs.webkit.org/show_bug.cgi?id=313175</a>&gt;
&lt;<a href="https://rdar.apple.com/175164594">rdar://175164594</a>&gt;

Reviewed by Said Abou-Hallawa.

`HTMLCanvasElement::getContext()` and `OffscreenCanvas::getContext()`
check `m_context` at the top, then call
`convert&lt;IDLDictionary&lt;...&gt;&gt;()` on the settings argument.  Dictionary
conversion invokes JS property getters, which can re-enter
`getContext()` on the same canvas and assign `m_context`.  The outer
call then proceeds to `createContext2d()`/`createContextWebGL()`/
`createContextBitmapRenderer()`, which overwrites `m_context` with a
new `unique_ptr`, destroying the inner context while its JS wrapper
is still alive.  `CanvasRenderingContext` forwards `ref()`/`deref()`
to its owning `CanvasBase`, so the wrapper&apos;s ref does not keep the
context alive; on GC sweep the wrapper&apos;s `deref()` reads `m_canvas`
from a freed `this`.

Re-check `m_context` (and `m_detached` for `OffscreenCanvas`) after
dictionary conversion.  If a re-entrant call set `m_context`, return
the existing context when the type matches and null otherwise,
matching the existing early-return semantics.

Also upgrade `ASSERT(!m_context)` to
`ASSERT_WITH_SECURITY_IMPLICATION(!m_context)` in all four
`createContext*()` methods.  These asserts guard the same invariant
this bug violates -- that `m_context` is assigned at most once --
and a violation is security-relevant.

Test: fast/canvas/canvas-getContext-reentrant.html

* LayoutTests/fast/canvas/canvas-getContext-reentrant-expected.txt: Add.
* LayoutTests/fast/canvas/canvas-getContext-reentrant.html: Add.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getContext):
(WebCore::HTMLCanvasElement::createContext2d):
(WebCore::HTMLCanvasElement::createContextWebGL):
(WebCore::HTMLCanvasElement::createContextBitmapRenderer):
(WebCore::HTMLCanvasElement::createContextWebGPU):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):

Identifier: 305413.763@safari-7624-branch

Identifier: 305413.729@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.839@webkitglib/2.52">https://commits.webkit.org/305877.839@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4bd6b34f02974a38afc4037c9497b50ec6982374
<pre>
Cherry-pick 9fd7e69ed2c4. <a href="https://bugs.webkit.org/show_bug.cgi?id=313623">https://bugs.webkit.org/show_bug.cgi?id=313623</a>

Use-after-free in HistoryController::recursiveGoToItem — popstate-reentrant setChildItem reallocates iterated m_children
<a href="https://bugs.webkit.org/show_bug.cgi?id=313623">https://bugs.webkit.org/show_bug.cgi?id=313623</a>
<a href="https://rdar.apple.com/175673154">rdar://175673154</a>

Reviewed by Ryosuke Niwa.

Iterate over a copy of the HistoryItem children vector since it can be
modified while looping.

Test: fast/history/popstate-add-iframes-during-history-back.html

* LayoutTests/fast/history/popstate-add-iframes-during-history-back-expected.txt: Added.
* LayoutTests/fast/history/popstate-add-iframes-during-history-back.html: Added.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::recursiveGoToItem):

Identifier: 305413.764@safari-7624-branch

Identifier: 305413.727@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.838@webkitglib/2.52">https://commits.webkit.org/305877.838@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3c26bb069924302ebad75a9abf3debef365fe3f9
<pre>
Cherry-pick bb9e30e27a73. <a href="https://bugs.webkit.org/show_bug.cgi?id=312405">https://bugs.webkit.org/show_bug.cgi?id=312405</a>

[JSC] Missing codeBlock-&gt;m_lock in repatchGetBySlowPathCall
<a href="https://bugs.webkit.org/show_bug.cgi?id=312405">https://bugs.webkit.org/show_bug.cgi?id=312405</a>
<a href="https://rdar.apple.com/174630697">rdar://174630697</a>

Reviewed by Yusuke Suzuki.

Adds usage of GCSafeConcurrentJSLocker in three repatch methods.
This avoids a data race.

Test: JSTests/stress/regress-174630697.js

* JSTests/stress/regress-174630697.js: Added.
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::repatchGetBySlowPathCall):
(JSC::repatchPutBySlowPathCall):
(JSC::repatchInBySlowPathCall):

Identifier: 305413.703@safari-7624-branch

Identifier: 305413.724@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.837@webkitglib/2.52">https://commits.webkit.org/305877.837@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 44500f3e61137bfe65a54f5609a1619b7d44a048
<pre>
Cherry-pick 729d412ab091. <a href="https://bugs.webkit.org/show_bug.cgi?id=311600">https://bugs.webkit.org/show_bug.cgi?id=311600</a>

[libpas] Fix OoBable code-paths in MAR code
<a href="https://bugs.webkit.org/show_bug.cgi?id=311600">https://bugs.webkit.org/show_bug.cgi?id=311600</a>
<a href="https://rdar.apple.com/173772317">rdar://173772317</a>

Reviewed by Yusuke Suzuki.

In the case that the allocation record table is controlled by an
attacker, we cannot trust the offsets contained inside, and should
assert that we do not read out-of-bounds based on them.

Identifier: 305413.727@safari-7624-branch

Identifier: 305413.723@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.836@webkitglib/2.52">https://commits.webkit.org/305877.836@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3b20bd23451c5c48d20f009075afbb7826a77aac
<pre>
Cherry-pick 701d9d99f21d. <a href="https://bugs.webkit.org/show_bug.cgi?id=312480">https://bugs.webkit.org/show_bug.cgi?id=312480</a>

[SharedWorker] Add MESSAGE_CHECK to establishSharedWorkerContextConnection
<a href="https://rdar.apple.com/174708287">rdar://174708287</a>

Reviewed by Per Arne Vollan (OOPS\!).

establishSharedWorkerContextConnection accepts a WebContent-supplied Site with no
MESSAGE_CHECK, allowing a compromised web process to hijack SharedWorker context
connections for arbitrary domains. This mirrors the fix applied to the ServiceWorker
equivalent (establishSWContextConnection) in <a href="https://rdar.apple.com/107063897">rdar://107063897</a>.

Two changes:
1. Add allowsFirstPartyForCookies validation with MESSAGE_CHECK_COMPLETION before
   creating the context connection, matching the ServiceWorker pattern.
2. In WebSharedWorkerServer::addContextConnection, skip contextConnectionCreated when
   the domain already has a registered connection (replace debug-only ASSERT with
   runtime guard).

No new tests. Covered by existing SharedWorker tests.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::establishSharedWorkerContextConnection):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::addContextConnection):

Identifier: 305413.712@safari-7624-branch

Identifier: 305413.722@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.835@webkitglib/2.52">https://commits.webkit.org/305877.835@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8282b7db8585bef0ee642079d79fbc33d732eea8
<pre>
Cherry-pick 9da5185f2406. <a href="https://bugs.webkit.org/show_bug.cgi?id=312480">https://bugs.webkit.org/show_bug.cgi?id=312480</a>

[WebCore] Capture WeakPtr to this (MediaMetadata) in ArtworkImageLoader callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=312480">https://bugs.webkit.org/show_bug.cgi?id=312480</a>
<a href="https://rdar.apple.com/174651594">rdar://174651594</a>

Reviewed by Geoffrey Garen.

In media artwork image loading, it is possible for a
callback lambda to outlive the lifetime of the
MediaMetadata which it captures with a raw &quot;this&quot;.

This callback is stored in ArtworkImageLoader::m_callback
and ArtworkImageLoader is owned by MediaMetadata.

The lambda captures a raw this to MediaMetadata during
MediaMetadata::tryNextArtworkImage.

However, it&apos;s possible for the lambda to outlive ArtworkImageLoader
and, in turn, MediaMetadata after beeing std::exchanged outside
of the artwork loader in ArtworkImageLoader::notifyFinished.
Then, it&apos;s possible for MediaMetadata to be destroyed while
the lambda has a dangling &quot;this&quot; pointer to the destroyed object.

This patch changes the lambda to capture a WeakPtr
to &quot;this&quot; (MediaMetadata) and returns early if it has
been destroyed. If weakThis is still alive, we keep it alive for the
duration of the lambda body with a RefPtr.

* LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash-expected.txt: Added.
* LayoutTests/fast/mediasession/metadata/artwork-image-loader-callback-crash.html: Added.
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::MediaMetadata::tryNextArtworkImage):
        Changed the artwork loader lambda to capture a WeakPtr
        to &quot;this&quot; and early return if weakThis is null.
        The rest of the lambda explicitly uses weakThis where needed.
* Source/WebCore/Modules/mediasession/MediaMetadata.h:
        Changed MediaMetadata to inherit from CanMakeWeakPtr.

Identifier: 305413.695@safari-7624-branch

Identifier: 305413.721@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.834@webkitglib/2.52">https://commits.webkit.org/305877.834@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/439862dca0b5c413455ecf981d7059990bd1e7d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172011 "5 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/45928 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181451 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129565 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173876 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47214 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45568 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129565 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174969 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47214 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114282 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47214 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45568 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30064 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47214 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183983 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33270 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36598 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45568 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142536 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45595 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142427 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46275 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110938 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26113 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46275 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117963 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204689 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44793 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39346 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54647 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44193 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44425 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44252 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->