### PR TITLE
Suppress duplicate CSP reports for speculative preloads

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-only-sends-reports-to-first-endpoint.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-only-sends-reports-to-first-endpoint.https.sub-expected.txt
@@ -2,5 +2,5 @@
 
 PASS Test that image does not load
 PASS Event is fired
-FAIL Violation report status OK. assert_equals: CSP report sent, but not expecting one. expected 0 but got 2
+FAIL Violation report status OK. assert_equals: CSP report sent, but not expecting one. expected 0 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-01-expected.txt
@@ -1,5 +1,5 @@
 
 
 PASS Violation report status OK.
-FAIL Test number of sent reports. assert_equals: Report count was not what was expected. expected 2 but got 4
+PASS Test number of sent reports.
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -510,8 +510,10 @@ bool CachedResourceLoader::allowedByContentSecurityPolicy(CachedResource::Type t
         return true;
 
     contentSecurityPolicy->setIsReportingToConsoleEnabled(shouldReportViolationAsConsoleMessage);
+    contentSecurityPolicy->setIsReportingEnabled(shouldReportViolationAsConsoleMessage);
     auto scope = makeScopeExit([&] {
         contentSecurityPolicy->setIsReportingToConsoleEnabled(true);
+        contentSecurityPolicy->setIsReportingEnabled(true);
     });
 
     // Only object-src governs object/embed elements, regardless of resource type (CSP3 §6.1.9).

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -260,6 +260,7 @@ public:
     const HashAlgorithmSetCollection& hashesToReport() LIFETIME_BOUND;
 
     void setIsReportingToConsoleEnabled(bool value) { m_isReportingToConsoleEnabled = value; }
+    void setIsReportingEnabled(bool value) { m_isReportingEnabled = value; }
 
     // Captures the current JavaScript source location from the call stack.
     // Used to preserve source location across async boundaries for CSP violation reporting.


### PR DESCRIPTION
#### b88fdb90af4d3363fb018f3e9140bfdc57ce5afb
<pre>
Suppress duplicate CSP reports for speculative preloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=318371">https://bugs.webkit.org/show_bug.cgi?id=318371</a>
<a href="https://rdar.apple.com/181161362">rdar://181161362</a>

Reviewed by Ryan Reno.

Speculative preloads and the subsequent parser-driven load both run CSP checks, causing blocked
resources to emit duplicate violation reports and events.

Disable all CSP reporting during speculative preloads, while preserving normal reporting for
`&lt;link rel=preload&gt;`. The parser-driven load still performs the authoritative CSP check and reports
each violation once.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-to-only-sends-reports-to-first-endpoint.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-01-expected.txt:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:

Canonical link: <a href="https://commits.webkit.org/316559@main">https://commits.webkit.org/316559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffabd6ba4c664467bd0a96977e8e17eb572a6d52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29a31177-8907-4658-8b29-a7fe0a1b2cca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133814 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94393 "2 flakes 21 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dab4682-c427-4a97-a1bd-975219a96057) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114287 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61a035b1-342f-408c-ae36-f0762f439826) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34116 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30070 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183989 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142540 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45601 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142431 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30683 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110944 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26221 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37520 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117969 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44799 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8777 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44199 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44431 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44258 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->