### PR TITLE
Check httpNavigationWithHTTPSOnlyError without constructing a new one

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2331,8 +2331,7 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
         }
 
         if (advancedPrivacyProtections().contains(AdvancedPrivacyProtections::HTTPSOnly)) {
-            if (auto httpNavigationWithHTTPSOnlyError = platformStrategies()->loaderStrategy()->httpNavigationWithHTTPSOnlyError(m_request); mainResourceOrError.error().domain() == httpNavigationWithHTTPSOnlyError.domain()
-                && mainResourceOrError.error().errorCode() == httpNavigationWithHTTPSOnlyError.errorCode()) {
+            if (platformStrategies()->loaderStrategy()->isHttpNavigationWithHTTPSOnlyError(mainResourceOrError.error())) {
                 DOCUMENTLOADER_RELEASE_LOG("loadMainResource: Unable to load main resource, URL has HTTP scheme with HTTPSOnly enabled");
                 cancelMainResourceLoad(mainResourceOrError.error());
                 return;

--- a/Source/WebCore/loader/LoaderStrategy.h
+++ b/Source/WebCore/loader/LoaderStrategy.h
@@ -115,6 +115,7 @@ public:
     virtual ResourceError fileDoesNotExistError(const ResourceResponse&) const = 0;
     virtual ResourceError httpsUpgradeRedirectLoopError(const ResourceRequest&) const = 0;
     virtual ResourceError httpNavigationWithHTTPSOnlyError(const ResourceRequest&) const = 0;
+    virtual bool isHttpNavigationWithHTTPSOnlyError(const ResourceError&) const = 0;
     virtual ResourceError pluginWillHandleLoadError(const ResourceResponse&) const = 0;
 
 protected:

--- a/Source/WebKit/Shared/WebErrors.cpp
+++ b/Source/WebKit/Shared/WebErrors.cpp
@@ -128,4 +128,9 @@ ResourceError httpNavigationWithHTTPSOnlyError(const ResourceRequest& request)
     return ResourceError(API::Error::webKitNetworkErrorDomain(), API::Error::Network::HTTPNavigationWithHTTPSOnlyError, request.url(), WEB_UI_STRING("Navigation failed because the request was for an HTTP URL with HTTPS-Only enabled", "WebKitErrorHTTPSOnlyHTTPURL description"));
 }
 
+bool isHttpNavigationWithHTTPSOnlyError(const WebCore::ResourceError& error)
+{
+    return error.domain() == API::Error::webKitNetworkErrorDomain() && error.errorCode() == API::Error::Network::HTTPNavigationWithHTTPSOnlyError;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebErrors.h
+++ b/Source/WebKit/Shared/WebErrors.h
@@ -52,6 +52,7 @@ WebCore::ResourceError cannotShowMIMETypeError(const WebCore::ResourceResponse&)
 WebCore::ResourceError fileDoesNotExistError(const WebCore::ResourceResponse&);
 WebCore::ResourceError httpsUpgradeRedirectLoopError(const WebCore::ResourceRequest&);
 WebCore::ResourceError httpNavigationWithHTTPSOnlyError(const WebCore::ResourceRequest&);
+bool isHttpNavigationWithHTTPSOnlyError(const WebCore::ResourceError&);
 WebCore::ResourceError pluginWillHandleLoadError(const WebCore::ResourceResponse&);
 
 #if USE(SOUP)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -1246,6 +1246,11 @@ ResourceError WebLoaderStrategy::httpNavigationWithHTTPSOnlyError(const Resource
     return WebKit::httpNavigationWithHTTPSOnlyError(request);
 }
 
+bool WebLoaderStrategy::isHttpNavigationWithHTTPSOnlyError(const WebCore::ResourceError& error) const
+{
+    return WebKit::isHttpNavigationWithHTTPSOnlyError(error);
+}
+
 ResourceError WebLoaderStrategy::pluginWillHandleLoadError(const ResourceResponse& response) const
 {
     return WebKit::pluginWillHandleLoadError(response);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.h
@@ -127,6 +127,7 @@ private:
     WebCore::ResourceError fileDoesNotExistError(const WebCore::ResourceResponse&) const final;
     WebCore::ResourceError httpsUpgradeRedirectLoopError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError httpNavigationWithHTTPSOnlyError(const WebCore::ResourceRequest&) const final;
+    bool isHttpNavigationWithHTTPSOnlyError(const WebCore::ResourceError&) const final;
     WebCore::ResourceError pluginWillHandleLoadError(const WebCore::ResourceResponse&) const final;
 
     struct SyncLoadResult {

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -99,6 +99,7 @@ private:
     WebCore::ResourceError fileDoesNotExistError(const WebCore::ResourceResponse&) const final;
     WebCore::ResourceError httpsUpgradeRedirectLoopError(const WebCore::ResourceRequest&) const final;
     WebCore::ResourceError httpNavigationWithHTTPSOnlyError(const WebCore::ResourceRequest&) const final;
+    bool isHttpNavigationWithHTTPSOnlyError(const WebCore::ResourceError&) const final;
     WebCore::ResourceError pluginWillHandleLoadError(const WebCore::ResourceResponse&) const final;
 
     bool isSuspendingPendingRequests() const { return !!m_suspendPendingRequestsCount; }

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm
@@ -103,3 +103,8 @@ WebCore::ResourceError WebResourceLoadScheduler::httpNavigationWithHTTPSOnlyErro
 {
     RELEASE_ASSERT_NOT_REACHED(); // This error should never be created in WebKit1 because HTTPSOnly/First aren't available.
 }
+
+bool WebResourceLoadScheduler::isHttpNavigationWithHTTPSOnlyError(const WebCore::ResourceError& error) const
+{
+    RELEASE_ASSERT_NOT_REACHED(); // This error should never be created in WebKit1 because HTTPSOnly/First aren't available.
+}


### PR DESCRIPTION
#### a1a55949c63662f939521a257dd897030d473a0a
<pre>
Check httpNavigationWithHTTPSOnlyError without constructing a new one
<a href="https://bugs.webkit.org/show_bug.cgi?id=318360">https://bugs.webkit.org/show_bug.cgi?id=318360</a>
<a href="https://rdar.apple.com/181151216">rdar://181151216</a>

Reviewed by Brady Eidson.

We shouldn&apos;t need to construct a new httpNavigationWithHTTPSOnlyError just to
check if the error we have is the of the same type. We instead add a new function
that checks this for us (similar to isBlockedError()).

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/LoaderStrategy.h:
* Source/WebKit/Shared/WebErrors.cpp:
(WebKit::isHttpNavigationWithHTTPSOnlyError):
* Source/WebKit/Shared/WebErrors.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::isHttpNavigationWithHTTPSOnlyError const):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.mm:
(WebResourceLoadScheduler::isHttpNavigationWithHTTPSOnlyError const):

Canonical link: <a href="https://commits.webkit.org/316411@main">https://commits.webkit.org/316411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ecaf935f641e2bd76a7238c62540344df1d7b9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181459 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f8cc085-b0a3-4f2f-8446-5218c1260869) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133812 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1987af0e-3b9f-42f3-a9a8-13288a8d999b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114285 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77f9380c-d7f0-4278-a691-c60e3a064999) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34117 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30072 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183991 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142541 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45603 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142432 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30684 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/110946 "Hash 4ecaf935 for PR 68465 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37522 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/117971 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44801 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8778 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44201 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44433 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->