### PR TITLE
[JSC] Fix B3 CSE extras adjustment

### DIFF
--- a/JSTests/stress/b3-cse-fix.js
+++ b/JSTests/stress/b3-cse-fix.js
@@ -1,0 +1,6 @@
+//@ runDefault("--jitPolicyScale=0", "--validateGraphAtEachPhase=1", "--useConcurrentJIT=0", "--validateDFGClobberize=1")
+
+for (let i = 0; i < 100; i++) {
+    for (let j = 0; j < 100; j++) {
+    }
+}

--- a/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
+++ b/Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp
@@ -78,18 +78,6 @@ using MemoryMatches = Vector<MemoryValue*, 1>;
 using WasmStructMatches = Vector<WasmStructFieldValue*, 1>;
 using WasmArrayMatches = Vector<WasmArrayElementValue*, 1>;
 
-// Only these node kinds can ever become a key in CSE::m_sets (they are the
-// dominating matches: MemoryValue / WasmStructFieldValue / WasmArrayElementValue).
-// Used to skip the per-value m_sets hash lookup in finalize() and to assert at
-// the add site.
-inline bool canHaveSets(Value* value)
-{
-    Opcode opcode = value->opcode();
-    return isMemoryAccess(opcode)
-        || opcode == WasmStructGet || opcode == WasmStructSet
-        || opcode == WasmArrayGet || opcode == WasmArraySet;
-}
-
 class MemoryValueMap {
 public:
     MemoryValueMap() { }
@@ -444,7 +432,7 @@ private:
             if (m_blocksWithSets.contains(block)) {
                 for (unsigned valueIndex = 0; valueIndex < block->size(); ++valueIndex) {
                     Value* value = block->at(valueIndex);
-                    if (!canHaveSets(value))
+                    if (!m_matched.contains(value))
                         continue;
                     auto iter = m_sets.find(value);
                     if (iter == m_sets.end())
@@ -977,9 +965,9 @@ private:
         m_value->replaceWithIdentity(placeholder);
 
         for (MemoryValue* match : matches) {
-            ASSERT(canHaveSets(match));
             m_blocksWithSets.add(match->owner);
             auto& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            m_matched.add(match);
             Value* value = replace(match, extras);
             if (!value) {
                 if (match->isStore())
@@ -1251,9 +1239,9 @@ private:
         m_value->replaceWithIdentity(placeholder);
 
         for (auto* match : matches) {
-            ASSERT(canHaveSets(match));
             m_blocksWithSets.add(match->owner);
-            Vector<Value*>& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            auto& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            m_matched.add(match);
             auto* value = replace(match, extras);
             ASSERT(value);
             m_ssa->newDef(var, match->owner, value);
@@ -1475,9 +1463,9 @@ private:
         m_value->replaceWithIdentity(placeholder);
 
         for (auto* match : matches) {
-            ASSERT(canHaveSets(match));
             m_blocksWithSets.add(match->owner);
-            Vector<Value*>& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            auto& extras = m_sets.add(match, Vector<Value*>()).iterator->value;
+            m_matched.add(match);
             auto* value = replace(match, extras);
             ASSERT(value);
             m_ssa->newDef(var, match->owner, value);
@@ -1591,6 +1579,7 @@ private:
     // Match -> extra fixup values (e.g. BitAnd masks for packed Wasm types),
     // flushed at match site during finalize().
     UncheckedKeyHashMap<Value*, Vector<Value*>> m_sets;
+    IndexSet<Value*> m_matched;
     // Blocks that own at least one m_sets key, so finalize() can skip whole blocks.
     IndexSet<BasicBlock*> m_blocksWithSets;
 


### PR DESCRIPTION
#### 2bd4edbe145cfb08dec3585fe4235c01869e1d7d
<pre>
[JSC] Fix B3 CSE extras adjustment
<a href="https://bugs.webkit.org/show_bug.cgi?id=318373">https://bugs.webkit.org/show_bug.cgi?id=318373</a>
<a href="https://rdar.apple.com/180277164">rdar://180277164</a>

Reviewed by Dan Hecht.

B3 CSE can handle store with narrower width. In this case, we emit
narrowing operations to reuse the value. For example,

    @a: Load32(...)
    @b: Store8(@a, LocationA)
    ...
    @d: Load8(LocationA)

is converted to

    @a: Load32(...)
    @b: Store8(@a, LocationA)
    ...
    @c: BitAnd(@a, 0xff)
    @d: Identity(@c)

So, we insert BitAnd to narrow @a to 8-bit size in this case.
To detect whether we need to insert these extras B3 values, we are
tracking it in m_sets.

But when we materialize it, querying to this hash table for each Value
in the graph is too costly, so we have a filter canHaveSet which checks
value&apos;s opcode to filter out the candidate. However this opcode set is
not the right one since these values can be converted to Nop / Identity
sometimes. For example, in the above CSE case, it is possible that we
detect that the above @b is meaningless and convert it to Nop because
the subsequent Store8(..., LocationA) exists (store elimination).

To filter correctly while keeping the efficacy of compile time, we add
IndexSet for matched values. Under the hood, it is BitVector and
efficienty handle the filtering.

Test: JSTests/stress/b3-cse-fix.js

* JSTests/stress/b3-cse-fix.js: Added.
* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:

Canonical link: <a href="https://commits.webkit.org/316339@main">https://commits.webkit.org/316339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0319f19d8d23d3291e48fb3a99efd57edd1111ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39382 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5b407f9-813d-4432-9374-77ee5a4fe806) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45604 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/181487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f6fe555-32b9-4f21-a5c4-539da6a1affb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175005 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/181487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eabe4e88-e1bb-4860-a2af-e78dac91a70d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30100 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2899 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184019 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33306 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45631 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142457 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46311 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37544 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204725 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44829 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8807 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/54659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44229 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->