### PR TITLE
Mark crash-on-overflow functions in WTF OverflowHandler.h as NODELETE

### DIFF
--- a/Source/WTF/wtf/OverflowHandler.h
+++ b/Source/WTF/wtf/OverflowHandler.h
@@ -47,14 +47,14 @@ public:
     }
 
 public:
-    constexpr bool hasOverflowed() const { return false; }
+    SUPPRESS_NODELETE constexpr bool NODELETE hasOverflowed() const { return false; }
 };
 
 class CrashOnOverflow {
 public:
     static constexpr OverflowPolicy policy = OverflowPolicy::CrashOnOverflow;
 
-    static NO_RETURN_DUE_TO_CRASH void overflowed()
+    SUPPRESS_NODELETE static NO_RETURN_DUE_TO_CRASH void NODELETE overflowed()
     {
         crash();
     }
@@ -67,7 +67,7 @@ public:
     }
 
 public:
-    bool hasOverflowed() const { return false; }
+    SUPPRESS_NODELETE bool NODELETE hasOverflowed() const { return false; }
 };
 
 class RecordOverflow {
@@ -90,7 +90,7 @@ protected:
 public:
     static constexpr OverflowPolicy policy = OverflowPolicy::RecordOverflow;
 
-    bool hasOverflowed() const { return m_overflowed; }
+    SUPPRESS_NODELETE bool NODELETE hasOverflowed() const { return m_overflowed; }
     void overflowed() { m_overflowed = true; }
 
 private:


### PR DESCRIPTION
#### a11cec5ce1613e458b58016ffae6aea347281594
<pre>
Mark crash-on-overflow functions in WTF OverflowHandler.h as NODELETE
<a href="https://bugs.webkit.org/show_bug.cgi?id=318384">https://bugs.webkit.org/show_bug.cgi?id=318384</a>
<a href="https://rdar.apple.com/181171258">rdar://181171258</a>

Reviewed by Geoffrey Garen and Keith Miller.

This patch is meant to suppress SaferCPP complaining about functions
that are marked NODELETE that cause a controlled crash

* Source/WTF/wtf/OverflowHandler.h:
(WTF::AssertNoOverflow::crash):
(WTF::AssertNoOverflow::hasOverflowed const):
(WTF::CrashOnOverflow::overflowed):
(WTF::CrashOnOverflow::crash):
(WTF::CrashOnOverflow::hasOverflowed const):
(WTF::RecordOverflow::hasOverflowed const):

Canonical link: <a href="https://commits.webkit.org/317805@main">https://commits.webkit.org/317805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/302f268a7c122dd14f9cc58cb34eed6949629aec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185554 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d299f44-159f-4d1a-ae7a-33f88e721200) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137027 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2cdb2014-200b-4d5c-8e2b-739f013b778f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37354326-0598-474b-a441-1a408c8f180c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39134 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37519 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/6312 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34024 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/37225 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187976 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49561 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50241 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145865 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40657 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122437 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48748 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12276 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48382 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48207 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->