### PR TITLE
Remove redundant info when sending FrameTreeSyncSerializationData across IPC

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -189,9 +189,8 @@ def generate_process_sync_client_impl(prefix, synched_datas):
             result.append('#if %s' % data.conditional)
         result.append('void %sSyncClient::broadcast%sToOtherProcesses(const %s& data)' % (prefix, data.name, data.fully_qualified_type))
         result.append('{')
-        result.append('    %sSyncDataVariant dataVariant;' % (prefix))
-        result.append('    dataVariant.emplace<std::to_underlying(%sSyncDataType::%s)>(data);' % (prefix, data.name))
-        result.append('    broadcast%sSyncDataToOtherProcesses({ %sSyncDataType::%s, WTF::move(dataVariant) });' % (prefix, prefix, data.name))
+        result.append('    broadcast%sSyncDataToOtherProcesses({ %sSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(%sSyncDataType::%s)>, data } });' % (prefix, prefix, prefix, data.name))
+
         result.append('}')
         if data.conditional is not None:
             result.append('#endif')
@@ -202,7 +201,6 @@ def generate_process_sync_client_impl(prefix, synched_datas):
 
 _process_sync_data_header_suffix = """
 struct {prefix}SyncSerializationData {{
-    {prefix}SyncDataType type;
     {prefix}SyncDataVariant value;
 }};
 
@@ -302,7 +300,7 @@ def generate_synched_data_header(prefix, variant_sorted_synched_datas, sync_data
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
         name = data.name[0].lower() + data.name[1:]
-        result.append('    %s %s = { };' % (data.fully_qualified_type, name))
+        result.append('    %s %s { };' % (data.fully_qualified_type, name))
         if data.conditional is not None:
             result.append('#endif')
 
@@ -347,7 +345,7 @@ namespace WebCore {{
 
 void data_type_name::update(const {prefix}SyncSerializationData& data)
 {{
-    switch (data.type) {{"""
+    switch (static_cast<{prefix}SyncDataType>(data.value.index())) {{"""
 
 _synched_data_impl_midfix = """    default:
         RELEASE_ASSERT_NOT_REACHED();
@@ -454,7 +452,6 @@ header: <WebCore/{prefix}SyncData.h>
 
 _process_sync_data_serialization_in_suffix = """
 [CustomHeader] struct WebCore::{prefix}SyncSerializationData {{
-    WebCore::{prefix}SyncDataType type;
     WebCore::{prefix}SyncDataVariant value;
 }};
 """
@@ -476,17 +473,6 @@ def generate_process_sync_data_serialiation_in(prefix, variant_sorted_synched_da
 
     result.append('};')
     result.append('')
-
-    result.append("enum class WebCore::%sSyncDataType : uint8_t {" % prefix)
-    for data in variant_sorted_synched_datas:
-        if data.conditional is not None:
-            result.append('#if %s' % data.conditional)
-        result.append('    %s,' % data.name)
-        if data.conditional is not None:
-            result.append('#endif')
-
-    result.append("};")
-    result.append(" ")
 
     for data in variant_sorted_synched_datas:
         if data.conditional is not None:

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -977,7 +977,7 @@ void Page::setHasInjectedUserScript()
 
 void Page::updateTopDocumentSyncData(const DocumentSyncSerializationData& data)
 {
-    switch (data.type) {
+    switch (static_cast<DocumentSyncDataType>(data.value.index())) {
     case DocumentSyncDataType::DocumentClasses:
     case DocumentSyncDataType::DocumentSecurityOrigin:
     case DocumentSyncDataType::DocumentURL:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8742,14 +8742,14 @@ void WebPageProxy::broadcastFrameTreeSyncData(IPC::Connection& connection, Frame
 
     // FIXME: This could instead be an option in FrameTreeSyncData.in to allow
     // certain properties to be mutable from non-frame-owning processes.
-    if (frameTreePropertyIsRestrictedToFrameOwningProcess(data.type)) {
+    if (frameTreePropertyIsRestrictedToFrameOwningProcess(static_cast<WebCore::FrameTreeSyncDataType>(data.value.index()))) {
         if (&webFrameProxy->process() != &process.get()) {
             // FIXME: make this a MESSAGE_CHECK.
             return;
         }
     }
 
-    if (data.type == WebCore::FrameTreeSyncDataType::FrameRect)
+    if (data.value.index() == std::to_underlying(WebCore::FrameTreeSyncDataType::FrameRect))
         webFrameProxy->setRemoteFrameRect(std::get<IntRect>(data.value));
 
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1415,7 +1415,7 @@ void WebPage::frameTreeSyncDataChangedInAnotherProcess(FrameIdentifier frameID, 
     if (coreFrame) {
         coreFrame->updateFrameTreeSyncData(data);
 
-        switch (data.type) {
+        switch (static_cast<FrameTreeSyncDataType>(data.value.index())) {
         case FrameTreeSyncDataType::FrameRect:
             frame->updateFrameRectFromRemote(coreFrame->frameTreeSyncData().frameRect);
             break;


### PR DESCRIPTION
#### f58d3e08fbbfdc5fa9f149e12d7f83ff16bf82aa
<pre>
Remove redundant info when sending FrameTreeSyncSerializationData across IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=318387">https://bugs.webkit.org/show_bug.cgi?id=318387</a>
<a href="https://rdar.apple.com/181173621">rdar://181173621</a>

Reviewed by Brady Eidson.

We were sending the type across IPC as a FrameTreeSyncDataType then sending the variant,
with many assumptions that the two were always equal.  Since they&apos;re always supposed to be
equal, remove the type and just use the variant&apos;s index as...its index.

Also, we were default constructing a variant, then destroying the variant&apos;s first type,
then calling emplace to insert the Nth type, then moving it.  Use WTF::InPlaceIndex instead,
which is our version of std::in_place_index.  This saves a constructor and a destructor call,
and it allows a possibility of a variant with no default constructable types.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(generate_process_sync_client_impl):
(generate_synched_data_header):
(generate_process_sync_data_serialiation_in):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateTopDocumentSyncData):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::broadcastFrameTreeSyncData):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::frameTreeSyncDataChangedInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/316357@main">https://commits.webkit.org/316357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f348e113b56b1f1f46901d92eac8ebbcb7ea87b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129628 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe67ba8f-2cde-4794-8c66-68dec72b7681) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6121a09-265d-4442-88bb-9b98049ffe0d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37274 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114332 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65f90d3d-915c-4089-ab92-f2c7aba06e69) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35905 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30127 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184047 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36661 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45658 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142480 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46338 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111001 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26116 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37567 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44856 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8832 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44256 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44315 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->