### PR TITLE
Gate script tracking privacy network request blocking on Resource Load Statistics

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -370,6 +370,10 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
     if (!networkResourceLoader->parameters().mayBlockNetworkRequest)
         return false;
 
+    CheckedPtr networkSession = m_networkProcess->networkSession(m_sessionID);
+    if (!networkSession || !networkSession->isTrackingPreventionEnabled())
+        return false;
+
     if (RefPtr topOrigin = networkResourceLoader->parameters().topOrigin) {
         if (RegistrableDomain(request.url()).matches(topOrigin->data()))
             return false;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
@@ -156,7 +156,8 @@ static bool supportsFingerprintingScriptRequests()
 }
 
 static RetainPtr<TestWKWebView> setUpWebViewForFingerprintingTests(NSString *pageURLString, id<WKUIDelegate> uiDelegate, NSDictionary<NSString *, NSString *> *responseData,
-    NSString *referrer = @"https://webkit.org", _WKWebsiteNetworkConnectionIntegrityPolicy policies = _WKWebsiteNetworkConnectionIntegrityPolicyNone, WKWebsiteDataStore *datastore = nil)
+    NSString *referrer = @"https://webkit.org", _WKWebsiteNetworkConnectionIntegrityPolicy policies = _WKWebsiteNetworkConnectionIntegrityPolicyNone, WKWebsiteDataStore *datastore = nil,
+    BOOL enableResourceLoadStatistics = YES)
 {
     RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
     for (_WKFeature *feature in WKPreferences._features) {
@@ -167,7 +168,7 @@ static RetainPtr<TestWKWebView> setUpWebViewForFingerprintingTests(NSString *pag
     }
 
     RetainPtr dataStore = datastore ?: [WKWebsiteDataStore defaultDataStore];
-    [dataStore _setResourceLoadStatisticsEnabled:YES];
+    [dataStore _setResourceLoadStatisticsEnabled:enableResourceLoadStatistics];
     [configuration setWebsiteDataStore:dataStore.get()];
     [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
     [[configuration defaultWebpagePreferences] _setNetworkConnectionIntegrityPolicy:policies];
@@ -226,6 +227,11 @@ static RetainPtr<TestWKWebView> setUpWebViewForFingerprintingTests(NSString *pag
 static RetainPtr<TestWKWebView> setUpWebViewForFingerprintingTests(NSString *pageURLString, WKWebsiteDataStore *datastore)
 {
     return setUpWebViewForFingerprintingTests(pageURLString, nil, @{ }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyNone, datastore);
+}
+
+static RetainPtr<TestWKWebView> setUpWebViewForFingerprintingTests(NSString *pageURLString, WKWebsiteDataStore *datastore, BOOL enableResourceLoadStatistics)
+{
+    return setUpWebViewForFingerprintingTests(pageURLString, nil, @{ }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyNone, datastore, enableResourceLoadStatistics);
 }
 
 static NSString *getBundleResourceAsText(NSString *filename, NSString *extension)
@@ -936,11 +942,8 @@ TEST(ScriptTrackingPrivacyTests, MainFrameNavigationNotBlocked)
     EXPECT_TRUE(receivedNavigationRequest);
 }
 
-TEST(ScriptTrackingPrivacyTests, CrossSiteFetchBlocked)
+static RetainPtr<NSString> crossSiteFetchResultToTrackerDomain(BOOL enableResourceLoadStatistics)
 {
-    if (!supportsFingerprintingScriptRequests())
-        return;
-
     FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
@@ -980,15 +983,29 @@ TEST(ScriptTrackingPrivacyTests, CrossSiteFetchBlocked)
     }];
 
     RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
-
-    RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get());
+    RetainPtr webView = setUpWebViewForFingerprintingTests(@"http://top-domain.org/index.html", dataStore.get(), enableResourceLoadStatistics);
 
     Util::waitForConditionWithLogging([&] -> bool {
         return [[webView stringByEvaluatingJavaScript:@"window.fetchResult || ''"] length] > 0;
     }, 10, @"Timed out waiting for fetch result.");
 
-    RetainPtr fetchResult = [webView stringByEvaluatingJavaScript:@"window.fetchResult"];
-    EXPECT_TRUE([fetchResult hasPrefix:@"error"]);
+    return [webView stringByEvaluatingJavaScript:@"window.fetchResult"];
+}
+
+TEST(ScriptTrackingPrivacyTests, CrossSiteFetchBlocked)
+{
+    if (!supportsFingerprintingScriptRequests())
+        return;
+
+    EXPECT_TRUE([crossSiteFetchResultToTrackerDomain(YES) hasPrefix:@"error"]);
+}
+
+TEST(ScriptTrackingPrivacyTests, CrossSiteFetchNotBlockedWhenResourceLoadStatisticsDisabled)
+{
+    if (!supportsFingerprintingScriptRequests())
+        return;
+
+    EXPECT_TRUE([crossSiteFetchResultToTrackerDomain(NO) hasPrefix:@"success"]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### d4033745346df8821905ee103002aa62a28a41c8
<pre>
Gate script tracking privacy network request blocking on Resource Load Statistics
<a href="https://bugs.webkit.org/show_bug.cgi?id=318388">https://bugs.webkit.org/show_bug.cgi?id=318388</a>
<a href="https://rdar.apple.com/181175224">rdar://181175224</a>

Reviewed by Matthew Finkel.

Tie the blocking gated by ScriptTrackingPrivacyNetworkRequestBlockingEnabled to tracking prevention:
when Resource Load Statistics is disabled on the network session, don&apos;t block requests to targeted
domains.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::shouldBlockForTrackingPolicy):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::setUpWebViewForFingerprintingTests):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, CrossSiteFetchBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, CrossSiteFetchNotBlockedWhenResourceLoadStatisticsDisabled)):

Canonical link: <a href="https://commits.webkit.org/316460@main">https://commits.webkit.org/316460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab2e68cdb83cf0d2ac317568bf9f5baacb86689e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129787 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46d11805-8449-4f1f-ae4a-1149e8d64a6b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133963 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d2a65f4-90f3-40d5-85ed-86b164626fae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154509 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92888363-a649-4cf2-93b3-ae87ed080847) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36031 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30287 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184216 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142728 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45823 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142613 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46501 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111213 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37683 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118250 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45018 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8960 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44413 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->