### PR TITLE
spotify.com: Queue pane animation has weird jump when entering screen

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-clamp-after-transform-shrinks-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-clamp-after-transform-shrinks-overflow-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Scroll offset is clamped when a transform animation shrinks scrollable overflow
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-clamp-after-transform-shrinks-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-clamp-after-transform-shrinks-overflow.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Scroll offset is clamped when a transform animation shrinks scrollable overflow</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-rendering">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #clip { position: relative; width: 240px; height: 240px; overflow: hidden; }
+  #real { width: 240px; height: 240px; }
+  #phantom { position: absolute; top: 0; left: 0; width: 240px; height: 240px;
+             transform: translateY(240px); will-change: transform; }
+</style>
+<div id="clip"><div id="real"></div><div id="phantom"></div></div>
+<script>
+const H = 240;
+const clip = document.getElementById('clip');
+const phantom = document.getElementById('phantom');
+
+promise_test(async function(t) {
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    // The transform extends scrollable overflow to 2H; scroll to that (transform-extended) max.
+    assert_equals(clip.scrollHeight, 2 * H, 'precondition: transform extends scrollable overflow to 2H');
+    clip.scrollTop = clip.scrollHeight;
+    assert_greater_than(clip.scrollTop, 0, 'precondition: scrolled into the transform-extended region');
+
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    const transitionEnd = new Promise(resolve => {
+        phantom.addEventListener('transitionend', resolve, { once: true });
+    });
+    const timeout = new Promise((resolve, reject) => {
+        t.step_timeout(() => reject(new Error('transitionend did not fire within the timeout')), 4000);
+    });
+
+    phantom.style.transition = 'transform 300ms linear';
+    phantom.style.transform = 'translateY(0px)';
+
+    await Promise.race([transitionEnd, timeout]);
+
+    // The transform is identity again, so the real overflow is H. The scroll offset, which was only valid
+    // because of the transform, must be clamped back to the valid range. Assert the settled state.
+    await new Promise(resolve => t.step_timeout(resolve, 150));
+    assert_equals(clip.scrollHeight, H, 'scrollable overflow recomputed after the transform shrinks');
+    assert_equals(clip.scrollTop, 0, 'scroll offset clamped after scrollable overflow shrinks');
+}, 'Scroll offset is clamped when a transform animation shrinks scrollable overflow');
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -63,6 +63,8 @@
 #include "RenderBox.h"
 #include "RenderBoxModelObject.h"
 #include "RenderElement.h"
+#include "RenderLayer.h"
+#include "RenderLayerScrollableArea.h"
 #include "RenderObjectInlines.h"
 #include "ScrollTimeline.h"
 #include "Settings.h"
@@ -2184,6 +2186,22 @@ void KeyframeEffect::animationDidFinish()
     if (canHaveAcceleratedRepresentation() && !m_isAssociatedWithProgressBasedTimeline)
         updateAcceleratedAnimationIfNecessary();
 #endif
+
+    // An accelerated transform animation runs on the compositor without triggering layout, so a transform that extends
+    // its scroll container's scrollable overflow leaves the container over-scrolled once the animation settles. Recompute
+    // overflow at completion so the scroll offset is re-clamped -- but only when the enclosing scroll container is actually
+    // scrolled, since otherwise there is nothing to re-clamp and forcing layout would needlessly repaint every composited
+    // transform animation on completion. webkit.org/b/318289.
+    if (animatablePropertiesContainTransformRelatedProperty(animatedProperties())) {
+        if (CheckedPtr renderer = this->renderer()) {
+            if (CheckedPtr scrollContainer = renderer->enclosingScrollableContainer()) {
+                CheckedPtr layer = scrollContainer->layer();
+                CheckedPtr scrollableArea = layer ? layer->scrollableArea() : nullptr;
+                if (scrollableArea && !scrollableArea->scrollOffset().isZero())
+                    renderer->setNeedsLayoutForOverflowChange();
+            }
+        }
+    }
 }
 
 void KeyframeEffect::animationPlaybackRateDidChange()


### PR DESCRIPTION
#### 1891c25bbb1c59cb0ed2b00f4adddf06bebbd0a4
<pre>
spotify.com: Queue pane animation has weird jump when entering screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=318289">https://bugs.webkit.org/show_bug.cgi?id=318289</a>
&lt;<a href="https://rdar.apple.com/problem/171019322">rdar://problem/171019322</a>&gt;

Reviewed by Dan Glastonbury and Simon Fraser.

The Spotify queue pane showed a &quot;jump&quot; when animating open: as it approached the top it
would overscroll and then snap back into position.

A transform contributes to its scroll container&apos;s scrollable overflow (see
RenderBox::applyPaintGeometryTransformToRect): a translated descendant extends the
container&apos;s scrollable area. An accelerated transform animation, however, runs on the
compositor and does not trigger layout, so while it is running the scroll container&apos;s
scrollable overflow is never recomputed. When such an animation settles (e.g. the queue
panel sliding in from a translateY toward 0), the scrollable overflow -- and any scroll
offset that was only reachable because of the animated transform -- is left stale, so
the container stays over-scrolled until some later layout happens to re-clamp it. That
late re-clamp is the visible &quot;hop&quot;.

Fix this by recomputing overflow when an accelerated transform-related animation
finishes. KeyframeEffect::animationDidFinish() now calls setNeedsLayoutForOverflowChange()
on the target when the effect animates a transform-related property. At completion the
transform has settled, so the scroll container&apos;s scrollable overflow is recomputed and
the scroll offset is clamped back into the valid range in the same update -- no visible
hop.

This is intentionally scoped to animation completion rather than to every transform
change since forcing an overflow recomputation on all transform changes regresses
animations inside form controls.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-clamp-after-transform-shrinks-overflow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scroll-clamp-after-transform-shrinks-overflow.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animationDidFinish):

Canonical link: <a href="https://commits.webkit.org/317136@main">https://commits.webkit.org/317136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d15810e4ab40cff97c60f1fa77c00817643c2c57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/42047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4106289-e906-4739-830e-0a250bef7f09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135609 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25f5e367-4c23-474c-ac2f-b86630bee9a9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/39045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/116087 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7afc96e-35c1-48d6-b466-91a2cac30899) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37686 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/36052 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32391 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/148109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186335 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144518 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144376 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38936 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48612 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32525 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114154 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39279 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120548 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47118 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10869 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46521 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46579 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->