### PR TITLE
[JSC] Introduce FIFO queue for GC marker prefetching

### DIFF
--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -486,6 +486,47 @@ void SlotVisitor::optimizeForStoppedMutator()
     m_canOptimizeForStoppedMutator = true;
 }
 
+// The highest cost of GC marking is a cache miss when reading a cell off the mark stack,
+// since cells sit at effectively random addresses. We insert a fixed-depth FIFO between
+// the mark stack and the scanner: pop a cell, issue a software prefetch on it, push it
+// to the FIFO tail, and scan the FIFO head. This is the approach proposed in [1].
+//
+// [1]: "Effective Prefetch for Mark-Sweep Garbage Collection", Garner et al., ISMM '07.
+// https://www.steveblackburn.org/pubs/papers/pf-ismm-2007.pdf
+static ALWAYS_INLINE void drainWithPrefetchPipeline(unsigned distance, const Invocable<const JSCell*()> auto& pop, const Invocable<void(const JSCell*)> auto& visit)
+{
+    static constexpr unsigned ringCapacity = 4;
+    static constexpr unsigned ringMask = ringCapacity - 1;
+    distance = std::max<unsigned>(std::min<unsigned>(distance, ringCapacity), 1);
+
+    const JSCell* ring[ringCapacity];
+    unsigned head = 0;
+    unsigned tail = 0;
+    unsigned count = 0;
+
+    do {
+        const JSCell* cell = pop();
+        if (!cell)
+            break;
+        __builtin_prefetch(cell);
+        ring[tail] = cell;
+        tail = (tail + 1) & ringMask;
+        ++count;
+    } while (count < distance);
+
+    while (count) {
+        const JSCell* cell = ring[head];
+        head = (head + 1) & ringMask;
+        if (const JSCell* next = pop()) {
+            __builtin_prefetch(next);
+            ring[tail] = next;
+            tail = (tail + 1) & ringMask;
+        } else
+            --count;
+        visit(cell);
+    }
+}
+
 NEVER_INLINE void SlotVisitor::drain(MonotonicTime timeout)
 {
     if (!m_isInParallelMode) {
@@ -506,24 +547,18 @@ NEVER_INLINE void SlotVisitor::drain(MonotonicTime timeout)
 
                 m_isFirstVisit = (&stack == &m_collectorStack);
 
-                // The highest cost of GC marking is a cache miss when reading a cell, coming from the GC marker stack,
-                // because each cell would be likely placed in a random place. We perform software prefetching onto
-                // one next cell while accessing the current cell to make memory fetching in flight while handling
-                // the current cell.
                 unsigned countdown = Options::minimumNumberOfScansBetweenRebalance();
-                auto popAndPrefetch = [&] ALWAYS_INLINE_LAMBDA -> const JSCell* {
-                    if (!countdown || !stack.canRemoveLast())
-                        return nullptr;
-                    --countdown;
-                    const JSCell* cell = stack.removeLast();
-                    __builtin_prefetch(cell);
-                    return cell;
-                };
-                for (const JSCell* next = popAndPrefetch(); next;) {
-                    const JSCell* cell = next;
-                    next = popAndPrefetch();
-                    visitChildren(cell);
-                }
+                drainWithPrefetchPipeline(
+                    Options::gcMarkingPrefetchDistance(),
+                    [&] ALWAYS_INLINE_LAMBDA -> const JSCell* {
+                        if (!countdown || !stack.canRemoveLast())
+                            return nullptr;
+                        --countdown;
+                        return stack.removeLast();
+                    },
+                    [&] (const JSCell* cell) ALWAYS_INLINE_LAMBDA {
+                        visitChildren(cell);
+                    });
                 return IterationStatus::Done;
             });
         propagateExternalMemoryVisitedIfNecessary();
@@ -571,16 +606,22 @@ size_t SlotVisitor::performIncrementOfDraining(size_t bytesRequested)
                         return IterationStatus::Continue;
 
                     stack.refill();
-                    
+
                     m_isFirstVisit = (&stack == &m_collectorStack);
 
                     unsigned countdown = Options::minimumNumberOfScansBetweenRebalance();
-                    while (countdown && stack.canRemoveLast() && !isDone()) {
-                        const JSCell* cell = stack.removeLast();
-                        cellBytesVisited += cell->cellSize();
-                        visitChildren(cell);
-                        countdown--;
-                    }
+                    drainWithPrefetchPipeline(
+                        Options::gcMarkingPrefetchDistance(),
+                        [&] ALWAYS_INLINE_LAMBDA -> const JSCell* {
+                            if (!countdown || !stack.canRemoveLast() || isDone())
+                                return nullptr;
+                            --countdown;
+                            return stack.removeLast();
+                        },
+                        [&] (const JSCell* cell) ALWAYS_INLINE_LAMBDA {
+                            cellBytesVisited += cell->cellSize();
+                            visitChildren(cell);
+                        });
                     return IterationStatus::Done;
                 });
             propagateExternalMemoryVisitedIfNecessary();

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -397,6 +397,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumDirectCallStackSize, 200, Normal, nullptr) \
     \
     v(Unsigned, minimumNumberOfScansBetweenRebalance, 100, Normal, nullptr) \
+    v(Unsigned, gcMarkingPrefetchDistance, 2, Normal, "FIFO prefetch queue depth for GC marking; 1-4 range, clamped to 4"_s) \
     v(Unsigned, numberOfGCMarkers, computeNumberOfGCMarkers(8), Normal, nullptr) \
     v(Bool, useParallelMarkingConstraintSolver, true, Normal, nullptr) \
     v(Unsigned, opaqueRootMergeThreshold, 1000, Normal, nullptr) \


### PR DESCRIPTION
#### f11140de4b09e8386aef203eca034aa27eec6249
<pre>
[JSC] Introduce FIFO queue for GC marker prefetching
<a href="https://bugs.webkit.org/show_bug.cgi?id=318394">https://bugs.webkit.org/show_bug.cgi?id=318394</a>
<a href="https://rdar.apple.com/181180265">rdar://181180265</a>

Reviewed by NOBODY (OOPS!).

This patch introduces the FIFO queue for GC makrer prefetching, which is
explained in the paper[1]. While the paper&apos;s optimal number is 4~, our
empirical measurement showed that 2 is the best in our case (of course,
the paper is roughly 20 years ago and hardware, workload everything is
different, so we need to tweak the number for our case, and that&apos;s the
2).

[1]: &quot;Effective Prefetch for Mark-Sweep Garbage Collection&quot;, Garner et al., ISMM &apos;07.

* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::drainWithPrefetchPipeline):
(JSC::SlotVisitor::drain):
(JSC::SlotVisitor::performIncrementOfDraining):
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f11140de4b09e8386aef203eca034aa27eec6249

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130304 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/863bef81-593b-4091-8057-995cf2dda843) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174613 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134354 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94833 "3 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e958d96-ee79-48a2-ba0f-9ca0bbd8f413) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114826 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac8e5dc1-63e3-4cbb-aa19-bd99c95df13b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34707 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30805 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3431 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184739 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34009 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143148 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/172148 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46338 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143025 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47016 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31247 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111985 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38031 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118768 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205426 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45533 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9358 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54849 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44933 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->