### PR TITLE
[HDR] Ensure that parsing the gain-map target pixelFormat is handled correctly

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp
@@ -109,6 +109,8 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
     unsigned inputPixelFormatType = CVPixelBufferGetPixelFormatType(baseImagePixelBuffer);
     RetainPtr inputColorSpace = CGImageGetColorSpace(basePlatformImage);
 
+    static constexpr OSType defaultTargetPixelFormat = kCVPixelFormatType_64RGBAHalf;
+
     // MARK: - Get the target CVPixelBuffer attributes.
     RetainPtr inputAttributes = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
     setDictionaryValue(inputAttributes, kCVPixelBufferWidthKey, width);
@@ -117,7 +119,7 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
     CFDictionarySetValue(inputAttributes, kCVImageBufferCGColorSpaceKey, inputColorSpace);
 
     RetainPtr attributesOptions = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-    setDictionaryValue(attributesOptions, kCGTargetPixelFormat, static_cast<unsigned>(kCVPixelFormatType_64RGBAHalf));
+    setDictionaryValue(attributesOptions, kCGTargetPixelFormat, static_cast<unsigned>(defaultTargetPixelFormat));
     setDictionaryValue(attributesOptions, kCGTargetHeadroom, targetHeadroom);
     CFDictionarySetValue(attributesOptions, kCGFlexRangeAlternateColorSpace, targetColorSpace);
     CFDictionarySetValue(attributesOptions, kCGTargetColorSpace, kCGColorSpaceDisplayP3_PQ);
@@ -136,9 +138,11 @@ PlatformImagePtr ShareableGainMap::applyGainMapToBaseImage(PlatformImagePtr base
     CFDictionarySetValue(targetAttributes, kCVPixelBufferIOSurfacePropertiesKey, surfaceProperties);
     CFDictionarySetValue(targetAttributes, kCVPixelBufferMetalCompatibilityKey, kCFBooleanTrue);
 
-    RetainPtr pixelFormatNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(targetAttributes, kCVPixelBufferPixelFormatTypeKey));
-    OSType targtePixelFormat;
-    CFNumberGetValue(pixelFormatNumber, kCFNumberSInt32Type, &targtePixelFormat);
+    OSType targtePixelFormat = defaultTargetPixelFormat;
+    if (RetainPtr pixelFormatNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(targetAttributes, kCVPixelBufferPixelFormatTypeKey))) {
+        if (!CFNumberGetValue(pixelFormatNumber, kCFNumberSInt32Type, &targtePixelFormat))
+            targtePixelFormat = defaultTargetPixelFormat;
+    }
 
     // MARK: - Create the target CVPixelBuffer.
     RetainPtr targetImagePixelBuffer = createScratchCVPixelBuffer(width, height, targtePixelFormat, targetAttributes, targetColorSpace, targetHeadroom);


### PR DESCRIPTION
#### cb497b2e07be89676f93a3e8ce0960b578c3a6af
<pre>
[HDR] Ensure that parsing the gain-map target pixelFormat is handled correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=318395">https://bugs.webkit.org/show_bug.cgi?id=318395</a>
<a href="https://rdar.apple.com/181180757">rdar://181180757</a>

Reviewed by Simon Fraser.

Check whether targetAttributes dictionary has an entry for kCVPixelBufferPixelFormatTypeKey
or not. Make sure CFNumberGetValue() succeeds parsing the return CFNumber. If anything went
wrong, we should fall back to the default pixel format.

* Source/WebCore/platform/graphics/cocoa/ShareableGainMap.cpp:
(WebCore::ShareableGainMap::applyGainMapToBaseImage const):

Canonical link: <a href="https://commits.webkit.org/316405@main">https://commits.webkit.org/316405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae1714f3ce38e39d675a84c9ae5019e4cdc492f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129650 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fce9b49b-31d6-4a51-9988-b6d355d301fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133863 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25a67066-bbfc-4b5a-a13a-04f26953b616) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154394 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114336 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6be65c3e-bf7e-449d-8dfd-2fdc204edc25) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35917 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30149 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184069 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142604 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45680 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142493 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46360 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111023 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26133 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37579 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118048 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44878 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8844 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44278 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->