### PR TITLE
SVGAnimatedPropertyPairAccessor::detach() causes needless refcount churn by calling Ref-returning helpers

### DIFF
--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
@@ -58,20 +58,10 @@ protected:
     const Ref<AnimatedPropertyType2>& property2(OwnerType& owner) const { return m_accessor2.property(owner); }
     const Ref<AnimatedPropertyType2>& property2(const OwnerType& owner) const { return m_accessor2.property(owner); }
 
-    Ref<AnimatedPropertyType1> propertyProperty1(const OwnerType& owner) const
-    {
-        return property1(owner);
-    }
-
-    Ref<AnimatedPropertyType2> propertyProperty2(const OwnerType& owner) const
-    {
-        return property2(owner);
-    }
-
     void detach(const OwnerType& owner) const override
     {
-        propertyProperty1(owner)->detach();
-        propertyProperty2(owner)->detach();
+        property1(owner)->detach();
+        property2(owner)->detach();
     }
 
     bool matches(const OwnerType& owner, const SVGAnimatedPropertyBase& animatedProperty) const override


### PR DESCRIPTION
#### b9927430aa6d68ef76529be30df020cd611646a2
<pre>
SVGAnimatedPropertyPairAccessor::detach() causes needless refcount churn by calling Ref-returning helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=318397">https://bugs.webkit.org/show_bug.cgi?id=318397</a>
<a href="https://rdar.apple.com/181183016">rdar://181183016</a>

Reviewed by Taher Ali.

SVGAnimatedPropertyPairAccessor::detach() called propertyProperty1() and
propertyProperty2(), which each return a Ref&lt;AnimatedProperty&gt; by value.
That constructs a temporary Ref just to call detach() on the pointee,
incurring a ref/deref pair on each call for no reason.

Call property1(owner) and property2(owner) instead, which return
const Ref&lt;AnimatedProperty&gt;&amp; by reference, avoiding the refcount traffic.
The propertyProperty1()/propertyProperty2() helpers had no other callers,
so remove them.

No change in behavior.

* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h:
(WebCore::SVGAnimatedPropertyPairAccessor::propertyProperty1 const): Deleted.
(WebCore::SVGAnimatedPropertyPairAccessor::propertyProperty2 const): Deleted.

Canonical link: <a href="https://commits.webkit.org/316404@main">https://commits.webkit.org/316404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a25d7782e80aaaed98d23b38fb16a0feeb3433

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129655 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee8ee899-992b-46ee-9fe8-26b56dee1554) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133867 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c892bb24-66b6-47e2-9cd2-a2fd3352cf75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175059 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114340 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0daa246-9e7f-4433-b6a5-2ec6a541a524) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35923 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30154 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184074 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142611 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45685 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38501 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46365 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111031 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37584 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118053 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44883 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8850 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44283 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44342 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->