### PR TITLE
PromiseResolveThenableJob should reject the promise when SpeciesConstructor throws

### DIFF
--- a/JSTests/stress/promise-resolve-thenable-job-species-throws.js
+++ b/JSTests/stress/promise-resolve-thenable-job-species-throws.js
@@ -1,0 +1,41 @@
+// ECMA-262 27.2.2.2 NewPromiseResolveThenableJob step c: if calling `then`
+// throws (here, SpeciesConstructor on the resolution promise), the promise
+// being resolved must be rejected with that error.
+//
+// The constructor is poisoned per-instance so Promise.prototype.then and the
+// global species watchpoint stay intact and the fast path is taken.
+
+function shouldBe(a, b) { if (a !== b) throw new Error(`FAIL: ${a} !== ${b}`); }
+
+const speciesError = new Error("species-boom");
+const inner = Promise.resolve();
+inner.constructor = {
+    get [Symbol.species]() { throw speciesError; }
+};
+
+let result = "pending";
+new Promise(resolve => resolve(inner)).then(
+    () => { result = "fulfilled"; },
+    e => { result = e; }
+);
+
+drainMicrotasks();
+shouldBe(result, speciesError);
+
+// Twin: the await/async-generator path (PromiseResolveThenableJobWithInternalMicrotaskFastSlow).
+let awaitResult = "pending";
+(async () => {
+    try {
+        const inner2 = Promise.resolve();
+        inner2.constructor = {
+            get [Symbol.species]() { throw speciesError; }
+        };
+        await inner2;
+        awaitResult = "fulfilled";
+    } catch (e) {
+        awaitResult = e;
+    }
+})();
+
+drainMicrotasks();
+shouldBe(awaitResult, speciesError);

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -207,16 +207,19 @@ static void promiseResolveThenableJobFastSlow(JSGlobalObject* globalObject, JSPr
     VM& vm = globalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    JSObject* constructor = promiseSpeciesConstructor(globalObject, promise);
-    if (scope.exception()) [[unlikely]]
-        return;
-
+    // https://tc39.es/ecma262/#sec-newpromiseresolvethenablejob
+    // NewPromiseResolveThenableJob step a: create resolving functions first so
+    // an abrupt completion of the inlined `then` (SpeciesConstructor or
+    // NewPromiseCapability throwing) routes to reject(error) per step c.
     auto [resolve, reject] = promiseToResolve->createResolvingFunctions(vm, globalObject);
 
-    auto capability = JSPromise::createNewPromiseCapability(globalObject, constructor);
+    JSObject* constructor = promiseSpeciesConstructor(globalObject, promise);
     if (!scope.exception()) [[likely]] {
-        promise->performPromiseThen(vm, globalObject, resolve, reject, capability);
-        return;
+        auto capability = JSPromise::createNewPromiseCapability(globalObject, constructor);
+        if (!scope.exception()) [[likely]] {
+            promise->performPromiseThen(vm, globalObject, resolve, reject, capability);
+            return;
+        }
     }
 
     JSValue error = scope.exception()->value();
@@ -236,16 +239,15 @@ static void promiseResolveThenableJobWithInternalMicrotaskFastSlow(JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    JSObject* constructor = promiseSpeciesConstructor(globalObject, promise);
-    if (scope.exception()) [[unlikely]]
-        return;
-
     auto [resolve, reject] = JSPromise::createResolvingFunctionsWithInternalMicrotask(vm, globalObject, task, context);
 
-    auto capability = JSPromise::createNewPromiseCapability(globalObject, constructor);
+    JSObject* constructor = promiseSpeciesConstructor(globalObject, promise);
     if (!scope.exception()) [[likely]] {
-        promise->performPromiseThen(vm, globalObject, resolve, reject, capability);
-        return;
+        auto capability = JSPromise::createNewPromiseCapability(globalObject, constructor);
+        if (!scope.exception()) [[likely]] {
+            promise->performPromiseThen(vm, globalObject, resolve, reject, capability);
+            return;
+        }
     }
 
     JSValue error = scope.exception()->value();


### PR DESCRIPTION
#### 0727fd0c102380a3145473dcacef52e5ec74bd2f
<pre>
PromiseResolveThenableJob should reject the promise when SpeciesConstructor throws
<a href="https://bugs.webkit.org/show_bug.cgi?id=318399">https://bugs.webkit.org/show_bug.cgi?id=318399</a>

Reviewed by NOBODY (OOPS!).

new Promise(r => r(p)) never settles when p is a Promise whose own
constructor[@@species] getter throws: promiseResolveThenableJobFastSlow
and its WithInternalMicrotask twin called promiseSpeciesConstructor
before creating the resolving functions and returned on the exception,
leaving nothing to reject. Per NewPromiseResolveThenableJob step c
(ECMA-262 27.2.2.2), the abrupt completion of the then call must reject
the promise. Create the resolving functions first (pure allocation,
cannot throw) and let the existing reject tail handle the exception.
Regressed in the C++ port of the promise jobs (bug 300130).

* JSTests/stress/promise-resolve-thenable-job-species-throws.js: Added.
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseResolveThenableJobFastSlow):
(JSC::promiseResolveThenableJobWithInternalMicrotaskFastSlow):
</pre>

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0727fd0c102380a3145473dcacef52e5ec74bd2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133889 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94446 "1 flakes 22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34219 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30179 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2967 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184100 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33385 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142636 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45710 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142520 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38595 "") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46390 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30785 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111066 "The change is no longer eligible for processing.") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26203 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37606 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118092 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204804 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44908 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8875 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54685 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->