### PR TITLE
<textPath> layout re-walks the whole path per glyph  (TextOnPathSimple)

### DIFF
--- a/LayoutTests/platform/ios/svg/batik/text/verticalText-expected.txt
+++ b/LayoutTests/platform/ios/svg/batik/text/verticalText-expected.txt
@@ -257,7 +257,7 @@ layer at (0,0) size 450x500
               chunk 1 (vertical) text run 14 at (162.38,26.76) startOffset 13 endOffset 14 height 13.29: " "
               chunk 1 (vertical) text run 15 at (173.37,34.17) startOffset 14 endOffset 15 height 13.29: "o"
               chunk 1 (vertical) text run 16 at (186.28,35.56) startOffset 15 endOffset 16 height 13.29: "n"
-              chunk 1 (vertical) text run 17 at (197.01,27.99) startOffset 16 endOffset 17 height 13.29: " "
+              chunk 1 (vertical) text run 17 at (197.01,28.00) startOffset 16 endOffset 17 height 13.29: " "
               chunk 1 (vertical) text run 18 at (206.66,18.86) startOffset 17 endOffset 18 height 13.29: "a"
               chunk 1 (vertical) text run 19 at (217.51,11.25) startOffset 18 endOffset 19 height 13.29: " "
               chunk 1 (vertical) text run 20 at (230.36,9.20) startOffset 19 endOffset 20 height 13.29: "P"

--- a/LayoutTests/platform/ios/svg/text/textLength-tspan-in-textPath-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/textLength-tspan-in-textPath-expected.txt
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
               RenderSVGInlineText {#text} at (504,333) size 30x21
                 chunk 1 text run 1 at (644.39,428.43) startOffset 0 endOffset 1 width 13.35: "F"
             RenderSVGInlineText {#text} at (476,399) size 26x20
-              chunk 1 text run 1 at (606.91,510.26) startOffset 0 endOffset 1 width 6.00: " "
+              chunk 1 text run 1 at (606.90,510.26) startOffset 0 endOffset 1 width 6.00: " "
             RenderSVGTSpan {tspan} at (424,449) size 32x32
               RenderSVGInlineText {#text} at (424,449) size 31x32
                 chunk 1 text run 1 at (546.61,579.73) startOffset 0 endOffset 1 width 17.33: "G"

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/text/textLength-tspan-in-textPath-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/text/textLength-tspan-in-textPath-expected.txt
@@ -40,7 +40,7 @@ layer at (8,8) size 575x575
           RenderSVGInlineText {#text} at (503,332) size 31x21
             chunk 1 text run 1 at (644.39,428.43) startOffset 0 endOffset 1 width 13.35: "F"
         RenderSVGInlineText {#text} at (475,398) size 27x20
-          chunk 1 text run 1 at (606.91,510.26) startOffset 0 endOffset 1 width 6.00: " "
+          chunk 1 text run 1 at (606.90,510.26) startOffset 0 endOffset 1 width 6.00: " "
         RenderSVGTSpan {tspan} at (424,448) size 32x33
           RenderSVGInlineText {#text} at (424,448) size 32x33
             chunk 1 text run 1 at (546.61,579.73) startOffset 0 endOffset 1 width 17.33: "G"

--- a/LayoutTests/platform/mac/svg/text/textLength-tspan-in-textPath-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/textLength-tspan-in-textPath-expected.txt
@@ -36,7 +36,7 @@ layer at (0,0) size 800x600
               RenderSVGInlineText {#text} at (503,332) size 31x21
                 chunk 1 text run 1 at (644.39,428.43) startOffset 0 endOffset 1 width 13.35: "F"
             RenderSVGInlineText {#text} at (475,398) size 27x20
-              chunk 1 text run 1 at (606.91,510.26) startOffset 0 endOffset 1 width 6.00: " "
+              chunk 1 text run 1 at (606.90,510.26) startOffset 0 endOffset 1 width 6.00: " "
             RenderSVGTSpan {tspan} at (424,448) size 32x33
               RenderSVGInlineText {#text} at (424,448) size 32x33
                 chunk 1 text run 1 at (546.61,579.73) startOffset 0 endOffset 1 width 17.33: "G"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2693,6 +2693,7 @@ platform/graphics/NativeImage.cpp
 platform/graphics/NativeImageSource.cpp
 platform/graphics/NullImageBufferBackend.cpp
 platform/graphics/Path.cpp
+platform/graphics/PathArcLengthMapper.cpp
 platform/graphics/PathImpl.cpp
 platform/graphics/PathSegment.cpp
 platform/graphics/PathSegmentData.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3009,6 +3009,8 @@
 		7246F02C2A1541B200FD74F1 /* PathSegment.h in Headers */ = {isa = PBXBuildFile; fileRef = 7246F0262A1540F200FD74F1 /* PathSegment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7246F02D2A1541B200FD74F1 /* PathStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 7246F0202A1540ED00FD74F1 /* PathStream.h */; };
 		7246F0302A15508000FD74F1 /* PathImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7246F0222A1540F000FD74F1 /* PathImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0318396A0000000000000011 /* PathArcLengthMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0318396A0000000000000001 /* PathArcLengthMapper.h */; };
+		0318396A0000000000000013 /* PathCurveSubdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 0318396A0000000000000003 /* PathCurveSubdivision.h */; };
 		7246F0312A15519800FD74F1 /* PlatformPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 7246F0272A15415900FD74F1 /* PlatformPath.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		724DCF2328486C9B0026ACF4 /* ImageBufferAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 724DCF1C284853650026ACF4 /* ImageBufferAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		724ED3321A3A8B2300F5F13C /* JSEXTBlendMinMax.h in Headers */ = {isa = PBXBuildFile; fileRef = 724ED3301A3A8B2300F5F13C /* JSEXTBlendMinMax.h */; };
@@ -14508,6 +14510,9 @@
 		7246F0222A1540F000FD74F1 /* PathImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathImpl.h; sourceTree = "<group>"; };
 		7246F0232A1540F000FD74F1 /* PathElement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathElement.h; sourceTree = "<group>"; };
 		7246F0242A1540F100FD74F1 /* PathImpl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PathImpl.cpp; sourceTree = "<group>"; };
+		0318396A0000000000000001 /* PathArcLengthMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathArcLengthMapper.h; sourceTree = "<group>"; };
+		0318396A0000000000000002 /* PathArcLengthMapper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PathArcLengthMapper.cpp; sourceTree = "<group>"; };
+		0318396A0000000000000003 /* PathCurveSubdivision.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathCurveSubdivision.h; sourceTree = "<group>"; };
 		7246F0252A1540F100FD74F1 /* PathSegment.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PathSegment.cpp; sourceTree = "<group>"; };
 		7246F0262A1540F200FD74F1 /* PathSegment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathSegment.h; sourceTree = "<group>"; };
 		7246F0272A15415900FD74F1 /* PlatformPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformPath.h; sourceTree = "<group>"; };
@@ -37026,6 +37031,9 @@
 				7B0E6DC82AB463E4005189E8 /* NullImageBufferBackend.h */,
 				B27535520B053814002CE64F /* Path.cpp */,
 				B27535530B053814002CE64F /* Path.h */,
+				0318396A0000000000000002 /* PathArcLengthMapper.cpp */,
+				0318396A0000000000000001 /* PathArcLengthMapper.h */,
+				0318396A0000000000000003 /* PathCurveSubdivision.h */,
 				7246F0232A1540F000FD74F1 /* PathElement.h */,
 				7246F0242A1540F100FD74F1 /* PathImpl.cpp */,
 				7246F0222A1540F000FD74F1 /* PathImpl.h */,
@@ -47876,7 +47884,9 @@
 				1AF5E4D51E56735B004A1F01 /* PasteboardWriterData.h in Headers */,
 				B27535800B053814002CE64F /* Path.h in Headers */,
 				7C193BC21F5E0EED0088F3E6 /* Path2D.h in Headers */,
+				0318396A0000000000000011 /* PathArcLengthMapper.h in Headers */,
 				07257B5D2E506CBF00AD0DF1 /* PathCG.h in Headers */,
+				0318396A0000000000000013 /* PathCurveSubdivision.h in Headers */,
 				7246F02B2A1541A000FD74F1 /* PathElement.h in Headers */,
 				7246F0302A15508000FD74F1 /* PathImpl.h in Headers */,
 				FB92DF4B15FED08700994433 /* PathOperation.h in Headers */,

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -29,6 +29,7 @@
 #include "Path.h"
 
 #include "AffineTransform.h"
+#include "PathArcLengthMapper.h"
 #include "PathStream.h"
 #include "PathTraversalState.h"
 #include "PlatformPathImpl.h"
@@ -388,6 +389,15 @@ PathTraversalState Path::traversalStateAtLength(float length) const
 FloatPoint Path::pointAtLength(float length) const
 {
     return traversalStateAtLength(length).current();
+}
+
+PathArcLengthMapper Path::arcLengthMapper() const
+{
+    PathArcLengthMapper mapper;
+    applyElements([&mapper](const PathElement& element) {
+        mapper.appendPathElement(element);
+    });
+    return mapper;
 }
 
 bool Path::contains(const FloatPoint& point, WindRule rule) const

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -40,6 +40,7 @@ namespace WebCore {
 
 class GraphicsContext;
 class LayoutRoundedRect;
+class PathArcLengthMapper;
 class PathTraversalState;
 
 class Path {
@@ -97,6 +98,9 @@ public:
     FloatPoint currentPoint() const;
     PathTraversalState traversalStateAtLength(float length) const;
     FloatPoint pointAtLength(float length) const;
+
+    // Precomputes an arc-length table for O(log n) repeated point-at-length queries (e.g. SVG <textPath>).
+    PathArcLengthMapper arcLengthMapper() const;
 
     WEBCORE_EXPORT bool contains(const FloatPoint&, WindRule = WindRule::NonZero) const;
     WEBCORE_EXPORT bool strokeContains(const FloatPoint&, NOESCAPE const Function<void(GraphicsContext&)>& strokeStyleApplier) const;

--- a/Source/WebCore/platform/graphics/PathArcLengthMapper.cpp
+++ b/Source/WebCore/platform/graphics/PathArcLengthMapper.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2006, 2007 Eric Seidel <eric@webkit.org>
+ * Copyright (C) 2015 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "PathArcLengthMapper.h"
+
+#include "PathCurveSubdivision.h"
+#include <wtf/MathExtras.h>
+
+namespace WebCore {
+
+void PathArcLengthMapper::addVertex(const FloatPoint& point, float segmentLength)
+{
+    m_totalLength += segmentLength;
+    m_vertices.append({ point, m_totalLength });
+    m_current = point;
+}
+
+void PathArcLengthMapper::appendPathElement(PathElement::Type type, std::span<const FloatPoint> points)
+{
+    // Record each leaf endpoint with its control-polygon length, matching how curveLength() accumulates.
+    auto appendCurveLeaves = [&](const auto& curve) {
+        forEachFlattenedCurveLeaf(curve, [&](const auto& leaf, float length, bool) {
+            addVertex(leaf.end, length);
+            return true;
+        });
+    };
+
+    switch (type) {
+    case PathElement::Type::MoveToPoint:
+        // Zero-length vertex so interpolation never spans the gap between subpaths.
+        m_subpathStart = points[0];
+        addVertex(points[0], 0);
+        break;
+    case PathElement::Type::AddLineToPoint:
+        addVertex(points[0], distanceLine(m_current, points[0]));
+        break;
+    case PathElement::Type::AddQuadCurveToPoint:
+        appendCurveLeaves(QuadraticBezier(m_current, points[0], points[1]));
+        break;
+    case PathElement::Type::AddCurveToPoint:
+        appendCurveLeaves(CubicBezier(m_current, points[0], points[1], points[2]));
+        break;
+    case PathElement::Type::CloseSubpath:
+        addVertex(m_subpathStart, distanceLine(m_current, m_subpathStart));
+        break;
+    }
+}
+
+auto PathArcLengthMapper::positionAtLength(float length) const -> Position
+{
+    if (m_vertices.isEmpty())
+        return { };
+    if (m_vertices.size() == 1)
+        return { m_vertices[0].point, 0 };
+
+    length = clampTo<float>(length, 0, m_totalLength);
+
+    // Smallest vertex index (>= 1) whose accumulated length reaches `length`.
+    size_t low = 1;
+    size_t high = m_vertices.size() - 1;
+    while (low < high) {
+        size_t mid = low + (high - low) / 2;
+        if (m_vertices[mid].accumulatedLength < length)
+            low = mid + 1;
+        else
+            high = mid;
+    }
+
+    const auto& end = m_vertices[low];
+    const auto& start = m_vertices[low - 1];
+
+    float angleInRadians = FloatPoint(end.point - start.point).slopeAngleRadians();
+    float offset = length - end.accumulatedLength; // <= 0: step back from the leaf's end point.
+
+    FloatPoint point = end.point;
+    point.move(offset * cosf(angleInRadians), offset * sinf(angleInRadians));
+
+    return { point, rad2deg(angleInRadians) };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathArcLengthMapper.h
+++ b/Source/WebCore/platform/graphics/PathArcLengthMapper.h
@@ -21,7 +21,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -32,55 +32,34 @@
 
 namespace WebCore {
 
-class PathTraversalState {
+// Precomputes a path's arc-length table so repeated point-at-length queries cost
+// O(log n) each rather than re-walking the path per call.
+class PathArcLengthMapper {
 public:
-    enum class Action {
-        TotalLength,
-        VectorAtLength,
-        SegmentAtLength,
+    struct Position {
+        FloatPoint point;
+        float angleInDegrees { 0 };
     };
 
-    PathTraversalState(Action, float desiredLength = 0);
+    void appendPathElement(const PathElement& element) { appendPathElement(element.type, element.points); }
 
-public:
-    bool processPathElement(PathElement::Type, std::span<const FloatPoint>);
-    bool processPathElement(const PathElement& element) { return processPathElement(element.type, element.points); }
-
-    Action action() const { return m_action; }
-    void setAction(Action action) { m_action = action; }
-    float desiredLength() const { return m_desiredLength; }
-    void setDesiredLength(float desiredLength) { m_desiredLength = desiredLength; }
-
-    // Traversing output -- should be read only
-    bool success() const { return m_success; }
     float totalLength() const { return m_totalLength; }
-    FloatPoint current() const { return m_current; }
-    float normalAngle() const { return m_normalAngle; }
+
+    // Point and tangent at `length` along the path; `length` is clamped to [0, totalLength()].
+    Position positionAtLength(float length) const;
 
 private:
-    void NODELETE closeSubpath();
-    void NODELETE moveTo(const FloatPoint&);
-    void NODELETE lineTo(const FloatPoint&);
-    void quadraticBezierTo(const FloatPoint&, const FloatPoint&);
-    void cubicBezierTo(const FloatPoint&, const FloatPoint&, const FloatPoint&);
+    void appendPathElement(PathElement::Type, std::span<const FloatPoint>);
+    void addVertex(const FloatPoint&, float segmentLength);
 
-    bool finalizeAppendPathElement();
-    bool appendPathElement(PathElement::Type, std::span<const FloatPoint>);
-
-private:
-    Action m_action;
-    bool m_success { false };
-
+    struct Vertex {
+        FloatPoint point;
+        float accumulatedLength { 0 };
+    };
+    Vector<Vertex> m_vertices;
     FloatPoint m_current;
-    FloatPoint m_start;
-
+    FloatPoint m_subpathStart;
     float m_totalLength { 0 };
-    float m_desiredLength { 0 };
-
-    // For normal calculations
-    FloatPoint m_previous;
-    float m_normalAngle { 0 }; // degrees
-    bool m_isZeroVector { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathCurveSubdivision.h
+++ b/Source/WebCore/platform/graphics/PathCurveSubdivision.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2006, 2007 Eric Seidel <eric@webkit.org>
+ * Copyright (C) 2015 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatPoint.h"
+#include "GeometryUtilities.h"
+#include <cmath>
+#include <optional>
+#include <utility>
+#include <wtf/StdLibExtras.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+constexpr float kPathSegmentLengthTolerance = 0.00001f;
+
+inline float NODELETE distanceLine(const FloatPoint& start, const FloatPoint& end)
+{
+    return std::hypot(end.x() - start.x(), end.y() - start.y());
+}
+
+struct QuadraticBezier {
+    QuadraticBezier() = default;
+    QuadraticBezier(const FloatPoint& s, const FloatPoint& c, const FloatPoint& e)
+        : start(s)
+        , control(c)
+        , end(e)
+    {
+    }
+
+    friend bool NODELETE operator==(const QuadraticBezier&, const QuadraticBezier&) = default;
+
+    float NODELETE approximateDistance() const
+    {
+        return distanceLine(start, control) + distanceLine(control, end);
+    }
+
+    // std::nullopt when halving no longer makes progress in float arithmetic.
+    std::optional<std::pair<QuadraticBezier, QuadraticBezier>> NODELETE split() const
+    {
+        QuadraticBezier left;
+        QuadraticBezier right;
+
+        left.control = midPoint(start, control);
+        right.control = midPoint(control, end);
+
+        FloatPoint leftControlToRightControl = midPoint(left.control, right.control);
+        left.end = leftControlToRightControl;
+        right.start = leftControlToRightControl;
+
+        left.start = start;
+        right.end = end;
+
+        if (left == *this || right == *this)
+            return std::nullopt;
+
+        return std::pair { left, right };
+    }
+
+    FloatPoint start;
+    FloatPoint control;
+    FloatPoint end;
+};
+
+struct CubicBezier {
+    CubicBezier() = default;
+    CubicBezier(const FloatPoint& s, const FloatPoint& c1, const FloatPoint& c2, const FloatPoint& e)
+        : start(s)
+        , control1(c1)
+        , control2(c2)
+        , end(e)
+    {
+    }
+
+    friend bool NODELETE operator==(const CubicBezier&, const CubicBezier&) = default;
+
+    float NODELETE approximateDistance() const
+    {
+        return distanceLine(start, control1) + distanceLine(control1, control2) + distanceLine(control2, end);
+    }
+
+    // std::nullopt when halving no longer makes progress in float arithmetic.
+    std::optional<std::pair<CubicBezier, CubicBezier>> NODELETE split() const
+    {
+        CubicBezier left;
+        CubicBezier right;
+
+        FloatPoint startToControl1 = midPoint(control1, control2);
+
+        left.start = start;
+        left.control1 = midPoint(start, control1);
+        left.control2 = midPoint(left.control1, startToControl1);
+
+        right.control2 = midPoint(control2, end);
+        right.control1 = midPoint(right.control2, startToControl1);
+        right.end = end;
+
+        FloatPoint leftControl2ToRightControl1 = midPoint(left.control2, right.control1);
+        left.end = leftControl2ToRightControl1;
+        right.start = leftControl2ToRightControl1;
+
+        if (left == *this || right == *this)
+            return std::nullopt;
+
+        return std::pair { left, right };
+    }
+
+    FloatPoint start;
+    FloatPoint control1;
+    FloatPoint control2;
+    FloatPoint end;
+};
+
+template<class CurveType>
+void forEachFlattenedCurveLeaf(const CurveType& originalCurve, NOESCAPE const Invocable<bool(const CurveType&, float, bool)> auto& processLeaf)
+{
+    static constexpr unsigned curveStackDepthLimit = 20;
+
+    Vector<CurveType, curveStackDepthLimit + 1> curveStack;
+    curveStack.append(originalCurve);
+
+    while (!curveStack.isEmpty()) {
+        auto curve = curveStack.takeLast();
+        float length = curve.approximateDistance();
+
+        if ((length - distanceLine(curve.start, curve.end)) > kPathSegmentLengthTolerance && curveStack.size() < curveStackDepthLimit) {
+            if (auto halves = curve.split()) {
+                curveStack.append(halves->second);
+                curveStack.append(halves->first);
+                continue;
+            }
+        }
+
+        if (!processLeaf(curve, length, curveStack.isEmpty()))
+            break;
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathTraversalState.cpp
+++ b/Source/WebCore/platform/graphics/PathTraversalState.cpp
@@ -21,143 +21,26 @@
 #include "config.h"
 #include "PathTraversalState.h"
 
-#include "GeometryUtilities.h"
+#include "PathCurveSubdivision.h"
 #include <wtf/MathExtras.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
-static const float kPathSegmentLengthTolerance = 0.00001f;
-
-static inline float NODELETE distanceLine(const FloatPoint& start, const FloatPoint& end)
-{
-    return std::hypot(end.x() - start.x(), end.y() - start.y());
-}
-
-struct QuadraticBezier {
-    QuadraticBezier() = default;
-    QuadraticBezier(const FloatPoint& s, const FloatPoint& c, const FloatPoint& e)
-        : start(s)
-        , control(c)
-        , end(e)
-    {
-    }
-
-    friend bool NODELETE operator==(const QuadraticBezier&, const QuadraticBezier&) = default;
-    
-    float NODELETE approximateDistance() const
-    {
-        return distanceLine(start, control) + distanceLine(control, end);
-    }
-    
-    bool NODELETE split(QuadraticBezier& left, QuadraticBezier& right) const
-    {
-        left.control = midPoint(start, control);
-        right.control = midPoint(control, end);
-        
-        FloatPoint leftControlToRightControl = midPoint(left.control, right.control);
-        left.end = leftControlToRightControl;
-        right.start = leftControlToRightControl;
-
-        left.start = start;
-        right.end = end;
-
-        return !(left == *this) && !(right == *this);
-    }
-    
-    FloatPoint start;
-    FloatPoint control;
-    FloatPoint end;
-};
-
-struct CubicBezier {
-    CubicBezier() = default;
-    CubicBezier(const FloatPoint& s, const FloatPoint& c1, const FloatPoint& c2, const FloatPoint& e)
-        : start(s)
-        , control1(c1)
-        , control2(c2)
-        , end(e)
-    {
-    }
-
-    friend bool NODELETE operator==(const CubicBezier&, const CubicBezier&) = default;
-
-    float NODELETE approximateDistance() const
-    {
-        return distanceLine(start, control1) + distanceLine(control1, control2) + distanceLine(control2, end);
-    }
-        
-    bool NODELETE split(CubicBezier& left, CubicBezier& right) const
-    {    
-        FloatPoint startToControl1 = midPoint(control1, control2);
-        
-        left.start = start;
-        left.control1 = midPoint(start, control1);
-        left.control2 = midPoint(left.control1, startToControl1);
-        
-        right.control2 = midPoint(control2, end);
-        right.control1 = midPoint(right.control2, startToControl1);
-        right.end = end;
-        
-        FloatPoint leftControl2ToRightControl1 = midPoint(left.control2, right.control1);
-        left.end = leftControl2ToRightControl1;
-        right.start = leftControl2ToRightControl1;
-
-        return !(left == *this) && !(right == *this);
-    }
-    
-    FloatPoint start;
-    FloatPoint control1;
-    FloatPoint control2;
-    FloatPoint end;
-};
-
-// FIXME: This function is possibly very slow due to the ifs required for proper path measuring
-// A simple speed-up would be to use an additional boolean template parameter to control whether
-// to use the "fast" version of this function with no PathTraversalState updating, vs. the slow
-// version which does update the PathTraversalState.  We'll have to shark it to see if that's necessary.
-// Another check which is possible up-front (to send us down the fast path) would be to check if
-// approximateDistance() + current total distance > desired distance
+// FIXME: A possible speed-up would be to check up front whether approximateDistance() plus the
+// current total distance already exceeds the desired distance, and skip subdividing when it does not.
 template<class CurveType>
 static float curveLength(const PathTraversalState& traversalState, const CurveType& originalCurve, FloatPoint& previous, FloatPoint& current)
 {
-    static const unsigned curveStackDepthLimit = 20;
-    CurveType curve = originalCurve;
-    Vector<CurveType, curveStackDepthLimit> curveStack;
+    bool isVectorAtLength = traversalState.action() == PathTraversalState::Action::VectorAtLength;
     float totalLength = 0;
 
-    while (true) {
-        float length = curve.approximateDistance();
-
-        CurveType leftCurve;
-        CurveType rightCurve;
-
-        if ((length - distanceLine(curve.start, curve.end)) > kPathSegmentLengthTolerance && curveStack.size() < curveStackDepthLimit && curve.split(leftCurve, rightCurve)) {
-            curve = leftCurve;
-            curveStack.append(rightCurve);
-            continue;
-        }
-
+    forEachFlattenedCurveLeaf(originalCurve, [&](const CurveType& curve, float length, bool isLastLeaf) {
         totalLength += length;
-        if (traversalState.action() == PathTraversalState::Action::VectorAtLength) {
-            previous = curve.start;
-            current = curve.end;
-            if (traversalState.totalLength() + totalLength > traversalState.desiredLength())
-                break;
-        }
-
-        if (curveStack.isEmpty())
-            break;
-
-        curve = curveStack.last();
-        curveStack.removeLast();
-    }
-
-    if (traversalState.action() != PathTraversalState::Action::VectorAtLength) {
-        ASSERT(curve.end == originalCurve.end);
         previous = curve.start;
         current = curve.end;
-    }
+        ASSERT_UNUSED(isLastLeaf, !isLastLeaf || curve.end == originalCurve.end);
+        return !isVectorAtLength || traversalState.totalLength() + totalLength <= traversalState.desiredLength();
+    });
 
     return totalLength;
 }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -22,7 +22,6 @@
 #include "config.h"
 #include "SVGTextLayoutEngine.h"
 
-#include "PathTraversalState.h"
 #include "RenderElementInlines.h"
 #include "RenderSVGTextPath.h"
 #include "SVGElement.h"
@@ -166,8 +165,11 @@ void SVGTextLayoutEngine::beginTextPathLayout(const RenderSVGTextPath& textPath,
     if (m_textPath.isEmpty())
         return;
 
+    // Precompute the arc-length table once so per-glyph queries are O(log n), not a full re-walk each (webkit.org/b/318396).
+    m_textPathMapper = m_textPath.arcLengthMapper();
+
     const auto& startOffset = textPath.startOffset();
-    m_textPathLength = m_textPath.length();
+    m_textPathLength = m_textPathMapper.totalLength();
     
     if (textPath.startOffset().lengthType() == SVGLengthType::Percentage)
         m_textPathStartOffset = startOffset.valueAsPercentage() * m_textPathLength;
@@ -602,15 +604,13 @@ void SVGTextLayoutEngine::layoutTextOnLineOrPath(InlineIterator::SVGTextBoxItera
             if (textPathOffset > m_textPathLength)
                 break;
 
-            auto traversalState(m_textPath.traversalStateAtLength(textPathOffset));
-            ASSERT(traversalState.success());
+            auto position = m_textPathMapper.positionAtLength(textPathOffset);
 
-            FloatPoint point = traversalState.current();
-            x = point.x();
-            y = point.y();
+            x = position.point.x();
+            y = position.point.y();
 
             // Compose with rotate attribute per SVG 2 §11.2.1.
-            angle += traversalState.normalAngle();
+            angle += position.angleInDegrees;
 
             // For vertical text on path, the actual angle has to be rotated 90 degrees anti-clockwise, not the orientation angle!
             if (m_isVerticalText)

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -21,6 +21,7 @@
 
 #include "InlineIteratorSVGTextBox.h"
 #include "Path.h"
+#include "PathArcLengthMapper.h"
 #include "SVGTextChunkBuilder.h"
 #include "SVGTextFragment.h"
 #include "SVGTextLayoutAttributes.h"
@@ -108,6 +109,7 @@ private:
 
     // Text on path layout
     Path m_textPath;
+    PathArcLengthMapper m_textPathMapper;
     float m_textPathLength { 0.0f };
     float m_textPathStartOffset { 0.0f };
     float m_textPathCurrentOffset { 0.0f };


### PR DESCRIPTION
#### 51ec1112daafae8037a6330c87597eba1342582c
<pre>
&lt;textPath&gt; layout re-walks the whole path per glyph  (TextOnPathSimple)
<a href="https://bugs.webkit.org/show_bug.cgi?id=318396">https://bugs.webkit.org/show_bug.cgi?id=318396</a>
<a href="https://rdar.apple.com/181181810">rdar://181181810</a>

Reviewed by Said Abou-Hallawa.

PerformanceTests/SVG/TextOnPathSimple.html lays out about 39x slower
than Chromium, and it gets worse as the path grows with the text.

layoutTextOnLineOrPath asked Path::traversalStateAtLength() for a point
once per glyph. That call keeps nothing between calls, so every glyph
walked the path from the start and re-split every curve. N glyphs on M
segments cost O(N*M).

This flattens the path once into a table of (point, accumulated length)
and binary searches it per glyph: O(M + N*log M). PathArcLengthMapper
subdivides curves exactly as PathTraversalState did, so glyph positions
are unchanged.

The subdivision loop they share now lives once in PathCurveSubdivision.h.

Two space glyphs move by 0.01px, from adding leaf lengths in one running
sum instead of per element:
  * svg/text/textLength-tspan-in-textPath.html 606.91 to 606.90,
  * and svg/batik/text/verticalText.svg 27.99 to 28.00 on ios.
Their baselines are updated.

Note that this does not fully close the gap with the other engines.
Building the table now costs more than querying it, so there is more to
win.

* LayoutTests/platform/ios/svg/batik/text/verticalText-expected.txt:
* LayoutTests/platform/ios/svg/text/textLength-tspan-in-textPath-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/text/textLength-tspan-in-textPath-expected.txt:
* LayoutTests/platform/mac/svg/text/textLength-tspan-in-textPath-expected.txt:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::arcLengthMapper const):
* Source/WebCore/platform/graphics/Path.h:
* Source/WebCore/platform/graphics/PathArcLengthMapper.cpp: Added.
(WebCore::PathArcLengthMapper::addVertex):
(WebCore::PathArcLengthMapper::appendPathElement):
(WebCore::PathArcLengthMapper::positionAtLength const):
* Source/WebCore/platform/graphics/PathArcLengthMapper.h: Copied from Source/WebCore/platform/graphics/PathTraversalState.h.
(WebCore::PathArcLengthMapper::appendPathElement):
(WebCore::PathArcLengthMapper::totalLength const):
* Source/WebCore/platform/graphics/PathCurveSubdivision.h: Added.
(WebCore::distanceLine):
(WebCore::QuadraticBezier::QuadraticBezier):
(WebCore::QuadraticBezier::approximateDistance const):
(WebCore::QuadraticBezier::split const):
(WebCore::CubicBezier::CubicBezier):
(WebCore::CubicBezier::approximateDistance const):
(WebCore::CubicBezier::split const):
(WebCore::forEachFlattenedCurveLeaf):
* Source/WebCore/platform/graphics/PathTraversalState.cpp:
(WebCore::curveLength):
(WebCore::distanceLine): Deleted.
(WebCore::QuadraticBezier::QuadraticBezier): Deleted.
(WebCore::QuadraticBezier::approximateDistance const): Deleted.
(WebCore::QuadraticBezier::split const): Deleted.
(WebCore::CubicBezier::CubicBezier): Deleted.
(WebCore::CubicBezier::approximateDistance const): Deleted.
(WebCore::CubicBezier::split const): Deleted.
* Source/WebCore/platform/graphics/PathTraversalState.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::beginTextPathLayout):
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:

Canonical link: <a href="https://commits.webkit.org/318600@main">https://commits.webkit.org/318600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/019bc896659e723cb6da1a9cdf442a2178aa87fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/187899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a65514e-ab59-4d5d-b048-da309908acff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138981 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96496 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b040614-5aa4-4cd8-8cb3-eac0244007a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159752 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119436 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4b361d7-0982-444e-89a1-dfcd482aa075) 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/39563 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39249 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36356 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/43806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190326 "Built successfully") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/51891 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39884 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52573 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35874 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147908 "Found 1 new API test failure: TestAutocleanups:/webkit/Autocleanups/ui-process-autocleanups (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42625 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124837 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119436 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51091 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14224 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50476 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50538 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->