### PR TITLE
Navigating away from a render-blocked document before it is revealed incorrectly reveals it and starts a cross-document view transition.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7167,7 +7167,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-m
 
 # Chromium specific test.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]
-webkit.org/b/278756 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal.html [ Failure ]
 
 # prerender not supported.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/prerender-removed-during-navigation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/abort-before-render.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/abort-before-render.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<head>
+  <style>
+  @view-transition {
+    navigation: auto;
+  }
+</style>
+<script id="blocker" async src="common.js?pipe=trickle(d10)" blocking="render"></script>
+<script src="/resources/testharness.js"></script>
+<script>
+const params = new URLSearchParams(location.search);
+const bc_channel = new BroadcastChannel(params.get("channel"));
+
+window.addEventListener("pagereveal", e => {
+  bc_channel.postMessage(`did reveal original page ${e.viewTransition ? "with" : "without"} transition`);
+});
+
+if (params.get("phase") !== "aborted") {
+  // While still render-blocked (before the first rendering opportunity), start a
+  // cross-document navigation and then let it be aborted: the destination responds
+  // with 204 No Content, which keeps this (the original) document. The original
+  // document must still be revealed, and no view transition should have started.
+  step_timeout(() => {
+    location.href = `?phase=aborted&channel=${bc_channel.name}&pipe=status(204)`;
+  }, 100);
+}
+</script>
+</head>
+
+<body>
+  Content
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reveal-after-aborted-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reveal-after-aborted-navigation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS an aborted navigation while render-blocked still reveals the original document
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reveal-after-aborted-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reveal-after-aborted-navigation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: aborted outbound navigation before reveal still reveals the original document</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-2/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#revealing-the-document">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  promise_test(async t => {
+    const result = await new Promise(resolve => {
+      const channel_name = `abort-nav-reveal-${new Date().valueOf()}`;
+      const bc = new BroadcastChannel(channel_name);
+      bc.addEventListener("message", e => resolve(e.data));
+      const popup = window.open(`resources/abort-before-render.html?channel=${channel_name}`);
+
+      t.add_cleanup(() => popup.close());
+    });
+
+    assert_equals(result, "did reveal original page without transition");
+  }, "an aborted navigation while render-blocked still reveals the original document");
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL when navigating away before revealing, never start a view transition assert_equals: expected "did reveal new page without transition" but got "did reveal old page"
+PASS when navigating away before revealing, never start a view transition
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8954,6 +8954,13 @@ void Document::reveal()
 {
     if (m_hasBeenRevealed)
         return;
+
+    // A navigation away from this document that will replace it is in progress, so this
+    // document is being discarded before it was ever revealed. Do not reveal it (and do
+    // not mark it revealed, so it can still reveal if the navigation is aborted).
+    if (RefPtr frame = this->frame(); frame && frame->loader().provisionalDocumentLoader())
+        return;
+
     m_hasBeenRevealed = true;
 
     PageRevealEvent::Init init;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1019,6 +1019,7 @@ public:
     void flushAutofocusCandidates();
 
     void reveal();
+    bool hasBeenRevealed() const { return m_hasBeenRevealed; }
 
     void hoveredElementDidDetach(Element&);
     void elementInActiveChainDidDetach(Element&);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2547,6 +2547,12 @@ CanTriggerCrossDocumentViewTransition DocumentLoader::navigationCanTriggerCrossD
     if (loadStartedDuringSwipeAnimation())
         return CanTriggerCrossDocumentViewTransition::No;
 
+    // A document that navigates away before it has been revealed (had its first
+    // rendering opportunity) has no captured state to animate from, so no outbound
+    // cross-document view transition is started.
+    if (!oldDocument.hasBeenRevealed())
+        return CanTriggerCrossDocumentViewTransition::No;
+
     if (std::holds_alternative<Document::SkipTransition>(oldDocument.resolveViewTransitionRule()))
         return CanTriggerCrossDocumentViewTransition::No;
 


### PR DESCRIPTION
#### fe161c5b7ed5c56432b7683c7bccb7d3c3015c13
<pre>
Navigating away from a render-blocked document before it is revealed incorrectly reveals it and starts a cross-document view transition.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318401">https://bugs.webkit.org/show_bug.cgi?id=318401</a>
<a href="https://rdar.apple.com/181191512">rdar://181191512</a>

Reviewed by Tim Nguyen.

When a render-blocked document is navigated away from before its first
rendering opportunity, the pending render-blocking resource is cancelled,
which unblocks rendering and lets a rendering update reveal the document
that is being discarded. This fired pagereveal on it and, because the
document was treated as revealed, set up an outbound cross-document view
transition. Per CSS View Transitions 2, a document only initiates an
outbound transition once it &quot;has been revealed&quot;, and pagereveal is tied
to the first rendering opportunity.

Skip revealing a document that has an in-progress navigation replacing it,
and don&apos;t start an outbound cross-document view transition unless the old
document has been revealed.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reveal-after-aborted-navigation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reveal-after-aborted-navigation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/resources/abort-before-render.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/navigation/skip-outbound-vt-before-reveal-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::reveal):
* Source/WebCore/dom/Document.h:
(WebCore::Document::hasBeenRevealed const):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::navigationCanTriggerCrossDocumentViewTransition):

Canonical link: <a href="https://commits.webkit.org/316446@main">https://commits.webkit.org/316446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1de5f9a1221ab569317efe3a871199c8f6fff82c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129674 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/173985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133886 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114359 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34216 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30173 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146369 "") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142631 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38529 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46384 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111060 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37604 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118089 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44902 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8866 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->