### PR TITLE
[GFC] Incorrect block axis sizes during sizing of intrinsic rows.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-001-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    height: 10px;
+}
+</style>
+<div class="item">XXXXXXXXXXXXXXX</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-001-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    height: 10px;
+}
+</style>
+<div class="item">XXXXXXXXXXXXXXX</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">
+<meta name="assert" content="An auto-sized row uses the grid item's automatic minimum (min-content) block size, measured against the item's own inline size.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="match" href="grid-item-block-axis-content-contribution-001-ref.html">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 10px;
+    grid-template-rows: auto;
+}
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    word-break: break-all;
+    grid-row: 1 / 2;
+}
+</style>
+<div class="grid">
+    <div class="item">XXXXXXXXXXXXXXX</div>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-002-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    height: 10px;
+}
+</style>
+<div class="item">XXXXXXXXXXXXXXX</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-002.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">
+<meta name="assert" content="A min-content row uses the grid item's min-content block-size contribution, measured against the item's own inline size.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="match" href="grid-item-block-axis-content-contribution-001-ref.html">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 10px;
+    grid-template-rows: min-content;
+}
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    word-break: break-all;
+    grid-row: 1 / 2;
+}
+</style>
+<div class="grid">
+    <div class="item">XXXXXXXXXXXXXXX</div>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-003-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    height: 10px;
+}
+</style>
+<div class="item">XXXXXXXXXXXXXXX</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-block-axis-content-contribution-003.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">
+<meta name="assert" content="A max-content row uses the grid item's max-content block-size contribution, measured against the item's own inline size.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<link rel="match" href="grid-item-block-axis-content-contribution-001-ref.html">
+<p>Test passes if there is a filled blue rectangle below and it is NOT taller than one line of text.</p>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 10px;
+    grid-template-rows: max-content;
+}
+.item {
+    font: 10px/1 Ahem;
+    color: blue;
+    background: blue;
+    width: 150px;
+    word-break: break-all;
+    grid-row: 1 / 2;
+}
+</style>
+<div class="grid">
+    <div class="item">XXXXXXXXXXXXXXX</div>
+</div>
+</html>

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -118,7 +118,7 @@ static BorderBoxSize blockContentSizeSuggestion(const PlacedGridItem& gridItem, 
 {
     // FIXME: Clamp by opposite-axis min/max sizes converted through the aspect ratio.
     ASSERT(!gridItem.preferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
-    return BorderBoxSize::fromIntegrationFunction(formattingContext.integrationUtils().minContentHeight(gridItem.layoutBox(), inlineAxisConstraint));
+    return BorderBoxSize::fromIntegrationFunction(formattingContext.integrationUtils().minContentHeightForGridItem(gridItem.layoutBox(), inlineAxisConstraint));
 }
 
 // https://drafts.csswg.org/css-overflow-3/#overflow-properties
@@ -463,15 +463,13 @@ LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, Layo
 // FIXME: this should be marginBoxHeight().
 LayoutUnit blockAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, const GridFormattingContext& formattingContext)
 {
-    formattingContext.integrationUtils().layoutWithFormattingContextForBox(gridItem.layoutBox(), inlineAxisConstraint);
-    return BorderBoxSize::fromIntegrationFunction(formattingContext.geometryForGridItem(gridItem.layoutBox()).borderBoxHeight()).value;
+    return BorderBoxSize::fromIntegrationFunction(formattingContext.integrationUtils().minContentContributionHeightForGridItem(gridItem.layoutBox(), inlineAxisConstraint)).value;
 }
 
 // FIXME: this should be marginBoxHeight().
 LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, const GridFormattingContext& formattingContext)
 {
-    formattingContext.integrationUtils().layoutWithFormattingContextForBox(gridItem.layoutBox(), inlineAxisConstraint);
-    return BorderBoxSize::fromIntegrationFunction(formattingContext.geometryForGridItem(gridItem.layoutBox()).borderBoxHeight()).value;
+    return BorderBoxSize::fromIntegrationFunction(formattingContext.integrationUtils().maxContentContributionHeightForGridItem(gridItem.layoutBox(), inlineAxisConstraint)).value;
 }
 
 // https://www.w3.org/TR/css-sizing-3/#behave-as-auto

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.h
@@ -51,7 +51,9 @@ enum class LogicalWidthType : uint8_t  {
 LayoutUnit formattingContextRootLogicalWidthForType(const Layout::ElementBox&, LogicalWidthType);
 
 enum class LogicalHeightType : uint8_t  {
-    MinContent
+    MinContent,
+    MinContentContribution,
+    MaxContentContribution
 };
 LayoutUnit formattingContextRootLogicalHeightForType(const Layout::ElementBox&, LogicalHeightType);
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -30,6 +30,7 @@
 #include "LayoutIntegrationFormattingContextLayout.h"
 #include "LayoutState.h"
 #include "RenderObject.h"
+#include "RenderObjectInlines.h"
 
 namespace WebCore {
 namespace Layout {
@@ -62,11 +63,46 @@ LayoutUnit IntegrationUtils::minContentHeight(const ElementBox& box) const
     return m_globalLayoutState->logicalHeightWithFormattingContextForBox(box, LayoutIntegration::LogicalHeightType::MinContent);
 }
 
-LayoutUnit IntegrationUtils::minContentHeight(const ElementBox& box, LayoutUnit inlineConstraint) const
+static LayoutUnit blockSizeForGridItem(const LayoutState& layoutState, const ElementBox& box, LayoutUnit inlineAxisConstraint, LayoutIntegration::LogicalHeightType logicalHeightType)
 {
     ASSERT(box.isGridItem());
-    m_globalLayoutState->layoutWithFormattingContextForBox(box, inlineConstraint, { });
-    return m_globalLayoutState->geometryForBox(box).borderBoxHeight();
+    CheckedRef renderer = downcast<RenderBox>(*box.rendererForIntegration());
+
+    switch (logicalHeightType) {
+    // A grid item's block-axis min-content size, min-content contribution and max-content
+    // contribution all resolve to its post-layout border-box block size at the given inline
+    // size, so these currently coincide.
+    case LayoutIntegration::LogicalHeightType::MinContent:
+    case LayoutIntegration::LogicalHeightType::MinContentContribution:
+    case LayoutIntegration::LogicalHeightType::MaxContentContribution: {
+        renderer->setGridAreaContentLogicalWidth(inlineAxisConstraint);
+        renderer->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+
+        layoutState.layoutWithFormattingContextForBox(box, { }, { });
+
+        renderer->clearGridAreaContentSize();
+
+        return layoutState.geometryForBox(box).borderBoxHeight();
+    }
+    }
+
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+LayoutUnit IntegrationUtils::minContentHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
+{
+    return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MinContent);
+}
+
+LayoutUnit IntegrationUtils::minContentContributionHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
+{
+    return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MinContentContribution);
+}
+
+LayoutUnit IntegrationUtils::maxContentContributionHeightForGridItem(const ElementBox& box, LayoutUnit inlineAxisConstraint) const
+{
+    return blockSizeForGridItem(m_globalLayoutState, box, inlineAxisConstraint, LayoutIntegration::LogicalHeightType::MaxContentContribution);
 }
 
 LayoutUnit IntegrationUtils::minContentLogicalWidthContribution(const ElementBox& box) const

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -48,7 +48,9 @@ public:
     LayoutUnit maxContentWidth(const ElementBox&) const;
     LayoutUnit minContentWidth(const ElementBox&) const;
     LayoutUnit minContentHeight(const ElementBox&) const;
-    LayoutUnit minContentHeight(const ElementBox&, LayoutUnit inlineConstraint) const;
+    LayoutUnit minContentHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
+    LayoutUnit minContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
+    LayoutUnit maxContentContributionHeightForGridItem(const ElementBox&, LayoutUnit inlineAxisConstraint) const;
     LayoutUnit minContentLogicalWidthContribution(const ElementBox&) const;
     LayoutUnit maxContentLogicalWidthContribution(const ElementBox&) const;
     void layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState&) const;


### PR DESCRIPTION
#### 561f5f0b1b232b530daee0a07dfbeee0c17d28fd
<pre>
[GFC] Incorrect block axis sizes during sizing of intrinsic rows.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318406">https://bugs.webkit.org/show_bug.cgi?id=318406</a>
<a href="https://rdar.apple.com/problem/181195816">rdar://problem/181195816</a>

Reviewed by Alan Baradlay.

During the row sizing portion of the track sizing algorithm, the
algorithm may query a grid item for at least three different types of
sizes:

- min-content height
- min-content height contribution
- max-content height contribution

We already have three existing APIs for these within GridLayoutUtils,
but they were not really doing the right thing. All three were
ultimately calling layoutWithFormattingContextForBox with some sort if
inline constraint. This inline constraint was getting set as the
overriding border box size on the renderer associated with the grid item
before calling layout on it. Instead, what should have been happening is
that this constraint should have been setting the *grid area content
width* which was computed from the previous step in the algorithm since
the grid area is the containing block for the item.

We can fix this by doing a couple of main things:

1.) Adding a dedicated API into IntegrationUtils for the min/max content
height contributions and renaming the minContentHeight API to
minContentHeightForGridItem.

This first makes the grid layout much more clear since instead of mixing
integration level code with grid layout code we just call into the
integration API with the same name. Instead of grid layout being
responsible for determining how to compute this size it moves to the
integration code where it does whatever is needed to get the right value
back from the render tree.

2.) Set the grid area content width on the renderer before calling into
layoutWithFormattingContextForBox. Note we do not pass in any
constraints to layoutWithFormattingContextForBox  since we do not want
it to set any overriding sizes on the renderer. This matches what
GridTrackSizingAlgorithm currently does to compute these sizes.

All three of these functions call into a helper function that switches
on the type of height the caller is interested in. Currently all three
cases do the same thing but this may change over time as we continue the
implementation.

Canonical link: <a href="https://commits.webkit.org/316469@main">https://commits.webkit.org/316469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd71c068ad4c42dba30ad1cedcf26d9bef01b2d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181793 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129897 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75631d97-6af2-4824-b351-80693cd2e556) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134041 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a14cb156-65bf-4d7f-b819-1f1432287604) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114512 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85a59404-f79e-42d0-94f9-f63399d63295) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36115 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30398 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184328 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37009 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142812 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38549 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46609 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111336 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37751 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118360 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45126 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9038 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44758 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->