### PR TITLE
Re-import content-security-policy/connect-src

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1192,6 +1192,9 @@ imported/w3c/web-platform-tests/content-security-policy/reporting-api/dedicated-
 
 # Skip Content Security Policy tests that time out
 imported/w3c/web-platform-tests/content-security-policy/child-src/child-src-cross-origin-load.sub.html [ Skip ]
+imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub.html [ Skip ]
+imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https.html [ Skip ]
+imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-none-block.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-self-block.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-star-allow.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Expecting logs: ["Pass"]
+PASS fetch with keepalive should be allowed by CSP
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' http://{{host}}:{{ports[http][0]}}; script-src 'self' 'unsafe-inline';">
+    <title>connect-src-fetch-keepalive-allowed</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["Pass"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+    <!-- enforcing policy:
+connect-src 'self' http://{{host}}:{{ports[http][0]}}; script-src 'self' 'unsafe-inline';
+-->
+</head>
+
+<body>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("FAIL");
+        });
+
+        promise_test(async function(t) {
+            try {
+                await fetch("http://{{host}}:{{ports[http][0]}}/common/blank.html", {
+                    keepalive: true
+                });
+                log("Pass");
+            } catch (e) {
+                log("Fail");
+            }
+        }, "fetch with keepalive should be allowed by CSP");
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Expecting logs: ["Pass", "violated-directive=connect-src"]
+PASS fetch with keepalive should be blocked by CSP
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self'; script-src 'self' 'unsafe-inline';">
+    <title>connect-src-fetch-keepalive-blocked</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["Pass", "violated-directive=connect-src"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("violated-directive=" + e.violatedDirective);
+        });
+
+        promise_test(async function(t) {
+            try {
+                await fetch("http://www1.{{host}}:{{ports[http][0]}}/common/blank.html", {
+                    keepalive: true
+                });
+                log("Fail");
+            } catch (e) {
+                log("Pass");
+            }
+        }, "fetch with keepalive should be blocked by CSP");
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Expecting logs: ["Pass", "violated-directive=connect-src"]
+PASS fetch with keepalive should be blocked when redirected to disallowed origin
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self'; script-src 'self' 'unsafe-inline';">
+    <title>connect-src-fetch-keepalive-redirect-to-blocked</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["Pass", "violated-directive=connect-src"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+</head>
+
+<body>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log("violated-directive=" + e.violatedDirective);
+        });
+
+        promise_test(async function(t) {
+            try {
+                await fetch("/common/redirect.py?location=http://www1.{{host}}:{{ports[http][0]}}/content-security-policy/support/fail.png", {
+                    keepalive: true
+                });
+                log("Fail");
+            } catch (e) {
+                // Fetch will reject with a TypeError when CSP blocks the redirect
+                log("Pass");
+            }
+        }, "fetch with keepalive should be blocked when redirected to disallowed origin");
+    </script>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL import should be allowed promise_test: Unhandled rejection with value: object "TypeError: Import attribute type "text" is not valid"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>connect-src-text-import-allowed</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="connect-src 'self'; script-src http://{{host}}:{{ports[http][0]}}/resources/testharness.js http://{{host}}:{{ports[http][0]}}/resources/testharnessreport.js 'unsafe-inline';"
+    />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <script>
+      promise_test(t => new Promise((resolve, reject) => {
+        window.addEventListener("securitypolicyviolation", (err) => {
+          if (err.blockedURI.endsWith("/common/text-plain.txt")) {
+            reject("Should not raise securitypolicyviolation.");
+          }
+        });
+        import("/common/text-plain.txt", { with: { type: "text" } }).then(resolve, reject)
+      }), "import should be allowed");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub-expected.txt
@@ -1,0 +1,5 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT connect-src-text-import-blocked Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>connect-src-text-import-blocked</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="connect-src 'none'; script-src 'self' 'unsafe-inline';"
+    />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <script>
+      promise_test((t) => {
+        let check_spv = new Promise((resolve) => {
+          window.addEventListener("securitypolicyviolation", (e) => {
+            if (e.blockedURI.endsWith("text-plain.txt")) {
+              resolve();
+            }
+          });
+        });
+
+        return Promise.all([
+          promise_rejects_js(t, TypeError, import("/common/text-plain.txt", { with: { type: "text" } })),
+          check_spv,
+        ]);
+      });
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS CSP connect-src url vs WebTransport. Expecting undefined
+PASS CSP connect-src url vs WebTransport. Expecting connect-src
+FAIL CSP connect-src url vs serverCertificateHashes. Expecting connect-src assert_equals: expected (string) "connect-src" but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="timeout" content="long">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'self' https://{{domains[www1]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py; script-src 'self' 'unsafe-inline';">
+  <title>connect-src-webtransport-allowed</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+
+const url1 = "https://{{domains[www1]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py";
+const url2 = "https://{{domains[www2]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py";
+
+const serverCertificateHashes = [
+  {algorithm: "sha-256", value: new Uint8Array(32)}
+];
+
+[
+  // Connection to url allowlisted in connect-src should be allowed.
+  {url: url1, options: {}},
+  // Connection to url not allowlisted in connect-src should be blocked.
+  {url: url2, options: {}, expected: "connect-src"},
+  // Connection with serverCertificateHashes to url allowlisted in connect-src
+  // should be blocked, since connect-src does not specify
+  // 'unsafe-webtransport-hashes'.
+  {url: url1, options: {serverCertificateHashes}, expected: "connect-src"},
+].forEach(({url, options, expected}) => promise_test(async t => {
+  const haveViolation = new Promise(r => window.onsecuritypolicyviolation = r);
+  try {
+    const wt = new WebTransport(url, options);
+    t.add_cleanup(() => wt.close());
+    wt.closed.catch(() => {});
+    await wt.ready;
+    assert_equals(expected, undefined, "allowed");
+  } catch (e) {
+    if (e.name != "WebTransportError") throw e;
+    const timeout = new Promise(r => t.step_timeout(() => r({}), 1000));
+    const {violatedDirective} = await Promise.race([haveViolation, timeout]);
+    assert_equals(violatedDirective, expected);
+  }
+}, `CSP connect-src url vs ${Object.keys(options)[0] || "WebTransport"}. Expecting ${expected}`));
+
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS CSP connect-src self vs WebTransport. Expecting connect-src
+PASS CSP connect-src self vs serverCertificateHashes. Expecting connect-src
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="timeout" content="long">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'self'; script-src 'self' 'unsafe-inline';">
+  <title>connect-src-webtransport-blocked</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+
+const url = "https://{{domains[www1]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py";
+
+const serverCertificateHashes = [
+  {algorithm: "sha-256", value: new Uint8Array(32)}
+];
+
+[
+  {url, options: {}, expected: "connect-src"},
+  {url, options: {serverCertificateHashes}, expected: "connect-src"},
+].forEach(({url, options, expected}) => promise_test(async t => {
+  const haveViolation = new Promise(r => window.onsecuritypolicyviolation = r);
+  try {
+    const wt = new WebTransport(url, options);
+    t.add_cleanup(() => wt.close());
+    wt.closed.catch(() => {});
+    await wt.ready;
+    assert_equals(expected, undefined, "allowed");
+  } catch (e) {
+    if (e.name != "WebTransportError") throw e;
+    const timeout = new Promise(r => t.step_timeout(() => r({}), 1000));
+    const {violatedDirective} = await Promise.race([haveViolation, timeout]);
+    assert_equals(violatedDirective, expected);
+  }
+}, `CSP connect-src self vs ${Object.keys(options)[0] || "WebTransport"}. Expecting ${expected}`));
+
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS CSP connect-src url webtransport-hashes vs WebTransport. Expecting undefined
+PASS CSP connect-src url webtransport-hashes vs WebTransport. Expecting connect-src
+FAIL CSP connect-src url webtransport-hashes vs serverCertificateHashes. Expecting undefined assert_equals: expected (undefined) undefined but got (string) "connect-src"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="timeout" content="long">
+  <meta http-equiv="Content-Security-Policy" content="connect-src 'self' 'unsafe-webtransport-hashes' https://{{domains[www1]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py; script-src 'self' 'unsafe-inline';">
+  <title>connect-src-webtransport-hashes</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+
+const url1 = "https://{{domains[www1]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py";
+const url2 = "https://{{domains[www2]}}:{{ports[webtransport-h3][0]}}/webtransport/handlers/echo.py";
+
+const serverCertificateHashes = [
+  {algorithm: "sha-256", value: new Uint8Array(32)}
+];
+
+[
+  {url: url1, options: {}},
+  {url: url2, options: {}, expected: "connect-src"},
+  {url: url2, options: {serverCertificateHashes}},
+].forEach(({url, options, expected}) => promise_test(async t => {
+  const haveViolation = new Promise(r => window.onsecuritypolicyviolation = r);
+  try {
+    const wt = new WebTransport(url, options);
+    t.add_cleanup(() => wt.close());
+    wt.closed.catch(() => {});
+    await wt.ready;
+    assert_equals(expected, undefined, "allowed");
+  } catch (e) {
+    if (e.name != "WebTransportError") throw e;
+    const timeout = new Promise(r => t.step_timeout(() => r({}), 1000));
+    const {violatedDirective} = await Promise.race([haveViolation, timeout]);
+    assert_equals(violatedDirective, expected);
+  }
+}, `CSP connect-src url webtransport-hashes vs ${Object.keys(options)[0] || "WebTransport"}. Expecting ${expected}`));
+
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/resources/simple-event-stream

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/support/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/support/shared-worker-make-xhr-allowed.sub.js

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-beacon-allowed.sub.html
@@ -20,14 +18,22 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-eventsource-allowed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-eventsource-redirect-to-blocked.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-allowed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-json-import-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-syncxmlhttprequest-allowed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-syncxmlhttprequest-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-syncxmlhttprequest-redirect-to-blocked.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-websocket-allowed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-websocket-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-websocket-self.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-allowed.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-blocked.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-xmlhttprequest-redirect-to-blocked.sub.html

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5290,6 +5290,7 @@ webkit.org/b/319950 imported/w3c/web-platform-tests/css/css-pseudo/marker-hit-te
 
 # WebTransport is Cocoa-only (non-Cocoa ports are a stub). https://bugs.webkit.org/show_bug.cgi?id=319008
 imported/w3c/web-platform-tests/webtransport/ [ Skip ]
+imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html [ Skip ]
 
 webkit.org/b/320057 imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html [ ImageOnlyFailure Pass ]
 

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -45,6 +45,7 @@ accessibility/mac/intersection-with-selection-range.html [ Skip ]
 
 # webkit.org/b/319008 WebTransport-over-HTTP/3 needs Network.framework QUIC SPI only present on Tahoe; skip the suite on Sequoia.
 imported/w3c/web-platform-tests/webtransport [ Skip ]
+imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html [ Skip ]
 
 
 

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -857,6 +857,15 @@
     "imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/content-security-policy/embedded-enforcement/required_csp-header-crlf.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 2077a44a217ba4ad32eb6573bc54c0013d219056
<pre>
Re-import content-security-policy/connect-src
<a href="https://bugs.webkit.org/show_bug.cgi?id=318410">https://bugs.webkit.org/show_bug.cgi?id=318410</a>
<a href="https://rdar.apple.com/181198809">rdar://181198809</a>

Reviewed by Ryan Reno.

Re-import content-security-policy/connect-src tests from wpt

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-allowed.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-blocked.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-fetch-keepalive-redirect-to-blocked.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-allowed.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-text-import-blocked.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-allowed.sub.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-hashes.sub.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/connect-src/w3c-import.log:
* LayoutTests/tests-options.json:
* LayoutTests/platform/mac-sequoia/TestExpectations:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/318160@main">https://commits.webkit.org/318160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce774b242a3334d4996fbcee7e59d380e477ff9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186932 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138187 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/473081c8-5f5e-44c0-ad66-61cac9045815) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41687 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118652 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38733 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38446 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35400 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189361 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/158483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147282 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39606 "Build is in progress. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Reviewed by Ryan Reno; Compiled WebKit (warnings); Skipped layout-tests; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51616 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147072 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41790 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50124 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13424 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49520 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49582 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->