### PR TITLE
[Wasm] Don't move a failed streaming Wasm plan back to Compiled

### DIFF
--- a/JSTests/wasm/stress/streaming-compile-invalid-function-body.js
+++ b/JSTests/wasm/stress/streaming-compile-invalid-function-body.js
@@ -1,0 +1,51 @@
+// Streaming compilation of a module whose function body fails validation used to
+// move the already-failed (Completed) plan's state machine backwards to Compiled,
+// hitting "ASSERTION FAILED: state >= m_state" in EntryPlan::moveToState.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// Section framing is valid, so the streaming parser accepts the bytes, but the
+// function body leaves an i32 on the stack and fails validation at compile time.
+const invalidFunctionBodyModule = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,             // type section: () -> ()
+    0x03, 0x02, 0x01, 0x00,                         // function section: 1 function of type 0
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x00, 0x0b, // code section: body is (i32.const 0)
+]);
+
+async function shouldRejectWithCompileError(promise) {
+    let error = null;
+    try {
+        await promise;
+    } catch (e) {
+        error = e;
+    }
+    shouldBe(error instanceof WebAssembly.CompileError, true);
+}
+
+async function main() {
+    for (let i = 0; i < 10; ++i) {
+        await shouldRejectWithCompileError($vm.createWasmStreamingCompilerForCompile(function (compiler) {
+            compiler.addBytes(invalidFunctionBodyModule);
+        }));
+
+        await shouldRejectWithCompileError($vm.createWasmStreamingCompilerForInstantiate(function (compiler) {
+            compiler.addBytes(invalidFunctionBodyModule);
+        }, {}));
+
+        // Also stream byte-by-byte.
+        await shouldRejectWithCompileError($vm.createWasmStreamingCompilerForCompile(function (compiler) {
+            for (const byte of invalidFunctionBodyModule)
+                compiler.addBytes(new Uint8Array([byte]));
+        }));
+    }
+}
+
+main().catch(function (error) {
+    print(String(error));
+    print(String(error.stack));
+    $vm.abort();
+});

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -174,7 +174,8 @@ void IPIntPlan::completeInStreaming()
 void IPIntPlan::didCompileFunctionInStreaming()
 {
     Locker locker { m_lock };
-    moveToState(EntryPlan::State::Compiled);
+    if (hasWork())
+        moveToState(EntryPlan::State::Compiled);
 }
 
 void IPIntPlan::didFailInStreaming(String&& message)


### PR DESCRIPTION
#### 95b9bdf57cef88c958a1182e8a6a687e7ae8ccfa
<pre>
[Wasm] Don&apos;t move a failed streaming Wasm plan back to Compiled
<a href="https://bugs.webkit.org/show_bug.cgi?id=318411">https://bugs.webkit.org/show_bug.cgi?id=318411</a>

Reviewed by Yusuke Suzuki.

When a function body fails validation during streaming compilation,
Plan::fail moves the plan to Completed on the worklist thread. The last
StreamingPlan&apos;s completion callback then unconditionally moved the plan
back to Compiled, breaking the monotonic state machine and hitting
&quot;ASSERTION FAILED: state &gt;= m_state&quot; on assertion-enabled builds. Guard
the transition with hasWork(), as the non-streaming path already does.

* JSTests/wasm/stress/streaming-compile-invalid-function-body.js: Added.
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::didCompileFunctionInStreaming):

Canonical link: <a href="https://commits.webkit.org/316510@main">https://commits.webkit.org/316510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1523077a9fda8c3078ac00f11565f41e680edc90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39476 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181584 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45698 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181584 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94457 "3 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154445 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181584 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35954 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34228 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30194 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2986 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184115 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33400 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36729 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38440 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142649 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45725 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46405 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111083 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37617 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118179 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204819 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44923 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8894 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44555 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->