### PR TITLE
[JSC] Parse the replacement template only once in `String#replace` with a global RegExp and `'$'` substitutions

### DIFF
--- a/JSTests/microbenchmarks/string-replace-regexp-global-substitution.js
+++ b/JSTests/microbenchmarks/string-replace-regexp-global-substitution.js
@@ -1,0 +1,18 @@
+function test(string, re)
+{
+    return string.replace(re, "$2:$1");
+}
+noInline(test);
+
+const parts = [];
+for (let i = 0; i < 200; ++i)
+    parts.push("name" + i + "=value" + i);
+const text = parts.join("&");
+const re = /(\w+)=(\w+)/g;
+
+let result;
+for (let i = 0; i < 20000; ++i)
+    result = test(text, re);
+
+if (!result.startsWith("value0:name0&value1:name1"))
+    throw new Error("bad result: " + result.substring(0, 30));

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1248,6 +1248,164 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearchNoBackreferences(VM
     RELEASE_AND_RETURN(scope, jsSpliceSubstringsWithSeparator(globalObject, string, source, sourceRanges.span().data(), sourceRanges.size(), replacementString, replacementCount));
 }
 
+struct StringReplaceTemplatePart {
+    enum class Type : uint8_t { Literal, Capture, MatchPrefix, MatchSuffix, NamedCapture };
+    Type type;
+    union {
+        struct {
+            unsigned offset;
+            unsigned length;
+        } range; // Literal / NamedCapture
+        unsigned captureIndex; // Capture
+    };
+
+    static StringReplaceTemplatePart literal(unsigned offset, unsigned length)
+    {
+        StringReplaceTemplatePart part;
+        part.type = Type::Literal;
+        part.range = { offset, length };
+        return part;
+    }
+
+    static StringReplaceTemplatePart capture(unsigned index)
+    {
+        StringReplaceTemplatePart part;
+        part.type = Type::Capture;
+        part.captureIndex = index;
+        return part;
+    }
+
+    static StringReplaceTemplatePart matchPrefix()
+    {
+        StringReplaceTemplatePart part;
+        part.type = Type::MatchPrefix;
+        return part;
+    }
+
+    static StringReplaceTemplatePart matchSuffix()
+    {
+        StringReplaceTemplatePart part;
+        part.type = Type::MatchSuffix;
+        return part;
+    }
+
+    static StringReplaceTemplatePart namedCapture(unsigned nameOffset, unsigned nameLength)
+    {
+        StringReplaceTemplatePart part;
+        part.type = Type::NamedCapture;
+        part.range = { nameOffset, nameLength };
+        return part;
+    }
+};
+
+using StringReplaceTemplateParts = Vector<StringReplaceTemplatePart, 16>;
+
+ALWAYS_INLINE void parseReplacementTemplate(StringReplaceTemplateParts& parts, StringView replacement, RegExp* regExp, size_t dollarPos)
+{
+    bool hasNamedCaptures = regExp->hasNamedCaptures();
+    size_t i = dollarPos;
+    unsigned offset = 0;
+    do {
+        if (i + 1 == replacement.length())
+            break;
+
+        char16_t ref = replacement[i + 1];
+        if (ref == '$') {
+            // "$$" -> "$"
+            ++i;
+            if (i - offset)
+                parts.append(StringReplaceTemplatePart::literal(offset, i - offset));
+            offset = i + 1;
+            continue;
+        }
+
+        int advance = 0;
+        StringReplaceTemplatePart part;
+        if (ref == '&')
+            part = StringReplaceTemplatePart::capture(0);
+        else if (ref == '`')
+            part = StringReplaceTemplatePart::matchPrefix();
+        else if (ref == '\'')
+            part = StringReplaceTemplatePart::matchSuffix();
+        else if (ref == '<') {
+            // Named back reference
+            if (!hasNamedCaptures)
+                continue;
+
+            size_t closingBracket = replacement.find('>', i + 2);
+            if (closingBracket == WTF::notFound)
+                continue;
+
+            unsigned nameLength = closingBracket - i - 2;
+            part = StringReplaceTemplatePart::namedCapture(i + 2, nameLength);
+            advance = nameLength + 1;
+        } else if (isASCIIDigit(ref)) {
+            // 1- and 2-digit back references are allowed
+            unsigned backrefIndex = ref - '0';
+            if (backrefIndex > regExp->numSubpatterns())
+                continue;
+            if (replacement.length() > i + 2) {
+                ref = replacement[i + 2];
+                if (isASCIIDigit(ref)) {
+                    unsigned twoDigitIndex = 10 * backrefIndex + ref - '0';
+                    if (twoDigitIndex <= regExp->numSubpatterns()) {
+                        backrefIndex = twoDigitIndex;
+                        advance = 1;
+                    }
+                }
+            }
+            if (!backrefIndex)
+                continue;
+            part = StringReplaceTemplatePart::capture(backrefIndex);
+        } else
+            continue;
+
+        if (i - offset)
+            parts.append(StringReplaceTemplatePart::literal(offset, i - offset));
+        i += 1 + advance;
+        offset = i + 1;
+        parts.append(part);
+    } while ((i = replacement.find('$', i + 1)) != notFound);
+
+    if (replacement.length() - offset)
+        parts.append(StringReplaceTemplatePart::literal(offset, replacement.length() - offset));
+}
+
+ALWAYS_INLINE void appendReplacementUsingTemplate(StringBuilder& result, std::span<const StringReplaceTemplatePart> parts, StringView replacement, StringView source, const int* ovector, RegExp* regExp)
+{
+    using Type = StringReplaceTemplatePart::Type;
+    for (auto& part : parts) {
+        switch (part.type) {
+        case Type::Literal:
+            result.append(replacement.substring(part.range.offset, part.range.length));
+            break;
+        case Type::Capture: {
+            int backrefStart = ovector[2 * part.captureIndex];
+            int backrefEnd = ovector[2 * part.captureIndex + 1];
+            if (backrefStart >= 0 && backrefEnd >= backrefStart)
+                result.append(source.substring(backrefStart, backrefEnd - backrefStart));
+            break;
+        }
+        case Type::MatchPrefix:
+            result.append(source.substring(0, ovector[0]));
+            break;
+        case Type::MatchSuffix:
+            result.append(source.substring(ovector[1]));
+            break;
+        case Type::NamedCapture: {
+            unsigned backrefIndex = regExp->subpatternIdForGroupName(replacement.substring(part.range.offset, part.range.length), ovector);
+            if (backrefIndex && backrefIndex <= regExp->numSubpatterns()) {
+                int backrefStart = ovector[2 * backrefIndex];
+                int backrefEnd = ovector[2 * backrefIndex + 1];
+                if (backrefStart >= 0 && backrefEnd >= backrefStart)
+                    result.append(source.substring(backrefStart, backrefEnd - backrefStart));
+            }
+            break;
+        }
+        }
+    }
+}
+
 ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSString* string, const String& source, RegExp* regExp, const String& replacementString)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1256,12 +1414,17 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
     if (dollarPos == notFound)
         RELEASE_AND_RETURN(scope, replaceAllWithStringUsingRegExpSearchNoBackreferences(vm, globalObject, string, source, regExp, replacementString));
 
+    StringReplaceTemplateParts templateParts;
+
     size_t lastIndex = 0;
     unsigned startPosition = 0;
     unsigned sourceLen = source.length();
 
-    Vector<Range<int32_t>, 16> sourceRanges;
-    Vector<String, 16> replacements;
+    bool anyMatch = false;
+    MatchResult firstMatch;
+    Vector<int, 32> firstOvector;
+    bool usingBuilder = false;
+    StringBuilder resultBuilder(OverflowPolicy::RecordOverflow);
 
     while (1) {
         int* ovector;
@@ -1270,14 +1433,23 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
         if (!result)
             break;
 
-        if (!sourceRanges.tryConstructAndAppend(lastIndex, result.start)) [[unlikely]]
-            OUT_OF_MEMORY(globalObject, scope);
-
-        StringBuilder replacement(OverflowPolicy::RecordOverflow);
-        substituteBackreferencesSlow(replacement, replacementString, source, ovector, regExp, dollarPos);
-        if (replacement.hasOverflowed()) [[unlikely]]
-            OUT_OF_MEMORY(globalObject, scope);
-        replacements.append(replacement.toString());
+        if (!anyMatch) {
+            anyMatch = true;
+            parseReplacementTemplate(templateParts, replacementString, regExp, dollarPos);
+            firstMatch = result;
+            firstOvector.append(std::span<const int> { ovector, static_cast<size_t>(regExp->offsetVectorSize()) });
+        } else {
+            if (!usingBuilder) {
+                usingBuilder = true;
+                resultBuilder.reserveCapacity(sourceLen);
+                resultBuilder.append(StringView { source }.substring(0, firstMatch.start));
+                appendReplacementUsingTemplate(resultBuilder, templateParts.span(), replacementString, source, firstOvector.span().data(), regExp);
+            }
+            resultBuilder.append(StringView { source }.substring(lastIndex, result.start - lastIndex));
+            appendReplacementUsingTemplate(resultBuilder, templateParts.span(), replacementString, source, ovector, regExp);
+            if (resultBuilder.hasOverflowed()) [[unlikely]]
+                OUT_OF_MEMORY(globalObject, scope);
+        }
 
         lastIndex = result.end;
         startPosition = lastIndex;
@@ -1295,14 +1467,24 @@ ALWAYS_INLINE JSString* replaceAllWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
         }
     }
 
-    if (!lastIndex && replacements.isEmpty())
+    if (!anyMatch)
         return string;
 
-    if (static_cast<unsigned>(lastIndex) < sourceLen) {
-        if (!sourceRanges.tryConstructAndAppend(lastIndex, sourceLen)) [[unlikely]]
+    if (!usingBuilder) {
+        StringBuilder replacement(OverflowPolicy::RecordOverflow);
+        appendReplacementUsingTemplate(replacement, templateParts.span(), replacementString, source, firstOvector.span().data(), regExp);
+        if (replacement.hasOverflowed()) [[unlikely]]
             OUT_OF_MEMORY(globalObject, scope);
+        String left = source.substringSharingImpl(0, firstMatch.start);
+        String right = source.substringSharingImpl(firstMatch.end);
+        RELEASE_AND_RETURN(scope, jsString(globalObject, left, replacement.toString(), right));
     }
-    RELEASE_AND_RETURN(scope, jsSpliceSubstringsWithSeparators(globalObject, string, source, sourceRanges.span().data(), sourceRanges.size(), replacements.span().data(), replacements.size()));
+
+    if (static_cast<unsigned>(lastIndex) < sourceLen)
+        resultBuilder.append(StringView { source }.substring(lastIndex));
+    if (resultBuilder.hasOverflowed()) [[unlikely]]
+        OUT_OF_MEMORY(globalObject, scope);
+    RELEASE_AND_RETURN(scope, jsString(vm, resultBuilder.toString()));
 }
 
 ALWAYS_INLINE JSString* replaceOneWithStringUsingRegExpSearch(VM& vm, JSGlobalObject* globalObject, JSString* string, const String& source, RegExp* regExp, const String& replacementString)


### PR DESCRIPTION
#### bef2808f4db21ed58331af48a14ce9bda14e17d7
<pre>
[JSC] Parse the replacement template only once in `String#replace` with a global RegExp and `&apos;$&apos;` substitutions
<a href="https://bugs.webkit.org/show_bug.cgi?id=318418">https://bugs.webkit.org/show_bug.cgi?id=318418</a>

Reviewed by Yusuke Suzuki.

When the replacement string of a global RegExp replace contains &apos;$&apos;,
replaceAllWithStringUsingRegExpSearch re-parsed the replacement template
and allocated an intermediate string for every match, and then copied
everything again when joining the result.

This patch parses the template into parts once per replace() call and
appends each match&apos;s substitution directly into a single StringBuilder.

When there is only one match, the result is built as a rope sharing the
source around the substitution, preserving the existing fast path for large
sources.

                                                   baseline                  patched

string-replace-regexp-global-substitution
                                              258.8735+-0.9881     ^    122.2286+-2.0821        ^ definitely 2.1179x faster

Test: JSTests/microbenchmarks/string-replace-regexp-global-substitution.js

* JSTests/microbenchmarks/string-replace-regexp-global-substitution.js: Added.
(test):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::StringReplaceTemplatePart::literal):
(JSC::StringReplaceTemplatePart::capture):
(JSC::StringReplaceTemplatePart::matchPrefix):
(JSC::StringReplaceTemplatePart::matchSuffix):
(JSC::StringReplaceTemplatePart::namedCapture):
(JSC::parseReplacementTemplate):
(JSC::appendReplacementUsingTemplate):
(JSC::replaceAllWithStringUsingRegExpSearch):

Canonical link: <a href="https://commits.webkit.org/316694@main">https://commits.webkit.org/316694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/333f899fb5e62a11025219f97b577e16d8cddbe9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129707 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45710 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133903 "4 flakes 4 failures") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94462 "2 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175111 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34239 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30206 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2983 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184128 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33412 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38429 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142655 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45737 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142541 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30801 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111095 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37632 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118178 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204831 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44935 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8891 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54691 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44335 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44394 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->