### PR TITLE
Regression(315450@main) boingboing.net articles often load without style

### DIFF
--- a/LayoutTests/http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body-expected.txt
+++ b/LayoutTests/http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body-expected.txt
@@ -1,0 +1,20 @@
+Tests that a 304 revalidation carrying explicit freshness does not overwrite the cached body with an empty body.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+running 1 tests
+
+Warming up cache: the initial network load stores the resource, with its body, in the disk cache.
+PASS tests[0].xhr.responseText is "selector-color-green-0123456789"
+
+Revalidate through the memory cache: the 304 (carrying a future Expires) updates the disk cache.
+PASS tests[0].xhr.responseText is "selector-color-green-0123456789"
+
+Clear the memory cache and load again: this comes from the disk cache and must still have the full body.
+response source: Disk cache
+PASS tests[0].xhr.responseText is "selector-color-green-0123456789"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body.html
+++ b/LayoutTests/http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body.html
@@ -1,0 +1,60 @@
+<script src="/js-test-resources/js-test-pre.js"></script>
+<script src="resources/cache-test.js"></script>
+<body>
+<script>
+
+// Regression test for a 304 revalidation response that carries explicit freshness
+// (Cache-Control: max-age / Expires) clobbering the cached body with an empty one.
+//
+// A memory-cache-driven revalidation sends a conditional request that reaches the network
+// process as originalRequest().isConditional(). On a 304, NetworkResourceLoader clears
+// m_cacheEntryForValidation (so the 304 is forwarded to WebCore) and then falls through to
+// tryStoreAsCacheEntry(). Since 315450@main, makeStoreDecision() accepts a 304 that carries
+// explicit freshness, so the bodiless 304 is stored over the good disk entry. The corruption
+// is invisible until a cold-memory-cache load reads it back from disk -- hence the
+// internals.clearMemoryCache() before the final load (and why this can't be a pure WPT test).
+
+var bodyContents = "selector-color-green-0123456789";
+
+var tests =
+[
+ { responseHeaders: { 'Expires': 'now(0)', 'ETag': 'match' }, expiresInFutureIn304: true, body: bodyContents },
+];
+
+description("Tests that a 304 revalidation carrying explicit freshness does not overwrite the cached body with an empty body.");
+
+debug("running " + tests.length + " tests");
+debug("");
+
+function runTests()
+{
+    debug("Warming up cache: the initial network load stores the resource, with its body, in the disk cache.");
+    loadResources(tests, function () {
+        shouldBeEqualToString("tests[0].xhr.responseText", bodyContents);
+
+        debug("");
+        debug("Revalidate through the memory cache: the 304 (carrying a future Expires) updates the disk cache.");
+        loadResourcesWithOptions(tests, { "SubresourceValidationPolicy": true }, function () {
+            shouldBeEqualToString("tests[0].xhr.responseText", bodyContents);
+
+            debug("");
+            debug("Clear the memory cache and load again: this comes from the disk cache and must still have the full body.");
+            loadResourcesWithOptions(tests, { "ClearMemoryCache": true }, function () {
+                debug("response source: " + internals.xhrResponseSource(tests[0].xhr));
+                shouldBeEqualToString("tests[0].xhr.responseText", bodyContents);
+                finishJSTest();
+            });
+        });
+    });
+}
+
+// Wait for the load event: CachedResourceLoader::determineRevalidationPolicy() aggressively
+// reuses resources (without revalidating) until the load event has fired, which would skip
+// the memory-cache revalidation this test depends on.
+if (document.readyState == 'complete')
+    runTests();
+else
+    addEventListener("load", runTests);
+
+</script>
+<script src="/js-test-resources/js-test-post.js"></script>

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -302,6 +302,9 @@ static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalR
     if (response.cacheControlContainsNoStore())
         return StoreDecision::NoDueToNoStoreResponse;
 
+    if (response.httpStatusCode() == httpStatus304NotModified)
+        return StoreDecision::NoDueToHTTPStatusCode;
+
     if (!WebCore::isStatusCodeCacheableByDefault(response.httpStatusCode())) {
         // http://tools.ietf.org/html/rfc7234#section-4.3.2
         bool hasExpirationHeaders = response.expires() || response.cacheControlMaxAge();
@@ -463,6 +466,13 @@ void Cache::retrieve(const WebCore::ResourceRequest& request, std::optional<Glob
         ASSERT(record.key == storageKey);
 
         auto entry = Entry::decodeStorageRecord(record);
+
+        // FIXME: This is a workaround for rdar://181130091, which we can drop after a release.
+        if (entry && entry->response().httpStatusCode() == httpStatus304NotModified) {
+            LOG(NetworkCache, "(NetworkProcess) discarding poisoned 304 entry from disk cache (rdar://181130091)");
+            completeRetrieve(WTF::move(completionHandler), nullptr, info);
+            return false;
+        }
 
         auto useDecision = entry ? makeUseDecision(networkProcess, sessionID, *entry, request) : UseDecision::NoDueToDecodeFailure;
         info.useDecision = useDecision;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -133,7 +133,8 @@ enum class StoreDecision {
     NoDueToNoStoreRequest,
     NoDueToUnlikelyToReuse,
     NoDueToStreamingMedia,
-    NoDueToRequestContainingFragments
+    NoDueToRequestContainingFragments,
+    NoDueToHTTPStatusCode
 };
 
 enum class UseDecision {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -35,6 +35,7 @@
 #include "NetworkSession.h"
 #include "PreconnectTask.h"
 #include <WebCore/DiagnosticLoggingKeys.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <pal/HysteresisActivity.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/NeverDestroyed.h>
@@ -435,6 +436,12 @@ void SpeculativeLoadManager::retrieveEntryFromStorage(const SubresourceInfo& inf
 
         auto entry = Entry::decodeStorageRecord(record);
         if (!entry) {
+            completionHandler(nullptr);
+            return false;
+        }
+
+        // FIXME: This is a workaround for rdar://181130091, which we can drop after a release.
+        if (entry->response().httpStatusCode() == httpStatus304NotModified) {
             completionHandler(nullptr);
             return false;
         }


### PR DESCRIPTION
#### ea125d52f300b8e221b6a54aa9731d45df85d36a
<pre>
Regression(315450@main) boingboing.net articles often load without style
<a href="https://bugs.webkit.org/show_bug.cgi?id=318413">https://bugs.webkit.org/show_bug.cgi?id=318413</a>
<a href="https://rdar.apple.com/181130091">rdar://181130091</a>

Reviewed by Youenn Fablet.

315450@main relaxed makeStoreDecision() to store any response carrying explicit
freshness regardless of status code, dropping the isStatusCodePotentiallyCacheable()
allowlist. This unintentionally made 304 (Not Modified) responses storable.

When a revalidation is driven by the memory cache, the conditional request reaches the
network process as originalRequest().isConditional(). After applying the 304 to the
existing entry via Cache::update(), NetworkResourceLoader clears m_cacheEntryForValidation
(to forward the 304 to WebCore) and falls through to tryStoreAsCacheEntry(). Because the
304 carries Cache-Control: max-age / Expires, makeStoreDecision() now returned Yes, and
the 304 -- which has no body -- was stored over the good entry with an empty body. The
empty entry is fresh, so it is served on every subsequent load: pages render broken
(e.g. stylesheets come back empty / with the wrong MIME type) and stay broken across
reloads until the cache is cleared. Private browsing is unaffected because it does not
use the persistent disk cache.

Fix: makeStoreDecision() never stores a 304. A 304 is a validation response, not a
complete representation; a successful revalidation is applied to the stored entry via
Cache::update(). Cache::store() already treats a non-Yes decision on a 304 as a
successful revalidation, so the just-updated entry is preserved rather than evicted.

Because the regression was in the tree for a while, some users already have poisoned
304 entries in their disk cache. Add a temporary workaround to discard any 304 entry read
back from the disk cache -- in both the normal (Cache::retrieve) and speculative
(SpeculativeLoadManager::retrieveEntryFromStorage) retrieval paths -- so the resource is
re-fetched and the entry heals itself. Returning false purges the poisoned record. This
is safe because a legitimately stored entry never has a 304 status. The workaround is
annotated with <a href="https://rdar.apple.com/181130091">rdar://181130091</a> and a FIXME to remove it once affected caches age out.

Test: memory-cache-revalidation-preserves-disk-cache-body.html exercises a memory-cache
revalidation whose 304 updates the disk cache, then clears the memory cache and asserts
the resource is still served intact from disk (&quot;Disk cache&quot;, full body). It fails without
the fix (empty body); it also fails with only the workaround (served &quot;Network&quot; instead of
&quot;Disk cache&quot;), confirming the test gates the fix and is not masked by the workaround.

Test: http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body.html

* LayoutTests/http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body-expected.txt: Added.
* LayoutTests/http/tests/cache/disk-cache/memory-cache-revalidation-preserves-disk-cache-body.html: Added.
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeStoreDecision):
(WebKit::NetworkCache::Cache::retrieve):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveEntryFromStorage):

Canonical link: <a href="https://commits.webkit.org/316381@main">https://commits.webkit.org/316381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edee6631f4b3502a487e56ec561d34217cbe9310

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129733 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72833ee1-6827-489c-82ed-a921bb4f5f81) 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133915 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/765237bd-7e45-4b44-88f6-f79ce8ba7b1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37355 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114388 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc31ed5f-a3e2-4348-9b5e-cf5ea5b35f1d) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/171499 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35986 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30242 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184171 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142681 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46443 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111128 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37647 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44961 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8916 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44361 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->