### PR TITLE
[Web Inspector] Empty std::optional dereference in Page.setCookie when "session" is omitted but "expires" is present

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -459,7 +459,7 @@ static std::optional<Cookie> parseCookieObject(Inspector::Protocol::ErrorString&
         return std::nullopt;
     }
 
-    cookie.session = *session;
+    cookie.session = session.value_or(false);
 
     auto sameSiteString = cookieObject->getString("sameSite"_s);
     if (!sameSiteString) {


### PR DESCRIPTION
#### a9de782f906f9c52c0a7e61db3625973ed9d6114
<pre>
[Web Inspector] Empty std::optional dereference in Page.setCookie when &quot;session&quot; is omitted but &quot;expires&quot; is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=318422">https://bugs.webkit.org/show_bug.cgi?id=318422</a>
<a href="https://rdar.apple.com/181204053">rdar://181204053</a>

Reviewed by Devin Rousso.

InspectorPageAgent::parseCookieObject() read the optional &quot;session&quot;
boolean and the optional &quot;expires&quot; double, then bailed only when *both*
were absent (`!session &amp;&amp; !cookie.expires`). It unconditionally
dereferenced the optional afterwards with `cookie.session = *session;`.

When a client sends a cookie object with &quot;expires&quot; present but &quot;session&quot;
omitted, the guard&apos;s condition is false, so execution falls through and
dereferences an empty std::optional&lt;bool&gt; — undefined behavior. The
input is fully controlled by the inspector frontend via the
Page.setCookie protocol command.

Since reaching the code past the guard already guarantees that either
&quot;session&quot; or &quot;expires&quot; is valid, default the session flag to false with
session.value_or(false) instead of dereferencing the optional. When
&quot;expires&quot; is set but &quot;session&quot; is omitted, defaulting to false is the
intended behavior anyway.

* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::parseCookieObject):

Canonical link: <a href="https://commits.webkit.org/316462@main">https://commits.webkit.org/316462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e37af00e4f44282f84872397b3800c65a765701

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129887 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8abb675-8d84-4736-a2ba-770941358875) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134029 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcd9df2a-8642-4256-b6fa-ea5421473b8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37462 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154574 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114500 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1b2278e-aad8-49af-b033-215b02be835d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36096 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30388 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36999 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142802 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45921 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142683 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38542 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46599 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111326 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37743 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45116 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9028 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44516 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->