### PR TITLE
[Web Inspector] adopted (constructable) stylesheets misclassified as User Agent in the per-frame CSS agent

### DIFF
--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
@@ -927,11 +927,19 @@ Inspector::Protocol::CSS::StyleSheetOrigin FrameCSSAgent::detectOrigin(CSSStyleS
     if (m_creatingViaInspectorStyleSheet)
         return Inspector::Protocol::CSS::StyleSheetOrigin::Inspector;
 
-    if (pageStyleSheet && !pageStyleSheet->ownerNode() && pageStyleSheet->href().isEmpty())
-        return Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent;
+    if (pageStyleSheet) {
+        // Constructable stylesheets (`new CSSStyleSheet()`, used via `adoptedStyleSheets`)
+        // have no owner node and no href, so guard against them before applying the
+        // ownerNode/href heuristic for user-agent stylesheets.
+        if (pageStyleSheet->wasConstructedByJS())
+            return Inspector::Protocol::CSS::StyleSheetOrigin::Author;
 
-    if (pageStyleSheet && pageStyleSheet->contents().isUserStyleSheet())
-        return Inspector::Protocol::CSS::StyleSheetOrigin::User;
+        if (!pageStyleSheet->ownerNode() && pageStyleSheet->href().isEmpty())
+            return Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent;
+
+        if (pageStyleSheet->contents().isUserStyleSheet())
+            return Inspector::Protocol::CSS::StyleSheetOrigin::User;
+    }
 
     if (!ownerDocument)
         return Inspector::Protocol::CSS::StyleSheetOrigin::Author;


### PR DESCRIPTION
#### a942e1e61628d1a24bc8d20f3dea469a9b523aa1
<pre>
[Web Inspector] adopted (constructable) stylesheets misclassified as User Agent in the per-frame CSS agent
<a href="https://bugs.webkit.org/show_bug.cgi?id=318423">https://bugs.webkit.org/show_bug.cgi?id=318423</a>
<a href="https://rdar.apple.com/181204768">rdar://181204768</a>

Reviewed by Devin Rousso.

FrameCSSAgent::detectOrigin lacked the wasConstructedByJS() guard that
InspectorCSSAgent::detectOrigin already has. A constructable stylesheet
(`new CSSStyleSheet()` applied via `document.adoptedStyleSheets`) has no
owner node and an empty href, so it fell into the User Agent branch of the
ownerNode/href heuristic. In the Web Inspector those author styles then
appeared as uneditable User Agent styles.

Mirror the InspectorCSSAgent fix: check wasConstructedByJS() first and
report such stylesheets as Author, keeping the two near-duplicate
detectOrigin implementations in sync.

FrameCSSAgent is only the active CSS backend dispatcher under Site
Isolation (it is created by FrameInspectorController per LocalFrame and
reached via FrameInspectorTarget), which is not enabled yet. The existing
regression test LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html
therefore exercises the page-level InspectorCSSAgent path, not this one,
so this fix is currently untestable via a protocol layout test. Once Site
Isolation is enabled that same test will cover the frame path.

* Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp:
(WebCore::FrameCSSAgent::detectOrigin):

Canonical link: <a href="https://commits.webkit.org/316433@main">https://commits.webkit.org/316433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b46e4a0cd66b2be20b7c1a9c8233ae0a65c2eb52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129716 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e746708-a935-4740-bb06-96a6f12fd6e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133950 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59dcc261-e08b-42a5-a61c-46111ce58080) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00f36a11-608e-4ab7-8bc0-6f0e8b9ccd17) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34245 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184203 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142707 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45746 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38518 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46426 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111104 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37629 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118174 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44944 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8897 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44576 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44403 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->