### PR TITLE
[Web Inspector] InspectorAuditResourcesObject::getResources() is O(n²) due to linear reverse lookup

### DIFF
--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -81,18 +81,16 @@ ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResou
         resource.mimeType = cachedResource->mimeType();
 
         bool exists = false;
-        for (const auto& entry : m_resources) {
-            if (entry.value == cachedResource) {
-                resource.id = entry.key;
-                exists = true;
-                break;
-            }
+        if (auto identifier = m_resourceIdentifiers.get(cachedResource); !identifier.isNull()) {
+            resource.id = identifier;
+            exists = true;
         }
         if (!exists) {
             cachedResource->addClient(clientForResource(*cachedResource));
 
             resource.id = String::number(m_resources.size() + 1);
             m_resources.add(resource.id, cachedResource);
+            m_resourceIdentifiers.add(cachedResource, resource.id);
         }
 
         resources.append(WTF::move(resource));

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -164,6 +164,7 @@ private:
     InspectorAuditCachedStyleSheetClient m_cachedStyleSheetClient;
 
     MemoryCompactRobinHoodHashMap<String, CachedResource*> m_resources;
+    HashMap<CachedResource*, String> m_resourceIdentifiers;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 99eab878b3818ba1605bfb1bb43d07a189ba5efb
<pre>
[Web Inspector] InspectorAuditResourcesObject::getResources() is O(n²) due to linear reverse lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=318425">https://bugs.webkit.org/show_bug.cgi?id=318425</a>
<a href="https://rdar.apple.com/181206139">rdar://181206139</a>

Reviewed by NOBODY (OOPS!).

getResources() maps each CachedResource to a previously-assigned string
identifier. m_resources is a forward map (identifier -&gt; CachedResource*),
so the reverse lookup (&quot;do I already have this resource, and what is its
id?&quot;) was done by linearly scanning the entire map for every resource
returned by cachedResourcesForFrame(). That is O(n) per resource, or
O(n²) per call. Because m_resources is never pruned, it accumulates every
resource seen across all getResources() calls for the object&apos;s lifetime,
so the scan grows unboundedly across repeated audit calls.

Add a reverse map m_resourceIdentifiers (CachedResource* -&gt; identifier)
kept in sync on insertion, turning the reverse lookup into O(1). Behavior
is unchanged: the reverse map keys on the same raw pointer the old scan
compared against, and HashMap::get() returns a null String for absent
keys, which is distinguishable from the always-non-null assigned ids.

* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::getResources):
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99eab878b3818ba1605bfb1bb43d07a189ba5efb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181607 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129718 "Failed to checkout and rebase branch from PR 68509") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b1c58b3-390e-40ec-b858-b7e66a118cfb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133907 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129718 "Failed to checkout and rebase branch from PR 68509") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dea00893-e637-4ecf-89eb-40e7c9ffb053) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175122 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114380 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c89646f7-4b1d-47af-8726-fa7a6dadfdbb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/35976 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34248 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30217 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184140 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142665 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45748 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142550 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46428 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111111 "Failed to checkout and rebase branch from PR 68509") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37635 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118180 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44946 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8901 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44346 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44578 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44405 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->