### PR TITLE
Cherry-pick 0743320ceb0e. https://bugs.webkit.org/show_bug.cgi?id=313915

### DIFF
--- a/JSTests/wasm/stress/wasm-resizable-buffer-resize-after-gc.js
+++ b/JSTests/wasm/stress/wasm-resizable-buffer-resize-after-gc.js
@@ -1,0 +1,40 @@
+// Resizing a Wasm-backed resizable ArrayBuffer should work
+// even after the originating WebAssembly.Memory is GC'd.
+
+function flushStackRoots(n) {
+    let a = [n, {}, n + 1, {}, {}];
+    if (n)
+        return flushStackRoots(n - 1);
+    return a;
+}
+
+for (let iter = 0; iter < 5; ++iter) {
+    let buf;
+    (function () {
+        let m = new WebAssembly.Memory({ initial: 1, maximum: 100 });
+        buf = m.toResizableBuffer();
+    })();
+    flushStackRoots(64);
+    fullGC();
+    flushStackRoots(64);
+    fullGC();
+
+    if (buf.byteLength !== 65536)
+        throw new Error("bad initial length: " + buf.byteLength);
+    if (!buf.resizable)
+        throw new Error("not resizable");
+
+    buf.resize(65536 * 100);
+
+    if (buf.byteLength !== 65536 * 100)
+        throw new Error("bad resized length: " + buf.byteLength);
+
+    let view = new Uint8Array(buf);
+    for (let i = 0; i < view.length; i += 4096) {
+        if (view[i] !== 0)
+            throw new Error("non-zero at " + i);
+    }
+    view[view.length - 1] = 0x42;
+    if (view[view.length - 1] !== 0x42)
+        throw new Error("write failed");
+}

--- a/LayoutTests/editing/async-clipboard/clipboard-write-item-crash-expected.txt
+++ b/LayoutTests/editing/async-clipboard/clipboard-write-item-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not hit assertions or crash under ASAN.
+
+PASS

--- a/LayoutTests/editing/async-clipboard/clipboard-write-item-crash.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-write-item-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncClipboardAPIEnabled=true ] -->
+<body><script>
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  testRunner.dumpAsText();
+}
+
+(async () => {
+  const item = new ClipboardItem({
+    "text/plain": new Promise(() => {}),
+    "text/html":  Promise.resolve("x"),
+    "text/uri-list": Promise.resolve("http://a/")
+  });
+
+  navigator.clipboard.write([item]).catch(() => {});
+
+  await 0; // Drain microtasks
+
+  navigator.clipboard.write([item]).catch(() => {});
+  
+  document.body.innerHTML = '<p>This test passes if WebKit does not hit assertions or crash under ASAN.</p><p>PASS</p>';
+
+  globalThis.testRunner?.notifyDone();
+})();
+</script>

--- a/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash-expected.txt
+++ b/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if PASS (no crash)

--- a/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash.html
+++ b/LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input>
+<iframe tabindex="0" srcdoc="<input tabindex='0'><script>parent.innerInput = document.querySelector('input');</script>"></iframe>
+<script>
+let iframe = document.querySelector('iframe');
+let outerInput = document.querySelector('input');
+let innerInput = null;
+
+if (window.testRunner && window.GCController) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    iframe.onload = () => setTimeout(runTest, 0);
+} else
+    document.write('<p>FAIL - This test requires testRunner and GCController</p>');
+
+function runTest() {
+    let innerInput = window.innerInput;
+    window.innerInput = null;
+
+    outerInput.addEventListener('blur', () => {
+        document.adoptNode(innerInput);
+        innerInput = null;
+        iframe.remove();
+        iframe = null;
+        GCController.collect();
+    }, { once: true });
+
+    outerInput.focus();
+    outerInput.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, view: window, detail: 0,
+        key: 'Tab', code: 'Tab', keyIdentifier: 'U+0009', location: 222, ctrlKey: false, altKey: true, shiftKey: false, metaKey: false }));
+
+    document.body.innerHTML = '<p>This test passes if PASS (no crash)</p>';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<title>WebKit crash in anchor scroll compensation code</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#scroll">
+
+<style>
+  #scroller {
+    overflow: scroll;
+    width: 500px;
+    height: 500px;
+  }
+
+  #anchor {
+    width: 50px;
+    height: 50px;
+    anchor-name: --anchor;
+  }
+
+  .anchored {
+    position: absolute;
+    /* Has to have a default anchor to trigger scroll compensation */
+    position-anchor: --anchor;
+    left: anchor(left);
+    width: 50px;
+    height: 50px;
+  }
+</style>
+
+<div id="scroller">
+  <div id="anchor"></div>
+</div>
+
+<div class="anchored"></div>
+<div class="anchored"></div>
+<div class="anchored"></div>
+<div class="anchored"></div>
+<div class="anchored"></div>
+
+<script>
+  scroller.scrollTop = 200;
+  // Force layout.
+  scroller.offsetTop;
+
+  scroller.remove();
+  // Force layout.
+  document.body.offsetTop;
+</script>

--- a/LayoutTests/streams/readable-stream-cancel-fake-promise-crash-expected.txt
+++ b/LayoutTests/streams/readable-stream-cancel-fake-promise-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not hit assertions or crash under ASAN.
+
+

--- a/LayoutTests/streams/readable-stream-cancel-fake-promise-crash.html
+++ b/LayoutTests/streams/readable-stream-cancel-fake-promise-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if WebKit does not hit assertions or crash under ASAN.</p>
+<div id="result"></div>
+<script>
+
+function FakePromise(executor) {
+    executor(() => {}, () => {});
+    return { }
+}
+
+const stream = new ReadableStream({
+    cancel(reason) {
+        Object.defineProperty(Promise, Symbol.species, {
+            configurable: true,
+            get() {
+                return FakePromise;
+            }
+        });
+        return new Promise(() => {});
+    }
+});
+stream.cancel("test reason");
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    setTimeout(() => testRunner.notifyDone(), 100);
+}
+</script>

--- a/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash-expected.txt
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash-expected.txt
@@ -1,0 +1,10 @@
+Reading WaveShaperNode.curve on the main thread while offline rendering accesses it on the audio thread should not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Test passed because it did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Reading WaveShaperNode.curve on the main thread while offline rendering accesses it on the audio thread should not crash.");
+
+jsTestIsAsync = true;
+
+let context = new OfflineAudioContext(2, 44100, 48000);
+let node = context.createWaveShaper();
+node.curve = new Float32Array(2);
+node.connect(context.destination);
+context.startRendering().then(() => {
+    testPassed("Test passed because it did not crash.");
+    finishJSTest();
+});
+for (let i = 0; i < 1000; i++)
+    void node.curve;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling-expected.txt
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling-expected.txt
@@ -1,0 +1,28 @@
+Tests WaveShaperDSPKernel::processCurveWithData handling of NaN, Infinity, and normal input values.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isNaN(output[0]) is false
+PASS isFinite(output[0]) is true
+PASS isNaN(output[1]) is false
+PASS isFinite(output[1]) is true
+PASS isNaN(output[2]) is false
+PASS isFinite(output[2]) is true
+PASS isNaN(output[3]) is false
+PASS isFinite(output[3]) is true
+PASS 0 is approximately 0
+PASS 0 is approximately 0
+PASS 0 is approximately 0
+PASS 0.5 is approximately 0.5
+PASS 1 is approximately 1
+PASS 0.5 is approximately 0.5
+PASS isFinite(output[1]) is true
+PASS 0.75 is approximately 0.75
+PASS isFinite(output[3]) is true
+PASS 0 is approximately 0
+PASS 0.5 is approximately 0.5
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling.html
+++ b/LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests WaveShaperDSPKernel::processCurveWithData handling of NaN, Infinity, and normal input values.");
+
+const curveSize = 256;
+const curve = Array.from({length: curveSize}, (_, i) => i / (curveSize - 1));
+
+function shouldBeCloseTo(actual, expected, tolerance) {
+    if (Math.abs(actual - expected) <= tolerance)
+        testPassed(actual + " is approximately " + expected);
+    else
+        testFailed(actual + " should be approximately " + expected);
+}
+
+// NaN Input
+output = internals.waveShaperProcessCurveWithData([NaN, NaN, NaN, NaN], curve);
+for (let i = 0; i < 4; i++) {
+    shouldBeFalse("isNaN(output[" + i + "])");
+    shouldBeTrue("isFinite(output[" + i + "])");
+}
+
+// Infinity Input
+output = internals.waveShaperProcessCurveWithData([Infinity], curve);
+shouldBeCloseTo(output[0], 0.0, 0.001);
+
+output = internals.waveShaperProcessCurveWithData([-Infinity], curve);
+shouldBeCloseTo(output[0], 0.0, 0.001);
+
+// Normal Input Range
+output = internals.waveShaperProcessCurveWithData([-1.0, 0.0, 1.0], curve);
+shouldBeCloseTo(output[0], curve[0], 0.001);
+shouldBeCloseTo(output[1], 0.5, 0.01);
+shouldBeCloseTo(output[2], curve[curveSize - 1], 0.001);
+
+// Mixed NaN and Valid Input
+output = internals.waveShaperProcessCurveWithData([0.0, NaN, 0.5, NaN], curve);
+shouldBeCloseTo(output[0], 0.5, 0.01);
+shouldBeTrue("isFinite(output[1])");
+shouldBeCloseTo(output[2], 0.75, 0.02);
+shouldBeTrue("isFinite(output[3])");
+
+// Empty Curve (passthrough)
+output = internals.waveShaperProcessCurveWithData([0.0, 0.5], []);
+shouldBeCloseTo(output[0], 0.0, 0.001);
+shouldBeCloseTo(output[1], 0.5, 0.001);
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -375,19 +375,6 @@ void ArrayBuffer::makeWasmMemory()
     m_isWasmMemory = true;
 }
 
-void ArrayBuffer::setAssociatedWasmMemory(Wasm::Memory* memory)
-{
-    // The pointer from a buffer to a memory is only required when the buffer is resizable non-shared,
-    // to direct a grow request to the memory (see ArrayBuffer::resize). In other scenarios
-    // the pointer is not necessary and we should not be setting it to anything but a nullptr.
-    ASSERT(isWasmMemory() && (isResizableNonShared() || !memory));
-#if ENABLE(WEBASSEMBLY)
-    m_associatedWasmMemory = memory;
-#else
-    UNUSED_PARAM(memory);
-#endif
-}
-
 void ArrayBuffer::refreshAfterWasmMemoryGrow(Wasm::Memory* memory)
 {
     ASSERT(isWasmMemory());
@@ -485,10 +472,10 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::grow(VM& vm, size_t newByteLength
     return result;
 }
 
-// Wasm JS API redefines the abstract operation HostResizeArrayBuffer as follows:
-// https://webassembly.github.io/threads/js-api/index.html#abstract-operation-hostresizearraybuffer
 Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLength)
 {
+    RELEASE_ASSERT(!isWasmMemory());
+
     auto memoryHandle = m_contents.m_memoryHandle;
     if (!memoryHandle || m_contents.m_shared) [[unlikely]]
         return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
@@ -502,12 +489,6 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
             return makeUnexpected(GrowFailReason::InvalidGrowSize);
 
         deltaByteLength = static_cast<int64_t>(newByteLength) - static_cast<int64_t>(m_contents.m_sizeInBytes);
-#if ENABLE(WEBASSEMBLY)
-        if (Options::useWasmMemoryToBufferAPIs()) {
-            if (isWasmMemory() && (deltaByteLength < 0 || deltaByteLength % PageCount::pageSize))
-                return makeUnexpected(GrowFailReason::InvalidGrowSize);
-        }
-#endif
         if (!deltaByteLength)
             return 0;
 
@@ -519,17 +500,6 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
         if (newPageCount != oldPageCount) {
             ASSERT(memoryHandle->maximum() >= newPageCount);
 
-#if ENABLE(WEBASSEMBLY)
-            if (Options::useWasmMemoryToBufferAPIs()) {
-                // If this is currently associated with a Wasm memory, let the memory do the growing.
-                // The memory will call back to our refreshAfterWasmMemoryGrow().
-                RefPtr<Wasm::Memory> memory = m_associatedWasmMemory.get();
-                if (memory) {
-                    std::ignore = memory->grow(vm, PageCount(newPageCount.pageCount() - oldPageCount.pageCount()));
-                    return deltaByteLength;
-                }
-            }
-#endif
             size_t desiredSize = newPageCount.bytes();
             RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
 

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -330,7 +330,6 @@ public:
 
     void makeWasmMemory();
     inline bool isWasmMemory();
-    void setAssociatedWasmMemory(Wasm::Memory*);
     // When a resizable buffer is associated with a non-shared Wasm memory, this function is called by the memory's growthSuccessCallback.
     void refreshAfterWasmMemoryGrow(Wasm::Memory*);
 
@@ -373,7 +372,6 @@ public:
 private:
     Checked<unsigned> m_pinCount { 0 };
     bool m_isWasmMemory { false };
-    WeakPtr<Wasm::Memory> m_associatedWasmMemory;
     // m_locked == true means that some API user fetched m_contents directly from a TypedArray object,
     // the buffer is backed by a WebAssembly.Memory, or is a SharedArrayBuffer.
     bool m_locked { false };

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
@@ -27,6 +27,9 @@
 #include "JSArrayBuffer.h"
 
 #include "JSCInlines.h"
+#if ENABLE(WEBASSEMBLY)
+#include "JSWebAssemblyMemory.h"
+#endif // ENABLE(WEBASSEMBLY)
 #include "TypedArrayController.h"
 
 namespace JSC {
@@ -81,6 +84,37 @@ size_t JSArrayBuffer::estimatedSize(JSCell* cell, VM& vm)
     size_t bufferEstimatedSize = thisObject->impl()->gcSizeEstimateInBytes();
     return Base::estimatedSize(cell, vm) + bufferEstimatedSize;
 }
+
+#if ENABLE(WEBASSEMBLY)
+JSWebAssemblyMemory* JSArrayBuffer::associatedWasmMemoryWrapper() const
+{
+    return m_associatedWasmMemoryWrapper.get();
+}
+
+void JSArrayBuffer::setAssociatedWasmMemoryWrapper(VM& vm, JSWebAssemblyMemory* wrapper)
+{
+    ASSERT(impl()->isWasmMemory() && impl()->isResizableNonShared());
+    m_associatedWasmMemoryWrapper.set(vm, this, wrapper);
+}
+
+void JSArrayBuffer::clearAssociatedWasmMemoryWrapper()
+{
+    m_associatedWasmMemoryWrapper.clear();
+}
+#endif // ENABLE(WEBASSEMBLY)
+
+template<typename Visitor>
+void JSArrayBuffer::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisObject = jsCast<JSArrayBuffer*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+#if ENABLE(WEBASSEMBLY)
+    visitor.append(thisObject->m_associatedWasmMemoryWrapper);
+#endif // ENABLE(WEBASSEMBLY)
+}
+
+DEFINE_VISIT_CHILDREN(JSArrayBuffer);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.h
@@ -27,8 +27,13 @@
 
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/WriteBarrier.h>
 
 namespace JSC {
+
+#if ENABLE(WEBASSEMBLY)
+class JSWebAssemblyMemory;
+#endif // ENABLE(WEBASSEMBLY)
 
 class JSArrayBuffer final : public JSNonFinalObject {
 public:
@@ -51,8 +56,16 @@ public:
     JS_EXPORT_PRIVATE bool isShared() const;
     ArrayBufferSharingMode sharingMode() const;
     bool isResizableOrGrowableShared() const { return m_impl->isResizableOrGrowableShared(); }
-    
+
+#if ENABLE(WEBASSEMBLY)
+    JSWebAssemblyMemory* associatedWasmMemoryWrapper() const;
+    void setAssociatedWasmMemoryWrapper(VM&, JSWebAssemblyMemory*);
+    void clearAssociatedWasmMemoryWrapper();
+#endif // ENABLE(WEBASSEMBLY)
+
     DECLARE_EXPORT_INFO;
+
+    DECLARE_VISIT_CHILDREN;
     
     // This is the default DOM unwrapping. It calls toUnsharedArrayBuffer().
     static ArrayBuffer* toWrapped(VM&, JSValue);
@@ -65,6 +78,11 @@ private:
     static size_t estimatedSize(JSCell*, VM&);
 
     ArrayBuffer* m_impl;
+    // For resizable non-shared Wasm buffers, this points back to the owning JSWebAssemblyMemory so
+    // that ArrayBuffer.prototype.resize can delegate to Wasm::Memory::grow.
+#if ENABLE(WEBASSEMBLY)
+    WriteBarrier<JSWebAssemblyMemory> m_associatedWasmMemoryWrapper;
+#endif // ENABLE(WEBASSEMBLY)
 };
 
 inline ArrayBuffer* toPossiblySharedArrayBuffer(VM&, JSValue value)

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -32,6 +32,11 @@
 #include "JSCInlines.h"
 #include <wtf/text/MakeString.h>
 
+#if ENABLE(WEBASSEMBLY)
+#include "JSWebAssemblyMemory.h"
+#include "WasmMemory.h"
+#endif
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
@@ -292,6 +297,29 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoFuncResize, (JSGlobalObject* globalObje
     if (!std::isfinite(newLength) || newLength < 0)
         return throwVMRangeError(globalObject, scope, "new length is out of range"_s);
     size_t newByteLength = static_cast<size_t>(newLength);
+
+#if ENABLE(WEBASSEMBLY)
+    // Wasm JS API redefines the abstract operation HostResizeArrayBuffer as follows:
+    // https://webassembly.github.io/threads/js-api/index.html#abstract-operation-hostresizearraybuffer
+    //
+    // Further, WebAssembly-originated resizable ArrayBuffers must defer resizing to the backing
+    // WebAssembly memory for correct handling of refreshing bounds-checking memories.
+    if (auto* jsMemory = thisObject->associatedWasmMemoryWrapper()) {
+        size_t oldByteLength = thisObject->impl()->byteLength();
+        if (newByteLength < oldByteLength)
+            return throwVMRangeError(globalObject, scope, "Cannot shrink WebAssembly memory"_s);
+        if (newByteLength % PageCount::pageSize)
+            return throwVMRangeError(globalObject, scope, makeString("WebAssembly memory cannot be resized to new byte length "_s, newByteLength, " because it is not a multiple of "_s, PageCount::pageSize));
+        size_t delta = newByteLength - oldByteLength;
+        if (delta) {
+            auto result = jsMemory->memory().grow(vm, PageCount::fromBytes(delta));
+            if (!result)
+                return throwVMRangeError(globalObject, scope, makeString("ArrayBuffer resize failed with new byte length "_s, newByteLength));
+        }
+        return JSValue::encode(jsUndefined());
+    }
+#endif
+
     if (!thisObject->impl()->resize(vm, newByteLength))
         return throwVMRangeError(globalObject, scope, makeString("ArrayBuffer resize failed with new byte length "_s, newByteLength));
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -472,7 +472,6 @@ void OptimizingJITCallee::linkExceptionHandlers(Vector<UnlinkedHandlerInfo> unli
 BBQCallee::~BBQCallee()
 {
     if (Options::freeRetiredWasmCode() && m_osrEntryCallee) {
-        ASSERT(m_osrEntryCallee->hasOneRef());
         m_osrEntryCallee->reportToVMsForDestruction();
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -327,14 +327,9 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
 
     // This is necessary since Callees are released under `Heap::stopThePeriphery()`, but that only stops JS compiler
     // threads and not wasm ones. So a weakly held BBQCallee and its OMGOSREntryCallee could die between the time we
-    // collect the callsites and when we actually repatch its callsites. Since BBQCallee owns OMGOSREntryCallee,
-    // keeping BBQCallee alive is enough to ensure that both are alive for the required duration.
-    //
-    // There is however an edge case here - it can happen that a BBQCallee has been freed but its OMGOSREntryCallee
-    // has been added to the pending-destruction set and not yet free'd. This means that m_osrEntryCallees will still
-    // hold a weak ref to it. In this scenario, BBQCallee won't be kept alive since it does not exist so we manually
-    // have to keep the OMGOSREntryCallee alive separately. This should only be done in this scenario else we will
-    // end up with multiple owners for OMGOSREntryCallee.
+    // collect the callsites and when we actually repatch its callsites. Additionally, after a re-tier (where a fresh
+    // BBQCallee replaces a retired one), m_osrEntryCallees may hold a stale weak ref to an OMGOSREntryCallee not
+    // owned by the current BBQCallee, so we always keep it alive unconditionally.
 
     // FIXME: These inline capacities were picked semi-randomly. We should figure out if there's a better number.
     Vector<Ref<BBQCallee>, 4> keepAliveBBQCallees;
@@ -363,8 +358,6 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
         if (!tuple)
             return;
 
-        bool bbqCalleeKeptAlive = false;
-        UNUSED_VARIABLE(bbqCalleeKeptAlive);
 #if ENABLE(WEBASSEMBLY_BBQJIT)
         // This callee could be weak but we still need to update it since it could call our BBQ callee
         // that we're going to want to destroy.
@@ -377,25 +370,15 @@ void CalleeGroup::updateCallsitesToCallUs(const AbstractLocker& locker, CodeLoca
             collectCallsites(bbqCallee.get());
             ASSERT(!bbqCallee->osrEntryCallee() || m_osrEntryCallees.find(callerIndex) != m_osrEntryCallees.end());
             keepAliveBBQCallees.append(bbqCallee.releaseNonNull());
-            bbqCalleeKeptAlive = true;
         }
 #endif
 #if ENABLE(WEBASSEMBLY_OMGJIT)
         collectCallsites(tuple->m_omgCallee.get());
         if (auto iter = m_osrEntryCallees.find(callerIndex); iter != m_osrEntryCallees.end()) {
             if (RefPtr callee = iter->value.get()) {
+                // Since there is a OMGOSREntryCallee, we need to collect all the callsites there and also keep it alive until we patch it.
                 collectCallsites(callee.get());
-                // If we track the OMGOSREntryCallee as a callsite there are 2 possibilities -
-                // 1. The BBQCallee is already being tracked - in this case we don't have to
-                //    track the OMGOSREntryCallee since the BBQCallee owns it and keeping the
-                //    BBQCallee alive is good enough to keep the OMGOSREntryCallee alive. Also,
-                //    OMGOSREntryCallee is only supposed to be owned by BBQCallee
-                // 2. The BBQCallee is not tracked - This happens if the BBQCallee is already
-                //    released but the OMGOSREntryCallee is still alive. In this case there is
-                //    no other strong reference to OMGOSREntryCallee so we have to keep it
-                //    alive here.
-                if (!bbqCalleeKeptAlive)
-                    keepAliveOSREntryCallees.append(callee.releaseNonNull());
+                keepAliveOSREntryCallees.append(callee.releaseNonNull());
             } else
                 m_osrEntryCallees.remove(iter);
         }

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -210,7 +210,7 @@ RefPtr<Memory> Memory::tryCreate(VM& vm, PageCount initial, PageCount maximum, M
     switch (sharingMode) {
     case MemorySharingMode::Default: {
         if (!initialBytes)
-            return adoptRef(new Memory(initial, maximum, MemorySharingMode::Default, WTF::move(growSuccessCallback)));
+            return adoptRef(*new Memory(initial, maximum, MemorySharingMode::Default, WTF::move(growSuccessCallback)));
 
         void* slowMemory = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, initialBytes);
         if (!slowMemory) {
@@ -258,6 +258,7 @@ Expected<PageCount, GrowFailReason> Memory::growShared(VM& vm, PageCount delta)
     PageCount oldPageCount;
     PageCount newPageCount;
     Expected<int64_t, GrowFailReason> result;
+
     {
         std::optional<Locker<Lock>> locker;
         // m_shared may not be exist, if this is zero byte memory with zero byte maximum size.

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -37,10 +37,9 @@
 #include <wtf/CagedPtr.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -53,7 +52,7 @@ class LLIntOffsetsExtractor;
 
 namespace Wasm {
 
-class Memory final : public RefCountedAndCanMakeWeakPtr<Memory> {
+class Memory final : public RefCounted<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Memory, JS_EXPORT_PRIVATE);
     friend LLIntOffsetsExtractor;
@@ -93,8 +92,6 @@ public:
     bool init(uint64_t, const uint8_t*, uint32_t);
 
     void registerInstance(JSWebAssemblyInstance&);
-
-    void checkLifetime() { ASSERT(!refCountDebugger().deletionHasBegun()); }
 
     static constexpr ptrdiff_t offsetOfHandle() { return OBJECT_OFFSETOF(Memory, m_handle); }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -51,7 +51,6 @@ void JSWebAssemblyMemory::adopt(Ref<Wasm::Memory>&& memory)
 {
     m_memory.swap(memory);
     ASSERT(m_memory->refCount() == 1);
-    m_memory->checkLifetime();
 }
 
 Structure* JSWebAssemblyMemory::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
@@ -104,10 +103,10 @@ void JSWebAssemblyMemory::associateArrayBuffer(JSGlobalObject* globalObject, boo
             m_buffer->makeShared();
     }
     m_buffer->makeWasmMemory();
-    if (m_buffer->isResizableNonShared())
-        m_buffer->setAssociatedWasmMemory(m_memory.ptr());
 
     auto* arrayBuffer = JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(m_buffer->sharingMode()), m_buffer.get());
+    if (m_buffer->isResizableNonShared())
+        arrayBuffer->setAssociatedWasmMemoryWrapper(vm, this);
     if (m_memory->sharingMode() == MemorySharingMode::Shared) {
         objectConstructorFreeze(globalObject, arrayBuffer);
         RETURN_IF_EXCEPTION(throwScope, void());
@@ -122,8 +121,9 @@ void JSWebAssemblyMemory::disassociateArrayBuffer(VM& vm)
     ASSERT(m_buffer);
     if (!m_buffer->isShared())
         m_buffer->detach(vm);
-    m_buffer->setAssociatedWasmMemory(nullptr);
     m_buffer = nullptr;
+    if (auto* wrapper = m_bufferWrapper.get())
+        wrapper->clearAssociatedWasmMemoryWrapper();
     m_bufferWrapper.clear();
 }
 
@@ -298,9 +298,6 @@ void JSWebAssemblyMemory::growSuccessCallback(VM& vm, PageCount oldPageCount, Pa
         }
     }
 
-    
-    memory().checkLifetime();
-    
     vm.heap.reportExtraMemoryAllocated(this, newPageCount.bytes() - oldPageCount.bytes());
 }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -123,7 +123,9 @@ JSWebAssemblyMemory* WebAssemblyMemoryConstructor::createMemoryFromDescriptor(JS
     auto* jsMemory = JSWebAssemblyMemory::create(vm, webAssemblyMemoryStructure);
 
     RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, initialPageCount, maximumPageCount, sharingMode, desiredMemoryMode,
-        [&vm, jsMemory] (Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); });
+        [&vm, jsMemory] (Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) {
+            jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount);
+        });
     if (!memory) {
         throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));
         return { };

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -128,10 +128,9 @@ void ClipboardItemBindingsDataSource::getType(const String& type, Ref<DeferredPr
 
 void ClipboardItemBindingsDataSource::clearItemTypeLoaders()
 {
-    for (auto& itemTypeLoader : m_itemTypeLoaders)
+    auto itemTypeLoaders = std::exchange(m_itemTypeLoaders, { });
+    for (auto& itemTypeLoader : itemTypeLoaders)
         itemTypeLoader->invokeCompletionHandler();
-
-    m_itemTypeLoaders.clear();
 }
 
 void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&& completion)

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
@@ -43,7 +43,7 @@ Ref<BlobEvent> BlobEvent::create(const AtomString& type, Init&& init, IsTrusted 
 BlobEvent::BlobEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
     : Event(EventInterfaceType::BlobEvent, type, init, isTrusted)
     , m_blob(init.data.releaseNonNull())
-    , m_timecode(init.timecode)
+    , m_timecode(init.timecode.value_or(0))
 {
 }
 

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.h
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.h
@@ -37,7 +37,7 @@ class BlobEvent final : public Event {
 public:
     struct Init : EventInit {
         RefPtr<Blob> data;
-        double timecode;
+        std::optional<double> timecode;
     };
     
     static Ref<BlobEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1188,7 +1188,7 @@ bool MediaSource::isTypeSupported(ScriptExecutionContext& context, const String&
     }
 
     MediaPlayer::SupportsType supported;
-    callOnMainThreadAndWait([&] {
+    callOnMainThreadAndWait([&supported, parameters = crossThreadCopy(WTF::move(parameters))] {
         supported = MediaPlayer::supportsType(parameters);
     });
 

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -437,7 +437,7 @@ Ref<DOMPromise> ReadableStream::cancel(JSDOMGlobalObject& globalObject, JSC::JSV
             return promise;
         }
 
-        auto* jsPromise = jsCast<JSC::JSPromise*>(result);
+        auto* jsPromise = jsDynamicCast<JSC::JSPromise*>(result);
         if (!jsPromise)
             return promise;
 

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -100,7 +100,7 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
 {
     if (RefPtr internalReader = this->internalDefaultReader()) {
         auto value = internalReader->readForBindings(globalObject);
-        auto* promise = jsCast<JSC::JSPromise*>(value);
+        auto* promise = jsDynamicCast<JSC::JSPromise*>(value);
         if (!promise)
             return;
 

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
@@ -30,7 +30,6 @@
 
 #include "AudioUtilities.h"
 #include "WaveShaperProcessor.h"
-#include <JavaScriptCore/Float32Array.h>
 #include <algorithm>
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
@@ -85,9 +84,7 @@ void WaveShaperDSPKernel::process(std::span<const float> source, std::span<float
 void WaveShaperDSPKernel::processCurve(std::span<const float> source, std::span<float> destination)
 {
     assertIsHeld(waveShaperProcessor()->processLock());
-    RefPtr curve = waveShaperProcessor()->curve();
-    auto curveData = curve ? curve->typedMutableSpan() : std::span<float> { };
-    processCurveWithData(source, destination, curveData);
+    processCurveWithData(source, destination, waveShaperProcessor()->curve().span());
 }
 
 void WaveShaperDSPKernel::processCurveWithData(std::span<const float> source, std::span<float> destination, std::span<const float> curveData)

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h
@@ -50,12 +50,13 @@ public:
     // Oversampling requires more resources, so let's only allocate them if needed.
     void lazyInitializeOversampling();
 
+    // Apply the shaping curve.
+    WEBCORE_EXPORT static void processCurveWithData(std::span<const float> source, std::span<float> destination, std::span<const float> curveData);
+
 private:
     bool isWaveShaperDSPKernel() const final { return true; }
 
-    // Apply the shaping curve.
     void processCurve(std::span<const float> source, std::span<float> destination);
-
     // Use up-sampling, process at the higher sample-rate, then down-sample.
     void processCurve2x(std::span<const float> source, std::span<float> destination);
     void processCurve4x(std::span<const float> source, std::span<float> destination);

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.cpp
@@ -81,27 +81,22 @@ ExceptionOr<void> WaveShaperNode::setCurveForBindings(RefPtr<Float32Array>&& cur
     if (curve && curve->length() < 2)
         return Exception { ExceptionCode::InvalidStateError, "Length of curve array cannot be less than 2"_s };
 
-    if (curve) {
-        // The specification states that we should maintain an internal copy of the curve so that
-        // subsequent modifications of the contents of the array have no effect.
-        auto clonedCurve = Float32Array::create(curve->data(), curve->length());
-        curve = WTF::move(clonedCurve);
-    }
-
-    waveShaperProcessor()->setCurveForBindings(curve.get());
+    // The specification states that we should maintain an internal copy of the curve so that
+    // subsequent modifications of the contents of the array have no effect.
+    waveShaperProcessor()->setCurveForBindings(curve ? Vector<float>(curve->typedSpan()) : Vector<float>());
     return { };
 }
 
 RefPtr<Float32Array> WaveShaperNode::curveForBindings()
 {
     ASSERT(isMainThread());
-    RefPtr curve = waveShaperProcessor()->curveForBindings();
-    if (!curve)
+    auto& curve = waveShaperProcessor()->curveForBindings();
+    if (curve.isEmpty())
         return nullptr;
 
     // Make a clone of our internal array so that JS cannot modify our internal array
     // on the main thread while the audio thread is using it for rendering.
-    return Float32Array::create(curve->data(), curve->length());
+    return Float32Array::create(curve.span());
 }
 
 static inline WaveShaperProcessor::OverSampleType processorType(OverSampleType type)
@@ -149,8 +144,7 @@ bool WaveShaperNode::propagatesSilence() const
         return false;
 
     Locker locker { AdoptLock, waveShaperProcessor()->processLock() };
-    RefPtr curve = waveShaperProcessor()->curve();
-    return !curve || !curve->length();
+    return waveShaperProcessor()->curve().isEmpty();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.h
@@ -30,6 +30,7 @@
 #include "OverSampleType.h"
 #include "WaveShaperOptions.h"
 #include "WaveShaperProcessor.h"
+#include <JavaScriptCore/Forward.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -29,7 +29,6 @@
 #include "WaveShaperProcessor.h"
 
 #include "WaveShaperDSPKernel.h"
-#include <JavaScriptCore/Float32Array.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -52,13 +51,13 @@ std::unique_ptr<AudioDSPKernel> WaveShaperProcessor::createKernel()
     return makeUnique<WaveShaperDSPKernel>(this);
 }
 
-void WaveShaperProcessor::setCurveForBindings(Float32Array* curve)
+void WaveShaperProcessor::setCurveForBindings(Vector<float>&& curve)
 {
     ASSERT(isMainThread());
     // This synchronizes with process().
     Locker locker { m_processLock };
 
-    m_curve = curve;
+    m_curve = WTF::move(curve);
 }
 
 void WaveShaperProcessor::setOversampleForBindings(OverSampleType oversample)

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.h
@@ -27,11 +27,10 @@
 #include "AudioDSPKernel.h"
 #include "AudioDSPKernelProcessor.h"
 #include "AudioNode.h"
-#include <JavaScriptCore/Forward.h>
 #include <memory>
 #include <wtf/Lock.h>
-#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -55,9 +54,9 @@ public:
 
     void process(const AudioBus& source, AudioBus& destination, size_t framesToProcess) final;
 
-    void setCurveForBindings(Float32Array*);
-    Float32Array* curveForBindings() WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_curve.get(); } // Doesn't grab the lock, only safe to call on the main thread.
-    Float32Array* curve() const WTF_REQUIRES_LOCK(m_processLock) { return m_curve.get(); }
+    void setCurveForBindings(Vector<float>&&);
+    const Vector<float>& curveForBindings() const LIFETIME_BOUND WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_curve; } // Doesn't grab the lock, only safe to call on the main thread.
+    const Vector<float>& curve() const LIFETIME_BOUND WTF_REQUIRES_LOCK(m_processLock) { return m_curve; }
 
     void setOversampleForBindings(OverSampleType);
     OverSampleType oversampleForBindings() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(isMainThread()); return m_oversample; } // Doesn't grab the lock, only safe to call on the main thread.
@@ -69,7 +68,7 @@ private:
     Type processorType() const final { return Type::WaveShaper; }
 
     // m_curve represents the non-linear shaping curve.
-    RefPtr<Float32Array> m_curve WTF_GUARDED_BY_LOCK(m_processLock);
+    Vector<float> m_curve WTF_GUARDED_BY_LOCK(m_processLock);
 
     OverSampleType m_oversample WTF_GUARDED_BY_LOCK(m_processLock) { OverSampleNone };
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -723,14 +723,14 @@ FocusableElementSearchResult FocusController::findAndFocusElementInDocumentOrder
     // that because some elements (e.g. HTMLInputElement and HTMLTextAreaElement) do extra work in
     // their focus() methods.
 
-    Document& newDocument = element->document();
+    RefPtr newDocument = element->document();
 
-    if (&newDocument != document) {
+    if (newDocument != document) {
         // Focus is going away from this document, so clear the focused node.
         document->setFocusedElement(nullptr);
     }
 
-    setFocusedFrame(newDocument.protectedFrame().get());
+    setFocusedFrame(newDocument->protectedFrame().get());
 
     if (caretBrowsing) {
         VisibleSelection newSelection(firstPositionInOrBeforeNode(element.get()), Affinity::Downstream);

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -880,10 +880,15 @@ void LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters(const 
     if (!renderView() || renderView()->renderTreeBeingDestroyed())
         m_anchorScrollAdjusters.clear();
     else {
+        HashSet<CheckedRef<RenderBox>> anchoredToUnregister;
+
         for (auto& adjuster : m_anchorScrollAdjusters) {
             if (adjuster.invalidateForScroller(scroller))
-                unregisterAnchorScrollAdjusterFor(*adjuster.anchored());
+                anchoredToUnregister.add(*adjuster.anchored());
         }
+
+        for (CheckedRef anchored : anchoredToUnregister)
+            unregisterAnchorScrollAdjusterFor(anchored);
     }
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -116,6 +116,24 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlayer);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlayerFactory);
 
+MediaEngineSupportParameters MediaEngineSupportParameters::isolatedCopy() &&
+{
+    SUPPRESS_UNCOUNTED_ARG return {
+        crossThreadCopy(WTF::move(type)),
+        crossThreadCopy(WTF::move(url)),
+        isMediaSource,
+        isMediaStream,
+        requiresRemotePlayback,
+        supportsLimitedMatroska,
+        crossThreadCopy(WTF::move(contentTypesRequiringHardwareSupport)),
+        crossThreadCopy(WTF::move(allowedMediaContainerTypes)),
+        crossThreadCopy(WTF::move(allowedMediaCodecTypes)),
+        WTF::move(allowedMediaVideoCodecIDs),
+        WTF::move(allowedMediaAudioCodecIDs),
+        WTF::move(allowedMediaCaptionFormatTypes),
+    };
+}
+
 // a null player to make MediaPlayer logic simpler
 
 class NullMediaPlayerPrivate final : public MediaPlayerPrivateInterface, public ThreadSafeRefCounted<NullMediaPlayerPrivate, WTF::DestructionThread::Main> {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -122,6 +122,8 @@ struct MediaEngineSupportParameters {
     std::optional<Vector<FourCC>> allowedMediaVideoCodecIDs;
     std::optional<Vector<FourCC>> allowedMediaAudioCodecIDs;
     std::optional<Vector<FourCC>> allowedMediaCaptionFormatTypes;
+
+    [[nodiscard]] WEBCORE_EXPORT MediaEngineSupportParameters isolatedCopy() &&;
 };
 
 struct SeekTarget {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -357,6 +357,7 @@
 
 #if ENABLE(WEB_AUDIO)
 #include "AudioContext.h"
+#include "WaveShaperDSPKernel.h"
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -5405,6 +5406,13 @@ void Internals::setAudioContextRestrictions(AudioContext& context, StringView re
             restrictions.add(AudioContext::BehaviorRestrictionFlags::RequirePageConsentForAudioStartRestriction);
     }
     context.addBehaviorRestriction(restrictions);
+}
+
+Vector<float> Internals::waveShaperProcessCurveWithData(Vector<float> source, Vector<float> curve)
+{
+    Vector<float> destination(source.size(), 0.0f);
+    WaveShaperDSPKernel::processCurveWithData(std::span { source }, std::span { destination }, std::span { curve });
+    return destination;
 }
 
 void Internals::useMockAudioDestinationCocoa()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -621,6 +621,9 @@ public:
     // BaseAudioContext lifetime testing.
     static uint64_t baseAudioContextIdentifier(const BaseAudioContext&);
     static bool isBaseAudioContextAlive(uint64_t contextID);
+
+    Vector<float> waveShaperProcessCurveWithData(Vector<float> source, Vector<float> curve);
+
 #endif
 
     unsigned numberOfIntersectionObservers(const Document&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -894,6 +894,8 @@ enum ContentsFormat {
     [Conditional=WEB_AUDIO] unsigned long long baseAudioContextIdentifier(BaseAudioContext context);
     [Conditional=WEB_AUDIO] boolean isBaseAudioContextAlive(unsigned long long contextID);
 
+    [Conditional=WEB_AUDIO] sequence<unrestricted float> waveShaperProcessCurveWithData(sequence<unrestricted float> source, sequence<unrestricted float> curve);
+
     DOMString counterValue(Element element);
     long pageNumber(Element element, optional unrestricted float pageWidth = 800, optional unrestricted float pageHeight = 600);
     sequence<DOMString> shortcutIconURLs();


### PR DESCRIPTION
#### 8663cacd3ae7b109eb1935577199e827d5b2f516
<pre>
Cherry-pick 0743320ceb0e. <a href="https://bugs.webkit.org/show_bug.cgi?id=313915">https://bugs.webkit.org/show_bug.cgi?id=313915</a>

BlobEvent::Init::timecode missing initializer leaks 8 bytes of uninitialized stack memory
<a href="https://rdar.apple.com/175759962">rdar://175759962</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313915">https://bugs.webkit.org/show_bug.cgi?id=313915</a>

Reviewed by Simon Fraser.

* Source/WebCore/Modules/mediarecorder/BlobEvent.cpp:
(WebCore::BlobEvent::BlobEvent):
* Source/WebCore/Modules/mediarecorder/BlobEvent.h:

Identifier: 305413.809@safari-7624-branch

Identifier: 305413.756@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.863@webkitglib/2.52">https://commits.webkit.org/305877.863@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9ff892e9e199b8873d56653fae8daa936b121185
<pre>
Cherry-pick 061b1c5b4012. <a href="https://bugs.webkit.org/show_bug.cgi?id=313691">https://bugs.webkit.org/show_bug.cgi?id=313691</a>

Heap use-after-free in ClipboardItemBindingsDataSource::clearItemTypeLoaders()
<a href="https://bugs.webkit.org/show_bug.cgi?id=313691">https://bugs.webkit.org/show_bug.cgi?id=313691</a>
<a href="https://rdar.apple.com/174651164">rdar://174651164</a>

Reviewed by Wenson Hsieh.

Avoid the use-after-free by moving the contents of Vector to a local variable.

Test: editing/async-clipboard/clipboard-write-item-crash.html

* LayoutTests/editing/async-clipboard/clipboard-write-item-crash-expected.txt: Added.
* LayoutTests/editing/async-clipboard/clipboard-write-item-crash.html: Added.
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::clearItemTypeLoaders):

Identifier: 305413.812@safari-7624-branch

Identifier: 305413.755@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.862@webkitglib/2.52">https://commits.webkit.org/305877.862@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b46112e2df12e450c68c4650d52ffc862bab0a1b
<pre>
Cherry-pick 84a5f91f00a5. <a href="https://bugs.webkit.org/show_bug.cgi?id=313063">https://bugs.webkit.org/show_bug.cgi?id=313063</a>

[JSC] Unconditionally keep OMGOSREntryCallee alive while updating its callsites
<a href="https://bugs.webkit.org/show_bug.cgi?id=313063">https://bugs.webkit.org/show_bug.cgi?id=313063</a>
<a href="https://rdar.apple.com/174492346">rdar://174492346</a>

Reviewed by Keith Miller.

After a re-tier, when a fresh BBQCallee replaces a retired one,
m_osrEntryCallees may hold a stale weak ref to an OMGOSREntryCallee not owned
by the current BBQCallee. Currently, updateCallsitesToCallUs will not track
this since it assumes that this OMGOSREntryCallee will be owned by the BBQCallee

This patch fixes it by unconditionally keeping the OMGOSREntryCallee alive
while we update all the callsites within it. The assert in ~BBQCallee is void
now since an OMGOSREntryCallee can now have multiple owners.

* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::BBQCallee::~BBQCallee):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::updateCallsitesToCallUs):

Identifier: 305413.784@safari-7624-branch

Identifier: 305413.753@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.861@webkitglib/2.52">https://commits.webkit.org/305877.861@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1a39ad3eac8e497bb38d4683bb359ee543368b0c
<pre>
Cherry-pick f9763c9248db. <a href="https://bugs.webkit.org/show_bug.cgi?id=313702">https://bugs.webkit.org/show_bug.cgi?id=313702</a>

Use-after-free in FocusController::findAndFocusElementInDocumentOrder
<a href="https://bugs.webkit.org/show_bug.cgi?id=313702">https://bugs.webkit.org/show_bug.cgi?id=313702</a>
<a href="https://rdar.apple.com/175673194">rdar://175673194</a>

Reviewed by Aditya Keerthi.

Fixed the bug by deploying a smart pointer.

Test: fast/events/new-focused-document-removal-during-blur-event-handler-crash.html

* LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash-expected.txt: Added.
* LayoutTests/fast/events/new-focused-document-removal-during-blur-event-handler-crash.html: Added.
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findAndFocusElementInDocumentOrderStartingWithFrame):

Identifier: 305413.804@safari-7624-branch

Identifier: 305413.752@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.860@webkitglib/2.52">https://commits.webkit.org/305877.860@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### d2361070280fa5110babefcdb986ae74c5267881
<pre>
Cherry-pick 3f06c62bc271. <a href="https://bugs.webkit.org/show_bug.cgi?id=313706">https://bugs.webkit.org/show_bug.cgi?id=313706</a>

Type confusion in ReadableStream.cancel() via jsCast&lt;JSPromise*&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=313706">https://bugs.webkit.org/show_bug.cgi?id=313706</a>
<a href="https://rdar.apple.com/174938744">rdar://174938744</a>

Reviewed by Chris Dumez and Mark Lam.

Replaced the use of unconditional jsCast with jsDynamicCast to fix the bug.

Test: streams/readable-stream-cancel-fake-promise-crash.html

* LayoutTests/streams/readable-stream-cancel-fake-promise-crash-expected.txt: Added.
* LayoutTests/streams/readable-stream-cancel-fake-promise-crash.html: Added.
* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::cancel):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
(WebCore::ReadableStreamDefaultReader::read):

Identifier: 305413.806@safari-7624-branch

Identifier: 305413.751@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.859@webkitglib/2.52">https://commits.webkit.org/305877.859@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 705f90086aff3cfd50a1061f58ebd857ce570079
<pre>
Cherry-pick c222f765786f. <a href="https://bugs.webkit.org/show_bug.cgi?id=313693">https://bugs.webkit.org/show_bug.cgi?id=313693</a>

MediaEngineSupportParameters is passed across a thread boundary without making an isolatedCopy().
<a href="https://rdar.apple.com/174652324">rdar://174652324</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313693">https://bugs.webkit.org/show_bug.cgi?id=313693</a>

Reviewed by Jean-Yves Avenard.

Allow MediaEngineSupporrtParameters to be used cross-thread by adding an isolatedCopy() method.

* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::isTypeSupported):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaEngineSupportParameters::isolatedCopy):
* Source/WebCore/platform/graphics/MediaPlayer.h:

Identifier: 305413.794@safari-7624-branch

Identifier: 305413.750@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.858@webkitglib/2.52">https://commits.webkit.org/305877.858@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4b475ff6d70b037b305e86b200d7df4fc1322a2e
<pre>
Cherry-pick 444a849510b9. <a href="https://bugs.webkit.org/show_bug.cgi?id=313528">https://bugs.webkit.org/show_bug.cgi?id=313528</a>

[css-anchor-position-1] removeScrollerFromAnchorScrollAdjusters mutates array when iterating through it
<a href="https://rdar.apple.com/175679565">rdar://175679565</a>

Reviewed by Elika Etemad.

LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters iterates
through m_anchorScrollAdjusters, and unregisters adjusters belonging to the
scroller by calling unregisterAnchorScrollAdjusterFor. unregisterAnchorScrollAdjusterFor
in turn removes adjusters also from m_anchorScrollAdjusters, which is being iterated on.
Vectors are not safe to modify when iterating through. Change the loop to save the list
of adjusters to be removed in a HashSet, then remove the saved adjusters after.

Test: imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scroll-compensation-crash.html: Added.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::removeScrollerFromAnchorScrollAdjusters):

Identifier: 305413.802@safari-7624-branch

Identifier: 305413.749@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.857@webkitglib/2.52">https://commits.webkit.org/305877.857@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f9e13512ae52d032b6722618aef76604b2a953d7
<pre>
Cherry-pick 0dcea6bac528. <a href="https://bugs.webkit.org/show_bug.cgi?id=313528">https://bugs.webkit.org/show_bug.cgi?id=313528</a>

[WebCore] Store WaveShaperProcessor curve as Vector&lt;float&gt; to avoid cross-thread RefCounted race
<a href="https://bugs.webkit.org/show_bug.cgi?id=313528">https://bugs.webkit.org/show_bug.cgi?id=313528</a>
<a href="https://rdar.apple.com/175171873">rdar://175171873</a>

Reviewed by Chris Dumez.

WaveShaperProcessor::m_curve was a RefPtr&lt;Float32Array&gt;. Float32Array inherits
RefCounted&lt;ArrayBufferView&gt;, whose refcount is non-atomic. 296577@main changed
the audio-thread readers in WaveShaperDSPKernel::processCurve and
WaveShaperNode::propagatesSilence to wrap waveShaperProcessor()-&gt;curve() in a
local RefPtr; the main-thread getter WaveShaperNode::curveForBindings() already
did the same lockless. The concurrent non-atomic ref/deref races; a lost
increment leaves the count one too low; a subsequent deref frees m_curve out
from under the processor; the next render quantum is a heap-use-after-free in
processCurve.

On builds with ENABLE(SECURITY_ASSERTIONS), RefCountDebugger&apos;s threading
checker traps first; on plain Release the UAF is reachable from web content via
OfflineAudioContext + the WaveShaperNode.curve getter.

Fix by storing the curve as Vector&lt;float&gt; instead of RefPtr&lt;Float32Array&gt;. The
internal curve was already cloned on set and on get, so the Float32Array wrapper
was vestigial. With a Vector there is no RefCounted object on the audio-thread
path; m_processLock continues to guard buffer replacement against audio-thread
reads. This matches AudioParamTimeline::ParamEvent::m_curve and
IIRProcessor::m_feedforward.

Test: webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html
* LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash-expected.txt: Added.
* LayoutTests/webaudio/WaveShaper/waveshaper-curve-getter-during-rendering-crash.html: Added.
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
(WebCore::WaveShaperDSPKernel::processCurve):
* Source/WebCore/Modules/webaudio/WaveShaperNode.cpp:
(WebCore::WaveShaperNode::setCurveForBindings):
(WebCore::WaveShaperNode::curveForBindings):
(WebCore::WaveShaperNode::propagatesSilence const):
* Source/WebCore/Modules/webaudio/WaveShaperNode.h:
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp:
(WebCore::WaveShaperProcessor::setCurveForBindings):
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.h:
(WebCore::WaveShaperProcessor::curveForBindings const):
(WebCore::WaveShaperProcessor::curve const):
(WebCore::WaveShaperProcessor::curveForBindings): Deleted.

Identifier: 305413.793@safari-7624-branch

Identifier: 305413.748@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.856@webkitglib/2.52">https://commits.webkit.org/305877.856@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 08f959f218a90fd267b4cbacf5ac4662ad7c1aa1
<pre>
Cherry-pick c0bd74757c6e. <a href="https://bugs.webkit.org/show_bug.cgi?id=305612">https://bugs.webkit.org/show_bug.cgi?id=305612</a>

Web Audio WaveShaperNode: NaN input produces out-of-bounds read in processCurve()
<a href="https://bugs.webkit.org/show_bug.cgi?id=305612">https://bugs.webkit.org/show_bug.cgi?id=305612</a>
<a href="https://rdar.apple.com/164364161">rdar://164364161</a>

Reviewed by Youenn Fablet.

NaN input samples bypass range checks since NaN comparisons always return false, causing
std::floor(NaN) to produce NaN which converts to a garbage unsigned index, resulting in an
out-of-bounds read.

Fix by guarding non-finite inputs and outputting silence (0.0f). Also clamp valid inputs to [-1, 1]
for additional safety.

The static helper processCurveWithData is introduced to allow unit testing the algorithm in
isolation without needing to instantiate a WaveShaperProcessor.

* LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling-expected.txt: Added.
* LayoutTests/webaudio/WaveShaper/waveshaper-nan-infinity-handling.html: Added.
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
(WebCore::WaveShaperDSPKernel::processCurve):
(WebCore::WaveShaperDSPKernel::processCurveWithData):
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::waveShaperProcessCurveWithData):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Identifier: 305413.86@safari-7624-branch
Canonical link: <a href="https://commits.webkit.org/305877.855@webkitglib/2.52">https://commits.webkit.org/305877.855@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4803334d528e3b56a4be62c611b7cdf2771455b5
<pre>
Cherry-pick 095fa99180ff. <a href="https://bugs.webkit.org/show_bug.cgi?id=313473">https://bugs.webkit.org/show_bug.cgi?id=313473</a>

[JSC] Keep JSWebAssemblyMemory alive from wasm-originated JSArrayBuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=313473">https://bugs.webkit.org/show_bug.cgi?id=313473</a>
<a href="https://rdar.apple.com/175674018">rdar://175674018</a>

Reviewed by Keith Miller.

Currently, ArrayBuffers that are created by WebAssembly.Memory.p.
toResizableBuffer do not keep that WebAssembly.Memory instance alive. This is a
memory safety footgun. While JS-originated resizable ABs reserve the virtual
memory of their max size up front, wasm-originated resizable ABs can either be
bounds-checking which do not reserve virtual memory up front, or signaling,
which do. Currently, because wasm-originated ArrayBuffers do not keep their
WebAssembly.Memory alive, non-wasm ArrayBuffer code has to be aware of this
implementation in case the WebAssembly.Memory gets collected. This complicates
the object representation space and is error-prone.

This PR simplifies this set up by making wasm-originated ArrayBuffers and their
originator WebAssembly.Memory exist in a GC lifetime cycle. This means
wasm-originated ABs _always_ delegate resizing to WebAssembly.Memory.

The weak pointer to the underlying Wasm::Memory in ArrayBuffers is no longer
needed and removed.

The spot fix to keep WebAssembly.Memory alive for the duration of
ArrayBuffer.prototype.resize from 305413.660@safari-7624-branch is also
reverted as this fix removes the need for it.

Test: JSTests/wasm/stress/wasm-resizable-buffer-resize-after-gc.js

* JSTests/wasm/stress/wasm-resizable-buffer-resize-after-gc.js: Added.
(flushStackRoots):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::resize):
(JSC::ArrayBuffer::setAssociatedWasmMemory): Deleted.
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/JSArrayBuffer.cpp:
(JSC::JSArrayBuffer::associatedWasmMemoryWrapper const):
(JSC::JSArrayBuffer::setAssociatedWasmMemoryWrapper):
(JSC::JSArrayBuffer::clearAssociatedWasmMemoryWrapper):
(JSC::JSArrayBuffer::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSArrayBuffer.h:
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::Memory):
(JSC::Wasm::Memory::create):
(JSC::Wasm::Memory::createZeroSized):
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::grow):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::adopt):
(JSC::JSWebAssemblyMemory::associateArrayBuffer):
(JSC::JSWebAssemblyMemory::disassociateArrayBuffer):
(JSC::JSWebAssemblyMemory::growSuccessCallback):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::WebAssemblyMemoryConstructor::createMemoryFromDescriptor):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTerminal):

Identifier: 305413.790@safari-7624-branch

Identifier: 305413.747@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.854@webkitglib/2.52">https://commits.webkit.org/305877.854@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eb172737152b3aa5b5e5a2207a552b7a0d21408

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172193 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46110 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181639 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129747 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174058 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47399 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45750 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133937 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129747 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175151 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47399 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47399 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45750 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30249 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47399 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184177 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33452 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36781 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45750 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142691 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45777 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142573 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46457 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111151 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26126 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46457 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118212 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204871 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44975 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39530 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54701 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44375 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44607 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44434 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->