### PR TITLE
Cherry-pick 38349@main (9b307b6cc06e). https://bugs.webkit.org/show_bug.cgi?id=309393

### DIFF
--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -317,20 +317,20 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-rgsa').resolvedOptions().calendar,
 // Calendar-sensitive format().
 shouldBe(Intl.DateTimeFormat('en-u-ca-buddhist', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2558 BE');
 shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-chinese', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['11/15/2015', '2015-11-15']);
-shouldBe(Intl.DateTimeFormat('en-u-ca-coptic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '4/15/1732 ERA1');
+shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-coptic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['4/15/1732 ERA1', '4/15/1732 AM']);
 shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-dangi', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['11/15/2015', '2015-11-15']);
-shouldBe(Intl.DateTimeFormat('en-u-ca-ethioaa', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '4/15/7508 ERA0');
-shouldBe(Intl.DateTimeFormat('en-u-ca-ethiopic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '4/15/2008 ERA1');
+shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-ethioaa', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['4/15/7508 ERA0', '4/15/7508 AA']);
+shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-ethiopic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['4/15/2008 ERA1', '4/15/2008 AM']);
 shouldBe(Intl.DateTimeFormat('en-u-ca-gregory', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');
 shouldBe(Intl.DateTimeFormat('en-u-ca-hebrew', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '13 Tevet 5776');
-shouldBe(Intl.DateTimeFormat('en-u-ca-indian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '10/4/1937 Saka');
+shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-indian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['10/4/1937 Saka', '10/4/1937 Śaka']);
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamicc', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/13/1437 AH');
 shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-ISO8601', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['12/25/2015', '2015-12-25']);
 shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-japanese', { timeZone: 'America/Los_Angeles' }).format(1451099872641), [ '12/25/27 H', '12/25/H27' ]);
 shouldBe(Intl.DateTimeFormat('en-u-ca-persian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '10/4/1394 AP');
 shouldBe(Intl.DateTimeFormat('en-u-ca-roc', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/104 Minguo');
-shouldBe(Intl.DateTimeFormat('en-u-ca-ethiopic-amete-alem', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '4/15/7508 ERA0');
+shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-ethiopic-amete-alem', { timeZone: 'America/Los_Angeles' }).format(1451099872641), ['4/15/7508 ERA0', '4/15/7508 AA']);
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-umalqura', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-tbla', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic-civil', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/13/1437 AH');

--- a/JSTests/stress/intl-extended-timezone-names.js
+++ b/JSTests/stress/intl-extended-timezone-names.js
@@ -1,6 +1,6 @@
 function shouldBe(actual, expected) {
     if (actual !== expected)
-        throw new Error("bad value: " + actual);
+        throw new Error("bad value: " + actual + " expected: " + expected);
 }
 
 let timeZoneNames = ["short", "long", "shortOffset", "longOffset", "shortGeneric", "longGeneric"];
@@ -58,11 +58,11 @@ timeZoneTest(date, "zh-Hant", {
 
 timeZoneTest(date, "ja-JP", {
     short: "2021/7/10 10:48:02 GMT-7",
-    long: "2021/7/10 10時48分02秒 アメリカ太平洋夏時間",
+    long: ["2021/7/10 10時48分02秒 アメリカ太平洋夏時間", "2021/7/10 10時48分02秒 米国太平洋夏時間"],
     shortOffset: "2021/7/10 10時48分02秒 GMT-7",
     longOffset: "2021/7/10 10時48分02秒 GMT-07:00",
     shortGeneric: "2021/7/10 10:48:02 ロサンゼルス時間",
-    longGeneric: "2021/7/10 10:48:02 アメリカ太平洋時間",
+    longGeneric: ["2021/7/10 10:48:02 アメリカ太平洋時間", "2021/7/10 10:48:02 米国太平洋時間"],
 });
 
 timeZoneTest(date, "ja-JP", {


### PR DESCRIPTION
#### d8075f950296e20e5767dabf0e26e6a5b38f1f84
<pre>
Cherry-pick 38349@main (9b307b6cc06e). <a href="https://bugs.webkit.org/show_bug.cgi?id=309393">https://bugs.webkit.org/show_bug.cgi?id=309393</a>

    [JSC] Fix Intl tests for compatibility with newer ICU/CLDR data
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309393">https://bugs.webkit.org/show_bug.cgi?id=309393</a>
    <a href="https://rdar.apple.com/171936645">rdar://171936645</a>

    Reviewed by Yusuke Suzuki.

    Newer versions of ICU/CLDR changed some locale data strings that caused
    test failures:

    * Coptic and Ethiopic calendar era abbreviations changed from
    ERA0/ERA1 to their proper abbreviations (AM, AA).
    * Indian calendar era name changed from &quot;Saka&quot; to &quot;Śaka&quot;.
    * Japanese timezone names changed from 米国 (kanji) to アメリカ
    (katakana) for &quot;America&quot;.

    Update the affected tests to accept both old and new variants.

    * JSTests/stress/intl-datetimeformat.js:
    Accept both ERA1/AM for Coptic and Ethiopic calendars, ERA0/AA for
    Ethiopic Amete Alem, and Saka/Śaka for the Indian calendar.

    * JSTests/stress/intl-extended-timezone-names.js:
    Accept both アメリカ and 米国 variants for ja-JP Pacific timezone names.
    Also improve shouldBe error message to show expected value.

    Canonical link: <a href="https://commits.webkit.org/308836@main">https://commits.webkit.org/308836@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.864@webkitglib/2.52">https://commits.webkit.org/305877.864@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bc21e7e31f57b8e317bb462c583b121194b96dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172196 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46113 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181642 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129750 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47402 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45753 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129750 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175154 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47402 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114403 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47402 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45753 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30252 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47402 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184180 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33455 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45753 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142689 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45780 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142571 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46460 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111208 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26128 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46460 "The change is no longer eligible for processing.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204874 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44978 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39533 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54702 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44378 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44610 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44437 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->