### PR TITLE
`ipc/loadping-firstpartyforcookies-message-check.html` is constant failure with assertions enabled

### DIFF
--- a/LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html
+++ b/LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html
@@ -44,6 +44,7 @@ promise_test(async (t) => {
                 },
             },
             cachePartition: '',
+            shouldBlockThirdPartyStorage: false,
             hiddenFromInspector: false,
         },
         requestBody: { data: {}, sandboxExtensionHandles: [] },
@@ -63,6 +64,7 @@ promise_test(async (t) => {
         hadMainFrameMainResourcePrivateRelayed: false,
         allowPrivacyProxy: true,
         advancedPrivacyProtections: 0,
+        mayBlockNetworkRequest: false,
         requiredCookiesVersion: 0n,
         identifier: { optionalValue: 99001n },
         requestBodySandboxExtensions: [],
@@ -129,6 +131,8 @@ promise_test(async (t) => {
         shouldRecordFrameLoadForStorageAccess: false,
         isInitiatorPrefetch: false,
         isInitiatedByDedicatedWorker: false,
+        globalPrivacyControlStatus: false,
+        shouldConsiderEnhancedSecurityForInsecureResponse:false,
     };
 
     CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5484,8 +5484,6 @@ webkit.org/b/317968 [ x86_64 ] imported/w3c/web-platform-tests/navigation-timing
 
 webkit.org/b/318434 ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html [ Crash Pass ]
 
-webkit.org/b/318634 ipc/loadping-firstpartyforcookies-message-check.html [ Failure ]
-
 webkit.org/b/319043 http/wpt/navigation-api/traverse-subframe-remote-sibling.sub.html [ Crash ]
 webkit.org/b/319044 imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom.html [ Failure ]
 webkit.org/b/319045 [ Debug ] accessibility/button-in-deep-dom.html [ Timeout ]

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -530,9 +530,7 @@ auto NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier proce
         return terminateOrDisallow;
     }
 
-    auto result = set.contains(firstPartyDomain);
-    ASSERT(result || terminateOrDisallow == AllowCookieAccess::Disallow);
-    return result ? AllowCookieAccess::Allow : terminateOrDisallow;
+    return set.contains(firstPartyDomain) ? AllowCookieAccess::Allow : terminateOrDisallow;
 }
 
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 9841b6f9f3840e5dc86f5d1097b73b929953be7b
<pre>
`ipc/loadping-firstpartyforcookies-message-check.html` is constant failure with assertions enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=318436">https://bugs.webkit.org/show_bug.cgi?id=318436</a>

Reviewed by Charlie Wolfe and Rupin Mittal.

Add missing `mayBlockNetworkRequest`, `globalPrivacyControlStatus`,
`shouldConsiderEnhancedSecurityForInsecureResponse`, and
`shouldBlockThirdPartyStorage` to `resourceLoadParameters` object.

With all these properties present, the test was crashing in debug builds
in `NetworkProcess::allowsFirstPartyForCookies()` at
`ASSERT(result || terminateOrDisallow == AllowCookieAccess::Disallow);`

It seems like this assertion is triggered on the exact case this test is
testing and can be dropped.

* LayoutTests/ipc/loadping-firstpartyforcookies-message-check.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allowsFirstPartyForCookies):

Canonical link: <a href="https://commits.webkit.org/317024@main">https://commits.webkit.org/317024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bf319c29386d2baeff26f7ba7552ae4242023a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131604 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135099 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95294 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37167 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31794 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185736 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143986 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143844 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38865 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48015 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31992 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113245 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38764 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119895 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46521 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10331 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->