### PR TITLE
Adapt temporal-iso8601-parse-bounds.js to this branch's Temporal support

### DIFF
--- a/JSTests/stress/temporal-iso8601-parse-bounds.js
+++ b/JSTests/stress/temporal-iso8601-parse-bounds.js
@@ -54,8 +54,12 @@ function shouldThrowRangeError(fn, msg) {
         ["PlainDate", "1976111"],
         ["PlainDate", "19761"],
     ];
-    for (const [type, string] of crashers)
+    for (const [type, string] of crashers) {
+        // ZonedDateTime is not implemented on this branch; skip unavailable types.
+        if (!Temporal[type])
+            continue;
         shouldThrowRangeError(() => Temporal[type].from(string), `${type}.from(${JSON.stringify(string)})`);
+    }
 }
 
 // Valid strings must keep working.
@@ -68,7 +72,8 @@ function shouldThrowRangeError(fn, msg) {
 
     shouldBe(Temporal.PlainYearMonth.from("2024-01").toString(), "2024-01", "YearMonth hyphenated");
     shouldBe(Temporal.PlainYearMonth.from("202401").toString(), "2024-01", "YearMonth compact");
-    shouldBe(Temporal.PlainYearMonth.from("2024-01[u-ca=iso8601]").toString(), "2024-01", "YearMonth annotated");
+    // Annotated PlainYearMonth/PlainMonthDay parsing and ZonedDateTime are not
+    // implemented on this branch (they postdate the fork), so those cases are omitted.
     shouldBe(Temporal.PlainYearMonth.from("19761118").toString(), "1976-11", "YearMonth compact full date");
     shouldBe(Temporal.PlainYearMonth.from("1976-11-18").toString(), "1976-11", "YearMonth full date");
     shouldBe(Temporal.PlainYearMonth.from("1976-11-18T15:23:30").toString(), "1976-11", "YearMonth full datetime");
@@ -78,11 +83,8 @@ function shouldThrowRangeError(fn, msg) {
     shouldBe(Temporal.PlainMonthDay.from("1214").toString(), "12-14", "MonthDay compact");
     shouldBe(Temporal.PlainMonthDay.from("--12-14").toString(), "12-14", "MonthDay double hyphen");
     shouldBe(Temporal.PlainMonthDay.from("--1214").toString(), "12-14", "MonthDay double hyphen compact");
-    shouldBe(Temporal.PlainMonthDay.from("1130[u-ca=iso8601]").toString(), "11-30", "MonthDay annotated");
-    shouldBe(Temporal.PlainMonthDay.from("1118[+01:00]").toString(), "11-18", "MonthDay timezone annotation");
     shouldBe(Temporal.PlainMonthDay.from("1976-11-18").toString(), "11-18", "MonthDay full date");
     shouldBe(Temporal.PlainMonthDay.from("1976-11-18T15:23:30").toString(), "11-18", "MonthDay full datetime");
 
     shouldBe(Temporal.PlainDateTime.from("2024-01-15T12:30").toString(), "2024-01-15T12:30:00", "PlainDateTime");
-    shouldBe(Temporal.ZonedDateTime.from("2024-01-15T12:30[UTC]").toString(), "2024-01-15T12:30:00+00:00[UTC]", "ZonedDateTime");
 }


### PR DESCRIPTION
#### 4070ba127a8ee7178c5242a31f24384100855ea1
<pre>
Adapt temporal-iso8601-parse-bounds.js to this branch&apos;s Temporal support
<a href="https://bugs.webkit.org/show_bug.cgi?id=318437">https://bugs.webkit.org/show_bug.cgi?id=318437</a>

Reviewed by Justin Michaud.

The parseDate buffer-overread fix from 314612@main (bug 316366) was
cherry-picked to this branch as b928de477a91, but the test it added
exercises Temporal features that postdate this branch&apos;s fork point and
are not implemented here:

- Temporal.ZonedDateTime does not exist on this branch.
- PlainYearMonth / PlainMonthDay do not parse calendar/timezone
  annotations (e.g. &quot;2024-01[u-ca=iso8601]&quot;, &quot;1130[u-ca=iso8601]&quot;,
  &quot;1118[+01:00]&quot;); only PlainDate does.

As a result the test threw TypeError/RangeError instead of the expected
results and failed in all 19 run modes. Skip unavailable types in the
&quot;crashers&quot; loop and drop the annotation/ZonedDateTime assertions from the
&quot;valid strings&quot; section. The buffer-overread regression coverage that
bug 316366 added is preserved via the remaining PlainDate/PlainMonthDay/
PlainYearMonth short-string cases.

* JSTests/stress/temporal-iso8601-parse-bounds.js:

Canonical link: <a href="https://commits.webkit.org/305877.865@webkitglib/2.52">https://commits.webkit.org/305877.865@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e7f9b434b3c644a52413cdcfb1fc2b7d83384c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172204 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46121 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181650 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129758 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47410 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45761 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133938 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129758 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47410 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114417 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47410 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45761 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30260 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47410 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184188 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33463 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45761 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142696 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45788 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142578 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46468 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111166 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26129 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46468 "The change is no longer eligible for processing.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204882 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/44986 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39541 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54705 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44386 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44618 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44445 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->