### PR TITLE
Cherry-pick(s) 2427c3fef353. rdar://180428726

### DIFF
--- a/Source/WebKit/Platform/IPC/FormDataReference.cpp
+++ b/Source/WebKit/Platform/IPC/FormDataReference.cpp
@@ -26,10 +26,13 @@
 #include "config.h"
 #include "FormDataReference.h"
 
+<<<<<<< HEAD
 #if PLATFORM(COCOA)
 #include "PathsBlockedForSandboxExtensions.h"
 #endif
 
+=======
+>>>>>>> 2427c3fef353 (FormDataReference validator accepts invalid sandbox extensions)
 namespace IPC {
 
 FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<WebKit::SandboxExtensionHandle>&& sandboxExtensionHandles)
@@ -38,20 +41,28 @@ FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<We
     if (!m_data)
         return;
 
+<<<<<<< HEAD
     unsigned fileCount = 0;
     for (auto& element : m_data->elements()) {
         if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
             ++fileCount;
 #if PLATFORM(COCOA)
+=======
+    for (auto& element : m_data->elements()) {
+        if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
+>>>>>>> 2427c3fef353 (FormDataReference validator accepts invalid sandbox extensions)
             const String& path = fileData->filename;
             if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
                 RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
                 m_data = nullptr;
                 break;
             }
+<<<<<<< HEAD
 #else
             UNUSED_VARIABLE(fileData);
 #endif // !PLATFORM(COCOA)
+=======
+>>>>>>> 2427c3fef353 (FormDataReference validator accepts invalid sandbox extensions)
         }
     }
 
@@ -64,7 +75,11 @@ FormDataReference::FormDataReference(RefPtr<WebCore::FormData>&& data, Vector<We
             consumedExtensions++;
     }
 
+<<<<<<< HEAD
     if (consumedExtensions != fileCount) {
+=======
+    if (consumedExtensions != m_data->filesCount()) {
+>>>>>>> 2427c3fef353 (FormDataReference validator accepts invalid sandbox extensions)
         RELEASE_LOG_ERROR(IPC, "FormDataReference: dropping body because a file sandbox extension could not be consumed");
         m_data = nullptr;
     }
@@ -78,12 +93,18 @@ Vector<WebKit::SandboxExtensionHandle> FormDataReference::sandboxExtensionHandle
     return WTF::compactMap(m_data->elements(), [](auto& element) -> std::optional<WebKit::SandboxExtensionHandle> {
         if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data)) {
             const String& path = fileData->filename;
+<<<<<<< HEAD
 #if PLATFORM(COCOA)
+=======
+>>>>>>> 2427c3fef353 (FormDataReference validator accepts invalid sandbox extensions)
             if (WebKit::pathIsBlockedForSandboxExtensions(path)) {
                 RELEASE_LOG(Process, "Form data file path was blocked for sandbox extension: %{private}s", path.utf8().data());
                 return std::nullopt;
             }
+<<<<<<< HEAD
 #endif // PLATFORM(COCOA)
+=======
+>>>>>>> 2427c3fef353 (FormDataReference validator accepts invalid sandbox extensions)
             if (auto handle = WebKit::SandboxExtension::createHandle(path, WebKit::SandboxExtension::Type::ReadOnly))
                 return { WTF::move(*handle) };
         }


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180428726 to main. The following sources [7e6fba53a8a6] will still need to be cherry-picked once the conflict is resolved.

```
FormDataReference validator accepts invalid sandbox extensions
https://bugs.webkit.org/show_bug.cgi?id=314948
rdar://176912134

Reviewed by Alex Christensen.

Check that sandbox extensions are not empty in FormDataReference::sandboxExtensionsAreSufficient.
We are checking that all extensions are successfully consumed in the FormDataReference constructor.
This patch is also removing the validator, since all validation is performed in the constructor.

* Source/WebKit/Platform/IPC/FormDataReference.serialization.in:
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::sandboxExtensionsAreSufficient):
* Source/WebKit/Platform/IPC/FormDataReference.cpp: Added.
(IPC::FormDataReference::FormDataReference):
(IPC::FormDataReference::sandboxExtensionHandles const):
* Source/WebKit/Platform/IPC/FormDataReference.h:
(IPC::FormDataReference::sandboxExtensionsAreSufficient): Deleted.
(IPC::FormDataReference::sandboxExtensionHandles const): Deleted.
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Originally-landed-as: 305413.939@safari-7624-branch (2427c3fef353). rdar://180428726


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0df531738245144d589ac9d6d534223ead66049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172206 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46123 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181652 "") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129760 "") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47412 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45763 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181652 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129760 "") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175164 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47412 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181652 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47412 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45763 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30262 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47412 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184190 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36794 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45763 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184190 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45790 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184190 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46470 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111169 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46470 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44988 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39543 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44388 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44620 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44447 "") | | | 
<!--EWS-Status-Bubble-End-->