### PR TITLE
[WTF] GCC 15 reports -Werror=uninitialized on m_weakCount read after ~T() in RefCountedWithInlineWeakPtr

### DIFF
--- a/Source/WTF/wtf/RefCountedWithInlineWeakPtr.h
+++ b/Source/WTF/wtf/RefCountedWithInlineWeakPtr.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -42,16 +43,24 @@ public:
 
     RefCountDebugger& refCountDebugger() const { return const_cast<RefCountDebugger&>(m_refCountDebugger); }
 
-protected:
-    RefCountedWithInlineWeakPtrBase() = default;
+    RefCountedWithInlineWeakPtrBase(unsigned weakCount)
+        : m_strongCount(0)
+        , m_weakCount(weakCount)
+    {
+        m_refCountDebugger.relaxAdoptionRequirement();
+    }
 
     ~RefCountedWithInlineWeakPtrBase()
     {
-        m_refCountDebugger.willDestroy(m_strongCount);
-        RELEASE_ASSERT(m_strongCount == 1);
-        // Use volatile to prevent compilers from eliminating this code. <https://webkit.org/b/304549>
-        *static_cast<volatile unsigned*>(&m_strongCount) = 0;
+        if (m_strongCount) {
+            m_refCountDebugger.willDestroy(m_strongCount);
+            RELEASE_ASSERT(m_strongCount == 1);
+        } else
+            RELEASE_ASSERT(m_weakCount == 1);
     }
+
+protected:
+    RefCountedWithInlineWeakPtrBase() = default;
 
     // Returns true if the pointer should be destroyed.
     bool derefBase() const
@@ -75,8 +84,11 @@ protected:
             return false;
         }
 
+        m_refCountDebugger.willDelete();
         return true;
     }
+
+    unsigned weakCount() const { return m_weakCount; }
 
 private:
     mutable unsigned m_strongCount { 1 };
@@ -111,12 +123,15 @@ private:
 
 template<typename T> void RefCountedWithInlineWeakPtr<T>::derefSlowCase() const
 {
+    unsigned weakCount = this->weakCount();
     const_cast<T*>(static_cast<const T*>(this))->~T();
+    new (const_cast<void*>(static_cast<const void*>(this))) RefCountedWithInlineWeakPtrBase(weakCount);
     weakDeref();
 }
 
 template<typename T> void RefCountedWithInlineWeakPtr<T>::weakDerefSlowCase() const
 {
+    const_cast<RefCountedWithInlineWeakPtrBase*>(static_cast<const RefCountedWithInlineWeakPtrBase*>(this))->~RefCountedWithInlineWeakPtrBase();
     T::operator delete(const_cast<T*>(static_cast<const T*>(this)));
 }
 


### PR DESCRIPTION
#### a6f7394ea2dac4e8c097139a0151f2e4b5e5053d
<pre>
[WTF] GCC 15 reports -Werror=uninitialized on m_weakCount read after ~T() in RefCountedWithInlineWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=318247">https://bugs.webkit.org/show_bug.cgi?id=318247</a>

Reviewed by NOBODY (OOPS!).

GCC 15 reported:

Source/WTF/wtf/RefCountedWithInlineWeakPtr.h:73:13:
  error: &apos;*(const WTF::RefCountedWithInlineWeakPtrBase*)&lt;unknown&gt;.WTF::RefCountedWithInlineWeakPtrBase::m_weakCount&apos;
  is used uninitialized [-Werror=uninitialized]
   73 |         if (m_weakCount != 1) {
      |             ^~~~~~~~~~~

RefCountedWithInlineWeakPtr&lt;T&gt; class was tricky. It destroyed the whole T
object if the strong ref counter became zero. But, it was still accessed even
though the object was already destroyed.

Construct a new RefCountedWithInlineWeakPtrBase object with the same weak ref
count at the same place after T is destroyed.

* Source/WTF/wtf/RefCountedWithInlineWeakPtr.h:
(WTF::RefCountedWithInlineWeakPtr&lt;T&gt;::derefSlowCase const):
(WTF::RefCountedWithInlineWeakPtr&lt;T&gt;::weakDerefSlowCase const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6f7394ea2dac4e8c097139a0151f2e4b5e5053d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134726 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95131 "1 flakes 22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155775 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115197 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36785 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35129 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31317 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4286 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185255 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34521 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143569 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46859 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143440 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47538 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112635 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38398 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119287 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46044 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10223 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->