### PR TITLE
Cherry-pick(s) 3dad3d258fe6. rdar://180436266

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4268,7 +4268,11 @@ void WebPageProxy::performDragOperation(DragData& dragData, const String& dragSt
         return;
 
     for (auto& fileName : dragData.fileNames())
+<<<<<<< HEAD
         protect(legacyMainFrameProcess())->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(fileName));
+=======
+        protectedLegacyMainFrameProcess()->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(fileName));
+>>>>>>> 3dad3d258fe6 (Validate EncodedFileData filenames in decidePolicyForNavigationAction)
 
 #if PLATFORM(GTK)
     URL url { dragData.asURL() };
@@ -9435,7 +9439,11 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     if (RefPtr body = request.httpBody()) {
         for (auto& element : body->elements()) {
             if (auto* fileData = std::get_if<WebCore::FormDataElement::EncodedFileData>(&element.data))
+<<<<<<< HEAD
                 MESSAGE_CHECK_COMPLETION(process, process->hasGrantedSandboxExtensionForFile(URL::fileURLWithFileSystemPath(fileData->filename)), completionHandler(PolicyDecision { isNavigatingToAppBoundDomain() }));
+=======
+                MESSAGE_CHECK_COMPLETION(process, process->hasGrantedSandboxExtensionForFile(fileData->filename), completionHandler(PolicyDecision { isNavigatingToAppBoundDomain() }));
+>>>>>>> 3dad3d258fe6 (Validate EncodedFileData filenames in decidePolicyForNavigationAction)
         }
     }
 
@@ -12531,7 +12539,11 @@ bool WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding(const Vector<S
             for (size_t i = 0, size = fileURLs.size(); i < size; ++i)
                 sandboxExtensionFiles.append(!transcodedURLs[i].isNull() ? transcodedURLs[i] : fileURLs[i]);
             for (auto& file : sandboxExtensionFiles)
+<<<<<<< HEAD
                 protect(legacyMainFrameProcess())->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(file));
+=======
+                protectedLegacyMainFrameProcess()->addPreviouslyApprovedFileURL(URL::fileURLWithFileSystemPath(file));
+>>>>>>> 3dad3d258fe6 (Validate EncodedFileData filenames in decidePolicyForNavigationAction)
             auto sandboxExtensionHandles = SandboxExtension::createReadOnlyHandlesForFiles("WebPageProxy::didChooseFilesForOpenPanel"_s, sandboxExtensionFiles);
             send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTF::move(sandboxExtensionHandles)));
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1632,11 +1632,34 @@ bool WebProcessProxy::wasPreviouslyApprovedFileURL(const URL& url) const
     return m_previouslyApprovedFilePaths.contains(fileSystemPath);
 }
 
+<<<<<<< HEAD
 bool WebProcessProxy::hasGrantedSandboxExtensionForFile(const URL& url) const
 {
     return m_mayHaveUniversalFileReadSandboxExtension
         || hasAssumedReadAccessToURL(url)
         || wasPreviouslyApprovedFileURL(url);
+=======
+bool WebProcessProxy::hasGrantedSandboxExtensionForFile(const String& filePath) const
+{
+    if (m_mayHaveUniversalFileReadSandboxExtension)
+        return true;
+
+    auto startsWithPath = [&filePath](const String& accessPath) {
+        return filePath.startsWith(accessPath);
+    };
+
+    auto& platformPaths = platformPathsWithAssumedReadAccess();
+    if (std::ranges::find_if(platformPaths, startsWithPath) != platformPaths.end())
+        return true;
+
+    if (std::ranges::find_if(m_localPathsWithAssumedReadAccess, startsWithPath) != m_localPathsWithAssumedReadAccess.end())
+        return true;
+
+    if (m_previouslyApprovedFilePaths.contains(filePath))
+        return true;
+
+    return false;
+>>>>>>> 3dad3d258fe6 (Validate EncodedFileData filenames in decidePolicyForNavigationAction)
 }
 
 void WebProcessProxy::recordUserGestureAuthorizationToken(FrameIdentifier frameID, PageIdentifier pageID, WTF::UUID authorizationToken)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -329,9 +329,13 @@ public:
     void addPreviouslyApprovedFileURL(const URL&);
     void addPreviouslyApprovedFileURLsFromFrameStateTree(const FrameState&);
     bool wasPreviouslyApprovedFileURL(const URL&) const;
+<<<<<<< HEAD
     bool hasGrantedSandboxExtensionForFile(const URL&) const;
 
     bool isAssociatedWithPage(WebPageProxyIdentifier) const;
+=======
+    bool hasGrantedSandboxExtensionForFile(const String& filePath) const;
+>>>>>>> 3dad3d258fe6 (Validate EncodedFileData filenames in decidePolicyForNavigationAction)
 
     void updateTextCheckerState();
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180436266 to main. The following sources [198d4dbb7907] will still need to be cherry-picked once the conflict is resolved.

```
Validate EncodedFileData filenames in decidePolicyForNavigationAction
rdar://174662982

Reviewed by Chris Dumez.

A compromised WebContent process can inject arbitrary file paths in
EncodedFileData within the HTTP body of DecidePolicyForNavigationActionAsync,
causing the UIProcess to mint sandbox extension tokens for those paths during
PSON. Add MESSAGE_CHECK_COMPLETION to validate each EncodedFileData filename
against hasGrantedSandboxExtensionForFile().

Register user-selected file paths via addPreviouslyApprovedFileURL() in
didChooseFilesForOpenPanel (3 variants) and performDragOperation (covers
both macOS and iOS drag-and-drop). Use URL::fileURLWithFileSystemPath()
since these parameters are file system paths, not file URLs.

The API test is a regression test verifying that cross-site form submission
with file upload succeeds after the fix — it does not test the negative
(MESSAGE_CHECK failure) path.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::hasGrantedSandboxExtensionForFile const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
(-[FileUploadPSONUIDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):
((ProcessSwap, SwapOnFormSubmissionWithFileUpload)):

Originally-landed-as: 305413.699@safari-7624-branch (3dad3d258fe6). rdar://180436266


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44a36a88f51c25c5e5ea0ace781e45c3b21f59d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172209 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46126 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181655 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47415 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45766 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181655 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175167 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47415 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181655 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47415 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45766 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30265 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47415 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184193 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36797 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45766 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184193 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45793 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184193 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46473 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111176 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46473 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44991 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39546 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44391 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44623 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44450 "") | | | 
<!--EWS-Status-Bubble-End-->