### PR TITLE
Cherry-pick(s) f7d3c0785bb0. rdar://180428980

### DIFF
--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -72,7 +72,11 @@ static std::optional<PermissionState> determineGeolocationPermissionState(Permis
     if (!window)
         return std::nullopt;
 
+<<<<<<< HEAD
     RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(protect(window->navigator()));
+=======
+    RefPtr geolocation = NavigatorGeolocation::optionalGeolocation(window->protectedNavigator());
+>>>>>>> f7d3c0785bb0 (UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate())
 
     switch (permissionState) {
     case PermissionState::Granted:
@@ -166,11 +170,14 @@ static Expected<PermissionState, Exception> processPermissionQueryResult(std::op
     if (!permissionState)
         return makeUnexpected(Exception { ExceptionCode::NotSupportedError, "Permissions::query does not support this API"_s });
 
+<<<<<<< HEAD
 #if !ENABLE(GEOLOCATION) && !ENABLE(MEDIA_STREAM)
     UNUSED_PARAM(permissionDescriptor);
     UNUSED_PARAM(document);
 #endif
 
+=======
+>>>>>>> f7d3c0785bb0 (UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate())
 #if ENABLE(GEOLOCATION)
     if (permissionDescriptor.name == PermissionName::Geolocation) {
         if (auto geolocationPermissionState = determineGeolocationPermissionState(*permissionState, document))

--- a/Source/WebCore/Modules/permissions/Permissions.h
+++ b/Source/WebCore/Modules/permissions/Permissions.h
@@ -58,7 +58,11 @@ public:
     static Ref<Permissions> create(NavigatorBase&);
     ~Permissions();
 
+<<<<<<< HEAD
     NavigatorBase* NODELETE navigator();
+=======
+    NavigatorBase* navigator();
+>>>>>>> f7d3c0785bb0 (UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate())
     void query(JSC::Strong<JSC::JSObject>, Ref<DeferredPromise>&&);
     WEBCORE_EXPORT static std::optional<PermissionQuerySource> sourceFromContext(const ScriptExecutionContext&);
     WEBCORE_EXPORT static std::optional<PermissionName> toPermissionName(const String&);


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://180428980 to main. The following sources [4aaa3c1477e2] will still need to be cherry-picked once the conflict is resolved.

```
UAF in WebContent due to Cross-thread destruction race of worker DeferredPromise via Permissions::query() + worker.terminate()
https://bugs.webkit.org/show_bug.cgi?id=312459
rdar://174651133

Reviewed by Ryosuke Niwa.

When Permissions::query() is called in a worker, we would dispatch a lambda
to the main thread, get the information and then try to go back to the
worker thread using ScriptExecutionContext::postTaskTo() in order to
call the promise with the result. However, in case of worker termination,
ScriptExecutionContext::postTaskTo() would fail and the lambda would get
destroyed on the main thread, without getting called. This would lead to
a security bug because the lambda was capturing the promise object which
is a worker object and thus should not get destroyed on the main thread.

To address the issue, we now store the promise in a HashMap on the
Permissions object. We then capture a promise identifier in the lambda
instead of the promise. In the ~Permissions() destructor, if there are
pending promises, we reject them.

I made the following changes also:
1. I used `Ref<DeferredPromise>` type for the promise instead of
   `DOMPromiseDeferred<IDLInterface<PermissionStatus>>` so that I could
   store the promise in a HashMap.
2. There was a LOT of code duplication in Permissions::query() for the
   main thread code path and the worker code path. I merged them so we
   now have a single code path for both. This simplifies things a lot.

Test: workers/permissions-query-crash.html

* LayoutTests/workers/permissions-query-crash-expected.txt: Added.
* LayoutTests/workers/permissions-query-crash.html: Added.
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::determineGeolocationPermissionState):
(WebCore::Permissions::~Permissions):
(WebCore::processPermissionQueryResult):
(WebCore::Permissions::query):
* Source/WebCore/Modules/permissions/Permissions.h:

Originally-landed-as: 305413.686@safari-7624-branch (f7d3c0785bb0). rdar://180428980


```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a323d28a90eb39dd1a3975832019fa14ab06e2dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172210 "") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46127 "") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181656 "") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174075 "") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47416 "") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45767 "") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/181656 "") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175168 "") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47416 "") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/181656 "") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47416 "") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/45767 "") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30266 "") | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47416 "") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184194 "") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36798 "") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/45767 "") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/184194 "") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45794 "") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/184194 "") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46474 "") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111177 "") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46474 "") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44992 "") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/39547 "") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44392 "") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44624 "") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44451 "") | | | 
<!--EWS-Status-Bubble-End-->