### PR TITLE
Cherry-pick 99867d817a6d. https://bugs.webkit.org/show_bug.cgi?id=313961

### DIFF
--- a/JSTests/stress/megamorphic-get-by-id-overrides-getter-exception-check.js
+++ b/JSTests/stress/megamorphic-get-by-id-overrides-getter-exception-check.js
@@ -1,0 +1,16 @@
+function megamorphicGetById(proto) {
+    var obj = {};
+    Object.defineProperty(obj, 'x', {
+        get() { this.__proto__ = proto; }
+    });
+    obj.x;
+    try { obj.byteLength; } catch { }
+}
+
+// Warm up to go megamorphic.
+for (var i = 0; i < testLoopCount; i++)
+    megamorphicGetById({});
+
+// Trigger the overridesGetOwnPropertySlot path: Float32Array.prototype
+// has a byteLength getter, so slot.getValue will call callGetter.
+megamorphicGetById(new Float32Array(16));

--- a/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto-expected.txt
+++ b/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto-expected.txt
@@ -1,0 +1,3 @@
+
+PASS applyConstraints while takePhoto is happening on a cloned track
+

--- a/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto.html
+++ b/LayoutTests/fast/mediastream/applyConstraints-with-takePhoto.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script>
+promise_test(async t => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 320 } });
+    const originalTrack = stream.getVideoTracks()[0];
+    const clonedTrack = originalTrack.clone();
+    const imageCapture = new ImageCapture(originalTrack);
+
+    for (let round = 0; round < 5; round++) {
+        const promises = [];
+        for (let i = 0; i < 10; i++) {
+            promises.push(imageCapture.takePhoto({imageWidth:1280, imageHeight:720}).catch(()=>{}));
+            promises.push(clonedTrack.applyConstraints({
+                width:{ideal:320+(i*100)}, height:{ideal:240+(i*75)}, frameRate:{ideal:15+i}
+            }).catch(()=>{}));
+        }
+        await Promise.allSettled(promises);
+    }
+
+    originalTrack.stop();
+    clonedTrack.stop();
+}, "applyConstraints while takePhoto is happening on a cloned track");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/ipc/create-audio-source-provider-twice-expected.txt
+++ b/LayoutTests/ipc/create-audio-source-provider-twice-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/create-audio-source-provider-twice.html
+++ b/LayoutTests/ipc/create-audio-source-provider-twice.html
@@ -1,0 +1,48 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done() { window.testRunner?.notifyDone(); }
+
+async function run() {
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+
+    let playerId = null;
+    const playerIdPromise = new Promise(resolve => {
+        const tap = new IPCWireTap('GPU', 'Outgoing');
+        tap.tapNext(CoreIPC.messages['RemoteMediaPlayerManagerProxy_CreateMediaPlayer'].name,
+            (proc, connId, msgName, typed, parsed) => {
+                playerId = parsed.identifier;
+                resolve();
+            });
+    });
+
+    const video = document.createElement('video');
+    video.src = '../media/content/test.mp4';
+    document.body.appendChild(video);
+    const metadataPromise = new Promise(resolve =>
+        video.addEventListener('loadedmetadata', resolve, { once: true }));
+
+    const timeout = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), 10000));
+
+    await Promise.race([Promise.all([playerIdPromise, metadataPromise]), timeout]);
+
+    for (let i = 0; i < 5; i++) {
+        CoreIPC.GPU.RemoteMediaPlayerProxy.SetShouldEnableAudioSourceProvider(playerId, { shouldEnable: true });
+        CoreIPC.GPU.RemoteMediaPlayerProxy.CreateAudioSourceProvider(playerId, {});
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+
+    done();
+}
+
+if (!window.IPC)
+    done();
+else
+    run().catch(done);
+</script>

--- a/LayoutTests/webanimations/accelerated-animation-suspension-crash-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-suspension-crash-expected.txt
@@ -1,0 +1,2 @@
+PASS if this does not crash.
+

--- a/LayoutTests/webanimations/accelerated-animation-suspension-crash.html
+++ b/LayoutTests/webanimations/accelerated-animation-suspension-crash.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<style>
+
+#target {
+    width:100px;
+    height:100px;
+    background:red;
+}
+
+.scroller {
+    overflow:scroll;
+    width:50px;
+    height:50px;
+}
+
+.scroller > div {
+    height:400px;
+}
+
+</style>
+
+<div id="target">PASS if this does not crash.</div>
+
+<script>
+
+(async function() {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    // (A) Seed m_timelines with extra entries so DocumentTimeline is not the last-iterated bucket.
+    let extraTimelines = [];
+    for (let i = 0; i < 32; i++) {
+      const source = document.createElement('div');
+      source.className='scroller';
+      source.appendChild(document.createElement('div'));
+      document.body.appendChild(source);
+      extraTimelines.push(new ScrollTimeline({ source }));   // each calls addTimeline()
+    }
+
+    // (B) Elements whose scroll-timeline-name will be dirtied later.
+    let pending = [];
+    for (let i = 0; i < 200; i++) {
+        const scroller = document.createElement('div');
+        scroller.className = 'scroller';
+        scroller.appendChild(document.createElement('div'));
+        document.body.appendChild(scroller);
+        pending.push(scroller);
+    }
+
+    // (C) Accelerated, width-dependent transform animation (translateX(%)).
+    let animation = target.animate(
+        { transform: 'translateX(50%)' },
+        1e6
+    );
+
+    // Wait two frames so the animation ticks, gets AcceleratedAction::Play, and runs accelerated.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    // (D) Re-arm m_needsForcedLayout.
+    animation.effect.setKeyframes({ transform: 'translateX(100%)' });
+    getComputedStyle(target).transform;      // flush style only
+    target.offsetWidth;                      // ensure renderer/layout up-to-date
+
+    // (E) Dirty style with new scroll-timeline-name on many elements WITHOUT flushing.
+    for (let i = 0; i < pending.length; i++)
+        pending[i].style.scrollTimelineName = '--st' + i;
+
+    // (F) Trigger AnimationTimelinesController::suspendAnimations() — the live m_timelines
+    //     iteration will reach DocumentTimeline, force layout via applyPendingAcceleratedAnimations(),
+    //     which calls addTimeline() for each dirtied element, rehashing the backing buffer mid-iteration.
+    window.internals?.suspendAnimations();
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt
+++ b/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html
+++ b/LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.internals)
+    internals.settings.setWebXREnabled(true);
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function forceGC()
+{
+    if (window.GCController)
+        GCController.collect();
+}
+
+async function run()
+{
+    let iframe = document.createElement('iframe');
+    iframe.srcdoc = '<!DOCTYPE html><body>child</body>';
+    document.body.appendChild(iframe);
+    await new Promise(resolve => { iframe.onload = resolve; });
+
+    let childXR = iframe.contentWindow.navigator.xr;
+
+    // Call the parent realm's requestSession on the child's XRSystem so that
+    // the resulting XRSession's wrapper lives in the parent realm while the
+    // owning WebXRSystem belongs to the child realm.
+    let session;
+    try {
+        session = await XRSystem.prototype.requestSession.call(childXR, 'inline');
+    } catch (e) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    childXR = null;
+    iframe.remove();
+    iframe = null;
+
+    // Allow the child realm's JSDOMWindow / Navigator / WebXRSystem to be
+    // collected, leaving the session with a stale back-reference.
+    for (let i = 0; i < 3; ++i) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        forceGC();
+    }
+
+    try {
+        await session.end();
+    } catch (e) {
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+run();
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -401,13 +401,15 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdDirectOptimize, EncodedJSValue, (Encode
 
 static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM& vm, CallFrame* callFrame, StructureStubInfo* stubInfo, JSValue baseValue, JSValue thisValue, CacheableIdentifier identifier, GetByKind kind)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     auto* uid = identifier.uid();
     PropertySlot slot(thisValue, PropertySlot::InternalMethodType::Get);
 
     if (!baseValue.isObject()) [[unlikely]] {
         if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
             repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
-        return baseValue.get(globalObject, uid, slot);
+        RELEASE_AND_RETURN(scope, baseValue.get(globalObject, uid, slot));
     }
 
     JSObject* baseObject = asObject(baseValue);
@@ -418,8 +420,10 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
         if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) [[unlikely]] {
             if (stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
                 repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
-            if (object->getNonIndexPropertySlot(globalObject, uid, slot))
-                return slot.getValue(globalObject, uid);
+            bool hasProperty = object->getNonIndexPropertySlot(globalObject, uid, slot);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (hasProperty)
+                RELEASE_AND_RETURN(scope, slot.getValue(globalObject, uid));
             return jsUndefined();
         }
 
@@ -444,7 +448,7 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
                 if (shouldGiveUp && stubInfo && stubInfo->considerRepatchingCacheMegamorphic(vm))
                     repatchGetBySlowPathCall(callFrame->codeBlock(), *stubInfo, kind);
             }
-            return slot.getValue(globalObject, uid);
+            RELEASE_AND_RETURN(scope, slot.getValue(globalObject, uid));
         }
 
         if (!structure->propertyAccessesAreCacheableForAbsence()) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -178,7 +178,7 @@ private:
     BlockType m_blockType;
     CatchKind m_catchKind;
 
-    int32_t m_pendingOffset { -1 };
+    std::optional<uint32_t> m_pendingOffset;
 
     uint32_t m_index { 0 };
     uint32_t m_pc { 0 }; // where am i?
@@ -594,7 +594,7 @@ public:
         auto& target = m_controlStructuresAwaitingCoalescing[index];
         if (target.isLoop) {
             ASSERT(target.m_entryResolved);
-            IPInt::BlockMetadata md = { static_cast<int32_t>(target.m_entryTarget.pc - loc.pc), static_cast<int32_t>(target.m_entryTarget.mc - loc.mc) };
+            IPInt::BlockMetadata md = checkedDelta(target.m_entryTarget, loc);
             WRITE_TO_METADATA(metadata + loc.mc, md, IPInt::BlockMetadata);
             RECORD_NEXT_INSTRUCTION(loc.pc, target.m_entryTarget.pc);
         } else {
@@ -655,9 +655,21 @@ private:
     // all jumps that go to the top level and return
     Vector<IPIntLocation> m_jumpLocationsAwaitingEnd;
 
-    inline uint32_t curPC() { return m_parser->currentOpcodeStartingOffset() - m_metadata->m_bytecodeOffset; }
-    inline uint32_t nextPC() { return m_parser->offset() - m_metadata->m_bytecodeOffset; }
-    inline uint32_t curMC() { return m_metadata->m_metadata.size(); }
+    inline uint32_t curPC() { return Checked<uint32_t>(m_parser->currentOpcodeStartingOffset()) - m_metadata->m_bytecodeOffset; }
+    inline uint32_t nextPC() { return Checked<uint32_t>(m_parser->offset()) - m_metadata->m_bytecodeOffset; }
+    // FIXME: Should return size_t, but BlockMetadata::deltaMC is int32_t and the interpreter loads it with loadpairi.
+    inline uint32_t curMC()
+    {
+        Checked<uint32_t> size = m_metadata->m_metadata.size();
+        return size;
+    }
+
+    static ALWAYS_INLINE IPInt::BlockMetadata checkedDelta(IPIntLocation to, IPIntLocation from)
+    {
+        Checked<int32_t> dPC = static_cast<int64_t>(to.pc) - static_cast<int64_t>(from.pc);
+        Checked<int32_t> dMC = static_cast<int64_t>(to.mc) - static_cast<int64_t>(from.mc);
+        return { dPC, dMC };
+    }
 
     CallInformation m_cachedCallInformation { };
     const FunctionSignature* m_cachedSignature { nullptr };
@@ -2154,7 +2166,7 @@ void IPIntGenerator::coalesceControlFlow(bool force)
         m_controlStructuresAwaitingCoalescing.shrink(0);
 
     for (auto& src : m_exitHandlersAwaitingCoalescing) {
-        IPInt::BlockMetadata md = { static_cast<int32_t>(here.pc - src.pc), static_cast<int32_t>(here.mc - src.mc) };
+        IPInt::BlockMetadata md = checkedDelta(here, src);
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
         RECORD_NEXT_INSTRUCTION(src.pc, here.pc);
     }
@@ -2167,13 +2179,13 @@ void IPIntGenerator::resolveEntryTarget(unsigned index, IPIntLocation loc)
     ASSERT(!control.m_entryResolved);
     for (auto& src : control.m_awaitingEntryTarget) {
         // write delta PC and delta MC
-        IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+        IPInt::BlockMetadata md = checkedDelta(loc, src);
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
         RECORD_NEXT_INSTRUCTION(src.pc, loc.pc); // FIXME: coalescing sequential blocks - should update instead of adding
     }
     if (control.isLoop) {
         for (auto& src : control.m_awaitingBranchTarget) {
-            IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+            IPInt::BlockMetadata md = checkedDelta(loc, src);
             WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
             RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
         }
@@ -2190,13 +2202,13 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     ASSERT(!control.m_exitResolved);
     for (auto& src : control.m_awaitingExitTarget) {
         // write delta PC and delta MC
-        IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+        IPInt::BlockMetadata md = checkedDelta(loc, src);
         WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
         RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
     }
     if (!control.isLoop) {
         for (auto& src : control.m_awaitingBranchTarget) {
-            IPInt::BlockMetadata md = { static_cast<int32_t>(loc.pc - src.pc), static_cast<int32_t>(loc.mc - src.mc) };
+            IPInt::BlockMetadata md = checkedDelta(loc, src);
             WRITE_TO_METADATA(m_metadata->m_metadata.mutableSpan().data() + src.mc, md, IPInt::BlockMetadata);
             RECORD_NEXT_INSTRUCTION(src.pc, loc.pc);
         }
@@ -2252,7 +2264,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     splitStack(signature, oldStack, newStack);
     block = ControlType(WTF::move(signature), m_stackSize.value() - newStack.size(), BlockType::Loop);
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
-    block.m_pendingOffset = -1; // no need to update!
+    block.m_pendingOffset = std::nullopt; // no need to update!
     block.m_pc = curPC();
     RECORD_NEXT_INSTRUCTION(block.m_pc, nextPC());
 
@@ -2286,7 +2298,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     block.m_index = m_controlStructuresAwaitingCoalescing.size();
     block.m_pc = curPC();
     block.m_mc = curMC();
-    block.m_pendingOffset = m_metadata->m_metadata.size();
+    block.m_pendingOffset = curMC();
     RECORD_NEXT_INSTRUCTION(block.m_pc, nextPC());
 
     m_coalesceQueue.append(QueuedCoalesceRequest { m_controlStructuresAwaitingCoalescing.size(), true });
@@ -2317,7 +2329,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
     changeStackSize(blockSignature.argumentCount());
     auto ifIndex = block.m_index;
 
-    auto mdIf = reinterpret_cast<IPInt::IfMetadata*>(m_metadata->m_metadata.mutableSpan().data() + block.m_pendingOffset);
+    auto mdIf = reinterpret_cast<IPInt::IfMetadata*>(m_metadata->m_metadata.mutableSpan().data() + *block.m_pendingOffset);
 
     // delta PC
     mdIf->elseDeltaPC = nextPC() - block.m_pc;
@@ -2329,7 +2341,7 @@ void IPIntGenerator::resolveExitTarget(unsigned index, IPIntLocation loc)
         mdIf->elseDeltaMC = curMC() - block.m_mc;
         block = ControlType(WTF::move(blockSignature), block.stackSize(), BlockType::Else);
         block.m_index = ifIndex;
-        block.m_pendingOffset = -1;
+        block.m_pendingOffset = std::nullopt;
         return { };
     }
 
@@ -2473,8 +2485,8 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         HandlerType::Catch,
         static_cast<uint32_t>(block.m_pc),
         static_cast<uint32_t>(block.m_pcEnd + 1), // + 1 since m_pcEnd is the PC of the catch bytecode, which should be included in the range
-        static_cast<uint32_t>(m_parser->offset() - m_metadata->m_bytecodeOffset),
-        static_cast<uint32_t>(m_metadata->m_metadata.size()),
+        nextPC(),
+        curMC(),
         m_tryDepth,
         exceptionIndex
     });
@@ -2512,8 +2524,8 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         HandlerType::CatchAll,
         static_cast<uint32_t>(block.m_pc),
         static_cast<uint32_t>(block.m_pcEnd + 1), // + 1 since m_pcEnd is the PC of the catch bytecode, which should be included in the range
-        static_cast<uint32_t>(m_parser->offset() - m_metadata->m_bytecodeOffset),
-        static_cast<uint32_t>(m_metadata->m_metadata.size()),
+        nextPC(),
+        curMC(),
         m_tryDepth,
         0
     });
@@ -2550,8 +2562,8 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         HandlerType::Delegate,
         static_cast<uint32_t>(data.m_pc),
         static_cast<uint32_t>(data.m_pcEnd + 1), // + 1 since m_pcEnd is the PC of the delegate bytecode, which should be included in the range
-        static_cast<uint32_t>(curPC()),
-        static_cast<uint32_t>(curMC()),
+        curPC(),
+        curMC(),
         m_tryDepth,
         targetDepth
     });
@@ -2776,7 +2788,7 @@ void IPIntGenerator::endTryTable(const ControlType& data)
         m_exitHandlersAwaitingCoalescing.append({ block.m_pc, block.m_mc });
     } else if (ControlType::isElse(block)) {
         // if it's not an if ... end, coalesce
-        if (block.m_pendingOffset != -1)
+        if (block.m_pendingOffset)
             m_exitHandlersAwaitingCoalescing.append({ block.m_pc, block.m_mc });
         m_coalesceQueue.append({ static_cast<unsigned>(block.m_index), false });
         --m_coalesceDebt;

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -398,7 +398,9 @@ void WebXRSession::shutdown(InitiatedBySystem initiatedBySystem)
 
     // 3. If the active immersive session is equal to session, set the active immersive session to null.
     // 4. Remove session from the list of inline sessions.
-    m_xrSystem.sessionEnded(*this);
+    RefPtr xrSystem = m_xrSystem.get();
+    if (xrSystem)
+        xrSystem->sessionEnded(*this);
 
     m_inputSources->clear();
 

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -168,7 +168,7 @@ private:
     bool m_shouldServiceRequestVideoFrameCallbacks { false };
     std::unique_ptr<EndPromise> m_endPromise;
 
-    WebXRSystem& m_xrSystem;
+    WeakPtr<WebXRSystem, WeakPtrImplWithEventTargetData> m_xrSystem;
     XRSessionMode m_mode;
     ThreadSafeWeakPtr<PlatformXR::Device> m_device;
     FeatureList m_requestedFeatures;

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -289,7 +289,7 @@ void AnimationTimelinesController::suspendAnimations()
 
     m_cachedCurrentTimeClearanceTimer.stop();
 
-    for (Ref timeline : m_timelines)
+    for (auto& timeline : copyToVectorOf<Ref<AnimationTimeline>>(m_timelines))
         timeline->suspendAnimations();
 
     m_isSuspended = true;

--- a/Source/WebCore/platform/graphics/MIMETypeCache.cpp
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.cpp
@@ -33,13 +33,20 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MIMETypeCache);
 
-HashSet<String>& MIMETypeCache::supportedTypes()
+void MIMETypeCache::ensureSupportedTypes()
 {
+    Locker locker { m_supportedTypesLock };
     if (!m_supportedTypes) {
         m_supportedTypes = HashSet<String> { };
         initializeCache(*m_supportedTypes);
     }
+}
 
+HashSet<String> MIMETypeCache::supportedTypes()
+{
+    ensureSupportedTypes();
+
+    Locker locker { m_supportedTypesLock };
     return *m_supportedTypes;
 }
 
@@ -51,7 +58,13 @@ bool MIMETypeCache::supportsContainerType(const String& containerType)
     if (isUnsupportedContainerType(containerType))
         return false;
 
-    return isStaticContainerType(containerType) || supportedTypes().contains(containerType);
+    if (isStaticContainerType(containerType))
+        return true;
+
+    ensureSupportedTypes();
+
+    Locker locker { m_supportedTypesLock };
+    return m_supportedTypes->contains(containerType);
 }
 
 MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeType)
@@ -59,11 +72,8 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
     if (mimeType.isEmpty())
         return MediaPlayerEnums::SupportsType::IsNotSupported;
 
-    if (m_cachedResults) {
-        auto it = m_cachedResults->find(mimeType);
-        if (it != m_cachedResults->end())
-            return it->value;
-    }
+    if (auto supports = getCachedResult(mimeType))
+        return *supports;
 
     auto result = MediaPlayerEnums::SupportsType::IsNotSupported;
     do {
@@ -90,20 +100,34 @@ MediaPlayerEnums::SupportsType MIMETypeCache::canDecodeType(const String& mimeTy
 
     } while (0);
 
-    if (!m_cachedResults)
-        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType>();
-    m_cachedResults->add(mimeType, result);
+    addCachedResult(mimeType, result);
 
     return result;
 }
 
 void MIMETypeCache::addSupportedTypes(const Vector<String>& newTypes)
 {
-    if (!m_supportedTypes)
-        m_supportedTypes = HashSet<String> { };
+    ensureSupportedTypes();
 
+    Locker locker { m_supportedTypesLock };
     for (auto& type : newTypes)
         m_supportedTypes->add(type);
+}
+
+std::optional<MediaPlayerEnums::SupportsType> MIMETypeCache::getCachedResult(const String& mimeType) const
+{
+    Locker locker { m_cachedResultsLock };
+    if (m_cachedResults)
+        return m_cachedResults->getOptional(mimeType);
+    return std::nullopt;
+}
+
+void MIMETypeCache::addCachedResult(const String& mimeType, MediaPlayerEnums::SupportsType result)
+{
+    Locker locker { m_cachedResultsLock };
+    if (!m_cachedResults)
+        m_cachedResults = HashMap<String, MediaPlayerEnums::SupportsType>();
+    m_cachedResults->add(mimeType, result);
 }
 
 bool MIMETypeCache::isStaticContainerType(StringView)
@@ -123,6 +147,7 @@ bool MIMETypeCache::isAvailable() const
 
 bool MIMETypeCache::isEmpty() const
 {
+    Locker locker { m_supportedTypesLock };
     return m_supportedTypes && m_supportedTypes->isEmpty();
 }
 

--- a/Source/WebCore/platform/graphics/MIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/MIMETypeCache.h
@@ -44,7 +44,7 @@ public:
 
     virtual bool isAvailable() const;
     virtual MediaPlayerEnums::SupportsType canDecodeType(const String&);
-    virtual HashSet<String>& supportedTypes();
+    virtual HashSet<String> supportedTypes();
 
     bool isEmpty() const;
     bool supportsContainerType(const String&);
@@ -53,6 +53,10 @@ protected:
     void addSupportedTypes(const Vector<String>&);
 
 private:
+    void ensureSupportedTypes();
+    std::optional<MediaPlayerEnums::SupportsType> getCachedResult(const String&) const;
+    void addCachedResult(const String&, MediaPlayerEnums::SupportsType);
+
     virtual bool isStaticContainerType(StringView);
     virtual bool isUnsupportedContainerType(const String&);
     virtual void initializeCache(HashSet<String>&);
@@ -60,8 +64,11 @@ private:
 
     bool shouldOverrideExtendedType(const ContentType&);
 
-    std::optional<HashSet<String>> m_supportedTypes;
-    std::optional<HashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults;
+    mutable Lock m_supportedTypesLock;
+    std::optional<HashSet<String>> m_supportedTypes WTF_GUARDED_BY_LOCK(m_supportedTypesLock);
+
+    mutable Lock m_cachedResultsLock;
+    std::optional<HashMap<String, MediaPlayerEnums::SupportsType>> m_cachedResults WTF_GUARDED_BY_LOCK(m_cachedResultsLock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h
@@ -42,7 +42,7 @@ public:
 
     bool isAvailable() const final;
     MediaPlayerEnums::SupportsType canDecodeType(const String&) final;
-    HashSet<String>& supportedTypes() final;
+    HashSet<String> supportedTypes() final;
 
 private:
     friend NeverDestroyed<AVStreamDataParserMIMETypeCache>;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm
@@ -74,7 +74,7 @@ MediaPlayerEnums::SupportsType AVStreamDataParserMIMETypeCache::canDecodeType(co
     return MediaPlayerEnums::SupportsType::IsNotSupported;
 }
 
-HashSet<String>& AVStreamDataParserMIMETypeCache::supportedTypes()
+HashSet<String> AVStreamDataParserMIMETypeCache::supportedTypes()
 {
     if (isAvailable())
         return MIMETypeCache::supportedTypes();
@@ -98,10 +98,14 @@ bool AVStreamDataParserMIMETypeCache::canDecodeExtendedType(const ContentType& t
     //  so just replace the container type with a valid one from AVAssetMIMETypeCache and ask that cache if it
     //  can decode this type.
     auto& assetCache = AVAssetMIMETypeCache::singleton();
-    if (!assetCache.isAvailable() || assetCache.supportedTypes().isEmpty())
+    if (!assetCache.isAvailable())
         return false;
 
-    String replacementType = makeStringByReplacingAll(type.raw(), type.containerType(), *assetCache.supportedTypes().begin());
+    auto supportedTypes = assetCache.supportedTypes();
+    if (supportedTypes.isEmpty())
+        return false;
+
+    String replacementType = makeStringByReplacingAll(type.raw(), type.containerType(), *supportedTypes.begin());
     return assetCache.canDecodeType(replacementType) == MediaPlayerEnums::SupportsType::IsSupported;
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -79,6 +79,8 @@
 
 #include <wtf/NativePromise.h>
 
+#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_webProcessConnection.get(), message)
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -1236,6 +1238,8 @@ void RemoteMediaPlayerProxy::setPlatformDynamicRangeLimit(PlatformDynamicRangeLi
 void RemoteMediaPlayerProxy::createAudioSourceProvider()
 {
 #if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
+    MESSAGE_CHECK(!m_remoteAudioSourceProvider, "RemoteAudioSourceProvider already created.");
+
     RefPtr player = m_player;
     if (!player)
         return;
@@ -1381,5 +1385,7 @@ void RemoteMediaPlayerProxy::sendInternalMessage(const WebCore::MessageForTestin
 }
 
 } // namespace WebKit
+
+#undef MESSAGE_CHECK
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -231,7 +231,7 @@ public:
             bool isObservingMedia = protectedThis->isObservingMedia();
             protectedThis->unobserveMedia();
 
-            source->applyConstraints(WTF::move(constraints), [weakThis = WTF::move(weakThis), &constraints, isObservingMedia, callback = WTF::move(callback)](auto&& error) mutable {
+            source->applyConstraints(constraints, [weakThis = WTF::move(weakThis), constraints, isObservingMedia, callback = WTF::move(callback)](auto&& error) mutable {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis) {
                     callback(RealtimeMediaSource::ApplyConstraintsError { { }, { } });

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -728,7 +728,7 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
         return;
 
     if (RefPtr webPageProxy = m_page.get()) {
-        ASSERT(webPageProxy->identifier() == item->pageID() && frameState->itemID == item->identifier());
+        MESSAGE_CHECK(process, webPageProxy->identifier() == item->pageID() && frameState->itemID == item->identifier());
 
         if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
             if (frameState->hasCachedPage)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -35,9 +35,14 @@
 #import <WebKit/WKBackForwardListPrivate.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKFrameTreeNode.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKSessionState.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/darwin/DispatchExtras.h>
@@ -929,3 +934,116 @@ TEST(WKBackForwardList, GoBackToPageAfterNavigatingIframeAndRestoringSession)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "b");
     EXPECT_WK_STREQ([webView URL].absoluteString, server.request("/example"_s).URL.absoluteString.UTF8String);
 }
+
+#if ENABLE(IPC_TESTING_API)
+
+static void enableIPCTestingAPI(WKWebViewConfiguration *configuration)
+{
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+}
+
+TEST(WKBackForwardList, BackForwardUpdateItemRejectsFileURL)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/page"_s, { "<!DOCTYPE html><html><body>page</body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto poolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [poolConfig setProcessSwapsOnNavigation:YES];
+    auto pool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfig.get()]);
+
+    auto configA = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configA setProcessPool:pool.get()];
+    enableIPCTestingAPI(configA.get());
+
+    auto webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configA.get()]);
+    [webViewA synchronouslyLoadRequest:server.request("/page"_s)];
+
+    // B shares A's process via _relatedWebView.
+    auto configB = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configB setProcessPool:pool.get()];
+    configB.get()._relatedWebView = webViewA.get();
+    enableIPCTestingAPI(configB.get());
+
+    auto webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configB.get()]);
+    [webViewB synchronouslyLoadRequest:server.request("/page"_s)];
+
+    EXPECT_EQ([webViewA _webProcessIdentifier], [webViewB _webProcessIdentifier]);
+
+    long long bPageID = [[webViewB stringByEvaluatingJavaScript:@"String(IPC.pageID)"] longLongValue];
+    EXPECT_GT(bPageID, 0LL);
+
+    // Using pushState on A, capture an `AddItem` IPC message for later use.
+    [webViewA stringByEvaluatingJavaScript:
+        @"(function() {"
+        "    var addName = null, updateName = null;"
+        "    var keys = Object.keys(IPC.messages);"
+        "    for (var i = 0; i < keys.length; i++) {"
+        "        if (keys[i].indexOf('BackForwardAddItem') !== -1 && keys[i].indexOf('InProcess') === -1)"
+        "            addName = IPC.messages[keys[i]].name;"
+        "        if (keys[i].indexOf('BackForwardUpdateItem') !== -1)"
+        "            updateName = IPC.messages[keys[i]].name;"
+        "    }"
+        "    window._updateItemMsgName = updateName;"
+        "    window._addBuf = null;"
+        "    IPC.addOutgoingMessageListener('UI', function(msg) {"
+        "        if (msg.name === addName && msg.buffer)"
+        "            window._addBuf = new Uint8Array(msg.buffer.slice(0));"
+        "    });"
+        "    history.pushState({}, '', '?pad=' + 'X'.repeat(40));"
+        "})()"
+    ];
+    int attempts = 0;
+    while (![[webViewA stringByEvaluatingJavaScript:@"window._addBuf ? 'ok' : ''"] isEqualToString:@"ok"] && ++attempts < 50)
+        TestWebKitAPI::Util::spinRunLoop(5);
+    EXPECT_LT(attempts, 50);
+
+    // Modify the captured buffer to carry a file:// URL, then send it as
+    // BackForwardUpdateItem to page B's destination ID. B's handler
+    // resolves A's item via the global itemForID map — the ownership
+    // check (item->pageID() vs B's identifier) must reject it.
+    NSString *attackJS = [NSString stringWithFormat:
+        @"(function() {"
+        "var HDR = 0x10;"
+        "var args = new Uint8Array(window._addBuf.buffer.slice(HDR));"
+        "var origURL = location.href;"
+        "var targetBase = 'file:///etc/passwd';"
+        "var padTarget = targetBase + '/'.repeat(Math.max(0, origURL.length - targetBase.length));"
+        "if (padTarget.length !== origURL.length) return 'FAIL:len_mismatch';"
+        "var oldBytes = new TextEncoder().encode(origURL);"
+        "var newBytes = new TextEncoder().encode(padTarget);"
+        "var count = 0;"
+        "for (var i = 0; i <= args.length - oldBytes.length; i++) {"
+        "    var match = true;"
+        "    for (var j = 0; j < oldBytes.length; j++) {"
+        "        if (args[i+j] !== oldBytes[j]) { match = false; break; }"
+        "    }"
+        "    if (match) {"
+        "        args.set(newBytes, i);"
+        "        count++;"
+        "        i += oldBytes.length - 1;"
+        "    }"
+        "}"
+        "if (!count) return 'FAIL:no_url_found';"
+        "IPC.sendMessage('UI', %lld, window._updateItemMsgName, args);"
+        "return 'sent:' + count;"
+        "})()", bPageID
+    ];
+    NSString *attackResult = [webViewA stringByEvaluatingJavaScript:attackJS];
+    EXPECT_TRUE([attackResult hasPrefix:@"sent:"]);
+
+    for (int i = 0; i < 100; i++)
+        TestWebKitAPI::Util::spinRunLoop();
+
+    WKBackForwardList *list = [webViewA backForwardList];
+    EXPECT_FALSE([list.currentItem.URL.absoluteString hasPrefix:@"file://"]);
+    for (WKBackForwardListItem *item in list.backList)
+        EXPECT_FALSE([item.URL.absoluteString hasPrefix:@"file://"]);
+}
+
+#endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### c3abddf6a1e00ff47696d34682811506326cbc9d
<pre>
Cherry-pick 99867d817a6d. <a href="https://bugs.webkit.org/show_bug.cgi?id=313961">https://bugs.webkit.org/show_bug.cgi?id=313961</a>

[WebXR] Use-after-free when ending an XRSession whose owning WebXRSystem has been garbage collected
<a href="https://rdar.apple.com/175674872">rdar://175674872</a>

Reviewed by REVIEWER.

WebXRSession held a raw reference (WebXRSystem&amp;) to its owning WebXRSystem.
When a session&apos;s wrapper lives in one realm but the XRSystem belongs to a
cross-realm iframe (e.g. via XRSystem.prototype.requestSession.call(childXR, ...)),
destroying the iframe can collect the child realm&apos;s JSDOMWindow / Navigator /
WebXRSystem while the parent-realm XRSession is still alive. Calling
session.end() then dereferences the stale pointer in shutdown() when it calls
m_xrSystem.sessionEnded(*this).

Fix by changing m_xrSystem from a raw reference to a
WeakPtr&lt;WebXRSystem, WeakPtrImplWithEventTargetData&gt; and guarding the
sessionEnded() call with a null check.

Test: webxr/xr-session-end-after-cross-realm-system-gc.html

* Source/WebCore/Modules/webxr/WebXRSession.h: Change m_xrSystem to WeakPtr.
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::shutdown): Guard sessionEnded call with a WeakPtr null check.
* LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc.html: Added.
* LayoutTests/webxr/xr-session-end-after-cross-realm-system-gc-expected.txt: Added.

Identifier: 305413.844@safari-7624-branch

Identifier: 305413.768@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.873@webkitglib/2.52">https://commits.webkit.org/305877.873@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 55aa91bcc82096e6bdeacc1bbd8bff336b62f844
<pre>
Cherry-pick f0d08798b749. <a href="https://bugs.webkit.org/show_bug.cgi?id=313961">https://bugs.webkit.org/show_bug.cgi?id=313961</a>

[web-animations] use-after-free in AnimationTimelinesController::suspendAnimations: m_timelines rehashes during iteration when DocumentTimeline::suspendAnimations forces layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=313961">https://bugs.webkit.org/show_bug.cgi?id=313961</a>
<a href="https://rdar.apple.com/175759878">rdar://175759878</a>

Reviewed by Simon Fraser.

Calling `AnimationTimelinesController::suspendAnimations()` ends up calling
`DocumentTimeline::applyPendingAcceleratedAnimations()` which may trigger
a style recalculation for the targets of accelerated animations.

Such style recalculations may update the animation-to-timeline relationships
due to the `scroll-timeline` and `view-timeline` set of properties. This, in
turn, will cause `AnimationTimelinesController::suspendAnimations()` to have
the list of timelines it iterates over mutate. As such we now make a copy of
that list prior to iteration.

The new test was generated with AI assistance and adapted.

Test: webanimations/accelerated-animation-suspension-crash.html

* LayoutTests/webanimations/accelerated-animation-suspension-crash-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-suspension-crash.html: Added.
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::suspendAnimations):

Identifier: 305413.836@safari-7624-branch

Identifier: 305413.767@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.872@webkitglib/2.52">https://commits.webkit.org/305877.872@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 52e0da7267e1da16c03edf8238922b5cef67dcdc
<pre>
Cherry-pick 6e81451ccd9a. <a href="https://bugs.webkit.org/show_bug.cgi?id=314002">https://bugs.webkit.org/show_bug.cgi?id=314002</a>

[JSC] getByIdMegamorphic needs a throw scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=314002">https://bugs.webkit.org/show_bug.cgi?id=314002</a>
<a href="https://rdar.apple.com/176129042">rdar://176129042</a>

Reviewed by Darin Adler, Yijia Huang, and Yusuke Suzuki.

getByIdMegamorphic can trigger user-defined getters, which can throw, and so
needs a throw scope.

Test: JSTests/stress/megamorphic-get-by-id-overrides-getter-exception-check.js

* JSTests/stress/megamorphic-get-by-id-overrides-getter-exception-check.js: Added.
(megamorphicGetById.get obj):
(megamorphicGetById):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::getByIdMegamorphic):

Identifier: 305413.833@safari-7624-branch

Identifier: 305413.766@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.871@webkitglib/2.52">https://commits.webkit.org/305877.871@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6b38672514930d80d3145e7dfb64e98c2f04e187
<pre>
Cherry-pick 34c25063c9cf. <a href="https://bugs.webkit.org/show_bug.cgi?id=313590">https://bugs.webkit.org/show_bug.cgi?id=313590</a>

Compromised WebContent process can gain arbitrary file URL access by spoofing back/forward list messages
<a href="https://rdar.apple.com/174512192">rdar://174512192</a>

Reviewed by Ben Nham and Per Arne Vollan.

Instead of debug-only asserting that an updated item belongs to the process, actaully message check it.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardUpdateItem):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(enableIPCTestingAPI):
(TEST(WKBackForwardList, BackForwardUpdateItemRejectsFileURL)):

Identifier: 305413.830@safari-7624-branch

Identifier: 305413.765@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.870@webkitglib/2.52">https://commits.webkit.org/305877.870@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9b151743c2552a6c6f09875979a3db08711fb7d0
<pre>
Cherry-pick d446d220d636. <a href="https://bugs.webkit.org/show_bug.cgi?id=313590">https://bugs.webkit.org/show_bug.cgi?id=313590</a>

Change IPInt m_pendingOffset to std::optional and add metadata offset overflow assertions
<a href="https://bugs.webkit.org/show_bug.cgi?id=313590">https://bugs.webkit.org/show_bug.cgi?id=313590</a>
<a href="https://rdar.apple.com/175673870">rdar://175673870</a>

Reviewed by Dan Hecht.

IPIntControlType::m_pendingOffset was int32_t but stored values from
m_metadata-&gt;m_metadata.size(). A function within maxFunctionSize can
generate metadata exceeding INT32_MAX via repeated calls to functions
with large signatures.

Add overflow checks to the 32 bit computations to avoid silently
producing invalid metadata addresses, and change m_pendingOffset to use
std::optional instead of a sentinel value.

A practical test would take too long to include.

* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::tryToResolveBranchTarget):
(JSC::Wasm::IPIntGenerator::curPC):
(JSC::Wasm::IPIntGenerator::nextPC):
(JSC::Wasm::IPIntGenerator::curMC):
(JSC::Wasm::IPIntGenerator::checkedDelta):
(JSC::Wasm::IPIntGenerator::coalesceControlFlow):
(JSC::Wasm::IPIntGenerator::resolveEntryTarget):
(JSC::Wasm::IPIntGenerator::resolveExitTarget):
(JSC::Wasm::IPIntGenerator::addLoop):
(JSC::Wasm::IPIntGenerator::addIf):
(JSC::Wasm::IPIntGenerator::addElseToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addCatchAllToUnreachable):
(JSC::Wasm::IPIntGenerator::addDelegateToUnreachable):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):

Identifier: 305413.828@safari-7624-branch

Identifier: 305413.764@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.869@webkitglib/2.52">https://commits.webkit.org/305877.869@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 12bc0eece89c125e3bec8c45a5d9b3fa9b3396d1
<pre>
Cherry-pick 720a8f0b10ab. <a href="https://bugs.webkit.org/show_bug.cgi?id=313842">https://bugs.webkit.org/show_bug.cgi?id=313842</a>

Data race on MIMETypeCache::m_cachedResults / m_supportedTypes in MIMETypeCache::canDecodeType
<a href="https://rdar.apple.com/175674693">rdar://175674693</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313842">https://bugs.webkit.org/show_bug.cgi?id=313842</a>

Reviewed by Eric Carlson.

It&apos;s unsafe to return a raw reference to an inner data member (without BorrowChecker)
as the underlying object can be mutated or freed leaving a dangling reference. Make two
changes to MIMETypeCache as a result:
- Require a lock be held to access the inner data member variable
- Return a copy of the inner member rather than a reference

* Source/WebCore/platform/graphics/MIMETypeCache.cpp:
(WebCore::MIMETypeCache::supportsContainerType):
(WebCore::MIMETypeCache::canDecodeType):
(WebCore::MIMETypeCache::addSupportedTypes):
(WebCore::MIMETypeCache::getCachedResult const):
(WebCore::MIMETypeCache::addCachedResult):
(WebCore::MIMETypeCache::supportedTypes):
(WebCore::MIMETypeCache::isEmpty const):
* Source/WebCore/platform/graphics/MIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVStreamDataParserMIMETypeCache.mm:
(WebCore::AVStreamDataParserMIMETypeCache::supportedTypes):
(WebCore::AVStreamDataParserMIMETypeCache::canDecodeExtendedType):

Identifier: 305413.822@safari-7624-branch

Identifier: 305413.763@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.868@webkitglib/2.52">https://commits.webkit.org/305877.868@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 056433367a17df390898280567467727aaf8aadf
<pre>
Cherry-pick 207238632262. <a href="https://bugs.webkit.org/show_bug.cgi?id=313571">https://bugs.webkit.org/show_bug.cgi?id=313571</a>

Heap UaF in GPU Process via MediaStreamTrack.clone() + ImageCapture.takePhoto() + applyConstraints()
<a href="https://rdar.apple.com/176025005">rdar://176025005</a>

Reviewed by Eric Carlson.

We store constraints in the callback by value instead of reference to make sure that the constraints are valid if the callback is called asynchronously.

Test: fast/mediastream/applyConstraints-with-takePhoto.html

* LayoutTests/fast/mediastream/applyConstraints-with-takePhoto-expected.txt: Added.
* LayoutTests/fast/mediastream/applyConstraints-with-takePhoto.html: Added.
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:

Identifier: 305413.816@safari-7624-branch

Identifier: 305413.759@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.867@webkitglib/2.52">https://commits.webkit.org/305877.867@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 2c4dc30626cc1c80f9be8b1a04d0c7117aa6c622
<pre>
Cherry-pick c5c267219314. <a href="https://bugs.webkit.org/show_bug.cgi?id=313571">https://bugs.webkit.org/show_bug.cgi?id=313571</a>

RemoteMediaPlayerProxy::createAudioSourceProvider should reject duplicate IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=313571">https://bugs.webkit.org/show_bug.cgi?id=313571</a>
<a href="https://rdar.apple.com/175035393">rdar://175035393</a>

Reviewed by Eric Carlson.

A well-behaved WebContent process sends CreateAudioSourceProvider at most once per
RemoteMediaPlayerProxy. A second message reaches AudioSourceProviderAVFObjC&apos;s
setConfigureAudioStorageCallback / setAudioCallback, which overwrite the callbacks
without taking tapStorage-&gt;lock while a MediaToolbox thread may be invoking them
under that lock, freeing the captured RemoteAudioSourceProviderProxy mid-use.
Reject the duplicate message with a MESSAGE_CHECK.

* LayoutTests/ipc/create-audio-source-provider-twice-expected.txt: Added.
* LayoutTests/ipc/create-audio-source-provider-twice.html: Added.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::createAudioSourceProvider):

Identifier: 305413.810@safari-7624-branch

Identifier: 305413.758@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.866@webkitglib/2.52">https://commits.webkit.org/305877.866@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3949e81efc53d37f38203ae63b118078a54373fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172229 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46146 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181676 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129785 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174094 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47435 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45786 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133958 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129785 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175187 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47435 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114429 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47435 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45786 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30285 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47435 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184214 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33488 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36817 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45786 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142722 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45813 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142598 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46493 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111202 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26136 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46493 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118248 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204907 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45011 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39566 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54712 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44411 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44643 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44470 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->