### PR TITLE
[iOS 27] chemicalguys.com sometimes hangs under TextExtraction::extractAllTextAndRects()

### DIFF
--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -432,10 +432,24 @@ static inline bool NODELETE isDescendantOf(TextIteratorBehaviors options, Node& 
     return node.isDescendantOf(&possibleAncestor);
 }
 
+static inline ContainerNode* NODELETE parentInComposedTreeIgnoringUserAgentShadow(Node& node)
+{
+    if (auto* slot = node.assignedSlot()) {
+        if (auto* shadowRoot = slot->containingShadowRoot(); shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent)
+            return slot;
+    }
+
+    if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(node))
+        return shadowRoot->host();
+
+    return node.parentNode();
+}
+
 static inline Node* NODELETE parentNodeOrShadowHost(TextIteratorBehaviors options, Node& node)
 {
     if (options.contains(TextIteratorBehavior::TraversesFlatTree)) [[unlikely]]
-        return node.parentInComposedTree();
+        return parentInComposedTreeIgnoringUserAgentShadow(node);
+
     return node.parentOrShadowHostNode();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -54,6 +54,7 @@
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <WebKit/_WKTextExtraction.h>
+#import <WebKit/_WKTextRun.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <pal/cocoa/ScreenTimeSoftLink.h>
 #import <pal/spi/cocoa/NSKeyedUnarchiverSPI.h>
@@ -766,6 +767,23 @@ TEST(TextExtractionTests, MinimalHTMLOutput)
     EXPECT_FALSE([debugText containsString:@"form"]);
     EXPECT_FALSE([debugText containsString:@"target"]);
     EXPECT_FALSE([debugText containsString:@"asdf"]);
+}
+
+TEST(TextExtractionTests, NestedDetailsDoesNotHang)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadHTMLString:@"<details><details>x<summary></summary></details></details>"];
+
+    __block bool done = false;
+    [webView _requestAllTextWithCompletionHandler:^(NSArray<_WKTextRun *> *) {
+        done = true;
+    }];
+    Util::run(&done);
 }
 
 TEST(TextExtractionTests, FilterOptions)


### PR DESCRIPTION
#### 31f6b383f7bee361fcdbe99b5f96f31052bc9f8b
<pre>
[iOS 27] chemicalguys.com sometimes hangs under TextExtraction::extractAllTextAndRects()
<a href="https://bugs.webkit.org/show_bug.cgi?id=318407">https://bugs.webkit.org/show_bug.cgi?id=318407</a>
<a href="https://rdar.apple.com/180538072">rdar://180538072</a>

Reviewed by Abrar Rahman Protyasha.

Consider the case where `TextIterator` (with the `TraversesFlatTree` option specified) traverses the
following content:

```
&lt;details&gt;
    &lt;details&gt;x&lt;summary&gt;&lt;/summary&gt;&lt;/details&gt;
&lt;/details&gt;
```

(with DOM tree)

```
&lt;body 0x10b3102b0&gt;
    &lt;details 0x10b3580b0&gt;
        &lt;details 0x10b358160&gt;
            &quot;x&quot; 0x10b3682a0
            &lt;summary 0x10b364220&gt;
```

...after descending into the `summary` element (`0x10b364220`), we ascend to the summary&apos;s assigned
slot; from there, `nextSibling` gives the sibling (content) slot, whose first assigned node is the
text node `&quot;x&quot;`. `&quot;x&quot;`&apos;s next sibling is the `summary` again. As a result, we bounce between the
`summary` element, its assigned `slot`, and the containing UA shadow root under the `details`
element.

To fix this, align the behavior of `TraversesFlatTree` to `assignedSlotIgnoringUserAgentShadow` in
`ComposedTreeIterator.h`, and skip slot elements in UA shadow roots when ascending the tree.

Test: TextExtractionTests.NestedDetailsDoesNotHang

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::parentInComposedTreeIgnoringUserAgentShadow):
(WebCore::parentNodeOrShadowHost):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::NestedDetailsDoesNotHang)):

Canonical link: <a href="https://commits.webkit.org/316430@main">https://commits.webkit.org/316430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53d89d8445607340206ac7aa6b79e9551a2b922f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129778 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2b9696b-9b94-456f-a8dc-c935574c16b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133952 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21913c67-24bc-473d-a141-eb0c8f4b2443) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/841ee0c3-f7f4-4e5f-b839-ae960b9c88fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36028 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184209 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142711 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45808 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38514 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46488 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111197 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37679 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45006 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8950 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44638 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->