### PR TITLE
[WebVTT] Cues with snapToLines == false should wrap

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Reference for WebVTT rendering, basic</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<link rel="stylesheet" href="support/webvtt-ref.css">
+<div class="video">
+    <div class="cue" style="top: 50cqh;">
+        <span class="cue-background">This is a test subtitle that will line break</span>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap.html
@@ -3,13 +3,12 @@
 <title>WebVTT rendering, basic</title>
 <link rel="match" href="basic-ref.html">
 <link rel="stylesheet" href="/fonts/ahem.css">
-<link rel="stylesheet" href="support/webvtt-reset.css">
 <link rel="stylesheet" href="support/webvtt-test.css">
 <script src="/common/reftest-wait.js"></script>
 <video autoplay>
     <source src="/media/white.webm" type="video/webm">
     <source src="/media/white.mp4" type="video/mp4">
-    <track src="support/test.vtt">
+    <track src="support/snap-to-line_long.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';
     waitForActiveCueAndTakeScreenshot();

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/snap-to-line_long.vtt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/snap-to-line_long.vtt
@@ -1,0 +1,5 @@
+WEBVTT
+
+NOTE set line as percentage would make 'snap-to-line' to false
+00:00:00.000 --> 00:00:05.000 line:50%
+This is a test subtitle that will line break

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css
@@ -6,6 +6,7 @@ body { margin: 0 }
     height: 180px;
     position: relative;
     outline: 1px solid black;
+    container-type: size;
 }
 
 /* The following CSS comes from 7.4. Applying CSS properties to WebVTT Node Objects. */

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-reset.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-reset.css
@@ -1,0 +1,14 @@
+/* Reset all css properties that can possibly be set on ::cue (8.2.1. The ::cue pseudo-element) to override any system styles. */
+::cue {
+    color: rgba(255,255,255,1);
+    opacity: 1;
+    visibility: visibile;
+    text-decoration: none;
+    text-shadow: none;
+    background: rgba(0,0,0,0.8);
+    outline: none;
+    font: 5cqh sans-serif;
+    white-space: pre-line;
+    text-combine-upright: none;
+    ruby-position: alternate;
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-test.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-test.css
@@ -8,17 +8,7 @@ video {
     outline: 1px solid black;
 }
 
-/* Reset all css properties that can possibly be set on ::cue (8.2.1. The ::cue pseudo-element) to override any system styles. */
 ::cue {
     color: green;
-    opacity: 1;
-    visibility: visibile;
-    text-decoration: none;
-    text-shadow: none;
-    background: rgba(0,0,0,0.8);
-    outline: none;
     font: 9px Ahem, sans-serif; /* Use Ahem because it improves test reliability. */
-    white-space: pre-line;
-    text-combine-upright: none;
-    ruby-position: alternate;
 }

--- a/Source/WebCore/html/track/TextTrackCueGeneric.h
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.h
@@ -61,8 +61,7 @@ public:
     const Color& highlightColor() const LIFETIME_BOUND { return m_highlightColor; }
     void setHighlightColor(const Color& color) { m_highlightColor = color; }
 
-    bool wrapTextDuringPercentageBasedPositioning() const override { return !m_preventLineWrapping; }
-    bool preventLineWrapping() const { return m_preventLineWrapping; }
+    bool preventLineWrapping() const override { return m_preventLineWrapping; }
     void setPreventLineWrapping(bool preventWrapping) { m_preventLineWrapping = preventWrapping; }
 
 private:

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -249,10 +249,10 @@ void VTTCueBox::applyCSSProperties()
     // unless if it is the child of a region, then it is to be relatively positioned.
     setInlineStyleProperty(CSSPropertyPosition, CSSValueAbsolute);
 
-    if (!cue->snapToLines())
+    if (cue->preventLineWrapping()) {
         setInlineStyleProperty(CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
-    if (!cue->snapToLines() && !cue->wrapTextDuringPercentageBasedPositioning())
         setInlineStyleProperty(CSSPropertyTextWrapMode, CSSValueNowrap);
+    }
 
     // Make sure shadow or stroke is not clipped.
     // NOTE: Set in text-tracks.css

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -219,7 +219,7 @@ public:
     const LineAndPositionSetting& width() const LIFETIME_BOUND { return m_width; }
     const LineAndPositionSetting& height() const LIFETIME_BOUND { return m_height; }
 
-    virtual bool wrapTextDuringPercentageBasedPositioning() const { return false; }
+    virtual bool preventLineWrapping() const { return false; }
 
 protected:
     VTTCue(Document&, const MediaTime& start, const MediaTime& end, String&& content);


### PR DESCRIPTION
#### 66904a7e842df9824bd80a3f5729b0f4cddb2c15
<pre>
[WebVTT] Cues with snapToLines == false should wrap
<a href="https://rdar.apple.com/178760948">rdar://178760948</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318446">https://bugs.webkit.org/show_bug.cgi?id=318446</a>

Reviewed by Eric Carlson.

Historically, WebKit has set `white-space:pre` on cues whose `snap-to-lines` flag is false,
in order to correctly implement CEA-608 and CTA-708 captions, which require wrapping to be
disabled. However this affects all cues whose `snap-to-lines` flag is false, not just in-band
closed-captions like 608/708, and this affects real sites, including Apple.com.

Narrowly scope the `white-space:pre` styles around cues who explicitly have `preventLineWrapping()`
enabled, which will only be in-band generic cues.

For the WPT tests, split out the &quot;reset&quot; of styles to the standard-defined defaults into its own
.css file, where `webvtt-test.css` just sets the styles under test; namely Ahem at a specific size.

For the ref tests, make the fake `.video` div a container, so container-relative size rules work.

Test: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap.html

* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/snap-to-line-wrap.html:
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/snap-to-line_long.vtt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-ref.css:
(.video):
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-reset.css:
(::cue):
* LayoutTests/imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/support/webvtt-test.css:
(::cue):
* Source/WebCore/html/track/TextTrackCueGeneric.h:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSProperties):
* Source/WebCore/html/track/VTTCue.h:
(WebCore::VTTCue::preventLineWrapping const):
(WebCore::VTTCue::wrapTextDuringPercentageBasedPositioning const): Deleted.

Canonical link: <a href="https://commits.webkit.org/316432@main">https://commits.webkit.org/316432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c445c284a2c388ca4858e8b5506a69bd61ccf096

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129783 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/681efdc0-b35f-4afe-bd83-539a37d9670c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133961 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/308efe7f-eb26-4ca3-af36-2380d06f94ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114432 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe31d010-d144-48ee-9951-6bd873f8d4fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36027 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30283 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184212 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36815 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142720 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38515 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46491 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111210 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37676 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45009 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8949 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44409 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44468 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->