### PR TITLE
WIP: [SI] Add a Storage domain for cookie inspection

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -270,6 +270,9 @@ http/tests/loading/resourceLoadStatistics/ [ Skip ]
 http/tests/cookies/multiple-cookies.https.html [ Skip ]
 http/tests/cookies/multiple-cookies-iframes.https.html [ Skip ]
 http/tests/cookies/max-partitioned-cookies.https.html [ Skip ]
+# Skipped by default: asserts a partitioned-cookie partitionKey that needs HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
+# (macOS 26.2+). platform/mac-wk2/TestExpectations re-enables it (expected Pass) on [ Tahoe+ ].
+http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https.html [ Skip ]
 http/tests/resourceLoadStatistics/ [ Skip ]
 http/tests/websocket/connection-refusal-in-frame-resource-load-statistics.html [ Skip ]
 http/tests/storageAccess/ [ Skip ]

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/resources/set-cookie-via-script.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/resources/set-cookie-via-script.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+<script>
+// Runs inside the cross-origin iframe, which is a separate WebContent process under Site Isolation.
+// Set a cookie from script for a path the parent frame never requests any resource from, so the
+// parent's process has no cached-resource URL that would match it. The in-process Page.getCookies
+// looks cookies up by the parent process's known resource URLs, so it cannot discover this cookie;
+// Storage.getCookies reads the authoritative NetworkProcess store and sees it regardless.
+document.cookie = "CrossOriginScriptCookie=PASS; path=/site-isolation/inspector/storage/private-scope/";
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/resources/set-cookie.py
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/resources/set-cookie.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs
+
+query = parse_qs(os.environ.get('QUERY_STRING', ''), keep_blank_values=True)
+name = query.get('name', [''])[0]
+value = query.get('value', [''])[0]
+secure = query.get('secure', [None])[0]
+exp_time = datetime.now(timezone.utc) + timedelta(hours=1)
+
+cookie = '{}={}; expires={} GMT; Max-Age=3600'.format(name, value, exp_time.strftime('%a, %d-%b-%Y %H:%M:%S'))
+if secure:
+    cookie += '; Secure'
+
+sys.stdout.write(
+    'Set-Cookie: {}\r\n'
+    'Content-Type: text/html\r\n\r\n'.format(cookie)
+)

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe-expected.txt
@@ -1,0 +1,10 @@
+Tests that Storage.getCookies sees a cookie set by script inside a cross-origin iframe under Site Isolation, which the in-process Page.getCookies cannot.
+
+
+== Running test suite: SiteIsolation.Storage.getCookies
+-- Running test case: SiteIsolation.Storage.getCookies.CrossOriginIframe
+PASS: Cross-origin iframe should be its own Frame Target (out-of-process).
+PASS: Storage.getCookies should see the cross-origin iframe's cookie.
+PASS: Cross-origin cookie value should be 'PASS'.
+PASS: Page.getCookies must NOT see the cross-origin iframe's cookie (it is out-of-process and the URL is unknown to the inspected page).
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html
@@ -1,0 +1,75 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function addCrossOriginIframeThatSetsCookie() {
+    let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+    let iframe = document.createElement("iframe");
+    iframe.name = "cookie-frame";
+    // Cross-origin => separate WebContent process under Site Isolation. The iframe's own script
+    // sets a cookie for a path the parent process never fetches.
+    iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/storage/resources/set-cookie-via-script.html`;
+    document.body.appendChild(iframe);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Storage.getCookies");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Storage.getCookies.CrossOriginIframe",
+        description: "A cookie set by script inside a cross-origin iframe (a separate WebContent process under Site Isolation) must be visible via Storage.getCookies, which reads the authoritative NetworkProcess store, and must NOT be visible via the in-process Page.getCookies, which can only find cookies for URLs the inspected page's process already knows about.",
+        async test() {
+            await WI.backendTarget.StorageAgent.enable();
+            await InspectorTest.evaluateInPage(`if (window.testRunner) testRunner.setAlwaysAcceptCookies(true);`);
+
+            // Adding the cross-origin iframe spawns a Frame Target under Site Isolation. Await it
+            // before asserting anything: TargetAdded is dispatched asynchronously, so the FrameTarget
+            // is not registered synchronously after evaluateInPage() returns. Awaiting the event is
+            // both the reliable "Site Isolation is active" signal and what lets the child's script run.
+            let targetAddedPromise = WI.targetManager.awaitEvent(WI.TargetManager.Event.TargetAdded);
+            InspectorTest.evaluateInPage("addCrossOriginIframeThatSetsCookie()");
+
+            let frameTarget = (await targetAddedPromise).data.target;
+            InspectorTest.expectThat(frameTarget instanceof WI.FrameTarget, "Cross-origin iframe should be its own Frame Target (out-of-process).");
+
+            // A freshly-added cross-origin frame target starts provisional; wait for it to commit so
+            // its script (which sets the cookie) has actually run in its own process.
+            if (frameTarget.isProvisional)
+                await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+
+            // The cookie write from the child's script round-trips to the NetworkProcess; poll until
+            // Storage.getCookies observes it.
+            let cookie = null;
+            for (let attempt = 0; attempt < 50 && !cookie; ++attempt) {
+                let {cookies} = await WI.backendTarget.StorageAgent.getCookies();
+                cookie = cookies.find((c) => c.name === "CrossOriginScriptCookie");
+                if (!cookie)
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+
+            InspectorTest.expectNotNull(cookie, "Storage.getCookies should see the cross-origin iframe's cookie.");
+            if (cookie)
+                InspectorTest.expectEqual(cookie.value, "PASS", "Cross-origin cookie value should be 'PASS'.");
+
+            // Negative control: Page.getCookies runs in the inspected page's process and looks up
+            // cookies only for URLs that process knows as resources. It has no resource URL for the
+            // private-scope path, so it must not see this cookie. If it did, the iframe would not
+            // be out-of-process and the test would not be exercising the Site Isolation path.
+            let {cookies: pageCookies} = await WI.pageTarget.PageAgent.getCookies();
+            let pageCookie = pageCookies.find((c) => c.name === "CrossOriginScriptCookie");
+            InspectorTest.expectNull(pageCookie, "Page.getCookies must NOT see the cross-origin iframe's cookie (it is out-of-process and the URL is unknown to the inspected page).");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Storage.getCookies sees a cookie set by script inside a cross-origin iframe under Site Isolation, which the in-process Page.getCookies cannot.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-expected.txt
@@ -1,0 +1,15 @@
+Tests that Storage.getCookies returns cookies from the NetworkProcess-backed cookie store under Site Isolation.
+
+
+== Running test suite: Storage.getCookies
+-- Running test case: Storage.getCookies.Enable
+Storage domain enabled.
+
+-- Running test case: Storage.getCookies.InitiallyEmpty
+PASS: Should be no cookies.
+
+-- Running test case: Storage.getCookies.AfterSet
+PASS: Should have found the 'Baseline' cookie.
+PASS: Cookie value should be 'PASS'.
+PASS: Cookie domain should be '127.0.0.1'.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies.html
@@ -1,0 +1,64 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function loadScriptWithURL(url) {
+    let script = document.createElement("script");
+    script.src = url;
+    script.addEventListener("load", (event) => {
+        TestPage.dispatchEventToFrontend("ScriptLoad");
+    });
+    document.body.appendChild(script);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Storage.getCookies");
+
+    suite.addTestCase({
+        name: "Storage.getCookies.Enable",
+        description: "Enable the Storage domain.",
+        async test() {
+            await WI.backendTarget.StorageAgent.enable();
+            InspectorTest.log("Storage domain enabled.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Storage.getCookies.InitiallyEmpty",
+        description: "There should be no cookies before any are set.",
+        async test() {
+            let {cookies} = await WI.backendTarget.StorageAgent.getCookies();
+            InspectorTest.expectEqual(cookies.length, 0, "Should be no cookies.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Storage.getCookies.AfterSet",
+        description: "A cookie set by a same-origin resource should be visible.",
+        async test() {
+            await Promise.all([
+                InspectorTest.awaitEvent("ScriptLoad"),
+                InspectorTest.evaluateInPage(`loadScriptWithURL("http://127.0.0.1:8000/site-isolation/inspector/storage/resources/set-cookie.py?name=Baseline&value=PASS")`),
+            ]);
+
+            let {cookies} = await WI.backendTarget.StorageAgent.getCookies();
+            let cookie = cookies.find((c) => c.name === "Baseline");
+
+            InspectorTest.expectNotNull(cookie, "Should have found the 'Baseline' cookie.");
+            InspectorTest.expectEqual(cookie.value, "PASS", "Cookie value should be 'PASS'.");
+            InspectorTest.expectEqual(cookie.domain, "127.0.0.1", "Cookie domain should be '127.0.0.1'.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Storage.getCookies returns cookies from the NetworkProcess-backed cookie store under Site Isolation.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https-expected.txt
@@ -1,0 +1,10 @@
+Probe: does Storage.getCookies surface a CHIPS partitioned cookie (set via the Partitioned attribute) with its partitionKey populated?
+
+
+== Running test suite: Storage.getCookies.Partitioned
+-- Running test case: Storage.getCookies.Partitioned.Probe
+PASS: Storage.getCookies should surface the partitioned cookie from the flat store.
+PASS: Partitioned cookie value should be 'PASS'.
+PASS: Partitioned cookie should carry a non-empty partitionKey.
+Observed partitionKey is a non-empty string: true
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https.html
@@ -1,0 +1,57 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true OptInPartitionedCookiesEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+// Set a CHIPS partitioned cookie from the page itself. The page is a top-level https document, so
+// the cookie is partitioned under this document's own site (first-party partition). Partitioned
+// cookies require Secure + SameSite=None + the Partitioned attribute, hence the .https.html context
+// and the OptInPartitionedCookiesEnabled preference above.
+function setPartitionedCookie() {
+    document.cookie = "PartitionedProbe=PASS; SameSite=None; Secure; Partitioned; path=/";
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Storage.getCookies.Partitioned");
+
+    suite.addTestCase({
+        name: "Storage.getCookies.Partitioned.Probe",
+        description: "Probe whether Storage.getCookies (which reads the flat authoritative store via API::HTTPCookieStore) surfaces a CHIPS partitioned cookie, and whether its partitionKey is populated. This settles whether partitioned cookies are visible now or genuinely need a separate per-partition read path.",
+        async test() {
+            await WI.backendTarget.StorageAgent.enable();
+            await InspectorTest.evaluateInPage(`if (window.testRunner) testRunner.setAlwaysAcceptCookies(true);`);
+
+            await InspectorTest.evaluateInPage("setPartitionedCookie()");
+
+            // The write round-trips to the NetworkProcess; poll until getCookies observes the cookie
+            // (or we exhaust attempts, in which case the probe result is "not visible").
+            let cookie = null;
+            for (let attempt = 0; attempt < 50 && !cookie; ++attempt) {
+                let {cookies} = await WI.backendTarget.StorageAgent.getCookies();
+                cookie = cookies.find((c) => c.name === "PartitionedProbe");
+                if (!cookie)
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+            }
+
+            InspectorTest.expectNotNull(cookie, "Storage.getCookies should surface the partitioned cookie from the flat store.");
+            if (cookie) {
+                InspectorTest.expectEqual(cookie.value, "PASS", "Partitioned cookie value should be 'PASS'.");
+                // The interesting bit: does the flat read carry the partition label through to the
+                // protocol object? Log presence explicitly so the expected output records reality.
+                InspectorTest.expectNotNull(cookie.partitionKey, "Partitioned cookie should carry a non-empty partitionKey.");
+                InspectorTest.log("Observed partitionKey is a non-empty string: " + (typeof cookie.partitionKey === "string" && cookie.partitionKey.length > 0));
+            }
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Probe: does Storage.getCookies surface a CHIPS partitioned cookie (set via the Partitioned attribute) with its partitionKey populated?</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies-expected.txt
@@ -1,0 +1,25 @@
+Tests Storage.setCookie (with partitioning) and Storage.deleteCookies by filter under Site Isolation.
+
+
+== Running test suite: Storage.setCookie and Storage.deleteCookies
+-- Running test case: Storage.setCookie.Enable
+Storage domain enabled.
+
+-- Running test case: Storage.setCookie.Roundtrip
+PASS: setCookie should return a partitionKey.
+PASS: An unpartitioned cookie's returned partitionKey should have no sourceOrigin.
+PASS: Should read back exactly one matching cookie.
+PASS: Cookie value should be 'PASS'.
+
+-- Running test case: Storage.setCookie.ExplicitPartitionKeyEchoed
+PASS: setCookie should return a partitionKey.
+PASS: Returned partitionKey should echo the explicit cookie partitionKey.
+
+-- Running test case: Storage.deleteCookies.ByFilter
+PASS: 'DeleteMe' should be gone.
+PASS: 'KeepMe' should remain.
+
+-- Running test case: Storage.deleteCookies.NoFilterRejected
+PASS: deleteCookies with no filter should produce an error.
+PASS: 'KeepMe' should still remain after the rejected delete.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html
@@ -1,0 +1,98 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Storage.setCookie and Storage.deleteCookies");
+
+    suite.addTestCase({
+        name: "Storage.setCookie.Enable",
+        async test() {
+            await WI.backendTarget.StorageAgent.enable();
+            InspectorTest.log("Storage domain enabled.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Storage.setCookie.Roundtrip",
+        description: "A cookie set via Storage.setCookie should be readable via Storage.getCookies. Without an explicit cookie partitionKey the cookie is unpartitioned, so the returned partitionKey has no sourceOrigin.",
+        async test() {
+            let {partitionKey} = await WI.backendTarget.StorageAgent.setCookie(
+                {
+                    name: "RoundtripCookie",
+                    value: "PASS",
+                    domain: "127.0.0.1",
+                    path: "/",
+                },
+                {type: "context"});
+            InspectorTest.expectNotNull(partitionKey, "setCookie should return a partitionKey.");
+            InspectorTest.expectNull(partitionKey.sourceOrigin, "An unpartitioned cookie's returned partitionKey should have no sourceOrigin.");
+
+            let {cookies} = await WI.backendTarget.StorageAgent.getCookies({name: "RoundtripCookie"});
+            InspectorTest.expectEqual(cookies.length, 1, "Should read back exactly one matching cookie.");
+            InspectorTest.expectEqual(cookies[0].value, "PASS", "Cookie value should be 'PASS'.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Storage.setCookie.ExplicitPartitionKeyEchoed",
+        description: "When the caller supplies an explicit cookie partitionKey, setCookie should echo it back as the returned partitionKey's sourceOrigin.",
+        async test() {
+            let {partitionKey} = await WI.backendTarget.StorageAgent.setCookie(
+                {
+                    name: "PartitionedCookie",
+                    value: "PASS",
+                    domain: "127.0.0.1",
+                    path: "/",
+                    partitionKey: "http://127.0.0.1",
+                },
+                {type: "context"});
+            InspectorTest.expectNotNull(partitionKey, "setCookie should return a partitionKey.");
+            InspectorTest.expectEqual(partitionKey.sourceOrigin, "http://127.0.0.1", "Returned partitionKey should echo the explicit cookie partitionKey.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Storage.deleteCookies.ByFilter",
+        description: "Deleting by filter should remove only the matching cookies.",
+        async test() {
+            await WI.backendTarget.StorageAgent.setCookie({name: "DeleteMe", value: "x", domain: "127.0.0.1", path: "/"});
+            await WI.backendTarget.StorageAgent.setCookie({name: "KeepMe", value: "y", domain: "127.0.0.1", path: "/"});
+
+            await WI.backendTarget.StorageAgent.deleteCookies({name: "DeleteMe"});
+
+            let {cookies} = await WI.backendTarget.StorageAgent.getCookies();
+            InspectorTest.expectEqual(cookies.filter((c) => c.name === "DeleteMe").length, 0, "'DeleteMe' should be gone.");
+            InspectorTest.expectEqual(cookies.filter((c) => c.name === "KeepMe").length, 1, "'KeepMe' should remain.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "Storage.deleteCookies.NoFilterRejected",
+        description: "deleteCookies with no filter must fail rather than delete the entire store (guards against an accidental global clear, matching BiDi).",
+        async test() {
+            try {
+                await WI.backendTarget.StorageAgent.deleteCookies();
+                InspectorTest.fail("deleteCookies with no filter should have failed.");
+            } catch (error) {
+                InspectorTest.expectThat(error, "deleteCookies with no filter should produce an error.");
+            }
+
+            // The cookie set by the previous case must still be present: the rejected call deleted nothing.
+            let {cookies} = await WI.backendTarget.StorageAgent.getCookies();
+            InspectorTest.expectEqual(cookies.filter((c) => c.name === "KeepMe").length, 1, "'KeepMe' should still remain after the rejected delete.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests Storage.setCookie (with partitioning) and Storage.deleteCookies by filter under Site Isolation.</p>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -725,6 +725,10 @@ http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-bloc
 [ Tahoe+ ] http/tests/cookies/accept-partitioned-first-and-third-party-cookies.https.html [ Pass ]
 [ Tahoe+ ] http/tests/clear-site-data/set-and-clear-cookies.https.html [ Pass ]
 [ Tahoe+ ] imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Pass ]
+# Needs HAVE(ALLOW_ONLY_PARTITIONED_COOKIES) (macOS 26.2+); the partitionKey it asserts is not populated on older OSes
+# where opt-in cookie partitioning is compiled out. Skipped by default in the generic LayoutTests/TestExpectations;
+# this cross-file override runs it (expected Pass) on Tahoe+.
+[ Tahoe+ ] http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https.html [ Pass ]
 
 # Enable again when fixing https://bugs.webkit.org/show_bug.cgi?id=208400.
 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies-ephemeral.https.html [ Skip ]

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1710,6 +1710,7 @@ set(JavaScriptCore_INSPECTOR_DOMAINS
     ${JAVASCRIPTCORE_DIR}/inspector/protocol/ScriptProfiler.json
     ${JAVASCRIPTCORE_DIR}/inspector/protocol/Security.json
     ${JAVASCRIPTCORE_DIR}/inspector/protocol/ServiceWorker.json
+    ${JAVASCRIPTCORE_DIR}/inspector/protocol/Storage.json
     ${JAVASCRIPTCORE_DIR}/inspector/protocol/Target.json
     ${JAVASCRIPTCORE_DIR}/inspector/protocol/Timeline.json
     ${JAVASCRIPTCORE_DIR}/inspector/protocol/Worker.json

--- a/Source/JavaScriptCore/DerivedSources-input.xcfilelist
+++ b/Source/JavaScriptCore/DerivedSources-input.xcfilelist
@@ -110,6 +110,7 @@ $(PROJECT_DIR)/inspector/protocol/Runtime.json
 $(PROJECT_DIR)/inspector/protocol/ScriptProfiler.json
 $(PROJECT_DIR)/inspector/protocol/Security.json
 $(PROJECT_DIR)/inspector/protocol/ServiceWorker.json
+$(PROJECT_DIR)/inspector/protocol/Storage.json
 $(PROJECT_DIR)/inspector/protocol/Target.json
 $(PROJECT_DIR)/inspector/protocol/Timeline.json
 $(PROJECT_DIR)/inspector/protocol/Worker.json

--- a/Source/JavaScriptCore/DerivedSources.make
+++ b/Source/JavaScriptCore/DerivedSources.make
@@ -303,6 +303,7 @@ INSPECTOR_DOMAINS := \
     $(JavaScriptCore)/inspector/protocol/ScriptProfiler.json \
     $(JavaScriptCore)/inspector/protocol/Security.json \
     $(JavaScriptCore)/inspector/protocol/ServiceWorker.json \
+    $(JavaScriptCore)/inspector/protocol/Storage.json \
     $(JavaScriptCore)/inspector/protocol/Target.json \
     $(JavaScriptCore)/inspector/protocol/Timeline.json \
     $(JavaScriptCore)/inspector/protocol/Worker.json \

--- a/Source/JavaScriptCore/inspector/protocol/Storage.json
+++ b/Source/JavaScriptCore/inspector/protocol/Storage.json
@@ -1,0 +1,114 @@
+{
+    "domain": "Storage",
+    "description": "Query and modify storage (cookies for now) under Site Isolation. Backed by the NetworkProcess-owned cookie store via API::HTTPCookieStore, so cross-origin iframe cookies are visible. The flat read also surfaces partitioned (CHIPS) cookies, each labeled with its partitionKey.",
+    "debuggableTypes": ["web-page"],
+    "targetTypes": ["web-page"],
+    "types": [
+        {
+            "id": "CookieSameSitePolicy",
+            "type": "string",
+            "enum": ["None", "Lax", "Strict"],
+            "description": "Same-Site policy of a cookie."
+        },
+        {
+            "id": "Cookie",
+            "type": "object",
+            "description": "Cookie object.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Cookie name." },
+                { "name": "value", "type": "string", "description": "Cookie value." },
+                { "name": "domain", "type": "string", "description": "Cookie domain." },
+                { "name": "path", "type": "string", "description": "Cookie path." },
+                { "name": "expires", "type": "number", "description": "Cookie expires." },
+                { "name": "session", "type": "boolean", "description": "True in case of session cookie." },
+                { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                { "name": "sameSite", "$ref": "CookieSameSitePolicy", "description": "Cookie Same-Site policy." },
+                { "name": "partitionKey", "type": "string", "optional": true, "description": "Cookie partition key." }
+            ]
+        },
+        {
+            "id": "CookieFilter",
+            "type": "object",
+            "description": "Filter parameters for cookie retrieval and deletion. Every provided field narrows the result set.",
+            "properties": [
+                { "name": "name", "type": "string", "optional": true, "description": "The name of the cookie." },
+                { "name": "value", "type": "string", "optional": true, "description": "The value of the cookie." },
+                { "name": "domain", "type": "string", "optional": true, "description": "The domain of the cookie." },
+                { "name": "path", "type": "string", "optional": true, "description": "The path of the cookie." },
+                { "name": "httpOnly", "type": "boolean", "optional": true, "description": "If the cookie is HTTP only." },
+                { "name": "secure", "type": "boolean", "optional": true, "description": "If the cookie is secure." }
+            ]
+        },
+        {
+            "id": "PartitionKey",
+            "type": "object",
+            "description": "Identifies the storage partition a cookie belongs to. At least one of 'userContext' or 'sourceOrigin' is present.",
+            "properties": [
+                { "name": "userContext", "type": "string", "optional": true, "description": "The user context identifier of the partition." },
+                { "name": "sourceOrigin", "type": "string", "optional": true, "description": "The serialization of the origin of resources that can access the storage partition." }
+            ]
+        },
+        {
+            "id": "PartitionDescriptorType",
+            "type": "string",
+            "description": "The type of storage partition descriptor.",
+            "enum": ["context"]
+        },
+        {
+            "id": "PartitionDescriptor",
+            "type": "object",
+            "description": "Describes a storage partition. Omit to target the inspected page's default data store. Type 'context' targets the inspected page's main-frame origin.",
+            "properties": [
+                { "name": "type", "$ref": "PartitionDescriptorType", "description": "The type of partition descriptor." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Marks the Storage domain enabled for this target. No tracking is started; cookies are read on demand from the authoritative store, so this is effectively a no-op kept for domain-lifecycle symmetry."
+        },
+        {
+            "name": "disable",
+            "description": "Marks the Storage domain disabled for this target. Counterpart to enable; a no-op beyond lifecycle bookkeeping."
+        },
+        {
+            "name": "getCookies",
+            "description": "Retrieves zero or more cookies which match the provided filter, within the given partition.",
+            "async": true,
+            "parameters": [
+                { "name": "filter", "$ref": "CookieFilter", "optional": true, "description": "Filter parameters for cookie retrieval." },
+                { "name": "partition", "$ref": "PartitionDescriptor", "optional": true, "description": "The storage partition in which to get cookies. Defaults to the origin of the inspected page's main frame." }
+            ],
+            "returns": [
+                { "name": "cookies", "type": "array", "items": { "$ref": "Cookie" }, "description": "The list of matching cookies." },
+                { "name": "partitionKey", "$ref": "PartitionKey", "description": "The storage partition key the cookies came from." }
+            ]
+        },
+        {
+            "name": "setCookie",
+            "description": "Creates a new cookie, replacing any cookie in the partition which matches.",
+            "async": true,
+            "parameters": [
+                { "name": "cookie", "$ref": "Cookie", "description": "The cookie to set." },
+                { "name": "partition", "$ref": "PartitionDescriptor", "optional": true, "description": "The storage partition in which to set the cookie. Defaults to the origin of the inspected page's main frame." }
+            ],
+            "returns": [
+                { "name": "partitionKey", "$ref": "PartitionKey", "description": "The storage partition key the cookie was set in." }
+            ]
+        },
+        {
+            "name": "deleteCookies",
+            "description": "Removes zero or more cookies which match the provided filter, within the given partition. A filter is required; omitting it fails rather than deleting every cookie.",
+            "async": true,
+            "parameters": [
+                { "name": "filter", "$ref": "CookieFilter", "optional": true, "description": "Filter parameters for cookie deletion. Required in practice: a request with no filter is rejected to avoid an accidental clear of the entire store." },
+                { "name": "partition", "$ref": "PartitionDescriptor", "optional": true, "description": "The storage partition in which to delete cookies. Defaults to the origin of the inspected page's main frame." }
+            ],
+            "returns": [
+                { "name": "partitionKey", "$ref": "PartitionKey", "description": "The storage partition key the cookies were deleted from." }
+            ]
+        }
+    ]
+}

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -155,6 +155,7 @@ WI.Target = class Target extends WI.Object
     get RuntimeAgent() { return this._agents.Runtime; }
     get ScriptProfilerAgent() { return this._agents.ScriptProfiler; }
     get ServiceWorkerAgent() { return this._agents.ServiceWorker; }
+    get StorageAgent() { return this._agents.Storage; }
     get TargetAgent() { return this._agents.Target; }
     get TimelineAgent() { return this._agents.Timeline; }
     get WorkerAgent() { return this._agents.Worker; }

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -629,6 +629,7 @@ UIProcess/Model/ModelProcessProxy.cpp
 
 UIProcess/Inspector/FrameInspectorTargetProxy.cpp
 UIProcess/Inspector/InspectorTargetProxy.cpp @cost:3
+UIProcess/Inspector/InspectorCookieStoreHelpers.cpp
 UIProcess/Inspector/PageInspectorTargetProxy.cpp @cost:3
 UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
 UIProcess/Inspector/WasmDebuggerDebuggable.cpp
@@ -640,6 +641,7 @@ UIProcess/Inspector/WebPageDebuggable.cpp
 UIProcess/Inspector/WebPageInspectorController.cpp
 
 UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
+UIProcess/Inspector/Agents/InspectorStorageAgent.cpp
 UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
 UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
 

--- a/Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "AutomationProtocolObjects.h"
+#include "InspectorCookieStoreHelpers.h"
 #include "Logging.h"
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionMacros.h"
@@ -41,7 +42,6 @@ namespace WebKit {
 using namespace Inspector;
 using PartitionKey = Inspector::Protocol::BidiStorage::PartitionKey;
 using PartialCookie = Inspector::Protocol::BidiStorage::PartialCookie;
-using CookieFilter = Inspector::Protocol::BidiStorage::CookieFilter;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiStorageAgent);
 
@@ -75,48 +75,6 @@ static Ref<JSON::ArrayOf<PartialCookie>> buildArrayForCookies(const Vector<WebCo
         cookies->addItem(buildObjectForCookie(cookie));
 
     return cookies;
-}
-
-static bool cookieMatchesFilter(const WebCore::Cookie& cookie, const RefPtr<JSON::Object> optionalFilter)
-{
-
-    String optionalFilterName = optionalFilter->getString("name"_s);
-    if (!optionalFilterName.isEmpty()) {
-        if (cookie.name != optionalFilterName)
-            return false;
-    }
-
-    auto optionalFilterValue = optionalFilter->getString("value"_s);
-    if (!optionalFilterValue.isEmpty()) {
-        if (cookie.value != optionalFilterValue)
-            return false;
-    }
-
-    auto optionalFilterDomain = optionalFilter->getString("domain"_s);
-    if (!optionalFilterDomain.isEmpty()) {
-        if (cookie.domain != optionalFilterDomain)
-            return false;
-    }
-
-    auto optionalFilterPath = optionalFilter->getString("path"_s);
-    if (!optionalFilterPath.isEmpty()) {
-        if (cookie.path != optionalFilterPath)
-            return false;
-    }
-
-    auto optionalFilterHttpOnly = optionalFilter->getBoolean("httpOnly"_s);
-    if (optionalFilterHttpOnly) {
-        if (cookie.httpOnly != optionalFilterHttpOnly.value())
-            return false;
-    }
-
-    auto optionalFilterSecure = optionalFilter->getBoolean("secure"_s);
-    if (optionalFilterSecure) {
-        if (cookie.secure != optionalFilterSecure.value())
-            return false;
-    }
-
-    return true;
 }
 
 Inspector::Protocol::ErrorStringOr<Ref<PartitionKey>> BidiStorageAgent::makePartitionKey(RefPtr<JSON::Object> partitionDescriptor)
@@ -196,12 +154,12 @@ void BidiStorageAgent::getCookies(RefPtr<JSON::Object>&& optionalFilter, RefPtr<
     if (!optionalFilter)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
 
-    resolvedCookieStore->cookies([callback = WTF::move(callback), filter = WTF::move(optionalFilter), partitionKey = WTF::move(partitionKey)](Vector<WebCore::Cookie>&& cookiesList) mutable {
+    resolvedCookieStore->cookies([callback = WTF::move(callback), filter = CookieFilter::fromProtocol(optionalFilter), partitionKey = WTF::move(partitionKey)](Vector<WebCore::Cookie>&& cookiesList) mutable {
         Vector<WebCore::Cookie> matchingCookies;
         matchingCookies.reserveInitialCapacity(cookiesList.size());
 
         for (const auto& cookie : cookiesList) {
-            if (cookieMatchesFilter(cookie, filter))
+            if (filter.matches(cookie))
                 matchingCookies.append(cookie);
         }
 
@@ -277,15 +235,13 @@ void BidiStorageAgent::deleteCookies(RefPtr<JSON::Object>&& optionalFilter, RefP
     if (!optionalFilter)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(InvalidParameter);
 
-    cookieStore->cookies([callback = WTF::move(callback), filter = WTF::move(optionalFilter), partitionKey = WTF::move(partitionKey), cookieStore](Vector<WebCore::Cookie>&& fetchedCookies) mutable {
+    cookieStore->cookies([callback = WTF::move(callback), filter = CookieFilter::fromProtocol(optionalFilter), partitionKey = WTF::move(partitionKey), cookieStore](Vector<WebCore::Cookie>&& fetchedCookies) mutable {
         Vector<WebCore::Cookie> toDelete;
         toDelete.reserveInitialCapacity(fetchedCookies.size());
 
-        if (filter) {
-            for (auto& cookie : fetchedCookies) {
-                if (cookieMatchesFilter(cookie, filter))
-                    toDelete.append(cookie);
-            }
+        for (auto& cookie : fetchedCookies) {
+            if (filter.matches(cookie))
+                toDelete.append(cookie);
         }
 
         if (toDelete.isEmpty()) {

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorStorageAgent.h"
+
+#include "APIHTTPCookieStore.h"
+#include "InspectorCookieStoreHelpers.h"
+#include "WebPageProxy.h"
+#include "WebsiteDataStore.h"
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <WebCore/Cookie.h>
+#include <WebCore/SecurityOriginData.h>
+#include <wtf/JSONValues.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/URL.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+using namespace Inspector;
+using Cookie = Inspector::Protocol::Storage::Cookie;
+using CookieSameSitePolicy = Inspector::Protocol::Storage::CookieSameSitePolicy;
+using PartitionKey = Inspector::Protocol::Storage::PartitionKey;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorStorageAgent);
+
+static CookieSameSitePolicy toProtocol(WebCore::Cookie::SameSitePolicy policy)
+{
+    switch (policy) {
+    case WebCore::Cookie::SameSitePolicy::None:
+        return CookieSameSitePolicy::None;
+    case WebCore::Cookie::SameSitePolicy::Lax:
+        return CookieSameSitePolicy::Lax;
+    case WebCore::Cookie::SameSitePolicy::Strict:
+        return CookieSameSitePolicy::Strict;
+    }
+    ASSERT_NOT_REACHED();
+    return CookieSameSitePolicy::None;
+}
+
+static WebCore::Cookie::SameSitePolicy fromProtocol(const String& sameSite)
+{
+    if (sameSite == "Strict"_s)
+        return WebCore::Cookie::SameSitePolicy::Strict;
+    if (sameSite == "Lax"_s)
+        return WebCore::Cookie::SameSitePolicy::Lax;
+    return WebCore::Cookie::SameSitePolicy::None;
+}
+
+static Ref<Cookie> buildObjectForCookie(const WebCore::Cookie& cookie)
+{
+    auto result = Cookie::create()
+        .setName(cookie.name)
+        .setValue(cookie.value)
+        .setDomain(cookie.domain)
+        .setPath(cookie.path)
+        .setExpires(cookie.expires.value_or(0))
+        .setSession(cookie.session)
+        .setHttpOnly(cookie.httpOnly)
+        .setSecure(cookie.secure)
+        .setSameSite(toProtocol(cookie.sameSite))
+        .release();
+
+    if (!cookie.partitionKey.isEmpty())
+        result->setPartitionKey(cookie.partitionKey);
+
+    return result;
+}
+
+static Ref<JSON::ArrayOf<Cookie>> buildArrayForCookies(const Vector<WebCore::Cookie>& cookiesList)
+{
+    auto cookies = JSON::ArrayOf<Cookie>::create();
+    for (const auto& cookie : cookiesList)
+        cookies->addItem(buildObjectForCookie(cookie));
+    return cookies;
+}
+
+InspectorStorageAgent::InspectorStorageAgent(WebPageAgentContext& context)
+    : InspectorAgentBase("Storage"_s, context)
+    , m_backendDispatcher(Inspector::StorageBackendDispatcher::create(context.backendDispatcher.get(), this))
+    , m_inspectedPage(context.inspectedPage)
+{
+}
+
+InspectorStorageAgent::~InspectorStorageAgent() = default;
+
+void InspectorStorageAgent::didCreateFrontendAndBackend()
+{
+}
+
+void InspectorStorageAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
+{
+}
+
+Inspector::Protocol::ErrorStringOr<void> InspectorStorageAgent::enable()
+{
+    return { };
+}
+
+Inspector::Protocol::ErrorStringOr<void> InspectorStorageAgent::disable()
+{
+    return { };
+}
+
+Inspector::Protocol::ErrorStringOr<Ref<API::HTTPCookieStore>> InspectorStorageAgent::cookieStoreForPartition(const RefPtr<JSON::Object>& partition)
+{
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage)
+        return makeUnexpected("Inspected page is gone"_s);
+
+    if (partition) {
+        auto type = partition->getString("type"_s);
+        if (type != "context"_s)
+            return makeUnexpected("Invalid partition descriptor"_s);
+    }
+
+    return Ref { protect(inspectedPage->websiteDataStore())->cookieStore() };
+}
+
+Inspector::Protocol::ErrorStringOr<Ref<PartitionKey>> InspectorStorageAgent::makePartitionKey(const RefPtr<JSON::Object>& partition)
+{
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage)
+        return makeUnexpected("Inspected page is gone"_s);
+
+    if (partition) {
+        auto type = partition->getString("type"_s);
+        if (type != "context"_s)
+            return makeUnexpected("Invalid partition descriptor"_s);
+    }
+
+    // All-optional builder: create() returns a Builder, release() yields the Ref.
+    auto partitionKey = PartitionKey::create().release();
+
+    URL pageURL { inspectedPage->currentURL() };
+    if (pageURL.isValid())
+        partitionKey->setSourceOrigin(WebCore::SecurityOriginData::fromURL(pageURL).toString());
+
+    return partitionKey;
+}
+
+// Not scoped to the inspected page's origins: under Site Isolation cookies span processes a single
+// web process can't reach, so per-origin grouping is the frontend's job. See the commit message.
+void InspectorStorageAgent::getCookies(RefPtr<JSON::Object>&& filter, RefPtr<JSON::Object>&& partition, Ref<GetCookiesCallback>&& callback)
+{
+    auto partitionKey = makePartitionKey(partition);
+    if (!partitionKey) {
+        callback->sendFailure(partitionKey.error());
+        return;
+    }
+
+    auto cookieStore = cookieStoreForPartition(partition);
+    if (!cookieStore) {
+        callback->sendFailure(cookieStore.error());
+        return;
+    }
+
+    Ref<API::HTTPCookieStore> store = cookieStore.value();
+    store->cookies([callback = WTF::move(callback), filter = CookieFilter::fromProtocol(filter), partitionKey = partitionKey.value()](Vector<WebCore::Cookie>&& cookiesList) mutable {
+        Vector<WebCore::Cookie> matchingCookies;
+        matchingCookies.reserveInitialCapacity(cookiesList.size());
+        for (const auto& cookie : cookiesList) {
+            if (filter.matches(cookie))
+                matchingCookies.append(cookie);
+        }
+        callback->sendSuccess(buildArrayForCookies(matchingCookies), WTF::move(partitionKey));
+    });
+}
+
+void InspectorStorageAgent::setCookie(Ref<JSON::Object>&& cookie, RefPtr<JSON::Object>&& partition, Ref<SetCookieCallback>&& callback)
+{
+    auto partitionKey = makePartitionKey(partition);
+    if (!partitionKey) {
+        callback->sendFailure(partitionKey.error());
+        return;
+    }
+
+    auto cookieStore = cookieStoreForPartition(partition);
+    if (!cookieStore) {
+        callback->sendFailure(cookieStore.error());
+        return;
+    }
+
+    auto name = cookie->getString("name"_s);
+    auto value = cookie->getString("value"_s);
+    auto domain = cookie->getString("domain"_s);
+    if (name.isEmpty() || domain.isEmpty()) {
+        callback->sendFailure("Cookie must have a name and a domain"_s);
+        return;
+    }
+
+    WebCore::Cookie webCoreCookie;
+    webCoreCookie.name = name;
+    webCoreCookie.value = value;
+    webCoreCookie.domain = domain;
+    webCoreCookie.path = cookie->getString("path"_s);
+    webCoreCookie.secure = cookie->getBoolean("secure"_s).value_or(false);
+    webCoreCookie.httpOnly = cookie->getBoolean("httpOnly"_s).value_or(false);
+    webCoreCookie.session = cookie->getBoolean("session"_s).value_or(false);
+    if (auto expires = cookie->getDouble("expires"_s))
+        webCoreCookie.expires = *expires;
+    if (auto sameSite = cookie->getString("sameSite"_s); !sameSite.isEmpty())
+        webCoreCookie.sameSite = fromProtocol(sameSite);
+
+    // Only partition when the caller asks; a synthesized key would break the set/get/delete round-trip.
+    if (auto explicitPartitionKey = cookie->getString("partitionKey"_s); !explicitPartitionKey.isEmpty())
+        webCoreCookie.partitionKey = explicitPartitionKey;
+
+    auto resolvedPartitionKey = PartitionKey::create().release();
+    if (!webCoreCookie.partitionKey.isEmpty())
+        resolvedPartitionKey->setSourceOrigin(webCoreCookie.partitionKey);
+
+    Vector<WebCore::Cookie> cookiesToSet;
+    cookiesToSet.append(WTF::move(webCoreCookie));
+
+    Ref<API::HTTPCookieStore> store = cookieStore.value();
+    store->setCookies(WTF::move(cookiesToSet), [callback = WTF::move(callback), partitionKey = WTF::move(resolvedPartitionKey)]() mutable {
+        callback->sendSuccess(WTF::move(partitionKey));
+    });
+}
+
+static void deleteCookiesSequentially(Ref<API::HTTPCookieStore> store, Vector<WebCore::Cookie> cookies, size_t index, Ref<PartitionKey> partitionKey, Ref<InspectorStorageAgent::DeleteCookiesCallback> callback)
+{
+    if (index >= cookies.size()) {
+        callback->sendSuccess(WTF::move(partitionKey));
+        return;
+    }
+    // Copy the target cookie out before the lambda moves `cookies` into its capture (unsequenced-read hazard).
+    auto cookieToDelete = cookies[index];
+    store->deleteCookie(cookieToDelete, [store, cookies = WTF::move(cookies), index, partitionKey = WTF::move(partitionKey), callback = WTF::move(callback)]() mutable {
+        deleteCookiesSequentially(WTF::move(store), WTF::move(cookies), index + 1, WTF::move(partitionKey), WTF::move(callback));
+    });
+}
+
+void InspectorStorageAgent::deleteCookies(RefPtr<JSON::Object>&& filter, RefPtr<JSON::Object>&& partition, Ref<DeleteCookiesCallback>&& callback)
+{
+    // Require an explicit filter: an empty request would clear the entire store (matches BidiStorageAgent).
+    if (!filter) {
+        callback->sendFailure("A filter is required to delete cookies"_s);
+        return;
+    }
+
+    auto partitionKey = makePartitionKey(partition);
+    if (!partitionKey) {
+        callback->sendFailure(partitionKey.error());
+        return;
+    }
+
+    auto cookieStore = cookieStoreForPartition(partition);
+    if (!cookieStore) {
+        callback->sendFailure(cookieStore.error());
+        return;
+    }
+
+    Ref<API::HTTPCookieStore> store = cookieStore.value();
+    store->cookies([store, callback = WTF::move(callback), filter = CookieFilter::fromProtocol(filter), partitionKey = partitionKey.value()](Vector<WebCore::Cookie>&& fetchedCookies) mutable {
+        Vector<WebCore::Cookie> toDelete;
+        toDelete.reserveInitialCapacity(fetchedCookies.size());
+        for (auto& cookie : fetchedCookies) {
+            if (filter.matches(cookie))
+                toDelete.append(cookie);
+        }
+
+        if (toDelete.isEmpty()) {
+            callback->sendSuccess(WTF::move(partitionKey));
+            return;
+        }
+
+        deleteCookiesSequentially(WTF::move(store), WTF::move(toDelete), 0, WTF::move(partitionKey), WTF::move(callback));
+    });
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WebPageInspectorAgentBase.h"
+#include <JavaScriptCore/InspectorBackendDispatchers.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/Forward.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+
+namespace API {
+class HTTPCookieStore;
+}
+
+namespace WebKit {
+
+class WebPageProxy;
+
+class InspectorStorageAgent final : public InspectorAgentBase, public Inspector::StorageBackendDispatcherHandler, public CanMakeCheckedPtr<InspectorStorageAgent> {
+    WTF_MAKE_NONCOPYABLE(InspectorStorageAgent);
+    WTF_MAKE_TZONE_ALLOCATED(InspectorStorageAgent);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorStorageAgent);
+public:
+    InspectorStorageAgent(WebPageAgentContext&);
+    ~InspectorStorageAgent();
+
+    // InspectorAgentBase
+    void didCreateFrontendAndBackend();
+    void willDestroyFrontendAndBackend(Inspector::DisconnectReason);
+
+    // StorageBackendDispatcherHandler
+    Inspector::Protocol::ErrorStringOr<void> enable();
+    Inspector::Protocol::ErrorStringOr<void> disable();
+    void getCookies(RefPtr<JSON::Object>&& filter, RefPtr<JSON::Object>&& partition, Ref<GetCookiesCallback>&&);
+    void setCookie(Ref<JSON::Object>&& cookie, RefPtr<JSON::Object>&& partition, Ref<SetCookieCallback>&&);
+    void deleteCookies(RefPtr<JSON::Object>&& filter, RefPtr<JSON::Object>&& partition, Ref<DeleteCookiesCallback>&&);
+
+private:
+    Inspector::Protocol::ErrorStringOr<Ref<API::HTTPCookieStore>> cookieStoreForPartition(const RefPtr<JSON::Object>& partition);
+    Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::Storage::PartitionKey>> makePartitionKey(const RefPtr<JSON::Object>& partition);
+
+    const Ref<Inspector::StorageBackendDispatcher> m_backendDispatcher;
+    WeakRef<WebPageProxy> m_inspectedPage;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/InspectorCookieStoreHelpers.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorCookieStoreHelpers.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorCookieStoreHelpers.h"
+
+#include <WebCore/Cookie.h>
+#include <wtf/JSONValues.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+CookieFilter CookieFilter::fromProtocol(const RefPtr<JSON::Object>& filter)
+{
+    CookieFilter parsed;
+    if (!filter)
+        return parsed;
+
+    parsed.name = filter->getString("name"_s);
+    parsed.value = filter->getString("value"_s);
+    parsed.domain = filter->getString("domain"_s);
+    parsed.path = filter->getString("path"_s);
+    parsed.httpOnly = filter->getBoolean("httpOnly"_s);
+    parsed.secure = filter->getBoolean("secure"_s);
+    return parsed;
+}
+
+bool CookieFilter::matches(const WebCore::Cookie& cookie) const
+{
+    if (!name.isEmpty() && cookie.name != name)
+        return false;
+
+    if (!value.isEmpty() && cookie.value != value)
+        return false;
+
+    if (!domain.isEmpty() && cookie.domain != domain)
+        return false;
+
+    if (!path.isEmpty() && cookie.path != path)
+        return false;
+
+    if (httpOnly && cookie.httpOnly != *httpOnly)
+        return false;
+
+    if (secure && cookie.secure != *secure)
+        return false;
+
+    return true;
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/InspectorCookieStoreHelpers.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorCookieStoreHelpers.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+struct Cookie;
+}
+
+namespace WebKit {
+
+// A parsed cookie filter shared by the Storage inspector domain and BiDi automation: parse the
+// protocol object once via fromProtocol(), then apply it with matches(). An empty filter matches every cookie.
+struct CookieFilter {
+    // Parses the protocol CookieFilter object. A null object yields an empty (match-everything) filter.
+    static CookieFilter fromProtocol(const RefPtr<JSON::Object>&);
+
+    bool matches(const WebCore::Cookie&) const;
+
+    String name;
+    String value;
+    String domain;
+    String path;
+    std::optional<bool> httpOnly;
+    std::optional<bool> secure;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -30,6 +30,7 @@
 #include "FrameInspectorTarget.h"
 #include "FrameInspectorTargetProxy.h"
 #include "InspectorBrowserAgent.h"
+#include "InspectorStorageAgent.h"
 #include "PageInspectorTarget.h"
 #include "PageInspectorTargetProxy.h"
 #include "ProvisionalFrameProxy.h"
@@ -511,6 +512,7 @@ void WebPageInspectorController::createLazyAgents()
     auto webPageContext = webPageAgentContext();
 
     m_agents.append(makeUniqueRef<InspectorBrowserAgent>(webPageContext));
+    m_agents.append(makeUniqueRef<InspectorStorageAgent>(webPageContext));
 
     if (protect(protect(m_inspectedPage)->preferences())->siteIsolationEnabled()) {
         // ProxyingNetworkAgent and ProxyingPageAgent are RefCounted (for IPC MessageReceiver)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2322,6 +2322,8 @@
 		C1E123BA20A11573002646F4 /* PDFContextMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = C1E123B920A11572002646F4 /* PDFContextMenu.h */; };
 		C3EE0FDA0234F84002CAF7FB /* ProxyingNetworkAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = EB43329193327F9D842EE004 /* ProxyingNetworkAgent.h */; };
 		C3EE0FDA0234F84002CAF7FC /* ProxyingPageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = EB43329193327F9D842EE005 /* ProxyingPageAgent.h */; };
+		AA10570005 /* InspectorStorageAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = AA10570002 /* InspectorStorageAgent.h */; };
+		AA10570006 /* InspectorCookieStoreHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA10570004 /* InspectorCookieStoreHelpers.h */; };
 		C4450D54570C4383A25745E6 /* _WKAutomationSessionPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = BC35BB81026B48A6A3BDAA80 /* _WKAutomationSessionPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C517388112DF8F4F00EE3F47 /* DragControllerAction.h in Headers */ = {isa = PBXBuildFile; fileRef = C517388012DF8F4F00EE3F47 /* DragControllerAction.h */; };
 		C54256B518BEC18C00DE4179 /* WKDateTimeInputControl.h in Headers */ = {isa = PBXBuildFile; fileRef = C54256AF18BEC18B00DE4179 /* WKDateTimeInputControl.h */; };
@@ -8582,6 +8584,10 @@
 		D246E13B2C61292700B41DE2 /* HTTPSBrowsingWarning.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = HTTPSBrowsingWarning.xcassets; sourceTree = "<group>"; };
 		D2CB01DAB4428B76CDA8AECC /* ProxyingNetworkAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyingNetworkAgent.cpp; sourceTree = "<group>"; };
 		D2CB01DAB4428B76CDA8AEDD /* ProxyingPageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProxyingPageAgent.cpp; sourceTree = "<group>"; };
+		AA10570001 /* InspectorStorageAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorStorageAgent.cpp; sourceTree = "<group>"; };
+		AA10570002 /* InspectorStorageAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorStorageAgent.h; sourceTree = "<group>"; };
+		AA10570003 /* InspectorCookieStoreHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorCookieStoreHelpers.cpp; sourceTree = "<group>"; };
+		AA10570004 /* InspectorCookieStoreHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorCookieStoreHelpers.h; sourceTree = "<group>"; };
 		D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTaskCocoa.h; sourceTree = "<group>"; };
 		D2E2FE6F29C8C4F900023E6B /* NetworkTaskCocoa.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = NetworkTaskCocoa.mm; sourceTree = "<group>"; };
 		D2FB53952E13020F00AF9D5C /* PageClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageClient.cpp; sourceTree = "<group>"; };
@@ -15188,6 +15194,8 @@
 		91D970D423DA6D250057DBC3 /* Inspector */ = {
 			isa = PBXGroup;
 			children = (
+				AA10570003 /* InspectorCookieStoreHelpers.cpp */,
+				AA10570004 /* InspectorCookieStoreHelpers.h */,
 				91D970D523DA6D500057DBC3 /* Agents */,
 				919793FE23DBC47400257892 /* Cocoa */,
 				91D970D723DA6D5B0057DBC3 /* ios */,
@@ -15226,6 +15234,8 @@
 		91D970D523DA6D500057DBC3 /* Agents */ = {
 			isa = PBXGroup;
 			children = (
+				AA10570001 /* InspectorStorageAgent.cpp */,
+				AA10570002 /* InspectorStorageAgent.h */,
 				9197940423DBC4BB00257892 /* InspectorBrowserAgent.cpp */,
 				9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */,
 				D2CB01DAB4428B76CDA8AECC /* ProxyingNetworkAgent.cpp */,
@@ -17850,6 +17860,8 @@
 			files = (
 				1A6280C51919949F006AD9F9 /* WebKit.h in Headers */,
 				1A6280C71919950C006AD9F9 /* WebKitPrivate.h in Headers */,
+				AA10570005 /* InspectorStorageAgent.h in Headers */,
+				AA10570006 /* InspectorCookieStoreHelpers.h in Headers */,
 				37A5E01418BBF93F000A081E /* _WKActivatedElementInfo.h in Headers */,
 				379A873618BBFA4300588AF2 /* _WKActivatedElementInfoInternal.h in Headers */,
 				449316A325DC7DC400AA66DE /* _WKAppHighlight.h in Headers */,


### PR DESCRIPTION
#### 74bc5de8363385d200ce43338756dcb6969bd424
<pre>
WIP: [SI] Add a Storage domain for cookie inspection
<a href="https://bugs.webkit.org/show_bug.cgi?id=308900">https://bugs.webkit.org/show_bug.cgi?id=308900</a>
<a href="https://rdar.apple.com/171780948">rdar://171780948</a>

Reviewed by Qianlang Chen.

Introduce a new Storage domain (cookies only for this pass) that runs entirely
UIProcess-side and talks to the authoritative store via API::HTTPCookieStore --
the same path BidiStorageAgent already uses. Reading the NetworkProcess-owned
store in one call sees cookies across every WebContent process, including those
set inside cross-origin iframes under Site Isolation, with no per-process fan-
out or routing. The old Page cookie commands are left untouched.

InspectorStorageAgent does no WebContent IPC (all work is UIProcess-local), so
unlike ProxyingPageAgent/ProxyingNetworkAgent it needs no MessageReceiver and
lives in the AgentRegistry. It is created unconditionally in
WebPageInspectorController::createLazyAgents alongside InspectorBrowserAgent,
not gated on siteIsolationEnabled(): the domain is useful with or without SI,
and reading the authoritative store is the correct model in both cases. Its
protocol domain is declared with targetTypes [&quot;web-page&quot;] so, like Browser, it
is owned by the UIProcess (multiplexing) target rather than the WebContent page
target; Target.js gains the matching StorageAgent accessor.

getCookies reads the flat authoritative store (API::HTTPCookieStore::cookies,
backed by WebCookieManager::GetAllCookies). This read surfaces BOTH unpartitioned
and partitioned (CHIPS) cookies; each cookie carries its partition in
Cookie.partitionKey, so partitioned cookies are visible and labeled (verified by
storage-get-partitioned-cookies.https.html). The only remaining partition work is
a documented per-URL+partition scoped lens (the storageKey PartitionDescriptor
arm), deferred to webkit.org/b/292393 -- not basic visibility.

The Storage domain exposes an explicit PartitionDescriptor parameter (context
now, storageKey stubbed for webkit.org/b/292393) and populates Cookie.partitionKey:
it is emitted on getCookies and, on setCookie, written onto the WebCore::Cookie
only when the caller supplies an explicit partitionKey. setCookie&apos;s returned
PartitionKey echoes where the cookie actually landed -- the explicit key if given,
otherwise empty -- rather than synthesizing the page&apos;s origin, so it never claims
an unpartitioned cookie lives in a partition. WebCore::Cookie::partitionKey already
existed and already rides the IPC to NetworkProcess; BiDi simply never set it. A
follow-up should bring BidiStorageAgent to parity via the shared helper.

deleteCookies requires an explicit filter: a request with no filter is rejected
rather than clearing the entire store (which, given the flat read above, would
include partitioned cookies). This matches BidiStorageAgent and keeps a
destructive clear from being the empty-argument default of a filtered command.

Cookie filtering is factored out of BidiStorageAgent into a shared
CookieStoreHelpers::cookieMatchesFilter so both frontends filter identically;
BidiStorageAgent is refactored onto it with no behavior change.

Opt-in cookie partitioning (CHIPS) is gated on HAVE(ALLOW_ONLY_PARTITIONED_COOKIES)
(macOS 26.2+); on older OSes it is compiled out and no partitionKey is populated.
storage-get-partitioned-cookies.https.html asserts a populated partitionKey, so
it is [ Skip ] by default in LayoutTests/TestExpectations and re-enabled with
[ Tahoe+ ] [ Pass ] in platform/mac-wk2/TestExpectations -- the same two-file
split as the existing CHIPS suite. The other three storage tests run everywhere.

Tests: http/tests/site-isolation/inspector/storage/storage-get-cookies.html
       http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html
       http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https.html
       http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/site-isolation/inspector/storage/resources/set-cookie-via-script.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/resources/set-cookie.py: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-cookies.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-get-partitioned-cookies.https.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/storage/storage-set-and-delete-cookies.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/DerivedSources-input.xcfilelist:
* Source/JavaScriptCore/DerivedSources.make:
* Source/JavaScriptCore/inspector/protocol/Storage.json: Added.
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.get StorageAgent): Added.
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp:
(WebKit::BidiStorageAgent::getCookies):
(WebKit::BidiStorageAgent::deleteCookies):
(WebKit::cookieMatchesFilter): Deleted.
* Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.cpp: Added.
(WebKit::toProtocol):
(WebKit::fromProtocol):
(WebKit::buildObjectForCookie):
(WebKit::buildArrayForCookies):
(WebKit::InspectorStorageAgent::InspectorStorageAgent):
(WebKit::InspectorStorageAgent::didCreateFrontendAndBackend):
(WebKit::InspectorStorageAgent::willDestroyFrontendAndBackend):
(WebKit::InspectorStorageAgent::enable):
(WebKit::InspectorStorageAgent::disable):
(WebKit::InspectorStorageAgent::cookieStoreForPartition):
(WebKit::InspectorStorageAgent::makePartitionKey):
(WebKit::InspectorStorageAgent::getCookies):
(WebKit::InspectorStorageAgent::setCookie):
(WebKit::deleteCookiesSequentially):
(WebKit::InspectorStorageAgent::deleteCookies):
* Source/WebKit/UIProcess/Inspector/Agents/InspectorStorageAgent.h: Added.
* Source/WebKit/UIProcess/Inspector/InspectorCookieStoreHelpers.cpp: Added.
(WebKit::CookieFilter::fromProtocol):
(WebKit::CookieFilter::matches const):
* Source/WebKit/UIProcess/Inspector/InspectorCookieStoreHelpers.h: Added.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::createLazyAgents):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/317129@main">https://commits.webkit.org/317129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd690d7c91706b3c3ccb2345dc8d46430b47f3dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48360 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/42141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/184004 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/132295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/48042 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/132295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177385 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/39126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/156486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/116168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/36136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32485 "Built successfully") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/4995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/148190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186430 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/35689 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/39651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/40333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/48027 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/156040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/144462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48706 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/114263 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26507 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/39362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/120661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/211480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/47213 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/211480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46673 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->