### PR TITLE
Sign in with Apple unsuccessful and causes reload due to problem - Received an invalid message 'RemoteObjectRegistry_InvokeMethod'

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1350,35 +1350,21 @@ bool WebProcessProxy::handleRemoteObjectRegistryMessage(IPC::Connection& connect
 {
     if (!WebPageProxyIdentifier::isValidIdentifier(decoder.destinationID()))
         return false;
+
     WebPageProxyIdentifier pageID(decoder.destinationID());
-
-    auto receiveMessage = [&] (WebPageProxy& page) {
-        if (RefPtr registry = page.uiRemoteObjectRegistry()) {
-            registry->didReceiveMessage(connection, decoder);
-            return true;
-        }
+    if (!isAssociatedWithPage(pageID))
         return false;
-    };
 
-    if (RefPtr page = m_pageMap.get(pageID))
-        return receiveMessage(*page);
+    RefPtr page = WebPageProxy::fromIdentifier(pageID);
+    if (!page)
+        return false;
 
-    for (Ref remotePage : m_remotePages) {
-        if (RefPtr page = remotePage->page(); page && page->identifier() == pageID)
-            return receiveMessage(*page);
-    }
+    RefPtr registry = page->uiRemoteObjectRegistry();
+    if (!registry)
+        return false;
 
-    for (Ref provisionalPage : m_provisionalPages) {
-        if (RefPtr page = provisionalPage->page(); page && page->identifier() == pageID)
-            return receiveMessage(*page);
-    }
-
-    for (Ref suspendedPage : m_suspendedPages) {
-        if (RefPtr page = suspendedPage->page(); page && page->identifier() == pageID)
-            return receiveMessage(*page);
-    }
-
-    return false;
+    registry->didReceiveMessage(connection, decoder);
+    return true;
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistry.h
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistry.h
@@ -58,6 +58,7 @@
 - (void)sendError:(NSError *)error completionHandler:(void (^)(NSError *))completionHandler;
 - (void)sendAwakener:(TestAwakener *)awakener completionHandler:(void (^)(TestAwakener *))completionHandler;
 - (void)getGroupIdentifier:(void(^)(NSString *))completionHandler;
+- (void)triggerCallToUIProcessOnClose;
 
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistry.mm
@@ -256,6 +256,46 @@ TEST(RemoteObjectRegistry, CallReplyBlockAfterOriginatingWebViewDeallocates)
     localObject->completionHandlerFromWebProcess();
 }
 
+// Regression test for the WebProcess termination that occurred when the WebProcess
+// sent a RemoteObjectRegistry::InvokeMethod IPC while handling WebPage::Close.
+// Before the fix, the UIProcess had already removed the page from WebProcessProxy's
+// page maps by the time the InvokeMethod arrived, so handleRemoteObjectRegistryMessage
+// returned false, the message was marked invalid, and didReceiveInvalidMessage killed
+// the WebProcess. The fix tracks pages pending close so isAssociatedWithPage stays
+// true until the WebPage::Close async reply arrives.
+TEST(RemoteObjectRegistry, InvokeMethodFromBundleDuringPageClose)
+{
+    auto localObject = adoptNS([[LocalObject alloc] init]);
+
+    NSString * const testPlugInClassName = @"RemoteObjectRegistryPlugIn";
+    auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:testPlugInClassName]);
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+
+    [[webView _remoteObjectRegistry] registerExportedObject:localObject.get() interface:localObjectInterface()];
+
+    id<RemoteObjectProtocol> object = [[webView _remoteObjectRegistry] remoteObjectProxyWithInterface:remoteObjectInterface()];
+
+    // Arm the bundle to send a UIProcess-bound InvokeMethod from
+    // -[WKWebProcessPlugIn webProcessPlugIn:willDestroyBrowserContextController:],
+    // which fires synchronously inside WebPage::close() in the WebProcess.
+    [object triggerCallToUIProcessOnClose];
+
+    // Round-trip through the bundle so we know the flag flip has been processed
+    // before we close the WKWebView.
+    __block bool roundTripDone = false;
+    [object sayHello:@"sync" completionHandler:^(NSString *) {
+        roundTripDone = true;
+    }];
+    TestWebKitAPI::Util::run(&roundTripDone);
+
+    // Triggers WebPage::Close → bundle InvokeMethod → UIProcess delivery.
+    [webView _close];
+
+    // With the bug, this hangs (message dropped, WebProcess terminated). With the fix,
+    // the local object's reply handler runs.
+    TestWebKitAPI::Util::run(&localObject->hasCompletionHandler);
+}
+
 @interface StringReplyObject : NSObject<StringReplyObjectProtocol> {
 @public
     bool calledCompletionHandler;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistryPlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteObjectRegistryPlugIn.mm
@@ -41,6 +41,7 @@
 @implementation RemoteObjectRegistryPlugIn {
     RetainPtr<WKWebProcessPlugInBrowserContextController> _browserContextController;
     RetainPtr<WKWebProcessPlugInController> _plugInController;
+    BOOL _shouldCallUIProcessOnClose;
 }
 
 - (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
@@ -144,6 +145,23 @@
 - (void)getGroupIdentifier:(void(^)(NSString *))completionHandler
 {
     completionHandler([_browserContextController _groupIdentifier]);
+}
+
+- (void)triggerCallToUIProcessOnClose
+{
+    _shouldCallUIProcessOnClose = YES;
+}
+
+- (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController willDestroyBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
+{
+    if (!_shouldCallUIProcessOnClose)
+        return;
+
+    // Send an InvokeMethod IPC to the UIProcess from inside WebPage::Close handling.
+    // Reproduces the race where the UIProcess receives the message after the page has
+    // been removed from WebProcessProxy's page maps.
+    id<LocalObjectProtocol> localObject = [[browserContextController _remoteObjectRegistry] remoteObjectProxyWithInterface:localObjectInterface()];
+    [localObject doSomethingWithCompletionHandler:^{ }];
 }
 
 @end


### PR DESCRIPTION
#### d06f9c09279f01de58eb0d9202d9b8a1ad92d679
<pre>
Sign in with Apple unsuccessful and causes reload due to problem - Received an invalid message &apos;RemoteObjectRegistry_InvokeMethod&apos;
<a href="https://rdar.apple.com/178567852">rdar://178567852</a>

Reviewed by Alex Christensen.

The injected bundle&apos;s -webProcessPlugIn:willDestroyBrowserContextController:
hook fires synchronously from WebPage::close() in the WebProcess, and bundle
clients are allowed to invoke a UIProcess-side _WKRemoteObjectRegistry method
from that hook. The resulting RemoteObjectRegistry::InvokeMethod IPC arrives
at the UIProcess after WebPageProxy::close() has synchronously called
WebProcessProxy::removeWebPage(), so the page is no longer in m_pageMap (or
m_remotePages / m_provisionalPages / m_suspendedPages).

WebProcessProxy::handleRemoteObjectRegistryMessage then returned false, which
caused the generated didReceiveMessage to mark the decoder invalid and the
IPC layer to call WebProcessProxy::didReceiveInvalidMessage, terminating an
otherwise well-behaved WebProcess.

To fix this, mark every content process for the page as pending-close before
dispatching Messages::WebPage::Close, and only clear the marker once the
async reply arrives. WebProcessProxy::isAssociatedWithPage already consults
m_pagesPendingClose, so a late-arriving InvokeMethod is now recognized and
delivered to the registry. m_pagesPendingClose is changed from HashSet to
HashCountedSet so the regular close path and the provisional-page-swap close
path compose correctly when both target the same page.

handleRemoteObjectRegistryMessage is reworked to consult isAssociatedWithPage
and look the page up via the global WebPageProxy::fromIdentifier, replacing
the four sequential map walks.

Note that this commit makes the branch more in-line with main after 314178@main.
314178@main already takes care of adding the page to m_pagesPendingClose while
we&apos;re sending the WebPage::Close IPC. Also include the fix from 314426@main,
since it fixed a crash introduced by 314178@main.

TLDR: this PR is essentially a merge for 314178@main &amp; 314178@main from
main so that WebProcessProxy::m_pagesPendingClose gets properly populated.
Then WebProcessProxy::handleRemoteObjectRegistryMessage() is updated to
call WebProcessProxy::isAssociatedWithPage() instead of duplicating its
logic. WebProcessProxy::isAssociatedWithPage also has the benefit of
checking m_pagesPendingClose already.

Update WKWebView.EvaluateJavaScriptBlockCrash test expectation to match
313673@main: now that Messages::WebPage::Close is an async-reply message,
the WebProcess is kept alive (via the shutdownPreventingScope held in the
Close reply handler) long enough for the pending evaluateJavaScript IPC to
be processed and reply with a successful empty result, instead of being
cancelled by Connection::cancelAsyncReplyHandlers when the connection is
invalidated. The completion handler is therefore invoked with a nil error,
matching the same test expectation update made in 313673@main.

Tests: RemoteObjectRegistry.InvokeMethodFromBundleDuringPageClose

* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::disconnect):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::close):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::sendPageCloseMessage):
(WebKit::WebProcessProxy::handleRemoteObjectRegistryMessage):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
(WebKit::WebPage::closeWithReply): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry.mm:
(TEST(RemoteObjectRegistry, InvokeMethodFromBundleDuringPageClose)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistryPlugIn.mm:
(-[RemoteObjectRegistryPlugIn triggerCallToUIProcessOnClose]):
(-[RemoteObjectRegistryPlugIn webProcessPlugIn:willDestroyBrowserContextController:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptBlockCrash)):

Originally-landed-as: 305413.880@safari-7624.4-branch (d0f2013438ba). <a href="https://rdar.apple.com/181073656">rdar://181073656</a>
Canonical link: <a href="https://commits.webkit.org/316477@main">https://commits.webkit.org/316477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f84b288c7ca17857d01342441eb1b90f529d796

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172385 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134073 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34405 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30442 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184372 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142845 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45975 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38557 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46653 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111381 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37770 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118404 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45170 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9058 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->