### PR TITLE
[JSC][Temporal] Polish Temporal.PlainDateTime: spec alignment, constructor and round() fixes

### DIFF
--- a/JSTests/stress/temporal-plain-datetime-ctor-nan-infinity.js
+++ b/JSTests/stress/temporal-plain-datetime-ctor-nan-infinity.js
@@ -1,0 +1,35 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+function shouldThrow(fn, msg) {
+    let threw = false;
+    try { fn(); } catch (e) { threw = e instanceof RangeError; }
+    if (!threw) throw new Error(`${msg}: expected RangeError`);
+}
+
+// Spec-positive: time-arg undefined defaults to 0 (Steps 5-10).
+shouldBe(new Temporal.PlainDateTime(2024, 1, 1).toString(),
+    "2024-01-01T00:00:00", "time args omitted");
+shouldBe(new Temporal.PlainDateTime(2024, 1, 1, undefined).toString(),
+    "2024-01-01T00:00:00", "explicit undefined hour");
+shouldBe(new Temporal.PlainDateTime(2024, 1, 1, 12, undefined).toString(),
+    "2024-01-01T12:00:00", "explicit undefined minute");
+shouldBe(new Temporal.PlainDateTime(2024, 1, 1, 12, 34, undefined, undefined, undefined, undefined).toString(),
+    "2024-01-01T12:34:00", "all trailing time args undefined");
+
+// Spec-negative: any non-finite input (NaN or ±Infinity) on date OR time args throws.
+shouldThrow(() => new Temporal.PlainDateTime(NaN, 1, 1), "NaN year");
+shouldThrow(() => new Temporal.PlainDateTime(undefined, 1, 1), "undefined year");
+shouldThrow(() => new Temporal.PlainDateTime(), "no args (undefined year)");
+shouldThrow(() => new Temporal.PlainDateTime(Infinity, 1, 1), "Infinity year");
+shouldThrow(() => new Temporal.PlainDateTime(2024, NaN, 1), "NaN month");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, NaN), "NaN day");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, 1, NaN), "NaN hour (not undefined)");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, 1, Infinity), "Infinity hour");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, 1, 12, NaN), "NaN minute (not undefined)");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, 1, 12, 34, 56, NaN), "NaN millisecond");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, 1, 12, 34, 56, 789, NaN), "NaN microsecond");
+shouldThrow(() => new Temporal.PlainDateTime(2024, 1, 1, 12, 34, 56, 789, 123, NaN), "NaN nanosecond");

--- a/JSTests/stress/temporal-plain-datetime-round.js
+++ b/JSTests/stress/temporal-plain-datetime-round.js
@@ -1,0 +1,83 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected "${expected}" but got "${actual}"`);
+}
+function shouldThrow(fn, errorType, msg) {
+    let caught;
+    try { fn(); } catch (e) { caught = e; }
+    if (!caught) throw new Error(`${msg}: expected ${errorType.name}`);
+    if (!(caught instanceof errorType)) throw new Error(`${msg}: expected ${errorType.name} but got ${caught.constructor.name}`);
+}
+
+// Base instant used throughout: 2024-06-15 13:24:36.123_456_789 (UTC-only ISO calendar).
+const base = new Temporal.PlainDateTime(2024, 6, 15, 13, 24, 36, 123, 456, 789);
+
+// --- Default mode is halfExpand. Validate every smallestUnit against the spec semantics. ---
+shouldBe(base.round("day").toString(), "2024-06-16T00:00:00", "round day default");
+shouldBe(base.round("hour").toString(), "2024-06-15T13:00:00", "round hour default");
+shouldBe(base.round("minute").toString(), "2024-06-15T13:25:00", "round minute default");
+shouldBe(base.round("second").toString(), "2024-06-15T13:24:36", "round second default");
+shouldBe(base.round("millisecond").toString(), "2024-06-15T13:24:36.123", "round ms default (.456789 < .5)");
+shouldBe(base.round("microsecond").toString(), "2024-06-15T13:24:36.123457", "round us default (.789 > .5)");
+shouldBe(base.round("nanosecond").toString(), "2024-06-15T13:24:36.123456789", "round ns identity");
+
+// --- All rounding modes against the same input for one unit (millisecond).
+//     Input fractional remainder below the ms boundary is 0.456789 ms, which is < 0.5,
+//     so every half-* mode rounds toward the floor (.123); only ceil/expand bump to .124. ---
+const ms = (mode) => base.round({ smallestUnit: "millisecond", roundingMode: mode }).toString();
+shouldBe(ms("halfExpand"), "2024-06-15T13:24:36.123", "ms halfExpand");
+shouldBe(ms("ceil"), "2024-06-15T13:24:36.124", "ms ceil");
+shouldBe(ms("floor"), "2024-06-15T13:24:36.123", "ms floor");
+shouldBe(ms("trunc"), "2024-06-15T13:24:36.123", "ms trunc");
+shouldBe(ms("halfCeil"), "2024-06-15T13:24:36.123", "ms halfCeil");
+shouldBe(ms("halfFloor"), "2024-06-15T13:24:36.123", "ms halfFloor");
+shouldBe(ms("halfTrunc"), "2024-06-15T13:24:36.123", "ms halfTrunc");
+shouldBe(ms("halfEven"), "2024-06-15T13:24:36.123", "ms halfEven");
+shouldBe(ms("expand"), "2024-06-15T13:24:36.124", "ms expand");
+
+// --- Rounding increments > 1 (must divide the maximum). ---
+shouldBe(base.round({ smallestUnit: "minute", roundingIncrement: 30 }).toString(),
+    "2024-06-15T13:30:00", "minute increment 30");
+shouldBe(base.round({ smallestUnit: "second", roundingIncrement: 15 }).toString(),
+    "2024-06-15T13:24:30", "second increment 15 (36 < 37.5)");
+shouldBe(base.round({ smallestUnit: "hour", roundingIncrement: 6 }).toString(),
+    "2024-06-15T12:00:00", "hour increment 6 (13 < 15)");
+
+// --- Boundary: rounding up across midnight bumps the date (day rollover). ---
+const lateNight = new Temporal.PlainDateTime(2024, 6, 15, 23, 59, 59, 999, 999, 999);
+shouldBe(lateNight.round("minute").toString(), "2024-06-16T00:00:00",
+    "halfExpand minute crosses midnight → next day");
+shouldBe(lateNight.round({ smallestUnit: "second", roundingMode: "ceil" }).toString(),
+    "2024-06-16T00:00:00", "ceil second crosses month boundary");
+
+// --- Day-rollover crossing month/year boundary. ---
+const lastDayOfYear = new Temporal.PlainDateTime(2024, 12, 31, 23, 59, 59, 999, 999, 999);
+shouldBe(lastDayOfYear.round("hour").toString(), "2025-01-01T00:00:00",
+    "year-end rollover via hour rounding");
+
+// --- Calendar preservation across round. ---
+const heb = new Temporal.PlainDateTime(2024, 1, 1, 13, 30, 0, 0, 0, 0, "hebrew");
+const roundedHeb = heb.round("hour");
+shouldBe(roundedHeb.calendarId, "hebrew", "round preserves hebrew calendar id");
+shouldBe(roundedHeb.toString(), "2024-01-01T14:00:00[u-ca=hebrew]", "round preserves hebrew toString");
+
+// --- String shorthand path: `pdt.round("hour")` ≡ `pdt.round({ smallestUnit: "hour" })`. ---
+shouldBe(base.round("hour").toString(), base.round({ smallestUnit: "hour" }).toString(), "string vs obj — hour");
+shouldBe(base.round("nanosecond").toString(), base.round({ smallestUnit: "nanosecond" }).toString(), "string vs obj — nanosecond");
+
+// --- Error paths. ---
+shouldThrow(() => base.round(), TypeError, "no arg → TypeError (Step 3)");
+shouldThrow(() => base.round(undefined), TypeError, "explicit undefined → TypeError");
+shouldThrow(() => base.round({}), RangeError, "missing smallestUnit (Required) → RangeError");
+shouldThrow(() => base.round({ smallestUnit: "year" }), RangeError, "year disallowed → RangeError");
+shouldThrow(() => base.round({ smallestUnit: "month" }), RangeError, "month disallowed → RangeError");
+shouldThrow(() => base.round({ smallestUnit: "week" }), RangeError, "week disallowed → RangeError");
+shouldThrow(() => base.round({ smallestUnit: "junk" }), RangeError, "unknown unit → RangeError");
+shouldThrow(() => base.round("year"), RangeError, "string year disallowed");
+shouldThrow(() => base.round("junk"), RangeError, "string junk disallowed");
+// Day is inclusive-bounded at 1; 2 is rejected.
+shouldThrow(() => base.round({ smallestUnit: "day", roundingIncrement: 2 }), RangeError, "day increment > 1 → RangeError");
+// Minute max is 60 exclusive; an indivisor like 7 fails.
+shouldThrow(() => base.round({ smallestUnit: "minute", roundingIncrement: 7 }), RangeError, "minute increment 7 (non-divisor of 60) → RangeError");

--- a/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDatePrototype.cpp
@@ -460,10 +460,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDatePrototypeFuncToPlainDateTime, (JSGloba
     }
 
     // Steps 5-6: CombineISODateAndTimeRecord + CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDate->plainDate(), WTF::move(plainTime));
+    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDate->plainDate(), WTF::move(plainTime), plainDate->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
-    if (result && plainDate->calendarID() != iso8601CalendarID())
-        result->setCalendarID(plainDate->calendarID());
     return JSValue::encode(result);
 }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -42,13 +42,6 @@ namespace JSC {
 
 const ClassInfo TemporalPlainDateTime::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TemporalPlainDateTime) };
 
-TemporalPlainDateTime* TemporalPlainDateTime::create(VM& vm, Structure* structure, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime)
-{
-    auto* object = new (NotNull, allocateCell<TemporalPlainDateTime>(vm)) TemporalPlainDateTime(vm, structure, WTF::move(plainDate), WTF::move(plainTime));
-    object->finishCreation(vm);
-    return object;
-}
-
 TemporalPlainDateTime* TemporalPlainDateTime::create(VM& vm, Structure* structure, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime, CalendarID calendarID)
 {
     auto* object = new (NotNull, allocateCell<TemporalPlainDateTime>(vm)) TemporalPlainDateTime(vm, structure, WTF::move(plainDate), WTF::move(plainTime));
@@ -70,70 +63,31 @@ TemporalPlainDateTime::TemporalPlainDateTime(VM& vm, Structure* structure, ISO86
 {
 }
 
-
 // https://tc39.es/proposal-temporal/#sec-temporal-createtemporaldatetime
-TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime)
+TemporalPlainDateTime* TemporalPlainDateTime::tryCreateIfValid(JSGlobalObject* globalObject, Structure* structure, ISO8601::PlainDate&& plainDate, ISO8601::PlainTime&& plainTime, CalendarID calendarID)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 1: If ISODateTimeWithinLimits(isoDateTime) is false, throw a RangeError exception.
     if (!ISO8601::isDateTimeWithinLimits(plainDate.year(), plainDate.month(), plainDate.day(), plainTime.hour(), plainTime.minute(), plainTime.second(), plainTime.millisecond(), plainTime.microsecond(), plainTime.nanosecond())) [[unlikely]] {
         throwRangeError(globalObject, scope, "date time is out of range of ECMAScript representation"_s);
         return { };
     }
 
-    return TemporalPlainDateTime::create(vm, structure, WTF::move(plainDate), WTF::move(plainTime));
+    // Steps 2-6: OrdinaryCreateFromConstructor + set [[ISODateTime]] and [[Calendar]] internal slots.
+    return TemporalPlainDateTime::create(vm, structure, WTF::move(plainDate), WTF::move(plainTime), calendarID);
 }
 
 static TemporalPlainDateTime* fromImpl(JSGlobalObject*, JSValue, JSObject*);
 
-// Implements ToTemporalDateTime core (steps 2-3); step 1 options handled by caller.
+// Property-bag + string tail of ToTemporalDateTime (steps 2.d-2.h + 3+); TPDT/PD/ZDT cases handled by the caller.
 static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue itemValue, JSObject* options)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (itemValue.isObject()) {
-        if (itemValue.inherits<TemporalPlainDateTime>()) {
-            // Step 2.a.i: GetOptionsObject + GetTemporalOverflowOption (validate only).
-            if (options) {
-                toTemporalOverflow(globalObject, options);
-                RETURN_IF_EXCEPTION(scope, { });
-            }
-            // Step 2.a.iii: Return CreateTemporalDateTime(item.[[ISODateTime]], item.[[Calendar]]).
-            auto* src = uncheckedDowncast<TemporalPlainDateTime>(itemValue);
-            auto* clone = TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), src->plainDate(), src->plainTime());
-            if (src->calendarID() != iso8601CalendarID())
-                clone->setCalendarID(src->calendarID());
-            return clone;
-        }
-
-        if (itemValue.inherits<TemporalPlainDate>()) {
-            // Step 2.c.i: GetOptionsObject + GetTemporalOverflowOption, return CreateTemporalDateTime.
-            if (options) {
-                toTemporalOverflow(globalObject, options);
-                RETURN_IF_EXCEPTION(scope, { });
-            }
-            auto* pd = uncheckedDowncast<TemporalPlainDate>(itemValue);
-            return TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), pd->plainDate(), { }, pd->calendarID());
-        }
-
-        if (itemValue.inherits<TemporalZonedDateTime>()) {
-            // Step 2.b.i: GetISODateTimeFor FIRST (before options — spec step order).
-            auto* zdt = uncheckedDowncast<TemporalZonedDateTime>(itemValue);
-            ISO8601::PlainDate date;
-            ISO8601::PlainTime time;
-            zdt->getLocalDateAndTime(globalObject, date, time);
-            RETURN_IF_EXCEPTION(scope, { });
-            // Step 2.b.ii: GetOptionsObject + overflow.
-            if (options) {
-                toTemporalOverflow(globalObject, options);
-                RETURN_IF_EXCEPTION(scope, { });
-            }
-            // Step 2.b.iii: CreateTemporalDateTime.
-            return TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), WTF::move(date), WTF::move(time), zdt->calendarID());
-        }
-
         JSObject* item = asObject(itemValue);
 
         // Step 2.d: GetTemporalCalendarIdentifierWithISODefault(item).
@@ -348,10 +302,8 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
         RETURN_IF_EXCEPTION(scope, { });
 
         // Step 2.h cont.: CreateTemporalDateTime(result, calendar).
-        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime));
+        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime), extractedCalendarId);
         RETURN_IF_EXCEPTION(scope, { });
-        if (result && isNonISO)
-            result->setCalendarID(extractedCalendarId);
         return result;
     }
 
@@ -387,10 +339,8 @@ static TemporalPlainDateTime* fromImpl(JSGlobalObject* globalObject, JSValue ite
             RETURN_IF_EXCEPTION(scope, { });
         }
         // Steps 9-13: CreateISODateRecord + CombineISODateAndTimeRecord + CreateTemporalDateTime.
-        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), plainTimeOptional.value_or(ISO8601::PlainTime()));
+        auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), plainTimeOptional.value_or(ISO8601::PlainTime()), calendarId);
         RETURN_IF_EXCEPTION(scope, { });
-        if (result && calendarId != iso8601CalendarID())
-            result->setCalendarID(calendarId);
         return result;
     }
 
@@ -414,10 +364,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::from(JSGlobalObject* globalObject,
             toTemporalOverflow(globalObject, optionsValue);
             RETURN_IF_EXCEPTION(scope, { });
             auto* src = uncheckedDowncast<TemporalPlainDateTime>(itemValue);
-            auto* clone = TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), src->plainDate(), src->plainTime());
-            if (src->calendarID() != iso8601CalendarID())
-                clone->setCalendarID(src->calendarID());
-            return clone;
+            return TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), src->plainDate(), src->plainTime(), src->calendarID());
         }
         if (itemValue.inherits<TemporalPlainDate>()) {
             // Step 2.c.i-ii: validate options, Step 2.c.iii: return CreateTemporalDateTime(date, midnight).
@@ -479,11 +426,10 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
     RETURN_IF_EXCEPTION(scope, { });
 
     if (!options) {
-        // Fast path: no options provided — all defaults, no rounding needed.
+        // Fast path: no options ⇒ Precision::Auto ⇒ RoundISODateTime is a no-op; Steps 12-14 collapse to ISODateTimeToString.
         auto base = toString();
-        auto calId = calendarIDAsString();
         if (calendarID() != iso8601CalendarID())
-            return makeString(base, "[u-ca="_s, calId, ']');
+            return makeString(base, "[u-ca="_s, calendarIDAsString(), ']');
         return base;
     }
 
@@ -517,8 +463,8 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
     // Step 11: Let precision be ToSecondsStringPrecisionRecord(smallestUnit, digits).
     auto data = toSecondsStringPrecisionRecord(smallestUnit, digits);
 
-    // Steps 12-14: RoundISODateTime + ISODateTimeWithinLimits check + ISODateTimeToString.
-    // Optimisation: if precision is ~auto~, rounding increment is 1 ns — a no-op for any mode.
+    // Steps 12-14: RoundISODateTime + ISODateTimeWithinLimits + ISODateTimeToString.
+    // Fast path: Precision::Auto ⇒ increment=1ns ⇒ rounding is a no-op.
     if (std::get<0>(data.precision) == Precision::Auto) {
         auto base = toString();
         auto calId = calendarIDAsString();
@@ -561,20 +507,25 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaindatetime
-ISO8601::Duration TemporalPlainDateTime::differenceTemporalPlainDateTime(
-    JSGlobalObject* globalObject, DifferenceOperation op,
-    TemporalPlainDateTime* other,
-    TemporalUnit smallestUnit, TemporalUnit largestUnit,
-    RoundingMode roundingMode, double increment)
+// Step 1 (ToTemporalDateTime on `other`) is done by the caller (host fn) before invoking this helper.
+template<DifferenceOperation op>
+ISO8601::Duration TemporalPlainDateTime::differenceTemporalPlainDateTime(JSGlobalObject* globalObject, TemporalPlainDateTime* other, JSValue optionsValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Step 2: If CalendarEquals(dateTime.[[Calendar]], other.[[Calendar]]) is false, throw a RangeError exception.
     if (m_calendarID != other->m_calendarID) [[unlikely]] {
         throwRangeError(globalObject, scope, "cannot compute difference between date-times with different calendars"_s);
         return { };
     }
 
+    // Step 3: settings = ? GetDifferenceSettings(operation, options, ~datetime~, «», ~nanosecond~, ~day~).
+    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, optionsValue, UnitGroup::DateTime, TemporalUnit::Nanosecond, TemporalUnit::Day, op);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Steps 4-8: If CompareISODateTime = 0 return zero-duration; else DifferenceISODateTime + optional round
+    //            + TemporalDurationFromInternal + negate-if-since (all fused in TemporalCore::differenceTemporalPlainDateTime).
     auto coreResult = TemporalCore::differenceTemporalPlainDateTime(op,
         plainDate(), plainTime(), other->plainDate(), other->plainTime(),
         m_calendarID, smallestUnit, largestUnit, roundingMode, increment);
@@ -582,134 +533,11 @@ ISO8601::Duration TemporalPlainDateTime::differenceTemporalPlainDateTime(
         throwTemporalError(globalObject, scope, coreResult.error());
         return { };
     }
+    // Step 9: Return result.
     return *coreResult;
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.with
-TemporalPlainDateTime* TemporalPlainDateTime::with(JSGlobalObject* globalObject, JSObject* temporalDateTimeLike, JSValue optionsValue)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    rejectObjectWithCalendarOrTimeZone(globalObject, temporalDateTimeLike);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    int32_t baseYear = year();
-    uint8_t baseMonth = month();
-    uint8_t baseDay = day();
-    if (!TemporalCore::calendarIsISO(m_calendarID)) {
-        auto calFields = TemporalCore::isoToCalendarFields(m_calendarID, m_plainDate);
-        if (calFields) {
-            baseYear = calFields->year;
-            baseMonth = calFields->month;
-            baseDay = calFields->day;
-        }
-    }
-
-    auto [y, m, d, optionalMonthCode, overflow, any] = TemporalPlainDate::mergeDateFields(globalObject, temporalDateTimeLike, optionsValue, baseYear, baseMonth, baseDay);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    bool requiresTimeProperty = any == TemporalAnyProperties::None;
-    auto [optionalHour, optionalMinute, optionalSecond, optionalMillisecond, optionalMicrosecond, optionalNanosecond] = TemporalPlainTime::toPartialTime(globalObject, temporalDateTimeLike, !requiresTimeProperty);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    auto plainDate = isoDateFromFields(globalObject, TemporalDateFormat::Date, y, m, d, optionalMonthCode, overflow, m_calendarID);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    ISO8601::Duration duration { };
-    duration.setField(TemporalUnit::Hour, optionalHour.value_or(hour()));
-    duration.setField(TemporalUnit::Minute, optionalMinute.value_or(minute()));
-    duration.setField(TemporalUnit::Second, optionalSecond.value_or(second()));
-    duration.setField(TemporalUnit::Millisecond, optionalMillisecond.value_or(millisecond()));
-    duration.setField(TemporalUnit::Microsecond, optionalMicrosecond.value_or(microsecond()));
-    duration.setField(TemporalUnit::Nanosecond, optionalNanosecond.value_or(nanosecond()));
-    auto plainTime = TemporalPlainTime::regulateTime(globalObject, WTF::move(duration), overflow);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime)));
-}
-
-// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.round
-TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject, JSValue optionsValue)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Steps 1-2: branding check done by the caller.
-
-    // Step 3: If roundTo is undefined, throw a TypeError exception.
-    if (optionsValue.isUndefined()) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.round requires a roundTo option"_s);
-        return { };
-    }
-
-    JSObject* options = nullptr;
-    std::optional<TemporalUnit> smallest;
-
-    if (optionsValue.isString()) {
-        // Step 4: If roundTo is a String, parse smallestUnit directly (optimisation — skip wrapper object).
-        auto string = optionsValue.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        smallest = temporalUnitType(string);
-        if (!smallest) [[unlikely]] {
-            throwRangeError(globalObject, scope, "smallestUnit is an invalid Temporal unit"_s);
-            return { };
-        }
-    } else {
-        // Step 5: Set roundTo to ? GetOptionsObject(roundTo).
-        options = intlGetOptionsObject(globalObject, optionsValue);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-
-    // Step 6: NOTE: The following steps read options in alphabetical order.
-    // Step 7: Let roundingIncrement be ? GetRoundingIncrementOption(roundTo).
-    auto roundingIncrement = temporalRoundingIncrement(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-    // Step 8: Let roundingMode be ? GetRoundingModeOption(roundTo, ~half-expand~).
-    auto roundingMode = temporalRoundingMode(globalObject, options, RoundingMode::HalfExpand);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    if (!smallest) {
-        // Step 9: Let smallestUnit be ? GetTemporalUnitValuedOption(roundTo, "smallestUnit", ~required~).
-        auto smallestUnitMaybeAuto = temporalUnitValued(globalObject, options, vm.propertyNames->smallestUnit, TemporalUnitDefault::Required);
-        RETURN_IF_EXCEPTION(scope, { });
-        // Step 10: Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~, « ~day~ »).
-        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::Day, "smallestUnit"_s);
-        RETURN_IF_EXCEPTION(scope, { });
-        smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
-    } else {
-        // Step 10 (string path): Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~, « ~day~ »).
-        // isCalendarUnit (unit <= Week) rejects year/month/week; day and time units pass.
-        if (isCalendarUnit(smallest.value())) [[unlikely]] {
-            throwRangeError(globalObject, scope, "smallestUnit is a disallowed unit"_s);
-            return { };
-        }
-    }
-
-    auto smallestUnit = smallest.value();
-
-    // Steps 11-12: If ~day~, maximum = 1 inclusive; else maximum = MaximumTemporalDurationRoundingIncrement, exclusive.
-    unsigned maximum = 1;
-    Inclusivity isInclusive = Inclusivity::Inclusive;
-    if (smallestUnit != TemporalUnit::Day) {
-        auto maximumOptional = TemporalCore::maximumRoundingIncrement(smallestUnit);
-        ASSERT(maximumOptional);
-        maximum = maximumOptional.value();
-        isInclusive = Inclusivity::Exclusive;
-    }
-    // Step 13: Perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, inclusive).
-    validateTemporalRoundingIncrement(globalObject, roundingIncrement, maximum, isInclusive);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 14: If smallestUnit is ~nanosecond~ and roundingIncrement = 1, return ! CreateTemporalDateTime.
-    // NOTE: roundTime with increment=1 and nanosecond is a no-op so step 15 covers this case too.
-
-    // Step 15: Let result be RoundISODateTime(plainDateTime.[[ISODateTime]], roundingIncrement, smallestUnit, roundingMode).
-    Int128 incrementNs = static_cast<Int128>(lengthInNanoseconds(smallestUnit)) * static_cast<Int128>(static_cast<int64_t>(roundingIncrement));
-    auto [roundedDate, roundedTime] = TemporalCore::roundISODateTime(plainDate(), m_plainTime, incrementNs, smallestUnit, roundingMode);
-
-    // Step 16: Return ? CreateTemporalDateTime(result, plainDateTime.[[Calendar]]).
-    RELEASE_AND_RETURN(scope, TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(roundedDate), WTF::move(roundedTime)));
-}
+template ISO8601::Duration TemporalPlainDateTime::differenceTemporalPlainDateTime<DifferenceOperation::Until>(JSGlobalObject*, TemporalPlainDateTime*, JSValue);
+template ISO8601::Duration TemporalPlainDateTime::differenceTemporalPlainDateTime<DifferenceOperation::Since>(JSGlobalObject*, TemporalPlainDateTime*, JSValue);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -41,9 +41,8 @@ public:
         return vm.temporalPlainDateTimeSpace<mode>();
     }
 
-    static TemporalPlainDateTime* create(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&);
-    static TemporalPlainDateTime* create(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID);
-    static TemporalPlainDateTime* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&);
+    static TemporalPlainDateTime* create(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID = iso8601CalendarID());
+    static TemporalPlainDateTime* tryCreateIfValid(JSGlobalObject*, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, CalendarID = iso8601CalendarID());
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     DECLARE_INFO;
@@ -53,8 +52,6 @@ public:
     ISO8601::PlainDate plainDate() const { return m_plainDate; }
     ISO8601::PlainTime plainTime() const { return m_plainTime; }
     CalendarID calendarID() const { return m_calendarID; }
-    void setCalendarId(WTF::StringView id) { m_calendarID = TemporalCore::calendarIDFromString(id); }
-    void setCalendarID(CalendarID id) { m_calendarID = id; }
     String calendarIDAsString() const { return TemporalCore::calendarIDToString(m_calendarID).toString(); }
 
 #define JSC_DEFINE_TEMPORAL_PLAIN_DATE_FIELD(name, capitalizedName) \
@@ -67,16 +64,14 @@ public:
     JSC_TEMPORAL_PLAIN_TIME_UNITS(JSC_DEFINE_TEMPORAL_PLAIN_TIME_FIELD);
 #undef JSC_DEFINE_TEMPORAL_PLAIN_TIME_FIELD
 
-    TemporalPlainDateTime* with(JSGlobalObject*, JSObject* temporalDateLike, JSValue options);
-    TemporalPlainDateTime* round(JSGlobalObject*, JSValue options);
-
     String monthCode() const { return ISO8601::monthCode(m_plainDate.month()); }
     uint8_t dayOfWeek() const { return ISO8601::dayOfWeek(m_plainDate); }
     uint16_t dayOfYear() const { return ISO8601::dayOfYear(m_plainDate); }
     uint8_t weekOfYear() const { return ISO8601::weekOfYear(m_plainDate); }
     int32_t yearOfWeek() const { return ISO8601::yearOfWeek(m_plainDate); }
 
-    ISO8601::Duration differenceTemporalPlainDateTime(JSGlobalObject*, DifferenceOperation, TemporalPlainDateTime*, TemporalUnit, TemporalUnit, RoundingMode, double);
+    template<DifferenceOperation>
+    ISO8601::Duration differenceTemporalPlainDateTime(JSGlobalObject*, TemporalPlainDateTime*, JSValue optionsValue);
 
     String toString(JSGlobalObject*, JSValue options) const;
     String toString(std::tuple<Precision, unsigned> precision = { Precision::Auto, 0 }) const
@@ -86,7 +81,6 @@ public:
 
 private:
     TemporalPlainDateTime(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&);
-    TemporalPlainDateTime(VM&, Structure*, ISO8601::PlainDate&&, ISO8601::PlainTime&&, String&&);
     DECLARE_DEFAULT_FINISH_CREATION;
 
     ISO8601::PlainDate m_plainDate;

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimeConstructor.cpp
@@ -90,28 +90,26 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Step 1: NewTarget check done by JSC engine.
+    // Step 1: If NewTarget is undefined, throw a TypeError. (Enforced by JSC engine.)
     JSObject* newTarget = asObject(callFrame->newTarget());
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, plainDateTimeStructure, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 2-10: ToIntegerWithTruncation for each positional arg.
-    // For date args (year/month/day, i < 3): NaN and ±Infinity throw RangeError.
-    // For time args (hour..nanosecond, i ≥ 3): undefined (NaN) defaults to 0; ±Infinity throws.
+    // Steps 2-4: Set isoYear/isoMonth/isoDay to ? ToIntegerWithTruncation(arg).
+    // Steps 5-10: For each of hour/minute/second/millisecond/microsecond/nanosecond:
+    //             if undefined, set to 0; else ? ToIntegerWithTruncation(arg).
     ISO8601::Duration duration { };
-    auto count = std::min<size_t>(callFrame->argumentCount(), numberOfTemporalPlainDateUnits + numberOfTemporalPlainTimeUnits);
-    for (unsigned i = 0; i < count; i++) {
+    constexpr unsigned dateUnits = numberOfTemporalPlainDateUnits;
+    constexpr unsigned totalUnits = dateUnits + numberOfTemporalPlainTimeUnits;
+    for (unsigned i = 0; i < totalUnits; i++) {
         unsigned durationIndex = i >= static_cast<unsigned>(TemporalUnit::Week) ? i + 1 : i;
-        double v = callFrame->uncheckedArgument(i).toNumber(globalObject);
+        JSValue arg = callFrame->argument(i);
+        if (i >= dateUnits && arg.isUndefined())
+            continue;
+        double v = arg.toIntegerWithTruncation(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        if (std::isnan(v)) {
-            if (i < static_cast<unsigned>(numberOfTemporalPlainDateUnits)) [[unlikely]]
-                return throwVMRangeError(globalObject, scope, "Temporal.PlainDateTime year/month/day must not be NaN"_s);
-            v = 0;
-        }
         if (!std::isfinite(v)) [[unlikely]]
             return throwVMRangeError(globalObject, scope, "Temporal.PlainDateTime properties must be finite"_s);
-        v = std::trunc(v);
         duration.setField(durationIndex, v);
     }
 
@@ -140,10 +138,8 @@ JSC_DEFINE_HOST_FUNCTION(constructTemporalPlainDateTime, (JSGlobalObject* global
     RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 18-19: CombineISODateAndTimeRecord + ? CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), WTF::move(plainTime));
+    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, structure, WTF::move(plainDate), WTF::move(plainTime), calId);
     RETURN_IF_EXCEPTION(scope, { });
-    if (result && calId != iso8601CalendarID())
-        result->setCalendarID(calId);
     return JSValue::encode(result);
 }
 
@@ -156,29 +152,10 @@ JSC_DEFINE_HOST_FUNCTION(callTemporalPlainDateTime, (JSGlobalObject* globalObjec
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.from
-// Step 1: Return ToTemporalDateTime(item, options).
 JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimeConstructorFuncFrom, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue itemValue = callFrame->argument(0);
-    JSValue optionsValue = callFrame->argument(1);
-
-    if (itemValue.inherits<TemporalPlainDateTime>()) {
-        // ToTemporalDateTime step 2.a: GetOptionsObject + GetTemporalOverflowOption, return new instance.
-        toTemporalOverflow(globalObject, optionsValue);
-        RETURN_IF_EXCEPTION(scope, { });
-        auto* src = uncheckedDowncast<TemporalPlainDateTime>(itemValue);
-        auto* cloned = TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), src->plainDate(), src->plainTime());
-        if (src->calendarID() != iso8601CalendarID())
-            cloned->setCalendarID(src->calendarID());
-        RELEASE_AND_RETURN(scope, JSValue::encode(cloned));
-    }
-
-    // ToTemporalDateTime remaining steps: property bag or string path,
-    // fields read before options for bags, string parsed first for strings.
-    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::from(globalObject, itemValue, optionsValue)));
+    // Step 1: Return ? ToTemporalDateTime(item, options).
+    return JSValue::encode(TemporalPlainDateTime::from(globalObject, callFrame->argument(0), callFrame->argument(1)));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTimePrototype.cpp
@@ -158,25 +158,27 @@ void TemporalPlainDateTimePrototype::finishCreation(VM& vm, JSGlobalObject*)
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal-adddurationtodatetime
-// Caller handles steps 1 (ToTemporalDuration) and 2 (negate if subtract).
+// Callers (add/subtract host fns) handle Step 1 (ToTemporalDuration) and Step 2 (negate for subtract).
+// Step 3 (ToInternalDurationRecordWith24HourDays) is implicit in our ISO8601::Duration representation.
 static EncodedJSValue addDurationToPlainDateTime(JSGlobalObject* globalObject, ThrowScope& scope, TemporalPlainDateTime* plainDateTime, ISO8601::Duration duration, JSValue optionsArg)
 {
-    // Steps 3-4: GetOptionsObject + GetTemporalOverflowOption.
+    // Step 4: Let resolvedOptions be ? GetOptionsObject(options).
     JSObject* options = intlGetOptionsObject(globalObject, optionsArg);
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 5-6: ToInternalDurationRecordWith24HourDays + AddTime(dateTime.[[Time]], duration).
+    // Step 5: Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
+    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 6: Let timeResult be AddTime(plainDateTime.[[ISODateTime]].[[Time]], internalDuration.[[Time]]).
     auto balancedTimeDuration = TemporalPlainTime::addTime(plainDateTime->plainTime(), duration);
     auto plainTime = TemporalPlainTime::validateAndCreateTimeRecord(globalObject, balancedTimeDuration);
     RETURN_IF_EXCEPTION(scope, { });
 
-    TemporalOverflow overflow = toTemporalOverflow(globalObject, options);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Step 7: AdjustDateDurationRecord — add carried days from AddTime into date duration.
+    // Step 7: Let dateDuration be ? AdjustDateDurationRecord(internalDuration.[[Date]], timeResult.[[Days]]).
     ISO8601::Duration dateDuration { duration.years(), duration.months(), duration.weeks(), duration.days() + balancedTimeDuration.days(), 0, 0, 0, 0, Int128(0), Int128(0) };
 
-    // Step 8: CalendarDateAdd(calendar, dateTime.[[ISODate]], dateDuration, overflow).
+    // Step 8: Let addedDate be ? CalendarDateAdd(calendar, plainDateTime.[[ISODateTime]].[[ISODate]], dateDuration, overflow).
     ISO8601::PlainDate plainDate;
     if (plainDateTime->calendarID() != iso8601CalendarID())
         plainDate = calendarDateAdd(globalObject, plainDateTime->calendarID(), plainDateTime->plainDate(), dateDuration, overflow);
@@ -185,10 +187,8 @@ static EncodedJSValue addDurationToPlainDateTime(JSGlobalObject* globalObject, T
     RETURN_IF_EXCEPTION(scope, { });
 
     // Steps 9-10: CombineISODateAndTimeRecord + CreateTemporalDateTime.
-    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime));
+    auto* result = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime), plainDateTime->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
-    if (result && plainDateTime->calendarID() != iso8601CalendarID())
-        result->setCalendarID(plainDateTime->calendarID());
     return JSValue::encode(result);
 }
 
@@ -198,11 +198,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncAdd, (JSGlobalObject*
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.add called on value that's not a PlainDateTime"_s);
 
-    // Step 1: Return ? AddDurationToDateTime(add, plainDateTime, duration, options).
+    // Step 3: Return ? AddDurationToDateTime(~add~, plainDateTime, temporalDurationLike, options).
     auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDateTime(globalObject, scope, plainDateTime, WTF::move(duration), callFrame->argument(1));
@@ -214,11 +215,12 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSubtract, (JSGlobalOb
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.subtract called on value that's not a PlainDateTime"_s);
 
-    // Step 1: Return ? AddDurationToDateTime(subtract, ...) — step 2 negates duration.
+    // Step 3: Return ? AddDurationToDateTime(~subtract~, plainDateTime, temporalDurationLike, options).
     auto duration = TemporalDuration::toTemporalDurationRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
     return addDurationToPlainDateTime(globalObject, scope, plainDateTime, -WTF::move(duration), callFrame->argument(1));
@@ -230,7 +232,7 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Steps 1-2: RequireInternalSlot + type check done by caller.
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.with called on value that's not a PlainDateTime"_s);
@@ -399,10 +401,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWith, (JSGlobalObject
     RETURN_IF_EXCEPTION(scope, { });
 
     // Step 17: CreateTemporalDateTime.
-    auto* withResult = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), ISO8601::PlainDate(dateResult->isoDate), WTF::move(newTime));
+    auto* withResult = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), ISO8601::PlainDate(dateResult->isoDate), WTF::move(newTime), calendarId);
     RETURN_IF_EXCEPTION(scope, { });
-    if (withResult && calendarId != iso8601CalendarID())
-        withResult->setCalendarID(calendarId);
     return JSValue::encode(withResult);
 }
 
@@ -425,10 +425,8 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithPlainTime, (JSGlo
     }
 
     // Steps 4-5: CombineISODateAndTimeRecord + CreateTemporalDateTime.
-    auto* wptResult = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDateTime->plainDate(), plainTime ? plainTime->plainTime() : ISO8601::PlainTime());
+    auto* wptResult = TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), plainDateTime->plainDate(), plainTime ? plainTime->plainTime() : ISO8601::PlainTime(), plainDateTime->calendarID());
     RETURN_IF_EXCEPTION(scope, { });
-    if (wptResult && plainDateTime->calendarID() != iso8601CalendarID())
-        wptResult->setCalendarID(plainDateTime->calendarID());
     return JSValue::encode(wptResult);
 }
 
@@ -438,17 +436,80 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncRound, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.round called on value that's not a PlainDateTime"_s);
 
-    // Step 3: if roundTo is undefined throw TypeError.
-    auto options = callFrame->argument(0);
-    if (options.isUndefined()) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.round requires an options argument"_s);
+    // Step 3: If roundTo is undefined, throw a TypeError exception.
+    JSValue optionsValue = callFrame->argument(0);
+    if (optionsValue.isUndefined()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.round requires a roundTo option"_s);
 
-    // Steps 4-15: RoundISODateTime + CreateTemporalDateTime — delegated to plainDateTime->round().
-    RELEASE_AND_RETURN(scope, JSValue::encode(plainDateTime->round(globalObject, options)));
+    JSObject* options = nullptr;
+    std::optional<TemporalUnit> smallest;
+
+    if (optionsValue.isString()) {
+        // Step 4: If roundTo is a String, parse smallestUnit directly (optimisation — skip wrapper object).
+        auto string = optionsValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        smallest = temporalUnitType(string);
+        if (!smallest) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, "smallestUnit is an invalid Temporal unit"_s);
+    } else {
+        // Step 5: Set roundTo to ? GetOptionsObject(roundTo).
+        options = intlGetOptionsObject(globalObject, optionsValue);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    // Step 6: NOTE: The following steps read options in alphabetical order.
+    // Step 7: Let roundingIncrement be ? GetRoundingIncrementOption(roundTo).
+    auto roundingIncrement = temporalRoundingIncrement(globalObject, options);
+    RETURN_IF_EXCEPTION(scope, { });
+    // Step 8: Let roundingMode be ? GetRoundingModeOption(roundTo, ~half-expand~).
+    auto roundingMode = temporalRoundingMode(globalObject, options, RoundingMode::HalfExpand);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!smallest) {
+        // Step 9: Let smallestUnit be ? GetTemporalUnitValuedOption(roundTo, "smallestUnit", ~required~).
+        auto smallestUnitMaybeAuto = temporalUnitValued(globalObject, options, vm.propertyNames->smallestUnit, TemporalUnitDefault::Required);
+        RETURN_IF_EXCEPTION(scope, { });
+        // Step 10: Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~, « ~day~ »).
+        validateTemporalUnitValue(globalObject, smallestUnitMaybeAuto, UnitGroup::Time, AllowedUnit::Day, "smallestUnit"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+        smallest = std::get<std::optional<TemporalUnit>>(smallestUnitMaybeAuto);
+    } else {
+        // Step 10 (string path): Perform ? ValidateTemporalUnitValue(smallestUnit, ~time~, « ~day~ »).
+        // isCalendarUnit (unit <= Week) rejects year/month/week; day and time units pass.
+        if (isCalendarUnit(smallest.value())) [[unlikely]]
+            return throwVMRangeError(globalObject, scope, "smallestUnit is a disallowed unit"_s);
+    }
+
+    auto smallestUnit = smallest.value();
+
+    // Steps 11-12: If smallestUnit is ~day~, maximum = 1 and inclusive = true;
+    //              else maximum = MaximumTemporalDurationRoundingIncrement(smallestUnit) and inclusive = false.
+    unsigned maximum = 1;
+    Inclusivity isInclusive = Inclusivity::Inclusive;
+    if (smallestUnit != TemporalUnit::Day) {
+        auto maximumOptional = TemporalCore::maximumRoundingIncrement(smallestUnit);
+        ASSERT(maximumOptional);
+        maximum = maximumOptional.value();
+        isInclusive = Inclusivity::Exclusive;
+    }
+    // Step 13: Perform ? ValidateTemporalRoundingIncrement(roundingIncrement, maximum, inclusive).
+    validateTemporalRoundingIncrement(globalObject, roundingIncrement, maximum, isInclusive);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    // Step 14: If smallestUnit is ~nanosecond~ and roundingIncrement = 1, return ! CreateTemporalDateTime.
+    //          (Absorbed into Step 15 — RoundISODateTime with increment=1 and unit=nanosecond is a no-op.)
+
+    // Step 15: Let result be RoundISODateTime(plainDateTime.[[ISODateTime]], roundingIncrement, smallestUnit, roundingMode).
+    Int128 incrementNs = static_cast<Int128>(lengthInNanoseconds(smallestUnit)) * static_cast<Int128>(static_cast<int64_t>(roundingIncrement));
+    auto [roundedDate, roundedTime] = TemporalCore::roundISODateTime(plainDateTime->plainDate(), plainDateTime->plainTime(), incrementNs, smallestUnit, roundingMode);
+
+    // Step 16: Return ? CreateTemporalDateTime(result, plainDateTime.[[Calendar]]).
+    RELEASE_AND_RETURN(scope, JSValue::encode(TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(roundedDate), WTF::move(roundedTime), plainDateTime->calendarID())));
 }
 
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.equals
@@ -457,31 +518,30 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncEquals, (JSGlobalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Steps 1-2: RequireInternalSlot + type check.
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.equals called on value that's not a PlainDateTime"_s);
 
-    // Step 3: other = ToTemporalDateTime(other).
+    // Step 3: Set other to ? ToTemporalDateTime(other).
     auto* other = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Step 4: CompareISODateTime(this, other) ≠ 0 → false.
+    // Step 4: If CompareISODateTime(plainDateTime.[[ISODateTime]], other.[[ISODateTime]]) ≠ 0, return false.
     if (plainDateTime->plainDate() != other->plainDate() || plainDateTime->plainTime() != other->plainTime())
         return JSValue::encode(jsBoolean(false));
 
-    // Step 5: CalendarEquals(this.[[Calendar]], other.[[Calendar]]).
+    // Step 5: Return CalendarEquals(plainDateTime.[[Calendar]], other.[[Calendar]]).
     return JSValue::encode(jsBoolean(plainDateTime->calendarID() == other->calendarID()));
 }
 
-// https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime
 // https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.tozoneddatetime
 JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncToZonedDateTime, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Steps 1-2: RequireInternalSlot.
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue());
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.toZonedDateTime called on value that's not a PlainDateTime"_s);
@@ -897,20 +957,16 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncUntil, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.until called on value that's not a PlainDateTime"_s);
 
-    // Step 3: other = ToTemporalDateTime(other).
+    // Step 3: Return ? DifferenceTemporalPlainDateTime(~until~, plainDateTime, other, options).
     auto* other = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 4-5: GetDifferenceSettings.
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, callFrame->argument(1), UnitGroup::DateTime, TemporalUnit::Nanosecond, TemporalUnit::Day);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Steps 6-9: DifferenceISODateTime + CreateTemporalDuration.
-    auto result = plainDateTime->differenceTemporalPlainDateTime(globalObject, DifferenceOperation::Until, other, smallestUnit, largestUnit, roundingMode, increment);
+    auto result = plainDateTime->differenceTemporalPlainDateTime<DifferenceOperation::Until>(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
@@ -922,20 +978,16 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncSince, (JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.since called on value that's not a PlainDateTime"_s);
 
-    // Step 3: other = ToTemporalDateTime(other).
+    // Step 3: Return ? DifferenceTemporalPlainDateTime(~since~, plainDateTime, other, options).
     auto* other = TemporalPlainDateTime::from(globalObject, callFrame->argument(0), jsUndefined());
     RETURN_IF_EXCEPTION(scope, { });
 
-    // Steps 4-5: GetDifferenceSettings(~since~, ...).
-    auto [smallestUnit, largestUnit, roundingMode, increment] = extractDifferenceOptions(globalObject, callFrame->argument(1), UnitGroup::DateTime, TemporalUnit::Nanosecond, TemporalUnit::Day, DifferenceOperation::Since);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    // Steps 6-9: DifferenceISODateTime + CreateTemporalDuration.
-    auto result = plainDateTime->differenceTemporalPlainDateTime(globalObject, DifferenceOperation::Since, other, smallestUnit, largestUnit, roundingMode, increment);
+    auto result = plainDateTime->differenceTemporalPlainDateTime<DifferenceOperation::Since>(globalObject, other, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(TemporalDuration::tryCreateIfValid(globalObject, WTF::move(result), globalObject->durationStructure())));
@@ -947,18 +999,16 @@ JSC_DEFINE_HOST_FUNCTION(temporalPlainDateTimePrototypeFuncWithCalendar, (JSGlob
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // Steps 1-2: branding.
     auto* plainDateTime = dynamicDowncast<TemporalPlainDateTime>(callFrame->thisValue().toThis(globalObject, ECMAMode::strict()));
     if (!plainDateTime) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Temporal.PlainDateTime.prototype.withCalendar called on value that's not a PlainDateTime"_s);
 
-    // Step 3: ToTemporalCalendarIdentifier(calendarLike).
+    // Step 3: Let calendar be ? ToTemporalCalendarIdentifier(calendarLike).
     auto newCalendarID = toTemporalCalendarIdentifier(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
-    // Step 4: CreateTemporalDateTime(isoDateTime, calendar).
-    auto* result = TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(),
-        plainDateTime->plainDate(), plainDateTime->plainTime());
-    result->setCalendarID(newCalendarID);
-    return JSValue::encode(result);
+    // Step 4: Return ! CreateTemporalDateTime(plainDateTime.[[ISODateTime]], calendar).
+    return JSValue::encode(TemporalPlainDateTime::create(vm, globalObject->plainDateTimeStructure(), plainDateTime->plainDate(), plainDateTime->plainTime(), newCalendarID));
 }
 
 // https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.yearofweek


### PR DESCRIPTION
#### a0433cfeb9ab17a6b63150f4eec507b660541b7b
<pre>
[JSC][Temporal] Polish Temporal.PlainDateTime: spec alignment, constructor and round() fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318454">https://bugs.webkit.org/show_bug.cgi?id=318454</a>
<a href="https://rdar.apple.com/181253131">rdar://181253131</a>

Reviewed by Yusuke Suzuki.

Fix two spec-conformance bugs, remove dead code, and align spec-step
comments across Temporal.PlainDateTime.

The constructor previously accepted NaN on time args (silently coercing
to 0) and skipped trailing arguments; ToIntegerWithTruncation now
throws RangeError on any non-finite value per spec.

Temporal.PlainDateTime.prototype.round dropped a non-ISO calendar
because tryCreateIfValid couldn&apos;t carry one. create() and
tryCreateIfValid() now take an optional CalendarID and every
&quot;tryCreateIfValid + setCalendarID&quot; callsite is collapsed accordingly.

Dead code removed: the never-called TemporalPlainDateTime::with()
impl, unreachable inherits&lt;TPDT/PD/ZDT&gt; branches inside fromImpl, the
undefined String&amp;&amp; constructor, the setCalendarID/setCalendarId
accessors, and the duplicated inherits&lt;TPDT&gt; fast-path in
temporalPlainDateTimeConstructorFuncFrom.

Tests:
JSTests/stress/temporal-plain-datetime-ctor-nan-infinity.js
JSTests/stress/temporal-plain-datetime-round.js

Canonical link: <a href="https://commits.webkit.org/316498@main">https://commits.webkit.org/316498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41ef7cb7ef531ffed4a7ea9ac49a09a174d52c74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181742 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129846 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f259cad9-3daf-4f5b-b027-951b94f6635c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134000 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbf45688-9db4-43c8-8399-5c90cc7b6c53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37435 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154543 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicy (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114471 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38099cbf-6699-43da-940d-8e47a289e798) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36069 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34333 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30347 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3081 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184275 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33551 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142764 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45880 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142645 "Found 2 new API test failures: TestWebKit:WebKit2UserMessageRoundTripTest.WKURL, WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46558 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30896 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111285 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26182 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37716 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118309 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204968 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45075 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8996 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54723 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44475 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->