### PR TITLE
Fix C++26 build

### DIFF
--- a/Source/JavaScriptCore/b3/B3Type.cpp
+++ b/Source/JavaScriptCore/b3/B3Type.cpp
@@ -62,7 +62,7 @@ void printInternal(PrintStream& out, Type type)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static_assert(std::is_standard_layout_v<JSC::B3::TypeKind> && std::is_trivial_v<JSC::B3::TypeKind>);
+static_assert(std::is_standard_layout_v<JSC::B3::TypeKind> && std::is_trivially_copyable_v<JSC::B3::TypeKind> && std::is_trivially_default_constructible_v<JSC::B3::TypeKind>);
 } // namespace WTF
 
 

--- a/Source/JavaScriptCore/jit/OperationResult.h
+++ b/Source/JavaScriptCore/jit/OperationResult.h
@@ -46,7 +46,8 @@ constexpr bool assertNotOperationSignature = ([] {
 template<typename T>
 concept canMakeExceptionOperationResult =
     std::is_standard_layout_v<T>
-    && std::is_trivial_v<T>
+    && std::is_trivially_copyable_v<T>
+    && std::is_trivially_default_constructible_v<T>
 #if CPU(ARM64) || CPU(ARM_THUMB2)
     && !std::is_floating_point_v<T> // The ARM64 ABI says that this should be returned in x0 instead of d0. Seems unlikely it's worth it to do the extra fmov.
 #endif

--- a/Source/JavaScriptCore/runtime/MarkedVector.h
+++ b/Source/JavaScriptCore/runtime/MarkedVector.h
@@ -331,8 +331,8 @@ public:
     template<typename U = T>
     U* data() { return std::bit_cast<U*>(m_buffer); }
 
-    [[nodiscard]] std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }
-    [[nodiscard]] std::span<T> mutableSpan() LIFETIME_BOUND { return { data(), size() }; }
+    [[nodiscard]] std::span<const T> span() const LIFETIME_BOUND { return std::span<const T>(data(), size()); }
+    [[nodiscard]] std::span<T> mutableSpan() LIFETIME_BOUND { return std::span<T>(data(), size()); }
 
     T* begin() { return std::bit_cast<T*>(m_buffer); }
     T* end() { return std::bit_cast<T*>(m_buffer) + m_size; }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/include/video_codec_interface.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/include/video_codec_interface.h
@@ -52,7 +52,7 @@ struct CodecSpecificInfoVP8 {
   size_t updatedBuffers[kBuffersCount];
   size_t updatedBuffersCount;
 };
-static_assert(std::is_trivial_v<CodecSpecificInfoVP8> &&
+static_assert(std::is_trivially_copyable_v<CodecSpecificInfoVP8> && std::is_trivially_default_constructible_v<CodecSpecificInfoVP8> &&
                   std::is_standard_layout_v<CodecSpecificInfoVP8>,
               "");
 
@@ -83,7 +83,7 @@ struct CodecSpecificInfoVP9 {
   uint8_t num_ref_pics;
   uint8_t p_diff[kMaxVp9RefPics];
 };
-static_assert(std::is_trivial_v<CodecSpecificInfoVP9> &&
+static_assert(std::is_trivially_copyable_v<CodecSpecificInfoVP9> && std::is_trivially_default_constructible_v<CodecSpecificInfoVP9> &&
                   std::is_standard_layout_v<CodecSpecificInfoVP9>,
               "");
 
@@ -94,7 +94,7 @@ struct CodecSpecificInfoH264 {
   bool base_layer_sync;
   bool idr_frame;
 };
-static_assert(std::is_trivial_v<CodecSpecificInfoH264> &&
+static_assert(std::is_trivially_copyable_v<CodecSpecificInfoH264> && std::is_trivially_default_constructible_v<CodecSpecificInfoH264> &&
                   std::is_standard_layout_v<CodecSpecificInfoH264>,
               "");
 
@@ -103,7 +103,7 @@ union CodecSpecificInfoUnion {
   CodecSpecificInfoVP9 VP9;
   CodecSpecificInfoH264 H264;
 };
-static_assert(std::is_trivial_v<CodecSpecificInfoUnion> &&
+static_assert(std::is_trivially_copyable_v<CodecSpecificInfoUnion> && std::is_trivially_default_constructible_v<CodecSpecificInfoUnion> &&
                   std::is_standard_layout_v<CodecSpecificInfoUnion>,
               "");
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bounded_inline_vector_impl.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bounded_inline_vector_impl.h
@@ -109,10 +109,10 @@ static constexpr int kSmallSize = 64;
 // Storage implementation for nontrivial element types.
 template <typename T,
           int fixed_capacity,
-          bool is_trivial = std::is_trivial<T>::value,
+          bool is_trivial = std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T>,
           bool is_small = (sizeof(T) * fixed_capacity <= kSmallSize)>
 struct Storage {
-  static_assert(!std::is_trivial<T>::value, "");
+  static_assert(!std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T>, "");
 
   template <
       typename... Ts,
@@ -158,7 +158,7 @@ struct Storage {
 // enough that we can cheaply copy everything.
 template <typename T, int fixed_capacity>
 struct Storage<T, fixed_capacity, /*is_trivial=*/true, /*is_small=*/true> {
-  static_assert(std::is_trivial<T>::value, "");
+  static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T>, "");
   static_assert(sizeof(T) * fixed_capacity <= kSmallSize, "");
 
   template <
@@ -180,7 +180,7 @@ struct Storage<T, fixed_capacity, /*is_trivial=*/true, /*is_small=*/true> {
 // enough that we want to avoid copying uninitialized elements.
 template <typename T, int fixed_capacity>
 struct Storage<T, fixed_capacity, /*is_trivial=*/true, /*is_small=*/false> {
-  static_assert(std::is_trivial<T>::value, "");
+  static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T>, "");
   static_assert(sizeof(T) * fixed_capacity > kSmallSize, "");
 
   template <

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/buffer.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/buffer.h
@@ -59,7 +59,7 @@ class BufferT {
   // deallocate. And we want T to be trivially copyable, so that we can copy T
   // instances with std::memcpy. This is precisely the definition of a trivial
   // type.
-  static_assert(std::is_trivial<T>::value, "T must be a trivial type.");
+  static_assert(std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T>, "T must be a trivial type.");
 
   // This class relies heavily on being able to mutate its data.
   static_assert(!std::is_const<T>::value, "T may not be const");

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/logging.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/logging.h
@@ -291,7 +291,7 @@ class LogMetadata {
   // both with a single instruction.)
   uint32_t line_and_sev_;
 };
-static_assert(std::is_trivial<LogMetadata>::value, "");
+static_assert(std::is_trivially_copyable_v<LogMetadata> && std::is_trivially_default_constructible_v<LogMetadata>, "");
 
 struct LogMetadataErr {
   LogMetadata meta;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/zero_memory.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/zero_memory.h
@@ -24,7 +24,7 @@ void ExplicitZeroMemory(void* ptr, size_t len);
 
 template <typename T,
           typename std::enable_if<!std::is_const<T>::value &&
-                                  std::is_trivial<T>::value>::type* = nullptr>
+                                  std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T>>::type* = nullptr>
 void ExplicitZeroMemory(std::span<T> a) {
   ExplicitZeroMemory(a.data(), a.size());
 }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/fuzz_data_helper.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/fuzz_data_helper.h
@@ -33,13 +33,13 @@ class FuzzDataHelper {
 
   // Reads and returns data of type T.
   template <typename T>
-    requires(std::is_trivial_v<T>)
+    requires(std::is_trivially_copyable_v<T> && is_trivially_default_constructible_v<T>)
   T Read();
 
   // Reads and returns data of type T. Returns default_value if not enough
   // fuzzer input remains to read a T.
   template <typename T>
-    requires(std::is_trivial_v<T>)
+    requires(std::is_trivially_copyable_v<T> && is_trivially_default_constructible_v<T>)
   T ReadOrDefaultValue(T default_value) {
     if (!CanReadBytes(sizeof(T))) {
       return default_value;
@@ -105,7 +105,7 @@ class FuzzDataHelper {
   // If sizeof(T) > BytesLeft then the remaining bytes will be used and the rest
   // of the object will be zero initialized.
   template <typename T>
-    requires(std::is_trivial_v<T>)
+    requires(std::is_trivially_copyable_v<T> && is_trivially_default_constructible_v<T>)
   void CopyTo(T& object) {
     std::span<uint8_t, sizeof(T)> object_memory(
         reinterpret_cast<uint8_t*>(&object), sizeof(T));
@@ -133,7 +133,7 @@ class FuzzDataHelper {
 };
 
 template <typename T>
-  requires(std::is_trivial_v<T>)
+  requires(std::is_trivially_copyable_v<T> && is_trivially_default_constructible_v<T>)
 T FuzzDataHelper::Read() {
   if constexpr (sizeof(T) == 1) {
     if (BytesLeft() == 0) {

--- a/Source/WTF/wtf/IndexMap.h
+++ b/Source/WTF/wtf/IndexMap.h
@@ -63,7 +63,8 @@ public:
         size_t oldSize = m_vector.size();
         m_vector.resize(size);
         // Vector::resize doesn't initialize new elements for trivial types.
-        if constexpr (std::is_trivial_v<Value>) {
+        if constexpr (std::is_trivially_copyable_v<Value>
+            && std::is_trivially_default_constructible_v<Value>) {
             if (size > oldSize)
                 std::fill(m_vector.begin() + oldSize, m_vector.end(), Value());
         }

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -65,7 +65,7 @@ struct VectorCopier {
     template<typename U, std::size_t Extent>
     static void uninitializedCopy(std::span<const U, Extent> src, std::span<T> dst)
     {
-        if constexpr (std::is_trivial_v<T> && std::same_as<T, U>)
+        if constexpr (std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T> && std::same_as<T, U>)
             memcpySpan(dst, src);
         else {
             for (size_t i = 0; i < src.size(); ++i)
@@ -768,8 +768,8 @@ public:
     static constexpr ptrdiff_t bufferMemoryOffset() { return Base::bufferMemoryOffset(); }
     [[nodiscard]] size_t capacity() const { return Base::capacity(); }
     [[nodiscard]] bool isEmpty() const { return !size(); }
-    [[nodiscard]] std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }
-    [[nodiscard]] std::span<T> mutableSpan() LIFETIME_BOUND { return { data(), size() }; }
+    [[nodiscard]] std::span<const T> span() const LIFETIME_BOUND { return std::span<const T>(data(), size()); }
+    [[nodiscard]] std::span<T> mutableSpan() LIFETIME_BOUND { return std::span<T>(data(), size()); }
 
     Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
     {

--- a/Source/WTF/wtf/VectorTraits.h
+++ b/Source/WTF/wtf/VectorTraits.h
@@ -58,7 +58,7 @@ namespace WTF {
     // Requiring std::has_unique_object_representations_v<T> to make sure the type doesn't have padding and can
     // be used with memcmp().
     template<typename T>
-    struct VectorTraits : VectorTraitsBase<std::is_standard_layout_v<T> && std::is_trivial_v<T> && std::has_unique_object_representations_v<T>, T> { };
+    struct VectorTraits : VectorTraitsBase<std::is_standard_layout_v<T> && std::is_trivially_copyable_v<T> && std::is_trivially_default_constructible_v<T> && std::has_unique_object_representations_v<T>, T> { };
 
     struct SimpleClassVectorTraits : VectorTraitsBase<false, void>
     {

--- a/Source/WTF/wtf/unicode/icu/ICUHelpers.h
+++ b/Source/WTF/wtf/unicode/icu/ICUHelpers.h
@@ -91,7 +91,7 @@ template<typename CharacterType, size_t inlineCapacity, typename ...OtherArgumen
 template<typename FirstArgumentType, typename ...OtherArgumentTypes> auto argumentTuple(FirstArgumentType&& firstArgument, OtherArgumentTypes&&... otherArguments)
 {
     // This technique of building a tuple and passing it twice does not work well for complex types, so assert this is a relatively simple one.
-    static_assert(std::is_trivial_v<std::remove_reference_t<FirstArgumentType>>);
+    static_assert(std::is_trivially_copyable_v<std::remove_reference_t<FirstArgumentType>> && std::is_trivially_default_constructible_v<std::remove_reference_t<FirstArgumentType>>);
     return tuple_cat(std::make_tuple(firstArgument), argumentTuple(std::forward<OtherArgumentTypes>(otherArguments)...));
 }
 

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -1315,14 +1315,14 @@ static std::optional<MarkedText> NODELETE markedTextForTextDecorationLineSpellin
 {
     if (!renderer.style().textDecorationLineInEffect().isSpellingError())
         return std::nullopt;
-    return std::make_optional<MarkedText>({ 0, static_cast<unsigned>(renderer.length()), MarkedText::Type::SpellingError });
+    return std::make_optional<MarkedText>(0, static_cast<unsigned>(renderer.length()), MarkedText::Type::SpellingError);
 }
 
 static std::optional<MarkedText> NODELETE markedTextForTextDecorationLineGrammarError(const RenderText& renderer)
 {
     if (!renderer.style().textDecorationLineInEffect().isGrammarError())
         return std::nullopt;
-    return std::make_optional<MarkedText>({ 0, static_cast<unsigned>(renderer.length()), MarkedText::Type::GrammarError });
+    return std::make_optional<MarkedText>(0, static_cast<unsigned>(renderer.length()), MarkedText::Type::GrammarError);
 }
 
 void TextBoxPainter::paintPlatformDocumentMarkers()


### PR DESCRIPTION
#### d89c8f0325bb0bf8639e8759ff24f67e646eb70f
<pre>
Fix C++26 build
<a href="https://bugs.webkit.org/show_bug.cgi?id=318456">https://bugs.webkit.org/show_bug.cgi?id=318456</a>
<a href="https://rdar.apple.com/181254230">rdar://181254230</a>

Reviewed by Abrar Rahman Protyasha.

This PR adapts to a few changes in C++26, making WebKit compile without warnings or errors.
The changes needed are as follows:

1. std::is_trivial and std::is_trivial_v have been deprecated, and the compiler suggested I replace
   their use with std::is_trivially_copyable_v&lt;T&gt; &amp;&amp; std::is_trivially_default_constructible_v&lt;T&gt;.
2. Something subtle changed with the std::span constructor with initializer lists, especially with
   std::span&lt;const bool&gt;.  A web search pointed me to wg21.link/p4144 though I can&apos;t say I&apos;ve
   followed along closely enough to know if that&apos;s the change. In any case, our Vector::span and
   Vector::mutableSpan need explicit std::span&lt;const T&gt;() and std::span&lt;T&gt; now to continue compiling.
3. std::make_optional with an initializer list and no additional args no longer compiles as used in
   markedTextForTextDecorationLineSpellingError and markedTextForTextDecorationLineGrammarError.
   I did not find the change that caused this to happen, but std::make_optional without an initializer
   list works before and after C++26, so I switch to that.

* Source/JavaScriptCore/b3/B3Type.cpp:
* Source/JavaScriptCore/jit/OperationResult.h:
* Source/JavaScriptCore/runtime/MarkedVector.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/include/video_codec_interface.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/bounded_inline_vector_impl.h:
(webrtc::bounded_inline_vector_impl::=):
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/buffer.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/logging.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/zero_memory.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/test/fuzzers/fuzz_data_helper.h:
* Source/WTF/wtf/IndexMap.h:
(WTF::IndexMap::resize):
* Source/WTF/wtf/Vector.h:
(WTF::VectorCopier::uninitializedCopy):
* Source/WTF/wtf/VectorTraits.h:
* Source/WTF/wtf/unicode/icu/ICUHelpers.h:
(WTF::CallBufferProducingFunction::argumentTuple):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::markedTextForTextDecorationLineSpellingError):
(WebCore::markedTextForTextDecorationLineGrammarError):

Canonical link: <a href="https://commits.webkit.org/316420@main">https://commits.webkit.org/316420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/004496eb23dfa726d57523a1ab4b5f13e23769fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129808 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4ab5aa1-f0d6-45d1-a026-3a7c84e3dc10) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133986 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94518 "Build is in progress. Recent messages:") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/481a741d-8f05-482e-b6c2-eef02c1476ea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37413 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b51087f-baf1-4098-b654-808352c584f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36047 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30309 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3060 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184237 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33513 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36895 "Build is being retried. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Failed to build and analyze WebKit") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142741 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45842 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142623 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46520 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111234 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26147 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37696 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204930 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45037 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8974 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->