### PR TITLE
[WebCore] Unconditionally pin AudioBuffer data in AudioBufferSourceNode::setBufferForBindings

### DIFF
--- a/LayoutTests/webaudio/audiobuffersource-detached-buffer-crash-expected.txt
+++ b/LayoutTests/webaudio/audiobuffersource-detached-buffer-crash-expected.txt
@@ -1,0 +1,11 @@
+AudioBufferSourceNode should not read from a freed channel buffer when the buffer is set before scheduling and its backing ArrayBuffer is then transferred and collected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS transferError instanceof TypeError is true
+PASS Rendering completed without crashing.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/audiobuffersource-detached-buffer-crash.html
+++ b/LayoutTests/webaudio/audiobuffersource-detached-buffer-crash.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("AudioBufferSourceNode should not read from a freed channel buffer when the buffer is set before scheduling and its backing ArrayBuffer is then transferred and collected.");
+
+jsTestIsAsync = true;
+
+function gc()
+{
+    if (window.GCController)
+        return GCController.collect();
+    for (let i = 0; i < 200; i++)
+        new ArrayBuffer(1 << 20);
+}
+
+var transferError = null;
+
+(async () => {
+    const sampleRate = 44100;
+    const ctx = new OfflineAudioContext(1, 256, sampleRate);
+    const audioBuffer = ctx.createBuffer(1, 0x4000, sampleRate);
+
+    const node = ctx.createBufferSource();
+    node.buffer = audioBuffer;
+
+    const channelBuffer = audioBuffer.getChannelData(0).buffer;
+    try {
+        structuredClone(channelBuffer, { transfer: [channelBuffer] });
+        testFailed("Transfer should have thrown because the buffer is pinned.");
+    } catch (e) {
+        transferError = e;
+    }
+    shouldBeTrue("transferError instanceof TypeError");
+    gc();
+    gc();
+
+    node.loop = true;
+    node.playbackRate.value = 0;
+    node.connect(ctx.destination);
+    node.start();
+
+    await ctx.startRendering();
+    testPassed("Rendering completed without crashing.");
+    finishJSTest();
+})();
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -654,7 +654,7 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(const Abstract
 
 ASCIILiteral errorMessageForTransfer(ArrayBuffer* buffer)
 {
-    ASSERT(buffer->isLocked());
+    ASSERT(!buffer->isDetachable());
     if (buffer->isShared())
         return "Cannot transfer a SharedArrayBuffer"_s;
     if (buffer->isWasmMemory())

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -214,6 +214,9 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
     double pitchRate = totalPitchRate();
     bool reverse = pitchRate < 0;
 
+    if (!bufferLength)
+        return false;
+
     // Avoid converting from time to sample-frames twice by computing
     // the grain end time first before computing the sample frame.
     unsigned maxFrame;
@@ -249,7 +252,7 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
 
         // Wrap back to the beginning of the loop.
         m_virtualReadIndex = (m_loopStart < 0) ? 0 : (m_loopStart * m_buffer->sampleRate());
-        m_virtualReadIndex = std::min(m_virtualReadIndex, static_cast<double>(bufferLength - 1));
+        m_virtualReadIndex = std::min(m_virtualReadIndex, static_cast<double>(bufferLength) - 1);
     }
 
     // Sanity check that our playback rate isn't larger than the loop size.
@@ -339,6 +342,9 @@ bool AudioBufferSourceNode::renderFromBuffer(AudioBus& bus, unsigned destination
 
         if (readIndex >= maxFrame)
             readIndex -= deltaFrames;
+
+        if (readIndex >= bufferLength)
+            return false;
 
         for (unsigned i = 0; i < numberOfChannels; ++i)
             std::ranges::fill(m_destinationChannels[i].subspan(writeIndex).first(framesToProcess), m_sourceChannels[i][readIndex]);
@@ -476,8 +482,7 @@ ExceptionOr<void> AudioBufferSourceNode::setBufferForBindings(RefPtr<AudioBuffer
     if (m_isGrain)
         adjustGrainParameters();
 
-    if (isPlayingOrScheduled())
-        acquireBufferContent();
+    acquireBufferContent();
 
     return { };
 }


### PR DESCRIPTION
#### a3630df607da4f1b31ea87bc631eaedd14c0b4b4
<pre>
[WebCore] Unconditionally pin AudioBuffer data in AudioBufferSourceNode::setBufferForBindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=313857">https://bugs.webkit.org/show_bug.cgi?id=313857</a>
<a href="https://rdar.apple.com/174651279">rdar://174651279</a>

Reviewed by Chris Dumez.

When a page tries to write an ArrayBuffer of audio data to an audio node
(writing to node.buffer), the page can free the ArrayBuffer&apos;s backing
store and leave the audio node to read the freed memory through a cached
pointer.

An AudioBufferSourceNode caches raw pointers into an AudioBuffer&apos;s channel
data when you set node.buffer. This happens in AudioBufferSourceNode::setBufferForBindings
where a pointer from a span is cached in m_sourceChannels[i].
Those pointers point into ArrayBuffer backing stores managed by JSC.
If the memory is not pinned, or detachable, then
the page can force the ArrayBuffer&apos;s backing store to be freed by
dropping the reference to the result of structuredClone on the original buffer
and kicking off a GC.

Two previous commits (one was a re-land), fixed this same bug by pinning
the memory (making it non-detachable), so that the backing store can&apos;t
be detached and leave a copy to be freed. In fact, pinning the memory
will cause structuredClone to fail with a TypeError.
1. <a href="https://rdar.apple.com/123510096">rdar://123510096</a>, <a href="https://bugs.webkit.org/show_bug.cgi?id=270007">https://bugs.webkit.org/show_bug.cgi?id=270007</a>
2. <a href="https://rdar.apple.com/126326144">rdar://126326144</a>, <a href="https://bugs.webkit.org/show_bug.cgi?id=272607">https://bugs.webkit.org/show_bug.cgi?id=272607</a>

Those patches are supposed to pin those ArrayBuffers (make them non-detachable)
to keep the memory alive, but it only pins if the node is already playing.
If you set the buffer before calling start() (i.e. when the node is in UNSCHEDULED_STATE),
the pin is skipped (since isPlayingOrScheduled() is false).

An attacker exploits this by:
1. Setting the buffer (spans cached, no pin)
2. Transferring the channel ArrayBuffer via structuredClone (detaches it)
3. Dropping the copy and triggering GC (backing store freed)
4. Starting playback with loop=true and playbackRate=0

The audio node then reads from freed memory through the dangling spans
during AudioBufferSourceNode::renderFromBuffer() when it reads
m_sourceChannels.

This patch removes the condition to pin the audio buffer
(mark it as non-detachable). Previously, the audio buffer was only
pinned when isPlayingOrScheduled() was true, however, this patch
pins the memory unconditionally. This way if the page tries
to call structuredClone, it will now throw a TypeError and
avoid the opportunity to free the backing store.

In addition, this patch adds the following defensive hardenings
in case the same exploit is triggered via another path:
1. Early return if bufferLength == 0 in AudioBufferSourceNode::renderFromBuffer()
    before the freed m_sourceChannels is read. bufferLength would be 0
    if the memory was detached (not pinned)
2. Fix the following code that calculates the index into
    the audio buffer in AudioBufferSourceNode::renderFromBuffer():

        m_virtualReadIndex = std::min(m_virtualReadIndex, static_cast&lt;double&gt;( bufferLength - 1));

    This patch changes the static cast from
        static_cast&lt;double&gt;(bufferLength - 1)
    to
        static_cast&lt;double&gt;(bufferLength) - 1
    since bufferLength is unsigned (size_t) so when
    bufferLength is 0, it previously could cause the unsigned
    (size_t) to underflow making the upper limit of the std::min
    bounds check effectively useless.
3. Add a guard to bounds check readIndex in the case where !pitchRate.
    This happens where the attacker sets node.playbackRate.value = 0;
    Every other branch already bounds-checks readIndex. This was the
    one path that didn&apos;t.

As a side note, an alternative approach to fix this bug, could be to
acquire an internal copy of the audio data which is not accessible from JS.
This is described in the webaudio spec and was attempted to be implemented
in a previous fix but caused increased memory usage and the tradeoff to
detach the memory was chosen instead.
See the message and FIXME from <a href="https://commits.webkit.org/272448.925@safari-7618-branch">https://commits.webkit.org/272448.925@safari-7618-branch</a>

This also updates an ASSERT in ArrayBuffer::errorMessageForTransfer
from ASSERT(buffer-&gt;isLocked()) to ASSERT(!buffer-&gt;isDetachable())
since the regression test is hitting this path and not keeping the buffer
alive via locking, but instead is pinning it (which isDetachable()
is aware of, unlike isLocked()).

Test: webaudio/audiobuffersource-detached-buffer-crash.html

* LayoutTests/webaudio/audiobuffersource-detached-buffer-crash-expected.txt: Added.
* LayoutTests/webaudio/audiobuffersource-detached-buffer-crash.html: Added.
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::errorMessageForTransfer):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::renderFromBuffer):
(WebCore::AudioBufferSourceNode::setBufferForBindings):

Originally-landed-as: 305413.815@safari-7624-branch (7aaeec1bad67). <a href="https://rdar.apple.com/180436186">rdar://180436186</a>
Canonical link: <a href="https://commits.webkit.org/305877.886@webkitglib/2.52">https://commits.webkit.org/305877.886@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b64fb23acc74b087e3aeba9f0b943168fb7e6843

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172362 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46280 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181814 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129918 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174227 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47573 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45923 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134052 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129918 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175320 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47573 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114523 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47573 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45923 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30419 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47573 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184349 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33623 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37030 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45923 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142827 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45952 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142708 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46630 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111357 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26160 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46630 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118381 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205040 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45147 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39708 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54739 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44547 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44779 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44606 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->