### PR TITLE
Cherry-pick cbd729a317dc. https://bugs.webkit.org/show_bug.cgi?id=313917

### DIFF
--- a/LayoutTests/streams/byob-close-exception-expected.txt
+++ b/LayoutTests/streams/byob-close-exception-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Read too much in a blob
+

--- a/LayoutTests/streams/byob-close-exception.html
+++ b/LayoutTests/streams/byob-close-exception.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async t => {
+    window.onerror = () => {
+        assert_not_reached("error should not fire");
+    };
+    window.addEventListener("unhandledrejection", e => {
+        assert_not_reached("there should no unhandled rejected promise");
+    });
+
+    for (let i = 0; i < 3; ++i) {
+        const response = new Response(new Blob([new Uint8Array([1, 2, 3])]));
+        const reader = response.body.getReader({ mode: "byob" });
+        await reader.read(new Uint32Array(1)).then(() => assert_not_reached("should fail"), () => { });
+    }
+}, "Read too much in a blob");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -138,7 +138,7 @@ ExceptionOr<void> ReadableByteStreamController::closeForBindings(JSDOMGlobalObje
     if (protectedStream()->state() != ReadableStream::State::Readable)
         return Exception { ExceptionCode::TypeError, "controller's stream is not readable"_s };
 
-    close(globalObject);
+    close(globalObject, ShouldThrowOnError::Yes);
     return { };
 }
 
@@ -238,7 +238,12 @@ void ReadableByteStreamController::didStart(JSDOMGlobalObject& globalObject)
 // Part of https://streams.spec.whatwg.org/#readablestream-close
 void ReadableByteStreamController::closeAndRespondToPendingPullIntos(JSDOMGlobalObject& globalObject)
 {
-    close(globalObject);
+    auto& vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm);
+
+    if (!close(globalObject, ShouldThrowOnError::No))
+        return;
+
     while (!m_pendingPullIntos.isEmpty())
         respond(globalObject, 0);
 }

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -92,7 +92,7 @@ public:
     void error(JSDOMGlobalObject&, JSC::JSValue);
 
     enum class ShouldThrowOnError : bool { No, Yes };
-    bool close(JSDOMGlobalObject&, ShouldThrowOnError = ShouldThrowOnError::Yes);
+    bool close(JSDOMGlobalObject&, ShouldThrowOnError);
     void closeAndRespondToPendingPullIntos(JSDOMGlobalObject&);
     size_t pullFromBytes(JSDOMGlobalObject&, JSC::ArrayBuffer&, size_t offset);
     ExceptionOr<void> enqueue(JSDOMGlobalObject&, JSC::ArrayBufferView&);

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -441,10 +441,15 @@ private:
         RefPtr branch2 = m_state->branch2();
 
         m_state->setReading(false);
+
+        bool shouldStopSteps = false;
         if (!m_state->canceled1() && branch1)
-            branch1->controller()->close(*globalObject);
+            shouldStopSteps = !branch1->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
         if (!m_state->canceled2() && branch2)
-            branch2->controller()->close(*globalObject);
+            shouldStopSteps |= !branch2->controller()->close(*globalObject, ReadableByteStreamController::ShouldThrowOnError::No);
+
+        if (shouldStopSteps)
+            return;
 
         if (branch1 && branch1->protectedController()->hasPendingPullIntos())
             branch1->protectedController()->respond(*globalObject, 0);

--- a/Source/WebCore/platform/mock/mediasource/MockBox.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockBox.cpp
@@ -92,7 +92,7 @@ MockInitializationBox::MockInitializationBox(ArrayBuffer* data)
 
     auto view = JSC::DataView::create(data, 0, data->byteLength());
     int32_t timeValue = view->get<int32_t>(8, true);
-    int32_t timeScale = view->get<int32_t>(12, true);
+    uint32_t timeScale = view->get<uint32_t>(12, true);
     m_duration = MediaTime(timeValue, timeScale);
     
     size_t offset = 16;
@@ -120,7 +120,7 @@ MockSampleBox::MockSampleBox(ArrayBuffer* data)
     ASSERT(m_length == 30);
 
     auto view = JSC::DataView::create(data, 0, data->byteLength());
-    int32_t timeScale = view->get<int32_t>(8, true);
+    uint32_t timeScale = view->get<uint32_t>(8, true);
 
     int32_t timeValue = view->get<int32_t>(12, true);
     m_presentationTimestamp = MediaTime(timeValue, timeScale);
@@ -128,8 +128,8 @@ MockSampleBox::MockSampleBox(ArrayBuffer* data)
     timeValue = view->get<int32_t>(16, true);
     m_decodeTimestamp = MediaTime(timeValue, timeScale);
 
-    timeValue = view->get<int32_t>(20, true);
-    m_duration = MediaTime(timeValue, timeScale);
+    uint32_t durationValue = view->get<uint32_t>(20, true);
+    m_duration = MediaTime(durationValue, timeScale);
 
     m_trackID = view->get<int32_t>(24, true);
     m_flags = view->get<uint8_t>(28, true);


### PR DESCRIPTION
#### f09ffa51faf485a4443b6ee919ef0a55e41c87f1
<pre>
Cherry-pick cbd729a317dc. <a href="https://bugs.webkit.org/show_bug.cgi?id=313917">https://bugs.webkit.org/show_bug.cgi?id=313917</a>

[WebCore] unchecked exception return in ReadableByteStreamController::closeAndRespondToPendingPullIntos and TeeDefaultReadRequest::runCloseSteps
<a href="https://rdar.apple.com/175673816">rdar://175673816</a>

Reviewed by Chris Dumez.

ReadableByteStreamController::closeAndRespondToPendingPullIntos() and
TeeDefaultReadRequest::runCloseSteps() both call close(globalObject) with
the default ShouldThrowOnError::Yes flag and discard the bool return value.
When the first pending pull-into has bytesFilled % elementSize != 0,
close() calls this-&gt;error(), then throwException(...), and returns false —
leaving a TypeError pending on the VM with no RETURN_IF_EXCEPTION guard in
any caller.

The sibling BYOB path (TeeBYOBReadRequest::runCloseSteps) was fixed in
<a href="https://rdar.apple.com/165613840">rdar://165613840</a> (303821@main) to use ShouldThrowOnError::No and check the
return; these two callers were not updated at the same time.

This patch mirrors the <a href="https://rdar.apple.com/165613840">rdar://165613840</a> pattern at both unfixed callers:
- Pass ShouldThrowOnError::No and check return value in both callers
- Stop processing pending pull-intos when close() fails

It also makes ShouldThrowOnError parameter non-optional to prevent future misuse.

Test: streams/byob-close-exception.html

* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
(WebCore::ReadableByteStreamController::closeForBindings):
(WebCore::ReadableByteStreamController::closeAndRespondToPendingPullIntos):
* Source/WebCore/Modules/streams/ReadableByteStreamController.h:
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
(WebCore::TeeDefaultReadRequest::runCloseSteps):

Identifier: 305413.819@safari-7624-branch

Identifier: 305413.761@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.875@webkitglib/2.52">https://commits.webkit.org/305877.875@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### be0658d5f50fc21c1ed500d803e3614ab64dbe93
<pre>
Cherry-pick 4f7a3cfefe44. <a href="https://bugs.webkit.org/show_bug.cgi?id=313917">https://bugs.webkit.org/show_bug.cgi?id=313917</a>

MockSampleBox should not have negative timeScales and duration
<a href="https://rdar.apple.com/174740124">rdar://174740124</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313917">https://bugs.webkit.org/show_bug.cgi?id=313917</a>

Reviewed by Simon Fraser.

* Source/WebCore/platform/mock/mediasource/MockBox.cpp:
(WebCore::MockInitializationBox::MockInitializationBox):
(WebCore::MockSampleBox::MockSampleBox):

Identifier: 305413.813@safari-7624-branch

Identifier: 305413.760@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.874@webkitglib/2.52">https://commits.webkit.org/305877.874@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a18185c3f0aafabbe28e41b257b52d45604b6396

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172261 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46179 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181712 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129817 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174126 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47472 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45821 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133980 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129817 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175219 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47472 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114451 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47472 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45821 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30318 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47472 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184246 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36883 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45821 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142744 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45851 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142626 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46529 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111243 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26143 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46529 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118280 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45046 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39607 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44446 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44678 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44505 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->