### PR TITLE
Cherry-pick 3270ebdb7366. https://bugs.webkit.org/show_bug.cgi?id=314850

### DIFF
--- a/JSTests/stress/arguments-elimination-multiple-inline-call-frames.js
+++ b/JSTests/stress/arguments-elimination-multiple-inline-call-frames.js
@@ -1,0 +1,38 @@
+//@ skip if $buildType == "debug"
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0", "--maximumFunctionForCallInlineCandidateBytecodeCostForFTL=500")
+
+let g = 0;
+function restY(c, ...r) { g = c ? 1 : 2; return r; }
+function h(c, ...r) { return r; }
+function h2(...r) { return r; }
+function sink() {
+    let out = [];
+    for (let i = 0; i < arguments.length; i++) out.push(arguments[i]);
+    return out;
+}
+noInline(sink);
+
+function restX(c, ...rx) {
+    let arr = [...rx, ...restY(c, ...rx)];
+    let dummy = [0, 0, 0, 0, 0, 0, 0, h(50, 9.9, 8.8)];
+    return [sink.apply(null, arr), dummy];
+}
+for (let i = 0; i < 1000000; i++) restX(i & 1, 0.1, 0.2);
+
+function makeSrc(k) {
+return `
+(function() {
+function victim${k}(c1) {
+    let q = restX(c1, 0.1, 0.2);
+    let z = h2(7.7, 6.6);
+    return [q, z];
+}
+noInline(victim${k});
+for (let i = 0; i < 1000000; i++) {
+    victim${k}(i & 1);
+}
+})()
+`;
+}
+
+for (let k = 0; k < 30; k++) eval(makeSrc(k));

--- a/JSTests/wasm/gc/transitive-type-retention-global.js
+++ b/JSTests/wasm/gc/transitive-type-retention-global.js
@@ -1,0 +1,24 @@
+// Regression test: Wasm Global must retain transitive TypeDefinition dependencies.
+// A global typed (ref null $f) where $f references struct type $s must keep $s alive
+// even after the module is collected.
+
+import { instantiate } from "./wast-wrapper.js";
+
+(function() {
+    let inst = instantiate(`
+        (module
+            (rec (type $s (struct (field i32) (field i32) (field i32) (field i32))))
+            (rec (type $f (func (param (ref null $s)) (result (ref null $s)))))
+            (global (export "g") (mut (ref null $f)) (ref.null $f))
+        )
+    `);
+
+    let g = inst.exports.g;
+    inst = null;
+
+    gc();
+    gc();
+
+    g.value;
+    g.value = null;
+})();

--- a/JSTests/wasm/gc/transitive-type-retention-table.js
+++ b/JSTests/wasm/gc/transitive-type-retention-table.js
@@ -1,0 +1,25 @@
+// Regression test: Wasm Table must retain transitive TypeDefinition dependencies.
+// A table typed (ref null $f) where $f references struct type $s must keep $s alive
+// even after the module is collected.
+
+import { instantiate } from "./wast-wrapper.js";
+
+(function() {
+    let inst = instantiate(`
+        (module
+            (rec (type $s (struct (field i32) (field i32) (field i32) (field i32))))
+            (rec (type $f (func (param (ref null $s)) (result (ref null $s)))))
+            (table (export "tbl") 10 10 (ref null $f))
+        )
+    `);
+
+    let tbl = inst.exports.tbl;
+    inst = null;
+
+    gc();
+    gc();
+
+    tbl.get(0);
+    tbl.set(0, null);
+    tbl.grow(0, null);
+})();

--- a/LayoutTests/editing/async-clipboard/clipboard-change-data-while-getting-type.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-change-data-while-getting-type.html
@@ -14,7 +14,7 @@
             description("This test verifies that if platform pasteboard contents are changed before reading from a ClipboardItem, the new contents of the pasteboard should not be exposed to the page and the result of getType() should be rejected. This test requires WebKitTestRunner.");
 
             await UIHelper.copyText("Foo");
-            items = await navigator.clipboard.read();
+            items = await readClipboardWithUserActivation();
             shouldBe("items.length", "1");
             await UIHelper.copyText("Bar");
             try {

--- a/LayoutTests/editing/async-clipboard/clipboard-get-type-with-old-items.html
+++ b/LayoutTests/editing/async-clipboard/clipboard-get-type-with-old-items.html
@@ -14,7 +14,7 @@
             description("This test verifies that it's still possible to read from the clipboard, after attempting to read data from stale items. Requires DumpRenderTree or WebKitTestRunner.");
 
             await UIHelper.copyText("Hello");
-            itemsBeforeChange = await navigator.clipboard.read();
+            itemsBeforeChange = await readClipboardWithUserActivation();
             shouldBe("itemsBeforeChange.length", "1");
 
             try {
@@ -26,7 +26,7 @@
             }
 
             await UIHelper.copyText("World");
-            itemsAfterChange = await navigator.clipboard.read();
+            itemsAfterChange = await readClipboardWithUserActivation();
             shouldBe("itemsAfterChange.length", "1");
 
             try {

--- a/LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js
+++ b/LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js
@@ -99,3 +99,26 @@ async function checkClipboardItemString(item, type, expectedString)
     else
         testFailed(`getType("${type}") resolved to "${observedString}; expected "${expectedString}"`);
 }
+
+// Calls navigator.clipboard.read() with a fresh user activation, as required by the W3C
+// Clipboard API spec. Adds a transient button to the document, activates it, and reads the
+// clipboard inside the click handler so that the relevant global object has transient
+// activation when read() is invoked.
+async function readClipboardWithUserActivation()
+{
+    return new Promise((resolve, reject) => {
+        const button = document.createElement("button");
+        button.textContent = "Read clipboard";
+        document.body.appendChild(button);
+        button.addEventListener("click", async () => {
+            try {
+                resolve(await navigator.clipboard.read());
+            } catch (error) {
+                reject(error);
+            } finally {
+                button.remove();
+            }
+        }, { once: true });
+        UIHelper.activateElement(button);
+    });
+}

--- a/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<body>
+<script>
+// WebCodecsAudioData::memoryCost() is called from JSWebCodecsAudioData::visitChildren on a
+// concurrent GC marker thread. It must not dereference m_data.audioData, since close() on the
+// main thread may concurrently null and free it.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const POOL = 200;
+const DURATION_MS = 2000;
+const startTime = Date.now();
+
+const buf = new Float32Array(4096);
+for (let i = 0; i < buf.length; i++)
+    buf[i] = Math.random();
+
+const init = {
+    format: "f32-planar",
+    sampleRate: 48000,
+    timestamp: 0,
+    data: buf,
+    numberOfFrames: 2048,
+    numberOfChannels: 2,
+};
+
+window.pool = new Array(POOL);
+for (let i = 0; i < POOL; i++)
+    pool[i] = new AudioData(init);
+
+let idx = 0;
+
+function closeOne() {
+    if (Date.now() - startTime > DURATION_MS) {
+        document.body.textContent = "Test passes if it does not crash.";
+        if (window.testRunner)
+            testRunner.notifyDone();
+        return;
+    }
+
+    pool[idx].close();
+    pool[idx] = new AudioData(init);
+    idx = (idx + 1) % POOL;
+
+    Promise.resolve().then(closeOne);
+}
+
+function pressureGC() {
+    if (Date.now() - startTime > DURATION_MS)
+        return;
+    for (let i = 0; i < 20; i++) {
+        let tmp = new AudioData(init);
+        tmp.close();
+    }
+    setTimeout(pressureGC, 10);
+}
+
+closeOne();
+pressureGC();
+</script>
+</body>

--- a/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied-expected.txt
+++ b/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied-expected.txt
@@ -1,0 +1,21 @@
+Verifies that a cross-origin iframe cannot read or write the clipboard by consuming transient user activation from the top-level page via postMessage. navigator.clipboard.readText(), navigator.clipboard.read(), navigator.clipboard.writeText(), and navigator.clipboard.write() in the iframe should all be rejected with NotAllowedError because transient activation does not propagate to cross-origin iframes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Result for navigator.clipboard.readText():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+Result for navigator.clipboard.read():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+Result for navigator.clipboard.writeText():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+Result for navigator.clipboard.write():
+PASS iframeStatus is "rejected"
+PASS iframeErrorName is "NotAllowedError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html
+++ b/LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncClipboardAPIEnabled=true JavaScriptCanAccessClipboard=false ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="/resources/js-test-pre.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<style>
+button, iframe {
+    display: block;
+    width: 400px;
+    height: 100px;
+}
+</style>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<button id="run">Click to postMessage clipboard request to cross-origin iframe</button>
+<iframe id="frame" src="http://localhost:8080/security/clipboard/resources/clipboard-access-from-iframe.html"></iframe>
+<script>
+description("Verifies that a cross-origin iframe cannot read or write the clipboard by consuming transient user activation from the top-level page via postMessage. navigator.clipboard.readText(), navigator.clipboard.read(), navigator.clipboard.writeText(), and navigator.clipboard.write() in the iframe should all be rejected with NotAllowedError because transient activation does not propagate to cross-origin iframes.");
+jsTestIsAsync = true;
+
+const frame = document.getElementById("frame");
+const runButton = document.getElementById("run");
+
+let pendingMethod = null;
+let pendingResolve = null;
+
+runButton.addEventListener("click", () => {
+    frame.contentWindow.postMessage({ method: pendingMethod }, "*");
+});
+
+async function testMethod(method) {
+    pendingMethod = method;
+    const result = await new Promise(resolve => {
+        pendingResolve = resolve;
+        UIHelper.activateElement(runButton);
+    });
+    window.iframeStatus = result.status;
+    window.iframeErrorName = result.errorName;
+    debug(`Result for navigator.clipboard.${method}():`);
+    shouldBeEqualToString("iframeStatus", "rejected");
+    shouldBeEqualToString("iframeErrorName", "NotAllowedError");
+}
+
+window.addEventListener("message", async event => {
+    if (!event.data)
+        return;
+
+    if (event.data.type === "iframe-loaded") {
+        if (!window.testRunner)
+            return;
+        await testMethod("readText");
+        await testMethod("read");
+        await testMethod("writeText");
+        await testMethod("write");
+        runButton.remove();
+        frame.remove();
+        finishJSTest();
+        return;
+    }
+
+    if (event.data.type === "iframe-result" && pendingResolve) {
+        const resolve = pendingResolve;
+        pendingResolve = null;
+        resolve(event.data);
+    }
+});
+</script>
+<script src="/resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/clipboard/resources/clipboard-access-from-iframe.html
+++ b/LayoutTests/http/tests/security/clipboard/resources/clipboard-access-from-iframe.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+async function invoke(method) {
+    switch (method) {
+    case "readText":
+        return navigator.clipboard.readText();
+    case "read":
+        return navigator.clipboard.read();
+    case "writeText":
+        return navigator.clipboard.writeText("iframe-written text");
+    case "write": {
+        const blob = new Blob(["iframe-written text"], { type: "text/plain" });
+        return navigator.clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+    }
+    }
+    throw new Error(`unknown method: ${method}`);
+}
+
+window.addEventListener("message", async event => {
+    if (!event.data)
+        return;
+
+    const method = event.data.method;
+    let result;
+    try {
+        await invoke(method);
+        result = { type: "iframe-result", method, status: "resolved" };
+    } catch (err) {
+        result = { type: "iframe-result", method, status: "rejected", errorName: err.name };
+    }
+    parent.postMessage(result, "*");
+});
+
+parent.postMessage({ type: "iframe-loaded" }, "*");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https-expected.txt
@@ -1,6 +1,8 @@
+Body needed for test_driver.click()
 
 PASS navigator.clipboard exists
 PASS navigator.clipboard.write([text/plain ClipboardItem]) succeeds
+FAIL navigator.clipboard.write([>1 ClipboardItems]) fails (not implemented) assert_unreached: Should have rejected: undefined Reached unreachable code
 PASS navigator.clipboard.write() fails (expect [ClipboardItem])
 PASS navigator.clipboard.write(null) fails (expect [ClipboardItem])
 PASS navigator.clipboard.write(DOMString) fails (expect [ClipboardItem])
@@ -15,6 +17,6 @@ FAIL navigator.clipboard.write(image/png DOMString) fails promise_rejects_js: fu
 }" ("TypeError")
 PASS navigator.clipboard.read() succeeds
 PASS navigator.clipboard.readText() succeeds
-FAIL navigator.clipboard.write(Promise<Blob>) succeeds promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: getPermissions"
-FAIL navigator.clipboard.write(Promise<Blob>s) succeeds promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: getPermissions"
+PASS navigator.clipboard.write(Promise<Blob>) succeeds
+PASS navigator.clipboard.write(Promise<Blob>s) succeeds
 

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html
@@ -2,9 +2,21 @@
 <meta charset="utf-8">
 <title>Async Clipboard input type validation tests</title>
 <link rel="help" href="https://w3c.github.io/clipboard-apis/#async-clipboard-api">
+<body>Body needed for test_driver.click()</body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/user-activation.js"></script>
 <script>
+
+// Permissions are required in order to invoke navigator.clipboard functions in
+// an automated test.
+async function getPermissions() {
+  await tryGrantReadPermission();
+  await tryGrantWritePermission();
+  await waitForUserActivation();
+}
 
 test(() => {
   assert_not_equals(navigator.clipboard, undefined);
@@ -13,6 +25,7 @@ test(() => {
 }, 'navigator.clipboard exists');
 
 promise_test(async () => {
+  await getPermissions();
   const blob = new Blob(['hello'], {type: 'text/plain'});
   const item = new ClipboardItem({'text/plain': blob});
 
@@ -20,38 +33,58 @@ promise_test(async () => {
 }, 'navigator.clipboard.write([text/plain ClipboardItem]) succeeds');
 
 promise_test(async t => {
+  await getPermissions();
+  const blob1 = new Blob(['hello'], {type: 'text/plain'});
+  const blob2 = new Blob(['world'], {type: 'text/plain'});
+
+  const item1 = new ClipboardItem({'text/plain': blob1});
+  const item2 = new ClipboardItem({'text/plain': blob2});
+
+  await promise_rejects_dom(t, "NotAllowedError",
+      navigator.clipboard.write([item1, item2]));
+}, 'navigator.clipboard.write([>1 ClipboardItems]) fails (not implemented)');
+
+promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError, navigator.clipboard.write());
 }, 'navigator.clipboard.write() fails (expect [ClipboardItem])');
 
 promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError, navigator.clipboard.write(null));
 }, 'navigator.clipboard.write(null) fails (expect [ClipboardItem])');
 
 promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError,
-                         navigator.clipboard.write('Bad string'));
+                           navigator.clipboard.write('Bad string'));
 }, 'navigator.clipboard.write(DOMString) fails (expect [ClipboardItem])');
 
 promise_test(async t => {
+  await getPermissions();
   const blob = new Blob(['hello'], {type: 'text/plain'});
   await promise_rejects_js(t, TypeError, navigator.clipboard.write(blob));
 }, 'navigator.clipboard.write(Blob) fails (expect [ClipboardItem])');
 
 promise_test(async () => {
+  await getPermissions();
   await navigator.clipboard.writeText('New clipboard text');
 }, 'navigator.clipboard.writeText(DOMString) succeeds');
 
 promise_test(async t => {
+  await getPermissions();
   await promise_rejects_js(t, TypeError,
-                         navigator.clipboard.writeText());
+                           navigator.clipboard.writeText());
 }, 'navigator.clipboard.writeText() fails (expect DOMString)');
 
 promise_test(async () => {
+  await getPermissions();
   const item = new ClipboardItem({'text/plain': 'test'});
   await navigator.clipboard.write([item]);
 }, 'navigator.clipboard.write({string : DOMString}) succeeds');
 
 promise_test(async () => {
+  await getPermissions();
   const fetched = await fetch('/clipboard-apis/resources/greenbox.png');
   const image = await fetched.blob();
   const item = new ClipboardItem({'image/png': image});
@@ -60,6 +93,7 @@ promise_test(async () => {
 }, 'navigator.clipboard.write({string : image/png Blob}) succeeds');
 
 promise_test(async() => {
+  await getPermissions();
   const fetched = await fetch('/clipboard-apis/resources/greenbox.png');
   const image = await fetched.blob();
   const item = new ClipboardItem({
@@ -70,17 +104,20 @@ promise_test(async() => {
 }, 'navigator.clipboard.write([text + png] succeeds');
 
 promise_test(async t => {
+  await getPermissions();
   const item = new ClipboardItem({'image/png': 'not an image'});
   await promise_rejects_js(t, TypeError, navigator.clipboard.write([item]));
 }, 'navigator.clipboard.write(image/png DOMString) fails');
 
 promise_test(async () => {
+  await getPermissions();
   const result = await navigator.clipboard.read();
   assert_true(result instanceof Object);
   assert_true(result[0] instanceof ClipboardItem);
 }, 'navigator.clipboard.read() succeeds');
 
 promise_test(async () => {
+  await getPermissions();
   const result = await navigator.clipboard.readText();
   assert_equals(typeof result, 'string');
 }, 'navigator.clipboard.readText() succeeds');

--- a/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/resources/user-activation.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/resources/user-activation.js
@@ -23,3 +23,33 @@ async function waitForUserActivation() {
   test_driver.click(document.body);
   await clickedPromise;
 }
+
+async function trySetPermission(perm, state) {
+  try {
+    await test_driver.set_permission({ name: perm }, state)
+  } catch {
+    // This is expected, as clipboard permissions are not supported by every engine
+    // and also the set_permission. The permission is not required by such engines as
+    // they require user activation instead.
+  }
+}
+
+async function tryGrantReadPermission() {
+  await trySetPermission("clipboard-read", "granted");
+}
+
+async function tryGrantWritePermission() {
+  await trySetPermission("clipboard-write", "granted");
+}
+
+async function sendPasteShortcutKey() {
+  const modifier = navigator.platform.includes("Mac") ? "\uE03d" // META
+                                                      : "\uE009"; // CONTROL
+  await new test_driver.Actions()
+    .keyDown(modifier)
+    .keyDown("v")
+    .keyUp("v")
+    .keyUp(modifier)
+    .send();
+}
+

--- a/LayoutTests/ipc/nested-display-list-draw-control-part-crash-expected.txt
+++ b/LayoutTests/ipc/nested-display-list-draw-control-part-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/nested-display-list-draw-control-part-crash.html
+++ b/LayoutTests/ipc/nested-display-list-draw-control-part-crash.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html><body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+let currentIdentifier = 0x4000 + Math.floor(Math.random() * 0x100000);
+function genId() { return currentIdentifier++; }
+
+async function main() {
+    if (!window.IPC)
+        return;
+
+    const { CoreIPC, ArgumentSerializer, StreamConnection } = await import('./coreipc.js');
+
+    // CoreIPC.js aliases RetainPtr<CGColorSpaceRef> -> CoreIPCCGColorSpace, but the
+    // generated coder wraps it in a leading `bool isEngaged`. Override the field type
+    // so serializeOptional inserts the bool.
+    CoreIPC.typeInfo['WebCore::PlatformColorSpace'][0].type =
+        'std::optional<WebKit::CoreIPCCGColorSpace>';
+
+    // CoreIPC.js's StreamConnection uses a 0.1s defaultTimeout which silently drops
+    // messages on a busy machine; use a longer one.
+    function newStreamConnectionLongTimeout() {
+        const pair = IPC.createStreamClientConnection(14, 60);
+        const sc = Object.create(StreamConnection.prototype);
+        sc.handle = pair[1];
+        sc.connection = pair[0];
+        sc.connection.open();
+        sc.newInterface = (name, id) => {
+            const iface = { connection: sc.connection };
+            for (const [k, v] of Object.entries(CoreIPC.messages)) {
+                const us = k.indexOf('_');
+                if (k.substring(0, us) !== name)
+                    continue;
+                const fn = k.substring(us + 1);
+                if (v.replyArguments === null) {
+                    iface[fn] = (args) => {
+                        const s = ArgumentSerializer.serializeArguments(v.arguments, args);
+                        sc.connection.sendMessage(id, v.name, s);
+                    };
+                } else {
+                    iface[fn] = (args, cb) => {
+                        const s = ArgumentSerializer.serializeArguments(v.arguments, args);
+                        sc.connection.sendWithAsyncReply(id, v.name, s, (r) => cb && cb(r));
+                    };
+                }
+            }
+            return iface;
+        };
+        return sc;
+    }
+
+    function createRemoteRenderingBackend() {
+        const streamConnection = newStreamConnectionLongTimeout();
+        const renderingBackendIdentifier = genId();
+        CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+            renderingBackendIdentifier: renderingBackendIdentifier,
+            connectionHandle: streamConnection
+        });
+        const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+        const didInitializeReply = streamConnection.connection.waitForMessage(
+            renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 5);
+        streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+        return { streamConnection, remoteRenderingBackend, remoteRenderingBackendIdentifier: renderingBackendIdentifier };
+    }
+
+    function createRemoteImageBuffer(rb) {
+        const imageBufferIdentifier = genId();
+        const graphicsContextIdentifier = genId();
+        rb.remoteRenderingBackend.CreateImageBuffer({
+            logicalSize: { width: 64, height: 64 },
+            renderingMode: 0,
+            renderingPurpose: 0,
+            resolutionScale: 1.0,
+            colorSpace: { serializableColorSpace: { alias: { optionalValue: { m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: 19 } } } } } },
+            bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+            identifier: imageBufferIdentifier,
+            contextIdentifier: graphicsContextIdentifier
+        });
+        return {
+            remoteGraphicsContext: rb.streamConnection.newInterface("RemoteGraphicsContext", graphicsContextIdentifier),
+            graphicsContextIdentifier
+        };
+    }
+
+    function createDisplayListRecorder(rb) {
+        const recorderIdentifier = genId();
+        rb.remoteRenderingBackend.CreateDisplayListRecorder({ identifier: recorderIdentifier });
+        return {
+            remoteGraphicsContext: rb.streamConnection.newInterface("RemoteGraphicsContext", recorderIdentifier),
+            recorderIdentifier
+        };
+    }
+
+    function createDisplayListFromRecorder(rb, recorderIdentifier) {
+        const displayListIdentifier = genId();
+        rb.remoteRenderingBackend.SinkDisplayListRecorderIntoDisplayList({
+            identifier: recorderIdentifier,
+            displayListIdentifier
+        });
+        return { displayListIdentifier };
+    }
+
+    function makeControlPartArgs(variantType, type, sizePx) {
+        const variant = (type === undefined) ? {} : { type: type };
+        return {
+            part: { subclasses: { variantType: variantType, variant: variant } },
+            borderRect: {
+                rect: { location: { x: 0, y: 0 }, size: { width: sizePx, height: sizePx } },
+                radiiTopLeft:     { width: 0, height: 0 },
+                radiiTopRight:    { width: 0, height: 0 },
+                radiiBottomLeft:  { width: 0, height: 0 },
+                radiiBottomRight: { width: 0, height: 0 }
+            },
+            deviceScaleFactor: 1,
+            style: {
+                states: 0, fontSize: 13, zoomFactor: 1,
+                accentColor: { data: {} }, textColor: { data: {} },
+                borderWidth: { top: 0, right: 0, bottom: 0, left: 0 }
+            }
+        };
+    }
+
+    function recordControlParts(ctx, sizePx, count) {
+        // Mix part types so the singleton ControlFactoryMac would touch several
+        // distinct lazy NSCell members and the shared WebControlView on every replay.
+        // StyleAppearance integer values match Source/WebCore/platform/StyleAppearance.h
+        // on this branch: None=0, Auto=1, Base=2, Checkbox=3, Radio=4, PushButton=5,
+        // SquareButton=6, Button=7, DefaultButton=8. If the enum reorders the test
+        // throws a SerializationError (visible text-diff failure) rather than silently
+        // passing.
+        const items = [
+            ['WebCore::ButtonPart', 7],          // Button         -> m_buttonCell
+            ['WebCore::ButtonPart', 8],          // DefaultButton  -> m_defaultButtonCell
+            ['WebCore::ButtonPart', 5],          // PushButton     -> m_buttonCell
+            ['WebCore::ToggleButtonPart', 3],    // Checkbox       -> m_checkboxCell
+            ['WebCore::ToggleButtonPart', 4],    // Radio          -> m_radioCell
+            ['WebCore::MenuListPart', undefined],
+            ['WebCore::SearchFieldPart', undefined],
+        ];
+        for (let i = 0; i < count; i++) {
+            const [vt, ty] = items[i % items.length];
+            ctx.DrawControlPart(makeControlPartArgs(vt, ty, sizePx));
+        }
+    }
+
+    // For one rendering backend: build innerDL (with DrawControlPart items), wrap it in
+    // outerDL (with a DrawDisplayList(innerDL) item), and create a CG-backed ImageBuffer
+    // whose RemoteGraphicsContext can replay outerDL.
+    function setupBackend(sizePx) {
+        const rb = createRemoteRenderingBackend();
+
+        const inner = createDisplayListRecorder(rb);
+        recordControlParts(inner.remoteGraphicsContext, sizePx, 30);
+        const innerDL = createDisplayListFromRecorder(rb, inner.recorderIdentifier);
+
+        const outer = createDisplayListRecorder(rb);
+        outer.remoteGraphicsContext.DrawDisplayList({ identifier: innerDL.displayListIdentifier });
+        const outerDL = createDisplayListFromRecorder(rb, outer.recorderIdentifier);
+
+        const ib = createRemoteImageBuffer(rb);
+
+        return { rb, ib, outerDL: outerDL.displayListIdentifier };
+    }
+
+    // Race nested DrawDisplayList replay across multiple RemoteRenderingBackend
+    // work-queue threads. Before the fix, the inner replay falls back to
+    // ControlFactory::singleton() and concurrently mutates shared NSCell state.
+    const A = setupBackend(20);
+    const B = setupBackend(200);
+    const C = setupBackend(40);
+    const D = setupBackend(120);
+
+    for (let i = 0; i < 0x40; i++) {
+        A.ib.remoteGraphicsContext.DrawDisplayList({ identifier: A.outerDL });
+        B.ib.remoteGraphicsContext.DrawDisplayList({ identifier: B.outerDL });
+        C.ib.remoteGraphicsContext.DrawDisplayList({ identifier: C.outerDL });
+        D.ib.remoteGraphicsContext.DrawDisplayList({ identifier: D.outerDL });
+    }
+
+    await new Promise(r => setTimeout(r, 2000));
+}
+
+setTimeout(() => {
+    main().catch(e => console.log('FAIL: ' + e + '\n' + (e.stack || '')))
+          .finally(() => window.testRunner?.notifyDone());
+}, 0);
+setTimeout(() => window.testRunner?.notifyDone(), 20000);
+</script>
+</body></html>

--- a/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private-expected.txt
@@ -1,0 +1,16 @@
+Tests that a reverse index cursor doesn't use-after-free when a record is deleted whose index key is the next-higher value from the cursor's current position.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+PASS cursorKeys.length is 3
+PASS cursorKeys[0] is 30
+PASS cursorKeys[1] is 20
+PASS cursorKeys[2] is 10
+Transaction completed successfully.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private.html
+++ b/LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private.html
@@ -1,0 +1,86 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script>
+description("Tests that a reverse index cursor doesn't use-after-free when a record " +
+            "is deleted whose index key is the next-higher value from the " +
+            "cursor's current position.");
+
+removeVendorPrefixes();
+
+var dbname = "index-cursor-reverse-delete-next-higher-key-private";
+var db, tx, store, index;
+var cursorKeys = [];
+
+var request = indexedDB.open(dbname);
+request.onupgradeneeded = function(event) {
+    db = event.target.result;
+    store = db.createObjectStore("store", { keyPath: "pk" });
+    index = store.createIndex("idx", "v");
+};
+request.onsuccess = function(event) {
+    db = event.target.result;
+    runTest();
+};
+request.onerror = unexpectedErrorCallback;
+
+function runTest() {
+    tx = db.transaction("store", "readwrite");
+    store = tx.objectStore("store");
+    index = store.index("idx");
+
+    // Add 3 records with distinct index keys: 10, 20, 30.
+    store.put({ pk: 1, v: 10 });
+    store.put({ pk: 2, v: 20 });
+    store.put({ pk: 3, v: 30 });
+
+    // Open a reverse key cursor on the index.
+    var cursorReq = index.openKeyCursor(null, "prev");
+    var step = 0;
+
+    cursorReq.onsuccess = function(event) {
+        var cursor = event.target.result;
+        if (!cursor) {
+            shouldBe("cursorKeys.length", "3");
+            shouldBe("cursorKeys[0]", "30");
+            shouldBe("cursorKeys[1]", "20");
+            shouldBe("cursorKeys[2]", "10");
+            return;
+        }
+
+        cursorKeys.push(cursor.key);
+
+        if (step === 0) {
+            // Cursor at indexKey=30, pk=3. The reverse_iterator base() = end().
+            // Advance to next lower key.
+            step++;
+            cursor.continue();
+        } else if (step === 1) {
+            // Cursor at indexKey=20, pk=2.  base() now = iterator-to-node-30.
+            // Delete pk=3 (indexKey=30).  This frees the node that base() references
+            // while indexValueChanged() early-returns (m_currentKey 20 != 30).
+            // Then advance -- without the fix this dereferences the freed node.
+            step++;
+            store.delete(3);
+            cursor.continue();
+        } else {
+            // Cursor at indexKey=10, pk=1 (should reach here after fix).
+            step++;
+            cursor.continue();
+        }
+    };
+
+    cursorReq.onerror = unexpectedErrorCallback;
+    tx.onerror = unexpectedErrorCallback;
+    tx.oncomplete = function() {
+        debug("Transaction completed successfully.");
+        finishJSTest();
+    };
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/streams/transform-stream-poisoned-iterator-crash-expected.txt
+++ b/LayoutTests/streams/transform-stream-poisoned-iterator-crash-expected.txt
@@ -1,0 +1,6 @@
+Tests that constructing a TransformStream does not crash when Array.prototype[Symbol.iterator] has been poisoned to return wrong-type objects.
+WebKit should not crash, and you should see PASS below.
+
+PASS: plain-object substitution threw TypeError
+PASS: object-reference substitution threw TypeError
+PASS: truncated iterator threw TypeError

--- a/LayoutTests/streams/transform-stream-poisoned-iterator-crash.html
+++ b/LayoutTests/streams/transform-stream-poisoned-iterator-crash.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that constructing a TransformStream does not crash when Array.prototype[Symbol.iterator] has been poisoned to return wrong-type objects.<br>
+WebKit should not crash, and you should see PASS below.</p>
+<div id="result"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// createInternalTransformStreamFromTransformer returns a 3-element array
+// that the C++ side iterates with convert<IDLSequence<IDLObject>>. By
+// poisoning Array.prototype[Symbol.iterator] we can substitute arbitrary
+// JS objects for the readable/writable entries. Without a runtime check,
+// the C++ side then treats those objects as JSReadableStream/JSWritableStream
+// and dereferences attacker-controlled memory.
+
+function check(label, fn) {
+    let message;
+    try {
+        fn();
+        message = "FAIL: " + label + " did not throw";
+    } catch (e) {
+        if (e instanceof TypeError)
+            message = "PASS: " + label + " threw TypeError";
+        else
+            message = "FAIL: " + label + " threw " + e;
+    }
+    const div = document.createElement("div");
+    div.textContent = message;
+    document.getElementById("result").appendChild(div);
+}
+
+const originalIterator = Array.prototype[Symbol.iterator];
+
+// Variant 1: substitute plain objects for the readable/writable slots.
+Array.prototype[Symbol.iterator] = function() {
+    const arr = this;
+    let i = 0;
+    return {
+        next() {
+            if (i >= arr.length)
+                return { done: true };
+            let val = arr[i];
+            if (arr.length === 3 && i >= 1)
+                val = { fake: true };
+            i++;
+            return { value: val, done: false };
+        }
+    };
+};
+check("plain-object substitution", () => new TransformStream());
+
+// Variant 2: substitute an object that holds a heap pointer (would survive
+// the initial dereference and trigger the write-increment / vtable hijack).
+let buf = new ArrayBuffer(65536);
+Array.prototype[Symbol.iterator] = function() {
+    const arr = this;
+    let i = 0;
+    return {
+        next() {
+            if (i >= arr.length)
+                return { done: true };
+            let val = arr[i];
+            if (arr.length === 3 && i >= 1)
+                val = { pad: 0, ptr: buf };
+            i++;
+            return { value: val, done: false };
+        }
+    };
+};
+check("object-reference substitution", () => new TransformStream());
+
+// Variant 3: truncated iterator returning fewer than 3 entries.
+Array.prototype[Symbol.iterator] = function() {
+    return { next() { return { done: true }; } };
+};
+check("truncated iterator", () => new TransformStream());
+
+Array.prototype[Symbol.iterator] = originalIterator;
+
+if (window.testRunner)
+    testRunner.notifyDone();
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -604,7 +604,7 @@ private:
             return interfere;
         };
 
-        auto removeViaKill = [&](BasicBlock* block, unsigned nodeIndex, Node* candidate) {
+        auto removeViaKill = [&](BasicBlock* block, const unsigned nodeIndex, Node* candidate) {
             if (!m_candidates.contains(candidate))
                 return;
 
@@ -660,21 +660,17 @@ private:
                 }
 
                 // This loop considers all nodes up to the nodeIndex, excluding the nodeIndex.
+                // scanIndex is a working copy so each inline call frame independently
+                // scans the full [0, nodeIndex) range.
                 //
-                // Note: nodeIndex here has a double meaning. Before entering this
-                // while loop, it refers to the remaining number of nodes that have
-                // yet to be processed. Inside the loop, it refers to the index
-                // of the current node to process (after we decrement it).
-                //
-                // If the remaining number of nodes is 0, we should not decrement nodeIndex.
-                // Hence, we must only decrement nodeIndex inside the while loop instead of
-                // in its condition statement. Note that this while loop is embedded in an
-                // outer for loop. If we decrement nodeIndex in the condition statement, a
-                // nodeIndex of 0 will become UINT_MAX, and the outer loop will wrongly
-                // treat this as there being UINT_MAX remaining nodes to process.
-                while (nodeIndex) {
-                    --nodeIndex;
-                    Node* node = block->at(nodeIndex);
+                // If the remaining number of nodes is 0, we should not decrement
+                // scanIndex. Hence, we must only decrement it inside the while loop
+                // instead of in its condition statement; otherwise a scanIndex of 0 would
+                // become UINT_MAX.
+                unsigned scanIndex = nodeIndex;
+                while (scanIndex) {
+                    --scanIndex;
+                    Node* node = block->at(scanIndex);
                     if (node == candidate)
                         break;
 
@@ -693,7 +689,7 @@ private:
                         NoOpClobberize());
 
                     if (found) {
-                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", block->at(nodeIndex));
+                        dataLogLnIf(DFGArgumentsEliminationPhaseInternal::verbose, "eliminating candidate: ", candidate, " because it is clobbered by ", block->at(scanIndex));
                         transitivelyRemoveCandidate(candidate);
                         return;
                     }

--- a/Source/JavaScriptCore/wasm/WasmGlobal.h
+++ b/Source/JavaScriptCore/wasm/WasmGlobal.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/WasmFormat.h>
 #include <JavaScriptCore/WasmLimits.h>
+#include <JavaScriptCore/WasmTypeDefinition.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
@@ -99,25 +100,28 @@ public:
 private:
     Global(Wasm::Type type, Wasm::Mutability mutability, uint64_t initialValue)
         : m_type(type)
-        , m_typeDefinition(TypeInformation::getRef(type.index))
         , m_mutability(mutability)
     {
         ASSERT(m_type != Types::V128);
+        if (auto typeDefinition = TypeInformation::getRef(type.index))
+            m_typeDependencies.emplace(Ref { *typeDefinition });
         m_value.m_primitive = initialValue;
     }
 
     Global(Wasm::Type type, Wasm::Mutability mutability, v128_t initialValue)
         : m_type(type)
-        , m_typeDefinition(TypeInformation::getRef(type.index))
         , m_mutability(mutability)
     {
         ASSERT(m_type == Types::V128);
+        if (auto typeDefinition = TypeInformation::getRef(type.index))
+            m_typeDependencies.emplace(Ref { *typeDefinition });
         m_value.m_vector = initialValue;
     }
 
     Wasm::Type m_type;
-    // If m_type came from a TypeDefinition, the following retains the definition to prevent a dangling m_type.
-    RefPtr<const Wasm::TypeDefinition> m_typeDefinition;
+    // If m_type came from a TypeDefinition, the following retains the definition
+    // and all transitively reachable types to prevent dangling TypeIndex values.
+    std::optional<WebAssemblyGCTypeDependencies> m_typeDependencies;
     Wasm::Mutability m_mutability;
     JSWebAssemblyGlobal* m_owner { nullptr };
     Value m_value;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -86,10 +86,11 @@ Table::Table(uint32_t initial, std::optional<uint32_t> maximum, Type wasmType, T
     : m_maximum(maximum)
     , m_type(type)
     , m_wasmType(wasmType)
-    , m_wasmTypeDefinition(TypeInformation::getRef(wasmType.index))
     , m_isFixedSized(maximum && maximum.value() == initial)
     , m_owner(nullptr)
 {
+    if (auto typeDefinition = TypeInformation::getRef(wasmType.index))
+        m_typeDependencies.emplace(Ref { *typeDefinition });
     setLength(initial);
     ASSERT(!m_maximum || *m_maximum >= m_length);
 }

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/WasmCallee.h>
 #include <JavaScriptCore/WasmFormat.h>
 #include <JavaScriptCore/WasmLimits.h>
+#include <JavaScriptCore/WasmTypeDefinition.h>
 #include <JavaScriptCore/WriteBarrier.h>
 #include <wtf/MallocPtr.h>
 #include <wtf/Ref.h>
@@ -106,8 +107,9 @@ protected:
     NO_UNIQUE_ADDRESS const std::optional<uint32_t> m_maximum;
     const TableElementType m_type;
     Type m_wasmType;
-    // If m_wasmType came from a TypeDefinition, the following retains the definition to prevent a dangling m_wasmType.
-    RefPtr<const TypeDefinition> m_wasmTypeDefinition;
+    // If m_wasmType came from a TypeDefinition, the following retains the definition
+    // and all transitively reachable types to prevent dangling TypeIndex values.
+    std::optional<WebAssemblyGCTypeDependencies> m_typeDependencies;
     bool m_isFixedSized { false };
     JSWebAssemblyTable* m_owner;
 };

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -37,13 +37,13 @@
 #include "JSBlob.h"
 #include "JSClipboardItem.h"
 #include "JSDOMPromiseDeferred.h"
+#include "LocalDOMWindow.h"
 #include "LocalFrameInlines.h"
 #include "Navigator.h"
 #include "PagePasteboardContext.h"
 #include "Pasteboard.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
-#include "UserGestureIndicator.h"
 #include "WebContentReader.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -51,6 +51,16 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Clipboard);
+
+// https://w3c.github.io/clipboard-apis/ requires the relevant global object to have transient
+// activation. Transient activation is not propagated to cross-origin iframes, so a user
+// interaction on a top-level page cannot be used by a cross-origin iframe to access the
+// clipboard via postMessage.
+static bool frameHasTransientActivation(const LocalFrame& frame)
+{
+    RefPtr window = frame.window();
+    return window && window->hasTransientActivation();
+}
 
 static bool shouldProceedWithClipboardWrite(const LocalFrame& frame)
 {
@@ -62,7 +72,7 @@ static bool shouldProceedWithClipboardWrite(const LocalFrame& frame)
     case ClipboardAccessPolicy::Allow:
         return true;
     case ClipboardAccessPolicy::RequiresUserGesture:
-        return UserGestureIndicator::processingUserGesture();
+        return frameHasTransientActivation(frame);
     case ClipboardAccessPolicy::Deny:
         return false;
     }
@@ -105,7 +115,7 @@ ScriptExecutionContext* Clipboard::scriptExecutionContext() const
 void Clipboard::readText(Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();
-    if (!frame) {
+    if (!frame || !frameHasTransientActivation(*frame)) {
         promise->reject(ExceptionCode::NotAllowedError);
         return;
     }
@@ -163,7 +173,7 @@ void Clipboard::read(Ref<DeferredPromise>&& promise)
     };
 
     RefPtr frame = this->frame();
-    if (!frame) {
+    if (!frame || !frameHasTransientActivation(*frame)) {
         rejectPromiseAndClearActiveSession();
         return;
     }

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
@@ -220,7 +220,12 @@ void MemoryIndexCursor::indexRecordsAllChanged()
 
 void MemoryIndexCursor::indexValueChanged(const IDBKeyData& key, const IDBKeyData& primaryKey)
 {
-    if (m_currentKey != key || m_currentPrimaryKey != primaryKey)
+    // For Prev/Prevunique cursors, m_currentIterator wraps std::set reverse_iterators
+    // whose stored base() points one element past the logical position. Erasing that
+    // adjacent element leaves base() dangling even though m_currentKey/m_currentPrimaryKey
+    // are unchanged, so for reverse cursors we must invalidate on any index mutation
+    // and let iterate() re-seek via reverseFind().
+    if (info().isDirectionForward() && (m_currentKey != key || m_currentPrimaryKey != primaryKey))
         return;
 
     m_currentIterator.invalidate();

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -117,9 +117,15 @@ ExceptionOr<CreateInternalTransformStreamResult> createInternalTransformStream(J
         return Exception { ExceptionCode::ExistingExceptionError };
 
     auto results = resultsConversionResult.releaseReturnValue();
-    ASSERT(results.size() == 3);
+    if (results.size() != 3) [[unlikely]]
+        return Exception { ExceptionCode::TypeError, "Internal TransformStream creation returned an unexpected number of values"_s };
 
-    return CreateInternalTransformStreamResult { results[0].get(), JSC::jsDynamicCast<JSReadableStream*>(results[1].get())->wrapped(), JSC::jsDynamicCast<JSWritableStream*>(results[2].get())->wrapped() };
+    auto* readable = JSC::jsDynamicCast<JSReadableStream*>(results[1].get());
+    auto* writable = JSC::jsDynamicCast<JSWritableStream*>(results[2].get());
+    if (!readable || !writable) [[unlikely]]
+        return Exception { ExceptionCode::TypeError, "Internal TransformStream creation returned values of unexpected types"_s };
+
+    return CreateInternalTransformStreamResult { results[0].get(), readable->wrapped(), writable->wrapped() };
 }
 
 template<typename Visitor>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -65,6 +65,7 @@ WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context)
 WebCodecsAudioData::WebCodecsAudioData(ScriptExecutionContext& context, WebCodecsAudioInternalData&& data)
     : ContextDestructionObserver(&context)
     , m_data(WTF::move(data))
+    , m_memoryCost(m_data.memoryCost())
 {
 }
 
@@ -151,6 +152,7 @@ ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::clone(ScriptExecutionCo
 // https://www.w3.org/TR/webcodecs/#dom-audiodata-close
 void WebCodecsAudioData::close()
 {
+    m_memoryCost.store(0, std::memory_order_relaxed);
     m_data.audioData = nullptr;
 
     m_isDetached = true;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h
@@ -84,13 +84,16 @@ public:
 
     const WebCodecsAudioInternalData& data() const { return m_data; }
 
-    size_t memoryCost() const { return m_data.memoryCost(); }
+    // memoryCost() may be called from a GC thread by the JS wrapper's visitChildren, so it must
+    // not touch m_data.audioData (which close() may concurrently null on the main thread).
+    size_t memoryCost() const { return m_memoryCost.load(std::memory_order_relaxed); }
 
 private:
     explicit WebCodecsAudioData(ScriptExecutionContext&);
     WebCodecsAudioData(ScriptExecutionContext&, WebCodecsAudioInternalData&&);
 
     WebCodecsAudioInternalData m_data;
+    std::atomic<size_t> m_memoryCost { 0 };
     bool m_isDetached { false };
 };
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp
@@ -39,6 +39,8 @@ void applyItem(GraphicsContext& context, ControlFactory& controlFactory, const I
     WTF::switchOn(item,
         [&](const DrawControlPart& item) {
             item.apply(context, controlFactory);
+        }, [&](const DrawDisplayList& item) {
+            item.apply(context, controlFactory);
         }, [&](const auto& item) {
             item.apply(context);
         }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -318,9 +318,9 @@ Ref<const DisplayList> DrawDisplayList::displayList() const
     return m_displayList;
 }
 
-void DrawDisplayList::apply(GraphicsContext& context) const
+void DrawDisplayList::apply(GraphicsContext& context, ControlFactory& controlFactory) const
 {
-    return context.drawDisplayList(m_displayList);
+    return context.drawDisplayList(m_displayList, controlFactory);
 }
 
 void DrawDisplayList::dump(TextStream& ts, OptionSet<AsTextFlag>) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -574,7 +574,7 @@ public:
 
     Ref<const DisplayList> displayList() const;
 
-    void apply(GraphicsContext&) const;
+    void apply(GraphicsContext&, ControlFactory&) const;
     void dump(TextStream&, OptionSet<AsTextFlag>) const;
 
 private:

--- a/Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h
@@ -90,11 +90,12 @@ inline bool applyPlatformParallel(typename ParallelJobs<ApplyParameters>::Worker
 
     // Copy together the parts of the image.
     currentY = 0;
+    int scratchHeight = calculateAdjustedBlockHeight(0);
     for (int job = 1; job < jobs; ++job) {
         ApplyParameters& params = parallelJobs.parameter(job);
-        int scratchHeight = calculateAdjustedBlockHeight(job);
 
         currentY += scratchHeight;
+        scratchHeight = calculateAdjustedBlockHeight(job);
 
         unsigned destinationOffset = currentY * scanline;
         unsigned scratchSize = scratchHeight * scanline;

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -49,45 +49,54 @@ SVGGeometryElement::SVGGeometryElement(const QualifiedName& tagName, Document& d
     }
 }
 
-float SVGGeometryElement::getTotalLength() const
+float SVGGeometryElement::calculateTotalLength() const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
-
-    auto* renderer = this->renderer();
+    CheckedPtr renderer = this->renderer();
     if (!renderer)
         return 0;
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(*renderer))
         return renderSVGShape->getTotalLength();
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(*renderer))
         return renderSVGShape->getTotalLength();
 
     ASSERT_NOT_REACHED();
     return 0;
 }
 
-ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
+float SVGGeometryElement::getTotalLength() const
 {
     protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    return calculateTotalLength();
+}
 
-    auto* renderer = this->renderer();
+ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::calculatePointAtLength(float distance) const
+{
+    CheckedPtr renderer = this->renderer();
     // Spec: If current element is a non-rendered element, throw an InvalidStateError.
     if (!renderer)
         return Exception { ExceptionCode::InvalidStateError };
 
-    // Spec: Clamp distance to [0, length].
-    distance = clampTo<float>(distance, 0, getTotalLength());
-
     // Spec: Return a newly created, detached SVGPoint object.
-    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(*renderer))
         return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 
-    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(renderer))
+    if (CheckedPtr renderSVGShape = dynamicDowncast<RenderSVGShape>(*renderer))
         return SVGPoint::create(renderSVGShape->getPointAtLength(distance));
 
     ASSERT_NOT_REACHED();
     return Exception { ExceptionCode::InvalidStateError };
+}
+
+ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
+{
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+
+    // Spec: Clamp distance to [0, length].
+    distance = clampTo<float>(distance, 0, calculateTotalLength());
+
+    return calculatePointAtLength(distance);
 }
 
 bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)

--- a/Source/WebCore/svg/SVGGeometryElement.h
+++ b/Source/WebCore/svg/SVGGeometryElement.h
@@ -56,6 +56,9 @@ protected:
 private:
     bool isSVGGeometryElement() const override { return true; }
 
+    float calculateTotalLength() const;
+    ExceptionOr<Ref<SVGPoint>> calculatePointAtLength(float distance) const;
+
     Ref<SVGAnimatedNumber> m_pathLength { SVGAnimatedNumber::create(this) };
 };
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h
@@ -31,6 +31,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/URL.h>
 #include <wtf/WorkQueue.h>
 
@@ -41,7 +42,7 @@ namespace WebKit {
 class WebExtensionSQLiteStatement;
 class WebExtensionSQLiteStore;
 
-class WebExtensionSQLiteDatabase final : public RefCounted<WebExtensionSQLiteDatabase> {
+class WebExtensionSQLiteDatabase final : public ThreadSafeRefCounted<WebExtensionSQLiteDatabase> {
     WTF_MAKE_NONCOPYABLE(WebExtensionSQLiteDatabase);
     WTF_MAKE_TZONE_ALLOCATED(WebExtensionSQLiteDatabase);
 


### PR DESCRIPTION
#### da427f199f92b9448c4f7dbade8e965255c30cab
<pre>
Cherry-pick 3270ebdb7366. <a href="https://bugs.webkit.org/show_bug.cgi?id=314850">https://bugs.webkit.org/show_bug.cgi?id=314850</a>

[JSC] DFGArgumentsEliminationPhase removeViaKill should reset node scan index between InlineCallFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=314850">https://bugs.webkit.org/show_bug.cgi?id=314850</a>
<a href="https://rdar.apple.com/176966728">rdar://176966728</a>

Reviewed by Yusuke Suzuki.

In DFGArgumentsEliminationPhase::eliminateCandidatesThatInterfere(), the removeViaKill
lambda contains two nested loops. The outer loop iterates over inline call frames. For
each frame, the inner loop is expected to iterate the nodes of the given basic block in
reverse order in the range [0, nodeIndex). However, because the inner loop mutates the
lambda parameter nodeIndex directly, this only works as intended for the first inline call
frame. Each subsequent call frame begins where the previous one left off.

The change introduces a separate iteration variable for the inner loop, which starts off
at nodeIndex for each inline call frame. nodeIndex parameter is marked as &apos;const&apos; to make
explicit the expectation that it should not change.

Test: JSTests/stress/arguments-elimination-multiple-inline-call-frames.js
Identifier: 305413.912@safari-7624-branch

Identifier: 305413.789@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.885@webkitglib/2.52">https://commits.webkit.org/305877.885@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1626efd119bf3e66be3122932b4d1412af665904
<pre>
Cherry-pick 526ac3579021. <a href="https://bugs.webkit.org/show_bug.cgi?id=314806">https://bugs.webkit.org/show_bug.cgi?id=314806</a>

Cross-Origin Iframe Can Read Clipboard via Top-Level User Interaction in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=314806">https://bugs.webkit.org/show_bug.cgi?id=314806</a>
<a href="https://rdar.apple.com/176023893">rdar://176023893</a>

Reviewed by Ryosuke Niwa.

navigator.clipboard.readText(), read(), writeText(), and write() relied on WebKit&apos;s
legacy UserGestureIndicator for activation checks (directly for writes, via
LocalFrame::requestDOMPasteAccess() for reads). LocalDOMWindow::processPostMessage
explicitly forwards the active UserGestureToken into the receiving iframe&apos;s event
handler, so a user click on a top-level page let a cross-origin iframe see &quot;processing
a user gesture&quot; and access the clipboard. This violates the W3C Clipboard API spec,
which requires transient activation on the relevant global object.

Fix this by checking LocalDOMWindow::hasTransientActivation() at the entry point of
each clipboard method. Transient activation is a property of the window and only
propagates to ancestor frames and same-origin descendant frames -- it is never
propagated to cross-origin descendants via postMessage. This matches the behavior of
Blink and Firefox.

Test: http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html

* LayoutTests/editing/async-clipboard/clipboard-change-data-while-getting-type.html:
* LayoutTests/editing/async-clipboard/clipboard-get-type-with-old-items.html:
* LayoutTests/editing/async-clipboard/resources/async-clipboard-helpers.js:
Fix existing tests so they keep passing.

* LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied-expected.txt: Added.
* LayoutTests/http/tests/security/clipboard/clipboard-access-in-cross-origin-iframe-denied.html: Added.
* LayoutTests/http/tests/security/clipboard/resources/clipboard-access-from-iframe.html: Added.
New test coverage.

* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/async-navigator-clipboard-basics.https.html:
* LayoutTests/imported/w3c/web-platform-tests/clipboard-apis/resources/user-activation.js:
Resync existing WPT test so it keeps passing.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::frameHasTransientActivation):
(WebCore::shouldProceedWithClipboardWrite):
(WebCore::Clipboard::readText):
(WebCore::Clipboard::read):

Identifier: 305413.908@safari-7624-branch

Identifier: 305413.788@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.884@webkitglib/2.52">https://commits.webkit.org/305877.884@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c4549075345945ceb1ca976cd1f2922aa5905148
<pre>
Cherry-pick 28d3cd063035. <a href="https://bugs.webkit.org/show_bug.cgi?id=314581">https://bugs.webkit.org/show_bug.cgi?id=314581</a>

[CoreIPC] [GPUP] Nested DrawDisplayList Replay Falls Back to ControlFactory::singleton() Leads to Concurrent NSCell UAF
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=314581">https://bugs.webkit.org/show_bug.cgi?id=314581</a>&gt;
&lt;<a href="https://rdar.apple.com/174674075">rdar://174674075</a>&gt;

Reviewed by Simon Fraser.

DisplayList::applyItem() only special-cases DrawControlPart, so a nested
DrawDisplayList item falls through to item.apply(context) and calls the
single-arg GraphicsContext::drawDisplayList, which substitutes
ControlFactory::singleton(). A compromised WCP can wrap DrawControlPart
items in a nested DrawDisplayList and replay it on multiple
RemoteRenderingBackends, racing the singleton ControlFactoryMac&apos;s shared
NSCell state across GPU-process work-queue threads.

Thread ControlFactory through DrawDisplayList::apply() and special-case
DrawDisplayList in applyItem() so nested replay uses the per-context
factory.

* LayoutTests/ipc/nested-display-list-draw-control-part-crash-expected.txt: Added.
* LayoutTests/ipc/nested-display-list-draw-control-part-crash.html: Added.
* Source/WebCore/platform/graphics/displaylists/DisplayListItem.cpp:
(WebCore::DisplayList::applyItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawDisplayList::apply const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:

Identifier: 305413.904@safari-7624-branch

Identifier: 305413.786@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.883@webkitglib/2.52">https://commits.webkit.org/305877.883@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c3615422ed78676755339656326552197308d8b1
<pre>
Cherry-pick 0a9952c703a7. <a href="https://bugs.webkit.org/show_bug.cgi?id=314569">https://bugs.webkit.org/show_bug.cgi?id=314569</a>

Use-after-free in WebExtensionSQLiteDatabase via cross-thread non-atomic RefCounted race.
<a href="https://webkit.org/b/314569">https://webkit.org/b/314569</a>
<a href="https://rdar.apple.com/176483124">rdar://176483124</a>

Reviewed by Abrar Rahman Protyasha.

WebExtensionSQLiteDatabase used a non-atomic RefCounted base despite its refcount being accessed
concurrently from both the WKWebExtensionSQLiteStore WorkQueue and the UI main thread, so
concurrent ref/deref operations could corrupt the count and cause a premature free.

* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.h: Use ThreadSafeRefCounted.

Identifier: 305413.879@safari-7624-branch

Identifier: 305413.783@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.882@webkitglib/2.52">https://commits.webkit.org/305877.882@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a093baf503690c93baaf3b5fd3f390d2aaf2f4da
<pre>
Cherry-pick cb2c361c977a. <a href="https://bugs.webkit.org/show_bug.cgi?id=314528">https://bugs.webkit.org/show_bug.cgi?id=314528</a>

[WebCore] TransformStream type confusion when Array.prototype[Symbol.iterator] is overridden
<a href="https://bugs.webkit.org/show_bug.cgi?id=314528">https://bugs.webkit.org/show_bug.cgi?id=314528</a>
<a href="https://rdar.apple.com/176568667">rdar://176568667</a>

Reviewed by Ryosuke Niwa.

createInternalTransformStream invokes the createInternalTransformStreamFromTransformer
builtin and converts its result via convert&lt;IDLSequence&lt;IDLObject&gt;&gt;, which uses
the JS iteration protocol. If a page overrides Array.prototype[Symbol.iterator],
it can substitute arbitrary objects for the readable/writable entries the
builtin would otherwise return. The only guard was ASSERT(results.size() == 3),
which is a no-op in release, after which jsDynamicCast&lt;JSReadableStream*&gt; /
jsDynamicCast&lt;JSWritableStream*&gt; were dereferenced unconditionally — turning a
non-matching object into a controlled type confusion (controlled deref via
m_wrapped, write-increment via Ref&lt;&gt;::ref(), and a vtable call on attacker
data when JS later touches .readable / .writable).

Replace the ASSERT with a runtime size check, null-check the jsDynamicCast
results, and throw a TypeError on either failure.

Test: streams/transform-stream-poisoned-iterator-crash.html

* LayoutTests/streams/transform-stream-poisoned-iterator-crash-expected.txt: Added.
* LayoutTests/streams/transform-stream-poisoned-iterator-crash.html: Added.
* Source/WebCore/Modules/streams/TransformStream.cpp:
(WebCore::createInternalTransformStream):

Identifier: 305413.875@safari-7624-branch

Identifier: 305413.781@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.881@webkitglib/2.52">https://commits.webkit.org/305877.881@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a6041eced9df75d84ef218994288ecce0107793e
<pre>
Cherry-pick 5d5fdc06de11. <a href="https://bugs.webkit.org/show_bug.cgi?id=314268">https://bugs.webkit.org/show_bug.cgi?id=314268</a>

REGRESSION(305413.516@safari-7624-branch): The height of the FEMorphology filter might be off by 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=314268">https://bugs.webkit.org/show_bug.cgi?id=314268</a>
<a href="https://rdar.apple.com/175674532">rdar://175674532</a>

Reviewed by Simon Fraser.

In <a href="https://commits.webkit.org/305413.516@safari-7624-branch">https://commits.webkit.org/305413.516@safari-7624-branch</a>, ParallelJobs are
used to apply the FEMorphology filter. Applying the filter in parallel happens
in two steps:

1. Split the destination pixel buffer into `jobs` horizontal strips and then
   dispatches them in parallel
2. When all the parallel jobs finish, the scratch outputs are stitched back via
   a gather loop.

The first job is done directly into the destination PixelBuffer. So no stitching
is needed for job_0. Stitching the rest of the jobs (job_1 .. job_{n-1}) requires
moving the y-position in destination PixelBuffer by the height of the previous
job. And it requires also calculating the height of the current job. The problem
is the height of the current job is used to move y-position. This may prevent
stitching the last line in the last job to the destination PixelBuffer.

* Source/WebCore/platform/graphics/filters/software/FilterEffectSoftwareParallelApplier.h:
(WebCore::applyPlatformParallel):

Identifier: 305413.865@safari-7624-branch

Identifier: 305413.777@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.880@webkitglib/2.52">https://commits.webkit.org/305877.880@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 2740ab9e70126f8328b7d26cd448233234078a70
<pre>
Cherry-pick 8678798b3372. <a href="https://bugs.webkit.org/show_bug.cgi?id=314235">https://bugs.webkit.org/show_bug.cgi?id=314235</a>

[JSC] Wasm Table and Global Missing Transitive TypeDefinition Retention
<a href="https://bugs.webkit.org/show_bug.cgi?id=314235">https://bugs.webkit.org/show_bug.cgi?id=314235</a>
<a href="https://rdar.apple.com/176031363">rdar://176031363</a>

Reviewed by Keith Miller.

Wasm::Global and Wasm::Table retain the immediate TypeDefinition behind
their m_wasmType, but not type definitions transitively reachable from it.
They should use WebAssemblyGCTypeDependencies instead to retain the entire
transitive closure of reachable TypeDefinitions, as Wasm::Tag does.

Tests: JSTests/wasm/gc/transitive-type-retention-global.js
       JSTests/wasm/gc/transitive-type-retention-table.js

Identifier: 305413.859@safari-7624-branch

Identifier: 305413.773@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.879@webkitglib/2.52">https://commits.webkit.org/305877.879@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b20421a9f2fce56620697f0dada4168eddc691c8
<pre>
Cherry-pick d1e59347508c. <a href="https://bugs.webkit.org/show_bug.cgi?id=314326">https://bugs.webkit.org/show_bug.cgi?id=314326</a>

Use-after-free in SVGGeometryElement::getPointAtLength — raw renderer pointer held across nested updateLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=314326">https://bugs.webkit.org/show_bug.cgi?id=314326</a>
<a href="https://rdar.apple.com/175670940">rdar://175670940</a>

Reviewed by Simon Fraser.

Between the call to `updateLayoutIgnorePendingStylesheets()` and the call to
`SVGGeometryElement::getTotalLength()`, `SVGGeometryElement::getPointAtLength()`
caches its renderer() in a raw pointer. The problem is `getTotalLength()` also
calls `updateLayoutIgnorePendingStylesheets()` which may delete the renderer.
This will make `getPointAtLength()` use-after-free the cached raw pointer renderer.

Rearrange the code such that `updateLayoutIgnorePendingStylesheets()` is called
only once per `getPointAtLength()` and read `this-&gt;renderer()` exactly before it
is referenced.

* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::calculateTotalLength const):
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::calculatePointAtLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
* Source/WebCore/svg/SVGGeometryElement.h:

Identifier: 305413.857@safari-7624-branch

Identifier: 305413.772@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.878@webkitglib/2.52">https://commits.webkit.org/305877.878@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5936fdec6d8d7c1c2ac043ac551ac956b0a0715f
<pre>
Cherry-pick 2102c1dad1d3. <a href="https://bugs.webkit.org/show_bug.cgi?id=313818">https://bugs.webkit.org/show_bug.cgi?id=313818</a>

use-after-free in WebCodecsAudioData::memoryCost() via concurrent GC marker / close()
<a href="https://rdar.apple.com/175520011">rdar://175520011</a>

Reviewed by Jean-Yves Avenard

WebCodecsAudioData is annotated with ReportExtraMemoryCost, so the generated
JS wrapper&apos;s visitChildren calls WebCodecsAudioData::memoryCost() from a
concurrent GC marker thread. memoryCost() dereferenced m_data.audioData (a
RefPtr&lt;PlatformRawAudioData&gt;) without synchronization while close() on the
main thread assigns m_data.audioData = nullptr and frees the
PlatformRawAudioData, leading to a heap-use-after-free in
PlatformRawAudioDataCocoa::memoryCost().

Cache the memory cost in a std::atomic&lt;size_t&gt; on WebCodecsAudioData,
computed once at construction time on the main thread and zeroed in close(),
so the GC-thread memoryCost() never touches the RefPtr. This matches the
existing pattern in ImageBitmap.

* LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash-expected.txt: Added.
* LayoutTests/fast/webcodecs/audio-data-close-during-gc-crash.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp:
(WebCore::WebCodecsAudioData::WebCodecsAudioData):
(WebCore::WebCodecsAudioData::close):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.h:
(WebCore::WebCodecsAudioData::memoryCost const):

Identifier: 305413.845@safari-7624-branch

Identifier: 305413.770@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.877@webkitglib/2.52">https://commits.webkit.org/305877.877@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6956d905e7f0b78b1f222c2b9dec2d83fce0be52
<pre>
Cherry-pick d14d12e915f3. <a href="https://bugs.webkit.org/show_bug.cgi?id=313818">https://bugs.webkit.org/show_bug.cgi?id=313818</a>

[CoreIPC] [NP] Heap UAF in WebCore::IDBServer::MemoryIndexCursor reverse iterator when a Prev/Prevunique cursor&apos;s next-higher index entry is deleted
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=313818">https://bugs.webkit.org/show_bug.cgi?id=313818</a>&gt;
&lt;<a href="https://rdar.apple.com/174678764">rdar://174678764</a>&gt;

Reviewed by Sihui Liu.

MemoryIndexCursor caches an IndexValueStore::Iterator across IPC messages.
For Prev/Prevunique cursors this wraps std::set&lt;IDBKeyData&gt;::reverse_iterator
objects (one for the outer IndexValueStore::m_orderedKeys set, one nested in
IndexValueEntry::Iterator for the inner per-index-key set). A
std::reverse_iterator stores a forward base() iterator pointing one element
past the logical position; for libc++ std::set that is a raw __tree_node*.

MemoryIndexCursor::indexValueChanged() only invalidates m_currentIterator
when the changed (key, primaryKey) equals the cursor&apos;s current logical
position. Deleting the next-higher index key (Variant A, outer set) or the
next-higher primary key under a shared index key (Variant B, inner set)
therefore frees exactly the __tree_node base() references while the guard
early-returns. The next IterateCursor IPC executes ++m_reverseIterator =&gt;
--base() =&gt; __tree_prev_iter(freed_node), a heap-use-after-free in
com.apple.WebKit.Networking reachable from a compromised WebContent process
via NetworkStorageManager IPC with WCP-controlled
IDBDatabaseIdentifier.m_isTransient = true forcing MemoryIDBBackingStore.

Fix by gating the equality early-return on info().isDirectionForward(). For
reverse cursors we now invalidate m_currentIterator on any index mutation;
iterate() already re-seeks via reverseFind(m_currentKey, m_currentPrimaryKey)
when the iterator is invalid. Both removeEntriesWithValueKey() erase paths
(outer m_orderedKeys.erase() and inner IndexValueEntry::removeKey()) reach
indexValueChanged() through MemoryIndex::notifyCursorsOfValueChange(), so
both variants are closed.

* LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/index-cursor-reverse-delete-next-higher-key-private.html: Added.
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp:
(WebCore::IDBServer::MemoryIndexCursor::indexValueChanged):

Identifier: 305413.842@safari-7624-branch

Identifier: 305413.769@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.876@webkitglib/2.52">https://commits.webkit.org/305877.876@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34f330f7dc62b83162cbfd6bc27083234bd72379

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172256 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46174 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181707 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129812 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174121 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47467 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45816 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133982 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129812 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175214 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47467 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114453 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47467 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45816 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30313 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47467 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184241 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33517 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36854 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45816 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142743 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/45846 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142625 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46524 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111238 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26144 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46524 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118275 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204934 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45041 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39602 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54719 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44441 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44673 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44500 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->