### PR TITLE
Cherry-pick de9fb008197a. https://bugs.webkit.org/show_bug.cgi?id=315538

### DIFF
--- a/JSTests/wasm/gc/private-fields-and-methods.js
+++ b/JSTests/wasm/gc/private-fields-and-methods.js
@@ -1,0 +1,170 @@
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+function testPrivateMethodOnStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    #m() {}
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot add private method to a WebAssembly GC object"
+  );
+
+  // Struct must remain usable after the rejected attempt.
+  assert.eq(m.exports.use(s), 42);
+}
+
+function testPrivateFieldOnStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    #x = 1;
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot define private field on a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(s), 42);
+}
+
+function testPrivateMethodOnArray() {
+  let m = instantiate(`
+    (module
+      (type (array i32))
+      (func (export "make") (result anyref)
+        (array.new 0 (i32.const 7) (i32.const 3)))
+      (func (export "use") (param (ref 0) i32) (result i32)
+        (array.get 0 (local.get 0) (local.get 1)))
+    )
+  `);
+  const a = m.exports.make();
+
+  class B { constructor() { return a; } }
+  class D extends B {
+    #m() {}
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot add private method to a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(a, 0), 7);
+}
+
+function testPrivateFieldOnArray() {
+  let m = instantiate(`
+    (module
+      (type (array i32))
+      (func (export "make") (result anyref)
+        (array.new 0 (i32.const 7) (i32.const 3)))
+      (func (export "use") (param (ref 0) i32) (result i32)
+        (array.get 0 (local.get 0) (local.get 1)))
+    )
+  `);
+  const a = m.exports.make();
+
+  class B { constructor() { return a; } }
+  class D extends B {
+    #x = 1;
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot define private field on a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(a, 0), 7);
+}
+
+function testPrivateGetterOnStruct() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    get #x() { return 1; }
+    constructor() { super(); }
+  }
+
+  assert.throws(
+    () => new D(),
+    TypeError,
+    "Cannot add private method to a WebAssembly GC object"
+  );
+
+  assert.eq(m.exports.use(s), 42);
+}
+
+function testGCSurvival() {
+  let m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (func (export "make") (result anyref)
+        (struct.new 0 (i32.const 42)))
+      (func (export "use") (param (ref 0)) (result i32)
+        (struct.get 0 0 (local.get 0)))
+    )
+  `);
+  const s = m.exports.make();
+
+  class B { constructor() { return s; } }
+  class D extends B {
+    #m() {}
+    constructor() { super(); }
+  }
+
+  try { new D(); } catch {}
+
+  // The struct must survive GC with its structure intact.
+  gc();
+  assert.eq(m.exports.use(s), 42);
+}
+
+testPrivateMethodOnStruct();
+testPrivateFieldOnStruct();
+testPrivateMethodOnArray();
+testPrivateFieldOnArray();
+testPrivateGetterOnStruct();
+testGCSurvival();

--- a/JSTests/wasm/stress/br-on-cast-reserved-flags.js
+++ b/JSTests/wasm/stress/br-on-cast-reserved-flags.js
@@ -1,0 +1,54 @@
+import * as assert from "../assert.js";
+import { watToWasm } from "../gc/wast-wrapper.js";
+
+// Regression test: br_on_cast must reject flags bytes with reserved bits set.
+//
+// Bug: the validator only extracts bits 0-1 from the flags byte without
+// rejecting bits 2-7. The IPInt interpreter reloads the raw flags byte and
+// computes allowNull = (flags >> 1), so setting bit 2 makes the runtime
+// treat a non-null target cast as nullable. This allows null to be typed as
+// a non-null reference — a type-system violation.
+
+// Compile a valid module with br_on_cast, then patch the flags byte to 0x05.
+// Valid flags=0x01 means: source nullable, target non-null.
+// Patched flags=0x05: same from validator's perspective (bits 0-1 unchanged in
+// the way that matters), but bit 2 set causes IPInt to derive allowNull=true.
+
+let wat = `
+(module
+  (type (struct))
+  (func (export "test") (result i32)
+    (block (result (ref 0))
+      (ref.null none)
+      (br_on_cast 0 (ref null any) (ref 0))
+      (drop)
+      (struct.new 0)
+    )
+    (ref.is_null)
+  )
+)
+`;
+
+let binary = watToWasm(wat);
+let bytes = new Uint8Array(binary);
+
+// Find the br_on_cast opcode (0xFB 0x18) and patch its flags byte.
+// The flags byte immediately follows the two-byte opcode: [0xFB, 0x18, flags, ...]
+let patched = false;
+for (let i = 0; i < bytes.length - 2; i++) {
+    if (bytes[i] === 0xFB && bytes[i + 1] === 0x18) {
+        let flagsOffset = i + 2;
+        assert.eq(bytes[flagsOffset], 0x01, "expected valid flags=0x01 (src nullable, tgt non-null)");
+        bytes[flagsOffset] = 0x05; // set reserved bit 2
+        patched = true;
+        break;
+    }
+}
+assert.truthy(patched, "should have found br_on_cast opcode in binary");
+
+// The module should be REJECTED because reserved bits are set.
+assert.throws(
+    () => new WebAssembly.Module(binary),
+    WebAssembly.CompileError,
+    "reserved bits"
+);

--- a/JSTests/wasm/stress/streaming-compile-try-table-agreement.js
+++ b/JSTests/wasm/stress/streaming-compile-try-table-agreement.js
@@ -1,0 +1,106 @@
+// Streaming and non-streaming WebAssembly compilation should agree on the
+// outcome of a given module: both succeed, or both fail with
+// WebAssembly.CompileError. This test pins that equivalence for a couple of
+// modules that exercise try_table together with other exception handling
+// constructs.
+
+// (module
+//   (tag $e)
+//   (func (export "run")
+//     block $h
+//       try_table (catch_all $h)
+//         throw $e
+//       end
+//     end
+//   )
+// )
+const tryTableOnly = new Uint8Array([
+    0x00,0x61,0x73,0x6d, 0x01,0x00,0x00,0x00,
+    0x01,0x04, 0x01, 0x60,0x00,0x00,
+    0x03,0x02, 0x01, 0x00,
+    0x0d,0x03, 0x01, 0x00,0x00,
+    0x07,0x07, 0x01, 0x03,0x72,0x75,0x6e, 0x00,0x00,
+    0x0a,0x0f, 0x01, 0x0d,
+        0x00,
+        0x02,0x40,
+        0x1f,0x40, 0x01, 0x02,0x00,
+        0x08,0x00,
+        0x0b,
+        0x0b,
+        0x0b,
+]);
+
+// (module
+//   (tag $e)
+//   (func (export "run")
+//     try
+//       nop
+//     catch_all
+//       rethrow 0
+//     end
+//     block $h
+//       try_table (catch_all $h)
+//         throw $e
+//       end
+//     end
+//   )
+// )
+const mixedEH = new Uint8Array([
+    0x00,0x61,0x73,0x6d, 0x01,0x00,0x00,0x00,
+    0x01,0x04, 0x01, 0x60,0x00,0x00,
+    0x03,0x02, 0x01, 0x00,
+    0x0d,0x03, 0x01, 0x00,0x00,
+    0x07,0x07, 0x01, 0x03,0x72,0x75,0x6e, 0x00,0x00,
+    0x0a,0x16, 0x01, 0x14,
+        0x00,
+        0x06,0x40,
+        0x01,
+        0x19,
+        0x09,0x00,
+        0x0b,
+        0x02,0x40,
+        0x1f,0x40, 0x01, 0x02,0x00,
+        0x08,0x00,
+        0x0b,
+        0x0b,
+        0x0b,
+]);
+
+const cases = [tryTableOnly, mixedEH];
+
+function compileNonStreaming(bytes) {
+    try { new WebAssembly.Module(bytes); return null; }
+    catch (e) { return e; }
+}
+
+async function compileStreaming(bytes) {
+    try {
+        await $vm.createWasmStreamingCompilerForInstantiate(
+            (compiler) => { compiler.addBytes(bytes); });
+        return null;
+    } catch (e) { return e; }
+}
+
+async function main() {
+    for (const bytes of cases) {
+        const ns = compileNonStreaming(bytes);
+        const s = await compileStreaming(bytes);
+
+        const nsFailed = ns !== null;
+        const sFailed = s !== null;
+        if (nsFailed !== sFailed)
+            throw new Error(`compile-path mismatch: non-streaming=${ns}, streaming=${s}`);
+        if (nsFailed) {
+            if (!(ns instanceof WebAssembly.CompileError))
+                throw new Error("non-streaming threw non-CompileError: " + ns);
+            if (!(s instanceof WebAssembly.CompileError))
+                throw new Error("streaming threw non-CompileError: " + s);
+        }
+    }
+}
+
+main().catch(e => {
+    print(String(e));
+    print(String(e.stack));
+    $vm.abort();
+});

--- a/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash-expected.txt
+++ b/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml
+++ b/LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<script><![CDATA[
+if (window.testRunner)
+    testRunner.dumpAsText();
+customElements.define('x-a', class extends HTMLElement {
+    constructor() {
+        super();
+        document.documentElement.appendChild(this);
+    }
+});
+]]></script>
+</head>
+<body>
+<p>This test passes if it does not crash.</p>
+<div id="container"><x-a></x-a></div>
+</body>
+</html>

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  body { margin: 0; height: 2000000px; }
+  @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+  #t {
+    position: fixed;
+    top: 10px; left: 10px;
+    width: 100px; height: 100px;
+    background: red;
+    will-change: transform;
+    animation: spin linear;
+    animation-timeline: scroll(root);
+  }
+  #t.noanim { animation: none; }
+</style>
+</head>
+<body>
+<div id="t"></div>
+<script>
+  window.testRunner?.waitUntilDone();
+  window.testRunner?.dumpAsText();
+  let t = document.getElementById('t');
+  let toggle = 0;
+  let iterations = 0;
+  function doScroll() {
+    let target = (window.scrollY < 1000000) ? 1900000 : 100;
+    window.scrollTo({ top: target, behavior: 'smooth' });
+  }
+  window.addEventListener('load', () => {
+    document.body.offsetHeight;
+    requestAnimationFrame(() => {
+      doScroll();
+      (function loop() {
+        if (toggle++ & 1) t.classList.remove('noanim');
+        else t.classList.add('noanim');
+        document.body.offsetHeight;
+        if ((toggle & 0xf) == 0) doScroll();
+        if (++iterations < 120)
+          setTimeout(loop, 8);
+        else {
+          document.body.textContent = 'PASS if no crash.';
+          window.testRunner?.notifyDone();
+        }
+      })();
+    });
+  });
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -881,7 +881,7 @@ inline bool JSObject::getPrivateField(JSGlobalObject* globalObject, PropertyName
     ASSERT(!slot.isVMInquiry());
     if (!JSObject::getPrivateFieldSlot(this, globalObject, propertyName, slot)) {
         throwException(globalObject, scope, createInvalidPrivateNameError(globalObject));
-        RELEASE_AND_RETURN(scope, false);
+        return false;
     }
     EXCEPTION_ASSERT(!scope.exception());
     RELEASE_AND_RETURN(scope, true);
@@ -894,7 +894,7 @@ inline void JSObject::setPrivateField(JSGlobalObject* globalObject, PropertyName
     PropertySlot slot(this, PropertySlot::InternalMethodType::HasProperty);
     if (!JSObject::getPrivateFieldSlot(this, globalObject, propertyName, slot)) {
         throwException(globalObject, scope, createInvalidPrivateNameError(globalObject));
-        RELEASE_AND_RETURN(scope, void());
+        return;
     }
     EXCEPTION_ASSERT(!scope.exception());
 
@@ -906,10 +906,16 @@ inline void JSObject::definePrivateField(JSGlobalObject* globalObject, PropertyN
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (type() == WebAssemblyGCObjectType) {
+        throwTypeError(globalObject, scope, "Cannot define private field on a WebAssembly GC object"_s);
+        return;
+    }
+
     PropertySlot slot(this, PropertySlot::InternalMethodType::HasProperty);
     if (JSObject::getPrivateFieldSlot(this, globalObject, propertyName, slot)) {
         throwException(globalObject, scope, createRedefinedPrivateNameError(globalObject));
-        RELEASE_AND_RETURN(scope, void());
+        return;
     }
     EXCEPTION_ASSERT(!scope.exception());
 
@@ -970,9 +976,14 @@ inline void JSObject::setPrivateBrand(JSGlobalObject* globalObject, JSValue bran
     Structure* structure = this->structure();
     if (structure->isBrandedStructure() && jsCast<BrandedStructure*>(structure)->checkBrand(asSymbol(brand))) {
         throwException(globalObject, scope, createReinstallPrivateMethodError(globalObject));
-        RELEASE_AND_RETURN(scope, void());
+        return;
     }
     EXCEPTION_ASSERT(!scope.exception());
+
+    if (type() == WebAssemblyGCObjectType) {
+        throwTypeError(globalObject, scope, "Cannot add private method to a WebAssembly GC object"_s);
+        return;
+    }
 
     scope.release();
 

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -229,10 +229,10 @@ void EntryPlan::compileFunctions()
     for (uint32_t index = functionIndex; index < functionIndexEnd; ++index)
         compileFunction(FunctionCodeIndex(index));
 
-    if (m_moduleInformation->m_usesModernExceptions.loadRelaxed() && m_moduleInformation->m_usesLegacyExceptions.loadRelaxed()) {
+    {
         Locker locker { m_lock };
-        fail(makeString("Module uses both legacy exceptions and try_table"_s));
-        return;
+        if (failIfMixedExceptionHandlingProposals())
+            return;
     }
 
     if (!areWasmToWasmStubsCompiled) {
@@ -265,6 +265,16 @@ void EntryPlan::complete()
         moveToState(State::Completed);
         runCompletionTasks();
     }
+}
+
+bool EntryPlan::failIfMixedExceptionHandlingProposals()
+{
+    if (m_moduleInformation->m_usesModernExceptions.loadRelaxed()
+        && m_moduleInformation->m_usesLegacyExceptions.loadRelaxed()) {
+        fail(makeString("Module uses both legacy exceptions and try_table"_s));
+        return true;
+    }
+    return false;
 }
 
 bool EntryPlan::completeSyncIfPossible()

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -118,6 +118,8 @@ protected:
     bool isComplete() const override { return m_state == State::Completed; }
     void complete() WTF_REQUIRES_LOCK(m_lock) override;
 
+    bool failIfMixedExceptionHandlingProposals() WTF_REQUIRES_LOCK(m_lock);
+
     virtual bool prepareImpl() = 0;
     virtual void compileFunction(FunctionCodeIndex functionIndex) = 0;
     virtual void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) = 0;

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -2814,6 +2814,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
             WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
+            WASM_VALIDATOR_FAIL_IF(flags & 0xFC, "reserved bits set in flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 
@@ -4312,6 +4313,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             auto opName = op == ExtGCOpType::BrOnCast ? "br_on_cast"_s : "br_on_cast_fail"_s;
             uint8_t flags;
             WASM_VALIDATOR_FAIL_IF(!parseUInt8(flags), "can't get flags byte for "_s, opName);
+            WASM_VALIDATOR_FAIL_IF(flags & 0xFC, "reserved bits set in flags byte for "_s, opName);
             bool hasNull1 = flags & 0x1;
             bool hasNull2 = flags & 0x2;
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -224,6 +224,8 @@ void IPIntPlan::didCompleteCompilation()
 void IPIntPlan::completeInStreaming()
 {
     Locker locker { m_lock };
+    if (failIfMixedExceptionHandlingProposals())
+        return;
     complete();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -349,6 +349,12 @@ static void copyExceptionPayloadToStack(const Wasm::FunctionSignature& tagType, 
     ASSERT(!payloadIndex);
 }
 
+static ALWAYS_INLINE IPIntLocal& rethrowSlotForDepth(IPIntLocal* pl, Wasm::IPIntCallee* callee, uint32_t depth)
+{
+    RELEASE_ASSERT(depth && depth <= callee->rethrowSlots());
+    return pl[static_cast<size_t>(callee->localSizeToAlloc()) + static_cast<size_t>(depth) - 1];
+}
+
 WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, IPIntStackEntry* stackPointer, IPIntLocal* pl)
 {
     VM& vm = instance->vm();
@@ -356,10 +362,8 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_and_clear_exception, CallFrame* callFrame, I
     RELEASE_ASSERT(!!throwScope.exception());
 
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
-    if (callee->rethrowSlots()) {
-        RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->rethrowSlots());
-        pl[callee->localSizeToAlloc() + vm.targetTryDepthForThrow - 1].i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
-    }
+    if (callee->rethrowSlots())
+        rethrowSlotForDepth(pl, callee, vm.targetTryDepthForThrow).i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
 
     if (stackPointer) {
         // We only have a stack pointer if we're doing a catch not a catch_all
@@ -383,10 +387,8 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception, CallFrame* callFra
     RELEASE_ASSERT(!!throwScope.exception());
 
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
-    if (callee->rethrowSlots()) {
-        RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->rethrowSlots());
-        pl[callee->localSizeToAlloc() + vm.targetTryDepthForThrow - 1].i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
-    }
+    if (callee->rethrowSlots())
+        rethrowSlotForDepth(pl, callee, vm.targetTryDepthForThrow).i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
 
     Exception* exception = throwScope.exception();
     stackPointer[0].ref = JSValue::encode(exception->value());
@@ -406,10 +408,8 @@ WASM_IPINT_EXTERN_CPP_DECL(retrieve_clear_and_push_exception_and_arguments, Call
     RELEASE_ASSERT(!!throwScope.exception());
 
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
-    if (callee->rethrowSlots()) {
-        RELEASE_ASSERT(vm.targetTryDepthForThrow <= callee->rethrowSlots());
-        pl[callee->localSizeToAlloc() + vm.targetTryDepthForThrow - 1].i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
-    }
+    if (callee->rethrowSlots())
+        rethrowSlotForDepth(pl, callee, vm.targetTryDepthForThrow).i64 = std::bit_cast<uint64_t>(throwScope.exception()->value());
 
     Exception* exception = throwScope.exception();
     auto* wasmException = jsSecureCast<JSWebAssemblyException*>(exception->value());
@@ -453,7 +453,7 @@ WASM_IPINT_EXTERN_CPP_DECL(throw_exception, CallFrame* callFrame, IPIntStackEntr
     WASM_RETURN_TWO(vm.targetMachinePCForThrow, nullptr);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntStackEntry* pl, unsigned tryDepth)
+WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntLocal* pl, unsigned tryDepth)
 {
     SlowPathFrameTracer tracer(instance->vm(), callFrame);
 
@@ -462,11 +462,11 @@ WASM_IPINT_EXTERN_CPP_DECL(rethrow_exception, CallFrame* callFrame, IPIntStackEn
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     Wasm::IPIntCallee* callee = IPINT_CALLEE(callFrame);
-    RELEASE_ASSERT(tryDepth <= callee->rethrowSlots());
+    auto& slot = rethrowSlotForDepth(pl, callee, tryDepth);
 #if CPU(ADDRESS64)
-    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(pl[callee->localSizeToAlloc() + tryDepth - 1].i64);
+    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(slot.i64);
 #else
-    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(pl[callee->localSizeToAlloc() + tryDepth - 1].i32);
+    JSWebAssemblyException* exception = std::bit_cast<JSWebAssemblyException*>(slot.i32);
 #endif
     RELEASE_ASSERT(exception);
     throwException(globalObject, throwScope, exception);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -78,7 +78,7 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_and_clear_exception, CallFrame*, IPIn
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(retrieve_clear_and_push_exception_and_arguments, CallFrame*, IPIntStackEntry* stack, IPIntLocal* pl);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_exception, CallFrame*, IPIntStackEntry* arguments, unsigned exceptionIndex);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, IPIntStackEntry* pl, unsigned tryDepth);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(rethrow_exception, CallFrame*, IPIntLocal* pl, unsigned tryDepth);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(throw_ref, CallFrame* callFrame, EncodedJSValue exnref);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);

--- a/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
@@ -63,8 +63,7 @@ bool JSTextTrackCueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> h
 template<typename Visitor>
 void JSTextTrackCue::visitAdditionalChildren(Visitor& visitor)
 {
-    if (auto* textTrack = wrapped().track())
-        addWebCoreOpaqueRoot(visitor, *textTrack);
+    wrapped().visitAdditionalChildren(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTextTrackCue);

--- a/Source/WebCore/html/track/InbandDataTextTrack.h
+++ b/Source/WebCore/html/track/InbandDataTextTrack.h
@@ -36,6 +36,7 @@ class DataCue;
 
 class InbandDataTextTrack final : public InbandTextTrack {
     WTF_MAKE_TZONE_ALLOCATED(InbandDataTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandDataTextTrack);
 public:
     static Ref<InbandDataTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandDataTextTrack();

--- a/Source/WebCore/html/track/InbandGenericTextTrack.h
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.h
@@ -52,6 +52,7 @@ private:
 
 class InbandGenericTextTrack final : public InbandTextTrack, private WebVTTParserClient {
     WTF_MAKE_TZONE_ALLOCATED(InbandGenericTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandGenericTextTrack);
 public:
     static Ref<InbandGenericTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandGenericTextTrack();

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class InbandTextTrack : public TextTrack, private InbandTextTrackPrivateClient {
     WTF_MAKE_TZONE_ALLOCATED(InbandTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandTextTrack);
 public:
     static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandTextTrack();

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.h
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.h
@@ -35,6 +35,7 @@ namespace WebCore {
 
 class InbandWebVTTTextTrack final : public InbandTextTrack, private WebVTTParserClient {
     WTF_MAKE_TZONE_ALLOCATED(InbandWebVTTTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InbandWebVTTTextTrack);
 public:
     static Ref<InbandTextTrack> create(ScriptExecutionContext&, InbandTextTrackPrivate&);
     virtual ~InbandWebVTTTextTrack();

--- a/Source/WebCore/html/track/LoadableTextTrack.h
+++ b/Source/WebCore/html/track/LoadableTextTrack.h
@@ -36,6 +36,7 @@ namespace WebCore {
 
 class LoadableTextTrack final : public TextTrack, private TextTrackLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED(LoadableTextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LoadableTextTrack);
 public:
     static Ref<LoadableTextTrack> create(HTMLTrackElement&, const AtomString& kind, const AtomString& label, const AtomString& language);
 

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -32,6 +32,7 @@
 #include <WebCore/PlatformTimeRanges.h>
 #include <WebCore/TextTrackCue.h>
 #include <WebCore/TrackBase.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
@@ -43,8 +44,9 @@ class TextTrackClient;
 class TextTrackCueList;
 class VTTRegionList;
 
-class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject {
+class TextTrack : public TrackBase, public EventTarget, public ActiveDOMObject, public CanMakeCheckedPtr<TextTrack> {
     WTF_MAKE_TZONE_ALLOCATED(TextTrack);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextTrack);
 public:
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, TrackID, const AtomString& label, const AtomString& language);
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -54,8 +54,10 @@
 #include "UserAgentParts.h"
 #include "VTTCue.h"
 #include "VTTRegionList.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <limits.h>
 #include <wtf/HexNumber.h>
+#include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/OptionSet.h>
@@ -228,6 +230,8 @@ TextTrackCue::TextTrackCue(Document& document, const MediaTime& start, const Med
 {
 }
 
+TextTrackCue::~TextTrackCue() = default;
+
 void TextTrackCue::didMoveToNewDocument(Document& newDocument)
 {
     ActiveDOMObject::didMoveToNewDocument(newDocument);
@@ -257,7 +261,7 @@ void TextTrackCue::willChange()
     if (++m_processingCueChanges > 1)
         return;
 
-    if (RefPtr track = m_track.get())
+    if (RefPtr track = this->track())
         track->cueWillChange(*this);
 }
 
@@ -269,7 +273,7 @@ void TextTrackCue::didChange(bool affectOrder)
 
     m_displayTreeNeedsUpdate = true;
 
-    if (RefPtr track = m_track.get())
+    if (RefPtr track = this->track())
         track->cueDidChange(*this, affectOrder);
 }
 
@@ -280,11 +284,13 @@ TextTrack* TextTrackCue::track() const
 
 RefPtr<TextTrack> TextTrackCue::protectedTrack() const
 {
+    ASSERT(isMainThread());
     return m_track.get();
 }
 
 void TextTrackCue::setTrack(TextTrack* track)
 {
+    Locker locker { m_trackLockForGC };
     m_track = track;
 }
 
@@ -355,10 +361,11 @@ void TextTrackCue::setIsActive(bool active)
 
 unsigned TextTrackCue::cueIndex() const
 {
-    ASSERT(m_track && m_track->cuesInternal());
-    if (!m_track)
+    RefPtr track = this->track();
+    ASSERT(track && track->cuesInternal());
+    if (!track)
         return std::numeric_limits<unsigned>::max();
-    RefPtr cuesInternal = m_track->cuesInternal();
+    RefPtr cuesInternal = track->cuesInternal();
     if (!cuesInternal)
         return std::numeric_limits<unsigned>::max();
 
@@ -396,7 +403,7 @@ bool TextTrackCue::isEqual(const TextTrackCue& other, TextTrackCue::CueMatchRule
 bool TextTrackCue::hasEquivalentStartTime(const TextTrackCue& cue) const
 {
     MediaTime startTimeVariance = MediaTime::zeroTime();
-    if (RefPtr track = m_track.get())
+    if (RefPtr track = this->track())
         startTimeVariance = track->startTimeVariance();
     else if (RefPtr track = cue.track())
         startTimeVariance = track->startTimeVariance();
@@ -538,6 +545,16 @@ void TextTrackCue::rebuildDisplayTree()
 
     m_displayTreeNeedsUpdate = false;
 }
+
+template<typename Visitor>
+void TextTrackCue::visitAdditionalChildren(Visitor& visitor)
+{
+    Locker locker { m_trackLockForGC };
+    if (m_track)
+        addWebCoreOpaqueRoot(visitor, *m_track);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(TextTrackCue);
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -38,6 +38,7 @@
 #include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/HTMLElement.h>
 #include <wtf/JSONValues.h>
+#include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
 
 namespace WebCore {
@@ -70,6 +71,7 @@ class TextTrackCue : public RefCounted<TextTrackCue>, public EventTarget, public
     WTF_MAKE_TZONE_ALLOCATED(TextTrackCue);
 public:
     static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);
+    ~TextTrackCue();
 
     // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
@@ -81,6 +83,8 @@ public:
     TextTrack* track() const;
     RefPtr<TextTrack> protectedTrack() const;
     void setTrack(TextTrack*);
+
+    template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
     const AtomString& id() const { return m_id; }
     void setId(const AtomString&);
@@ -165,7 +169,8 @@ private:
     MediaTime m_endTime;
     int m_processingCueChanges { 0 };
 
-    WeakPtr<TextTrack, WeakPtrImplWithEventTargetData> m_track;
+    Lock m_trackLockForGC;
+    CheckedPtr<TextTrack> m_track;
 
     const RefPtr<DocumentFragment> m_cueNode;
     const RefPtr<TextTrackCueBox> m_displayTree;

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
@@ -187,6 +187,9 @@ bool FEBlendNeonApplier::apply(const Filter&, std::span<const Ref<FilterImage>> 
     auto effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     auto sourcePixelArrayB = input2.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectBDrawingRect);
 
+    if (!sourcePixelArrayA || !sourcePixelArrayB)
+        return false;
+
     unsigned sourcePixelArrayLength = sourcePixelArrayA->bytes().size();
     ASSERT(sourcePixelArrayLength == sourcePixelArrayB->bytes().size());
 

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -141,25 +141,26 @@ ImageBuffer* FilterImage::imageBufferFromPixelBuffer()
     return m_imageBuffer.get();
 }
 
-static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer)
+static bool copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer)
 {
     ASSERT(sourcePixelBuffer.size() == destinationPixelBuffer.size());
 
     auto destinationSize = destinationPixelBuffer.size();
     auto rowBytes = CheckedUint32(destinationSize.width()) * 4;
     if (rowBytes.hasOverflowed()) [[unlikely]]
-        return;
+        return false;
 
     ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes() };
     PixelBufferConversionView destination { destinationPixelBuffer.format(), rowBytes, destinationPixelBuffer.bytes() };
 
     convertImagePixels(source, destination, destinationSize);
+    return true;
 }
 
-static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
+static bool copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
 {
-    auto sourcePixelBufferRect = IntRect { { }, sourcePixelBuffer.size() };
-    auto destinationPixelBufferRect = IntRect { { }, destinationPixelBuffer.size() };
+    const auto sourcePixelBufferRect = IntRect { { }, sourcePixelBuffer.size() };
+    const auto destinationPixelBufferRect = IntRect { { }, destinationPixelBuffer.size() };
 
     auto sourceRectClipped = intersection(sourcePixelBufferRect, sourceRect);
     auto destinationRect = IntRect { { }, sourceRectClipped.size() };
@@ -173,13 +174,9 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     destinationRect.intersect(destinationPixelBufferRect);
     sourceRectClipped.setSize(destinationRect.size());
 
-    // Initialize the destination to transparent black, if not entirely covered by the source.
-    if (destinationRect.size() != destinationPixelBufferRect.size())
-        destinationPixelBuffer.zeroFill();
-
     // Early return if the rect does not intersect with the source.
     if (destinationRect.isEmpty())
-        return;
+        return false;
 
     auto size = CheckedUint32(sourceRectClipped.width()) * 4;
     auto destinationBytesPerRow = CheckedUint32(destinationPixelBufferRect.width()) * 4;
@@ -188,7 +185,11 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     auto sourceOffset = sourceRectClipped.y() * sourceBytesPerRow + CheckedUint32(sourceRectClipped.x()) * 4;
 
     if (size.hasOverflowed() || destinationBytesPerRow.hasOverflowed() || sourceBytesPerRow.hasOverflowed() || destinationOffset.hasOverflowed() || sourceOffset.hasOverflowed()) [[unlikely]]
-        return;
+        return false;
+
+    // Initialize the destination to transparent black, if not entirely covered by the source.
+    if (destinationRect.size() != destinationPixelBufferRect.size())
+        destinationPixelBuffer.zeroFill();
 
     auto destinationPixel = destinationPixelBuffer.bytes().subspan(destinationOffset.value());
     auto sourcePixel = sourcePixelBuffer.bytes().subspan(sourceOffset.value());
@@ -200,6 +201,8 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
         }
         memcpySpan(destinationPixel, sourcePixel.first(size));
     }
+
+    return true;
 }
 
 static RefPtr<PixelBuffer> getConvertedPixelBuffer(ImageBuffer& imageBuffer, AlphaPremultiplication alphaFormat, const IntRect& sourceRect, DestinationColorSpace colorSpace, ImageBufferAllocator& allocator)
@@ -272,11 +275,15 @@ PixelBuffer* FilterImage::pixelBuffer(AlphaPremultiplication alphaFormat)
         return nullptr;
 
     if (alphaFormat == AlphaPremultiplication::Unpremultiplied) {
-        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Premultiplied))
-            copyImageBytes(*sourcePixelBuffer, *pixelBuffer);
+        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Premultiplied)) {
+            if (!copyImageBytes(*sourcePixelBuffer, *pixelBuffer))
+                return nullptr;
+        }
     } else {
-        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Unpremultiplied))
-            copyImageBytes(*sourcePixelBuffer, *pixelBuffer);
+        if (auto& sourcePixelBuffer = pixelBufferSlot(AlphaPremultiplication::Unpremultiplied)) {
+            if (!copyImageBytes(*sourcePixelBuffer, *pixelBuffer))
+                return nullptr;
+        }
     }
 
     return pixelBuffer.get();
@@ -292,11 +299,13 @@ RefPtr<PixelBuffer> FilterImage::getPixelBuffer(AlphaPremultiplication alphaForm
     if (!pixelBuffer)
         return nullptr;
 
-    copyPixelBuffer(*pixelBuffer, sourceRect);
+    if (!copyPixelBuffer(*pixelBuffer, sourceRect))
+        return nullptr;
+
     return pixelBuffer;
 }
 
-void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
+bool FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect)
 {
     auto alphaFormat = destinationPixelBuffer.format().alphaFormat;
     auto& colorSpace = destinationPixelBuffer.format().colorSpace;
@@ -309,8 +318,8 @@ void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const Int
             if (m_imageBuffer) {
                 IntRect rect { { }, m_absoluteImageRect.size() };
                 if (auto convertedPixelBuffer = getConvertedPixelBuffer(Ref { *m_imageBuffer }, alphaFormat, rect, colorSpace, m_allocator))
-                    copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
-                return;
+                    return copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
+                return false;
             }
         }
 
@@ -318,15 +327,15 @@ void FilterImage::copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const Int
     }
 
     if (!sourcePixelBuffer)
-        return;
+        return false;
 
     if (requiresPixelBufferColorSpaceConversion(colorSpace)) {
         if (auto convertedPixelBuffer = getConvertedPixelBuffer(*sourcePixelBuffer, alphaFormat, colorSpace, m_allocator))
-            copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
-        return;
+            return copyImageBytes(*convertedPixelBuffer, destinationPixelBuffer, sourceRect);
+        return false;
     }
 
-    copyImageBytes(*sourcePixelBuffer, destinationPixelBuffer, sourceRect);
+    return copyImageBytes(*sourcePixelBuffer, destinationPixelBuffer, sourceRect);
 }
 
 void FilterImage::correctPremultipliedPixelBuffer()

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -75,7 +75,7 @@ public:
     PixelBuffer* pixelBuffer(AlphaPremultiplication);
 
     RefPtr<PixelBuffer> getPixelBuffer(AlphaPremultiplication, const IntRect& sourceRect, std::optional<DestinationColorSpace> = std::nullopt);
-    void copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect);
+    bool copyPixelBuffer(PixelBuffer& destinationPixelBuffer, const IntRect& sourceRect);
 
     void correctPremultipliedPixelBuffer();
     void transformToColorSpace(const DestinationColorSpace&);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -882,6 +882,23 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     if (willConstructCustomElement) [[unlikely]] {
         customElementReactionStack.reset();
         markupInsertionCountIncrementer.reset();
+        // Draining the reaction stack runs the custom element constructor, which may
+        // have re-parented newElement, adopted it into another document, or detached
+        // the current parser node. parserAppendChild requires its argument to have no
+        // parent and to share our document.
+        // FIXME: We are misusing the upgrade-an-element machinery here to emulate
+        // synchronous custom element construction. Per HTML's "create an element for
+        // a token" with willExecuteScript=true we should run the constructor inside
+        // Document::createElement (via constructElementWithFallback), which post-
+        // validates parent/children/attributes/document and falls back to
+        // HTMLUnknownElement on violation, like HTMLDocumentParser does in
+        // runScriptsForPausedTreeBuilder. Switching to that would also fix the
+        // spec-incorrect attribute-ordering above (we currently set attributes before
+        // the constructor runs).
+        if (!m_currentNode || newElement->parentNode() || &newElement->document() != &m_currentNode->document()) {
+            stopParsing();
+            return;
+        }
     }
 
     newElement->beginParsingChildren();

--- a/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
+++ b/Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp
@@ -140,12 +140,8 @@ void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifi
             if (!keysSuccessfullySet.size())
                 return;
 
-            if (keysSuccessfullySet.size() != data.size()) {
-                for (const auto& key : data.keys()) {
-                    if (!keysSuccessfullySet.contains(key))
-                        data.remove(key);
-                }
-            }
+            if (keysSuccessfullySet.size() != data.size())
+                data.removeIf([&](auto& entry) { return !keysSuccessfullySet.contains(entry.key); });
 
             fireStorageChangedEventIfNeeded(existingKeysAndValues, data, dataType);
         });

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -302,6 +302,8 @@ void RemoteScrollingTree::tryToApplyLayerPositions()
 #if ENABLE(THREADED_ANIMATIONS)
 void RemoteScrollingTree::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate)
 {
+    ASSERT(isMainRunLoop());
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (!m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry = makeUnique<RemoteProgressBasedTimelineRegistry>();
     m_progressBasedTimelineRegistry->update(*this, processIdentifier, timelinesUpdate);
@@ -311,6 +313,7 @@ void RemoteScrollingTree::updateTimelinesRegistration(WebCore::ProcessIdentifier
 
 RefPtr<const RemoteAnimationTimeline> RemoteScrollingTree::timeline(const TimelineID& timelineID) const
 {
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (m_progressBasedTimelineRegistry)
         return m_progressBasedTimelineRegistry->get(timelineID);
     return nullptr;
@@ -318,12 +321,14 @@ RefPtr<const RemoteAnimationTimeline> RemoteScrollingTree::timeline(const Timeli
 
 void RemoteScrollingTree::updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode& node)
 {
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (m_progressBasedTimelineRegistry)
         m_progressBasedTimelineRegistry->updateTimelinesForNode(node);
 }
 
 HashSet<Ref<RemoteProgressBasedTimeline>> RemoteScrollingTree::timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID scrollingNodeID) const
 {
+    Locker locker { m_progressBasedTimelineRegistryLock };
     if (m_progressBasedTimelineRegistry)
         return m_progressBasedTimelineRegistry->timelinesForScrollingNodeIDForTesting(scrollingNodeID);
     return { };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -116,7 +116,8 @@ protected:
     void updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
 
 private:
-    std::unique_ptr<RemoteProgressBasedTimelineRegistry> m_progressBasedTimelineRegistry;
+    mutable Lock m_progressBasedTimelineRegistryLock;
+    std::unique_ptr<RemoteProgressBasedTimelineRegistry> m_progressBasedTimelineRegistry WTF_GUARDED_BY_LOCK(m_progressBasedTimelineRegistryLock);
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -37,6 +37,7 @@
 #include "FrameTreeNodeData.h"
 #include "JSHandleInfo.h"
 #include "LoadedWebArchive.h"
+#include "Logging.h"
 #include "MessageSenderInlines.h"
 #include "NetworkProcessMessages.h"
 #include "ProvisionalFrameCreationParameters.h"
@@ -557,7 +558,53 @@ void WebFrameProxy::commitProvisionalFrame(IPC::Connection& connection, FrameIde
 
 void WebFrameProxy::getFrameInfo(CompletionHandler<void(std::optional<FrameInfoData>&&)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebFrame::GetFrameInfo(), WTF::move(completionHandler));
+    sendWithAsyncReply(Messages::WebFrame::GetFrameInfo(), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](auto&& frameInfo) mutable {
+        if (!frameInfo)
+            return completionHandler({ });
+
+        if (frameInfo->isMainFrame != isMainFrame()) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: isMainFrame mismatch");
+            frameInfo->isMainFrame = isMainFrame();
+        }
+        if (frameInfo->frameID != frameID()) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: frameID mismatch");
+            frameInfo->frameID = frameID();
+        }
+        if (frameInfo->request.url() != url()) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: URL mismatch");
+            frameInfo->request = ResourceRequest { URL { url() } };
+        }
+        auto securityOrigin = SecurityOriginData::fromURL(url());
+        if (frameInfo->securityOrigin != securityOrigin) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: security origin mismatch");
+            frameInfo->securityOrigin = WTF::move(securityOrigin);
+        }
+        auto topOrigin = SecurityOriginData::fromURL(rootFrame()->url());
+        if (frameInfo->topOrigin != topOrigin) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: topOrigin mismatch");
+            frameInfo->topOrigin = WTF::move(topOrigin);
+        }
+        if (frameInfo->certificateInfo != certificateInfo()) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: certificateInfo mismatch");
+            frameInfo->certificateInfo = certificateInfo();
+        }
+        if (frameInfo->processID != process().processID()) {
+            RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: process ID mismatch");
+            frameInfo->processID = process().processID();
+        }
+        if (m_page) {
+            if (frameInfo->webPageProxyID != m_page->identifier()) {
+                RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: webPageProxyID mismatch");
+                frameInfo->webPageProxyID = m_page->identifier();
+            }
+        } else {
+            if (frameInfo->webPageProxyID) {
+                RELEASE_LOG_ERROR(IPC, "WebFrameProxy::getFrameInfo: had unexpected webPageProxyID");
+                frameInfo->webPageProxyID = std::nullopt;
+            }
+        }
+        completionHandler(WTF::move(*frameInfo));
+    });
 }
 
 void WebFrameProxy::getFrameTree(CompletionHandler<void(std::optional<FrameTreeNodeData>&&)>&& completionHandler)

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -305,7 +305,7 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_zeroed_inline(size_t size, p
 
     result = bmalloc_try_allocate_impl(size, 1, allocation_mode);
     if (PAS_MAR_SHOULD_LOG(allocation_mode, (void*) result.begin))
-        return PAS_MAR_TRACK_ALLOCATION((void*)result.begin, size);
+        return PAS_MAR_TRACK_ALLOCATION_AND_ZERO(result, size);
     return (void*)pas_allocation_result_zero(result, size).begin;
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		536770341CC8022800D425B1 /* WebScriptObjectDescription.mm in Sources */ = {isa = PBXBuildFile; fileRef = 536770331CC8022800D425B1 /* WebScriptObjectDescription.mm */; };
 		53EC25411E96FD87000831B9 /* PriorityQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53EC253F1E96BC80000831B9 /* PriorityQueue.cpp */; };
 		53FCDE6B229EFFB900598ECF /* IsoHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FCDE6A229EFFB900598ECF /* IsoHeap.cpp */; };
+		53FCDE6C229EFFB900598ECF /* MAR.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53FCDE6D229EFFB900598ECF /* MAR.cpp */; };
 		5597F8361D9596C80066BC21 /* SynchronizedFixedQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5597F8341D9596C80066BC21 /* SynchronizedFixedQueue.cpp */; };
 		55F9D2E52205031800A9AB38 /* AdditionalSupportedImageTypes.mm in Sources */ = {isa = PBXBuildFile; fileRef = 55F9D2E42205031800A9AB38 /* AdditionalSupportedImageTypes.mm */; };
 		562C003E2E82F4AC009D428B /* SafeFontParser-Worker.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 562C00362E82F4A7009D428B /* SafeFontParser-Worker.html */; };
@@ -3141,6 +3142,7 @@
 		536770351CC812F900D425B1 /* WebScriptObjectDescription.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = WebScriptObjectDescription.html; sourceTree = "<group>"; };
 		53EC253F1E96BC80000831B9 /* PriorityQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PriorityQueue.cpp; sourceTree = "<group>"; };
 		53FCDE6A229EFFB900598ECF /* IsoHeap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsoHeap.cpp; sourceTree = "<group>"; };
+		53FCDE6D229EFFB900598ECF /* MAR.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MAR.cpp; sourceTree = "<group>"; };
 		55226A2E1EB969B600C36AD0 /* large-red-square-image.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "large-red-square-image.html"; sourceTree = "<group>"; };
 		5597F8341D9596C80066BC21 /* SynchronizedFixedQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SynchronizedFixedQueue.cpp; sourceTree = "<group>"; };
 		55A817FB218100E00004A39A /* AdditionalSupportedImageTypes.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AdditionalSupportedImageTypes.mm; sourceTree = "<group>"; };
@@ -5446,6 +5448,7 @@
 			isa = PBXGroup;
 			children = (
 				53FCDE6A229EFFB900598ECF /* IsoHeap.cpp */,
+				53FCDE6D229EFFB900598ECF /* MAR.cpp */,
 			);
 			path = bmalloc;
 			sourceTree = "<group>";
@@ -7707,6 +7710,7 @@
 				A57D54F61F3395D000A97AA7 /* Logger.cpp in Sources */,
 				A1C7D7D32AB817A90055AD62 /* LoggerCocoa.mm in Sources */,
 				D04CF93F285C77CA005D6337 /* MachSendRight.cpp in Sources */,
+				53FCDE6C229EFFB900598ECF /* MAR.cpp in Sources */,
 				4909EE3A2D09480C88982D56 /* Markable.cpp in Sources */,
 				7C83DEED1D0A590C00FEBCF3 /* MathExtras.cpp in Sources */,
 				7C83DEF11D0A590C00FEBCF3 /* MediaTime.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if !USE(SYSTEM_MALLOC) && BUSE(LIBPAS) && OS(DARWIN)
+
+#include <bmalloc/bmalloc.h>
+#include <bmalloc/pas_mar_registry.h>
+#include <cstring>
+#include <vector>
+
+namespace TestWebKitAPI {
+
+static unsigned pageIndexOf(void* p)
+{
+    return static_cast<unsigned>((reinterpret_cast<uintptr_t>(p) >> PAS_MAR_PAGE_SHIFT) % PAS_MAR_PROBABILITY);
+}
+
+static void testZeroedAllocationAfterPriming(bool marEnabled)
+{
+    pas_mar_initialize();
+
+    constexpr size_t size = 128;
+    constexpr int warmup = 8192;
+    constexpr int retries = 8192;
+
+    // Warm up: prime many equally sized slots with 0xAB, then free them all so
+    // their bytes stay at 0xAB in the backing memory. Subsequent allocations
+    // at the same size will reuse these slots from bmalloc's free list.
+    std::vector<void*> primed;
+    primed.reserve(warmup);
+    for (int i = 0; i < warmup; ++i) {
+        void* p = bmalloc::api::tryZeroedMalloc(size, bmalloc::CompactAllocationMode::NonCompact);
+        ASSERT_TRUE(p);
+        WTF::memsetSpan(std::span { reinterpret_cast<uint8_t*>(p), size }, 0xAB);
+        primed.push_back(p);
+    }
+    for (void* p : primed)
+        bmalloc::api::free(p);
+
+    // Discover the page bmalloc will actually serve subsequent allocations
+    // from: ask it for one and see where it lands, then free that slot so
+    // it goes back on the free list.
+    void* probe = bmalloc::api::tryZeroedMalloc(size, bmalloc::CompactAllocationMode::NonCompact);
+    ASSERT_TRUE(probe);
+    const unsigned targetPage = pageIndexOf(probe);
+    bmalloc::api::free(probe);
+
+    pas_mar_enabled = marEnabled;
+    pas_mar_qualifying_page_index = targetPage;
+
+    // Reallocate and inspect. For every allocation that lands in the MAR qualifying page,
+    // the MAR branch of bmalloc_try_allocate_zeroed_inline runs (when enabled).
+    // If that branch fails to zero, we'll see the 0xAB pattern from the previous occupant.
+    int runsInTargetPage = 0;
+    for (int i = 0; i < retries; ++i) {
+        void* buf = bmalloc::api::tryZeroedMalloc(size, bmalloc::CompactAllocationMode::NonCompact);
+        std::span bufSpan { reinterpret_cast<uint8_t*>(buf), size };
+        ASSERT_TRUE(buf);
+
+        if (pageIndexOf(buf) == targetPage) {
+            for (size_t j = 0; j < size; ++j) {
+                uint8_t byte { };
+                WTF::memcpySpan(std::span { &byte, 1 }, bufSpan.subspan(j, 1));
+                EXPECT_EQ(byte, 0u) << " at offset " << j << " in iteration " << i;
+            }
+            ++runsInTargetPage;
+        }
+
+        bmalloc::api::free(buf);
+    }
+
+    // Fail loudly if we never exercised the target page. The test would be vacuous otherwise.
+    EXPECT_GT(runsInTargetPage, 0);
+
+    pas_mar_enabled = false;
+}
+
+TEST(bmalloc, MARZeroedAllocationWithMARDisabled)
+{
+    testZeroedAllocationAfterPriming(false);
+}
+
+TEST(bmalloc, MARZeroedAllocationWithMAREnabled)
+{
+    testZeroedAllocationAfterPriming(true);
+}
+
+} // namespace TestWebKitAPI
+
+#endif


### PR DESCRIPTION
#### bc2c08c0be62fe91811ca2e285df031cf04eaec4
<pre>
Cherry-pick de9fb008197a. <a href="https://bugs.webkit.org/show_bug.cgi?id=315538">https://bugs.webkit.org/show_bug.cgi?id=315538</a>

[WebKit Process Model] Use-after-free in WebExtensionContext::storageSet from HashMap mutation during keys() iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=315538">https://bugs.webkit.org/show_bug.cgi?id=315538</a>
<a href="https://rdar.apple.com/177375129">rdar://177375129</a>

Reviewed by Timothy Hatcher.

When WebExtensionStorageSQLiteStore::setKeyedData hits an INSERT error
mid-batch (e.g. SQLITE_FULL), it returns a keysSuccessfullySet vector
that is non-empty but smaller than the input map. The completion lambda
in storageSet then iterated `data.keys()` while calling `data.remove()`
inside the loop. `keys()` returns a live iterator range backed by raw
pointers into the HashTable buffer, and remove() can shrink/rehash and
free that buffer, leaving the iterator dangling — a heap UAF in the UI
Process driven by IPC from the WebContent process.

Replace the iterate-and-mutate loop with HashMap::removeIf, which walks
the table safely.

* Source/WebKit/UIProcess/Extensions/API/WebExtensionContextAPIStorage.cpp:
(WebKit::WebExtensionContext::storageSet):

Identifier: 305413.961@safari-7624-branch

Identifier: 305413.805@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.896@webkitglib/2.52">https://commits.webkit.org/305877.896@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1c19f7b2abfd741b09e44fe8bdebb204118ac2be
<pre>
Cherry-pick 55fe8eb4c2a9. <a href="https://bugs.webkit.org/show_bug.cgi?id=315365">https://bugs.webkit.org/show_bug.cgi?id=315365</a>

Streaming compiler does not reject mixed legacy and spec-correct EH
<a href="https://bugs.webkit.org/show_bug.cgi?id=315365">https://bugs.webkit.org/show_bug.cgi?id=315365</a>
<a href="https://rdar.apple.com/177030377">rdar://177030377</a>

Reviewed by Yijia Huang.

Legacy EH instructions are not defined in the wasm spec but are still
supported for backwards compatibility. Functions must either use legacy
or standards compliant EH instructions but not both, and the streaming
compiler needs to be updated to enforce this.

Test: JSTests/wasm/stress/streaming-compile-try-table-agreement.js

* JSTests/wasm/stress/streaming-compile-try-table-agreement.js: Added.
(compileNonStreaming):
(async compileStreaming):
(async main):
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::compileFunctions):
(JSC::Wasm::EntryPlan::failIfMixedExceptionHandlingProposals):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::completeInStreaming):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::rethrowSlotForDepth):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h:

Identifier: 305413.963@safari-7624-branch

Identifier: 305413.804@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.895@webkitglib/2.52">https://commits.webkit.org/305877.895@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f0b744f0c4d106c6a6388f11c12bd92128fb8a2b
<pre>
Cherry-pick 3bff1cc45724. <a href="https://bugs.webkit.org/show_bug.cgi?id=314585">https://bugs.webkit.org/show_bug.cgi?id=314585</a>

Fix Cross-thread use-after-free in RemoteScrollingTree::m_progressBasedTimelineRegistry
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=314585">https://bugs.webkit.org/show_bug.cgi?id=314585</a>&gt;
&lt;<a href="https://rdar.apple.com/176483524">rdar://176483524</a>&gt;

Reviewed by Antoine Quint.

m_progressBasedTimelineRegistry was freed on the main thread by
updateTimelinesRegistration() while the ScrollingThread read it via
serviceScrollAnimations -&gt; updateProgressBasedTimelinesForNode,
producing an ASan heap-use-after-free. The reader held m_treeLock; the
writer held only m_animationLock, so the two paths were not serialized.

Add a dedicated m_progressBasedTimelineRegistryLock that guards the
registry pointer and is acquired by every reader and writer. A separate
lock avoids self-deadlock when scrollingTreeNodeDidScroll() reaches
updateProgressBasedTimelinesForNode from the commit path with
m_treeLock already held.

Test: webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html

* LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/scroll-driven-animation-registry-update-crash.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::updateTimelinesRegistration):
(WebKit::RemoteScrollingTree::timeline const):
(WebKit::RemoteScrollingTree::updateProgressBasedTimelinesForNode):
(WebKit::RemoteScrollingTree::timelinesForScrollingNodeIDForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:

Identifier: 305413.960@safari-7624-branch

Identifier: 305413.801@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.894@webkitglib/2.52">https://commits.webkit.org/305877.894@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1cd01f7eccb9f4b1662f3a76c6d9ada1572ecbd1
<pre>
Cherry-pick 525600a227a6. <a href="https://bugs.webkit.org/show_bug.cgi?id=314438">https://bugs.webkit.org/show_bug.cgi?id=314438</a>

[JSC] Disallow defining private names on WasmGC objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=314438">https://bugs.webkit.org/show_bug.cgi?id=314438</a>
<a href="https://rdar.apple.com/176445615">rdar://176445615</a>

Reviewed by Yusuke Suzuki.

While the spec currently technically allows for defining private fields and
methods on WasmGC objects, this is against the spirit of those objects being
fixed-layout.

For compat, both V8 and SpiderMonkey also disallow addition of private names on
WasmGC objects.

Test: JSTests/wasm/gc/private-fields-and-methods.js

* JSTests/wasm/gc/private-fields-and-methods.js: Added.
(testPrivateMethodOnStruct.B):
(testPrivateMethodOnStruct.D.prototype.m):
(testPrivateMethodOnStruct.D):
(testPrivateMethodOnStruct):
(testPrivateFieldOnStruct.B):
(testPrivateFieldOnStruct.D):
(testPrivateFieldOnStruct):
(testPrivateMethodOnArray.B):
(testPrivateMethodOnArray.D.prototype.m):
(testPrivateMethodOnArray.D):
(testPrivateMethodOnArray):
(testPrivateFieldOnArray.B):
(testPrivateFieldOnArray.D):
(testPrivateFieldOnArray):
(testPrivateGetterOnStruct.B):
(testPrivateGetterOnStruct.D.prototype.get x):
(testPrivateGetterOnStruct.D):
(testPrivateGetterOnStruct):
(testGCSurvival.B):
(testGCSurvival.D.prototype.m):
(testGCSurvival.D):
(testGCSurvival):
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::getPrivateField):
(JSC::JSObject::setPrivateField):
(JSC::JSObject::definePrivateField):
(JSC::JSObject::setPrivateBrand):

Identifier: 305413.881@safari-7624-branch

Identifier: 305413.800@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.893@webkitglib/2.52">https://commits.webkit.org/305877.893@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 62ebf28b87693f9cb042c968f3c8bcdad8d27913
<pre>
Cherry-pick 19beaaec03d0. <a href="https://bugs.webkit.org/show_bug.cgi?id=314679">https://bugs.webkit.org/show_bug.cgi?id=314679</a>

[WebCore] use-after-free in Style::TreeResolver — XMLDocumentParser::startElementNs missing parentNode re-check after custom-element upgrade
<a href="https://rdar.apple.com/177479772">rdar://177479772</a>

Reviewed by Ryosuke Niwa.

Draining the custom element reaction stack in startElementNs runs the
constructor synchronously, which can re-parent newElement, adopt it into
another document, or detach the current parser node. parserAppendChild
requires its argument to have no parent and to share our document, so
falling through into it leaves the tree linked into two child lists.

Re-check those invariants after the reaction stack drains and stop
parsing if any of them no longer holds. A spec-aligned follow-up should
route XML element creation through constructElementWithFallback like
HTMLDocumentParser does, which post-validates and falls back to
HTMLUnknownElement; a FIXME records that.

Test: fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml
* LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash-expected.txt: Added.
* LayoutTests/fast/custom-elements/xml-parser-reparent-during-construction-crash.xhtml: Added.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):

Identifier: 305413.947@safari-7624-branch

Identifier: 305413.798@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.892@webkitglib/2.52">https://commits.webkit.org/305877.892@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fc7f707775c1238b9cff03898cdfe6ab22e36534
<pre>
Cherry-pick d945beacb08e. <a href="https://bugs.webkit.org/show_bug.cgi?id=314679">https://bugs.webkit.org/show_bug.cgi?id=314679</a>

[libpas] bmalloc_try_allocate_zeroed_inline calls PAS_MAR_TRACK_ALLOCATION instead of PAS_MAR_TRACK_ALLOCATION_AND_ZERO on MAR branch, returning unzeroed memory
<a href="https://rdar.apple.com/175683200">rdar://175683200</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314679">https://bugs.webkit.org/show_bug.cgi?id=314679</a>

Reviewed by Yusuke Suzuki.

This patch changes `bmalloc_try_allocate_zeroed_inline` so that it
zeroes the returned memory in the case where the MAR predicate matches.

Tests: Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp

* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
(bmalloc_try_allocate_zeroed_inline): Zero the returned memory.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/bmalloc/MAR.cpp: Added.
(TestWebKitAPI::pageIndexOf):
(TestWebKitAPI::testZeroedAllocationAfterPriming):
(TestWebKitAPI::TEST(bmalloc, MARZeroedAllocationWithMARDisabled)):
(TestWebKitAPI::TEST(bmalloc, MARZeroedAllocationWithMAREnabled)):

Identifier: 305413.946@safari-7624-branch

Identifier: 305413.797@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.891@webkitglib/2.52">https://commits.webkit.org/305877.891@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f3c37d7ca6bd5771a3caaf4ea06da65436d4c6b8
<pre>
Cherry-pick 6d5ae0fc9aa1. <a href="https://bugs.webkit.org/show_bug.cgi?id=315223">https://bugs.webkit.org/show_bug.cgi?id=315223</a>

WasmGC should reject reserved bits in br_on_cast/br_on_cast_fail flags byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=315223">https://bugs.webkit.org/show_bug.cgi?id=315223</a>
<a href="https://rdar.apple.com/176190526">rdar://176190526</a>

Reviewed by Dan Hecht.

In br_on_cast and br_on_cast_fail flag bits other than 0 and 1 are
reserved. The validator currently does not check that reserved bits are
0 and IPInt assumes reserved bits are 0. This patch makes the validator
check the reserved bits.

Test: JSTests/wasm/stress/br-on-cast-reserved-flags.js

* JSTests/wasm/stress/br-on-cast-reserved-flags.js: Added.
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Identifier: 305413.945@safari-7624-branch

Identifier: 305413.796@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.890@webkitglib/2.52">https://commits.webkit.org/305877.890@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b5ec6fa781103e8e372a3a9318330b11df40672c
<pre>
Cherry-pick 133b57500c3a. <a href="https://bugs.webkit.org/show_bug.cgi?id=314952">https://bugs.webkit.org/show_bug.cgi?id=314952</a>

Data race in JSTextTrackCue::visitAdditionalChildrenInGCThread leading to use-after-free (variant of bug 311800)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314952">https://bugs.webkit.org/show_bug.cgi?id=314952</a>
<a href="https://rdar.apple.com/177248996">rdar://177248996</a>

Reviewed by Geoffrey Garen.

JSTextTrackCue::visitAdditionalChildrenInGCThread() was accessing
`TrackTraceCue::m_track` from the GC thread, even though it is a WeakPtr
which can get nulled out on the main thread.

To address the issue:
- Turn `TrackTraceCue::m_track` into a CheckedPtr. This is OK because the
  ~Track() destructor takes care of nulling out its cues&apos; m_track pointer
  explicitly.
- Add a Lock to synchronize setting m_track on the main thread in
  `TextTrackCue::setTrack()` and accessing it on the GC thread.

* Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp:
(WebCore::JSTextTrackCue::visitAdditionalChildren):
* Source/WebCore/html/track/InbandDataTextTrack.h:
* Source/WebCore/html/track/InbandGenericTextTrack.h:
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/InbandWebVTTTextTrack.h:
* Source/WebCore/html/track/LoadableTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::willChange):
(WebCore::TextTrackCue::didChange):
(WebCore::TextTrackCue::track const):
(WebCore::TextTrackCue::protectedTrack const):
(WebCore::TextTrackCue::setTrack):
(WebCore::TextTrackCue::cueIndex const):
(WebCore::TextTrackCue::hasEquivalentStartTime const):
(WebCore::TextTrackCue::visitAdditionalChildren):
* Source/WebCore/html/track/TextTrackCue.h:

Identifier: 305413.937@safari-7624-branch

Identifier: 305413.794@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.889@webkitglib/2.52">https://commits.webkit.org/305877.889@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 965d271f45c1e4ef886087721b20a4ed951913d9
<pre>
Cherry-pick 332b0cbb0bb4. <a href="https://bugs.webkit.org/show_bug.cgi?id=315006">https://bugs.webkit.org/show_bug.cgi?id=315006</a>

Missing validation of frameInfo in WebFrameProxy::getFrameInfo()
<a href="https://bugs.webkit.org/show_bug.cgi?id=315006">https://bugs.webkit.org/show_bug.cgi?id=315006</a>
<a href="https://rdar.apple.com/176816153">rdar://176816153</a>

Reviewed by Ryosuke Niwa.

Harden WebFrameProxy::getFrameInfo() so the security-relevant fields of
the FrameInfoData struct returned by WebProcess are now validated.
In case of mismatch, we overwrite with correct values and log an error
message instead of doing a MESSAGE_CHECK, to reduce risk.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::getFrameInfo):

Identifier: 305413.931@safari-7624-branch

Identifier: 305413.793@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.888@webkitglib/2.52">https://commits.webkit.org/305877.888@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ccff81d1a5490d19887a8d5506abc58327730b9f
<pre>
Cherry-pick dbf10417aa9e. <a href="https://bugs.webkit.org/show_bug.cgi?id=314906">https://bugs.webkit.org/show_bug.cgi?id=314906</a>

FilterImage may return uninitialized PixelBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=314906">https://bugs.webkit.org/show_bug.cgi?id=314906</a>
<a href="https://rdar.apple.com/176813834">rdar://176813834</a>

Reviewed by Darin Adler.

FilterImage provides three different representations of the image: ImageBuffer,
Unpremultiplied PixelBuffer and Premultiplied PixelBuffer. These three buffers
are lazily created. Each of them is created only when it is needed. But keep in
mind they are copies of each other. In other words, when one is created it has
to copy the pixels from the existing buffers. Otherwise it has to be zero-filled.

A problem may happen when copying the pixels from one buffer to a newly created
buffer fails. In this case we send uninitialized PixelBuffer which may expose user
private data. Not able to copy existing pixels to the PixelBuffer should be treated
as an error. So a null PixelBuffer should be returned in this case.

* Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp:
(WebCore::FEBlendNeonApplier::apply const):
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::copyImageBytes):
(WebCore::FilterImage::pixelBuffer):
(WebCore::FilterImage::getPixelBuffer):
(WebCore::FilterImage::copyPixelBuffer):
* Source/WebCore/platform/graphics/filters/FilterImage.h:

Identifier: 305413.919@safari-7624-branch

Identifier: 305413.791@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.887@webkitglib/2.52">https://commits.webkit.org/305877.887@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c7d066593cf1c277d68fafda5d45564d066ec74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172410 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46328 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181863 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129966 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174275 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47621 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45997 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129966 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175368 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47621 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114572 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47621 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/45997 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30467 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47621 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184397 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33671 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37078 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/45997 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142863 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46000 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142744 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46678 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111413 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26161 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46678 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118429 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205088 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45195 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39756 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54757 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44595 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44827 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44654 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->