### PR TITLE
platform/mac/media/audio-session-deactivated-when-suspended.html is flaky failure

### DIFF
--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -497,26 +497,21 @@ void MediaSessionManagerInterface::sessionWillBeginPlayback(PlatformMediaSession
         // is visible to JS observers (e.g., the 'playing' event handler reading
         // internals.audioSessionActive()) by the time play() resolves.
         //
-        // Set m_becameActive on IPC success, not optimistically. An optimistic
-        // pre-IPC update would allow an interleaved maybeDeactivateAudioSession
-        // (triggered by a readyState or updateSessionState callback during the
-        // async window) to pass the !m_becameActive guard and send a spurious
-        // tryToSetActive(false) IPC. That deactivation IPC optimistically clears
-        // configuration().isActive before the "playing" event task runs, causing
-        // internals.audioSessionActive() to return false inside the handler.
-        // Setting m_becameActive only on success avoids that race.
-        //
-        // The session-deleted-before-reply case (e.g., iframe GC'd during the
-        // async window) is handled by the !activeAudioSessionRequired() check
-        // below: if no audio is needed after activation, deactivate immediately.
+        // Complete the playback admission FIRST — completeWillBeginPlayback()
+        // drives the session to State::Playing (via clientWillBeginPlayback's
+        // completion), so activeAudioSessionRequired() below reflects the real
+        // state. Checking before completion would see a not-yet-Playing session,
+        // wrongly report "no active session needed", and fire a spurious
+        // maybeDeactivateAudioSession(). The session-deleted case (e.g. iframe GC'd
+        // during the async window) never reaches Playing, so the check still
+        // deactivates and doesn't leak an active session.
         AudioSession::singleton().tryToSetActive(true)->whenSettled(RunLoop::mainSingleton(),
             [this, protectedThis = Ref { *this }, completeWillBeginPlayback = WTF::move(completeWillBeginPlayback)](auto&& result) mutable {
-                if (result) {
+                if (result)
                     m_becameActive = true;
-                    if (!activeAudioSessionRequired())
-                        maybeDeactivateAudioSession();
-                }
                 completeWillBeginPlayback(result.has_value());
+                if (result && !activeAudioSessionRequired())
+                    maybeDeactivateAudioSession();
             });
         return;
     }
@@ -605,6 +600,16 @@ void MediaSessionManagerInterface::sessionStateChanged(PlatformMediaSessionInter
 void MediaSessionManagerInterface::sessionCanProduceAudioChanged()
 {
     MEDIASESSIONMANAGERINTERFACE_RELEASE_LOG(SessionCanProduceAudioChanged);
+
+    // Activate synchronously so isActive() reflects the newly-audible
+    // state immediately. The WebContent process always holds a RemoteAudioSession
+    // (GPU process is always enabled), whose tryToSetActive sets m_active
+    // optimistically+synchronously — so internals.audioSessionActive() (and any
+    // 'playing'-handler read) sees the correct state without waiting for the
+    // debounced task below, which can otherwise land after the 'playing' event.
+    // No-op unless activeAudioSessionRequired(); redundant with the deferred call,
+    // which coalesces at RemoteAudioSession's IPC FIFO.
+    maybeActivateAudioSession();
 
     if (m_alreadyScheduledSessionStatedUpdate)
         return;


### PR DESCRIPTION
#### c3780e04920d6908a5810a914f6707d3cf916c1c
<pre>
platform/mac/media/audio-session-deactivated-when-suspended.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=318467">https://bugs.webkit.org/show_bug.cgi?id=318467</a>
<a href="https://rdar.apple.com/181251988">rdar://181251988</a>

Reviewed by NOBODY (OOPS!).

Since AudioSession activation became asynchronous, the audio session for a
playing <video> element is activated from an asynchronous task rather than
synchronously. When the media player finishes probing audio tracks,
HTMLMediaElement::canProduceAudioChanged() calls
MediaSessionManagerInterface::sessionCanProduceAudioChanged(), which enqueued
maybeActivateAudioSession() and updateSessionState() on the main thread. Under
load that task can run after the "playing" event, so a "playing" handler that
reads internals.audioSessionActive() (as this test does) can observe the session
as inactive even though it is about to be activated, causing the flaky failure.

The WebContent process always holds a RemoteAudioSession and
RemoteAudioSession::tryToSetActiveInternal() updates its active state
optimistically and synchronously. Calling maybeActivateAudioSession()
synchronously from sessionCanProduceAudioChanged() therefore makes isActive()
reflect the newly-audible state immediately, before the "playing" event fires,
without waiting for the debounced task. The synchronous call is a no-op unless
activeAudioSessionRequired(), and the redundant call still made from the
debounced task coalesces at RemoteAudioSession's IPC FIFO, so no additional IPC
is sent. updateSessionState() (audio session category and buffer size) remains
on the debounced task.

Additionally, in sessionWillBeginPlayback()'s activation path, complete the
playback admission before evaluating activeAudioSessionRequired(): completing
transitions the session to Playing, so the subsequent check reflects the real
state instead of a not-yet-Playing session and no longer fires a spurious
maybeDeactivateAudioSession(). The session-deleted case (e.g. an iframe garbage
collected during the async activation window) never reaches Playing, so the
check still deactivates and does not leak an active session.

* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::sessionWillBeginPlayback):
(WebCore::MediaSessionManagerInterface::sessionCanProduceAudioChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3780e04920d6908a5810a914f6707d3cf916c1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130216 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7a95bc9-5105-4552-803d-4b61a6f25ba4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134290 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94772 "3 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11930eb2-9279-46a0-a04f-6a9a9d3c953c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114762 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/213afbaf-7f88-46e3-a39e-78525235b4f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36327 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30717 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184651 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143080 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46250 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142957 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46928 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31173 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111857 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37967 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118680 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45445 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9282 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44845 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45077 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44904 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->