### PR TITLE
Web Inspector: Incorrect assertion of available agents for web-page target

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js
@@ -33,13 +33,8 @@ WI.MultiplexingBackendTarget = class MultiplexingBackendTarget extends WI.Target
         const targetId = "multi";
         super(parentTarget, targetId, WI.UIString("Web Page"), WI.TargetType.WebPage, InspectorBackend.backendConnection);
 
-        // Browser and Target are the only domains always present on the multiplexing
-        // target. Network and Page are optional: Network only appears under Site
-        // Isolation (ProxyingNetworkAgent), and both may be absent when inspecting an
-        // older device whose protocol predates them. The proxying Page domain, when
-        // present, lets the UIProcess PageAgent aggregate the frame tree across
-        // WebContent processes under Site Isolation. See NetworkManager.initializeTarget().
-        console.assert(Array.shallowEqual(Object.keys(this._agents).sort(), ["Browser", "Target"]));
+        console.assert(this.hasDomain("Browser"));
+        console.assert(this.hasDomain("Target"));
     }
 
     // Target


### PR DESCRIPTION
#### d5f7f99c4aa94a91eaff0b48a54351f658644521
<pre>
Web Inspector: Incorrect assertion of available agents for web-page target
<a href="https://bugs.webkit.org/show_bug.cgi?id=318470">https://bugs.webkit.org/show_bug.cgi?id=318470</a>

Reviewed by BJ Burg.

The assertion was wrong because the target might in fact have the Page
and Network domains which are introduced to support site isolation, and
the shallow-equality would fail. Browser and Target are the two domains
that must exist.

The comment and the explanation was correct but that constructor wasn&apos;t
the right context to include it. Remove it.

No new tests: no observable behavior change.

* Source/WebInspectorUI/UserInterface/Protocol/MultiplexingBackendTarget.js:
(WI.MultiplexingBackendTarget):

Canonical link: <a href="https://commits.webkit.org/316703@main">https://commits.webkit.org/316703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38eac71fd66857fd6ccd0e3cca8295c2df3a698

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129844 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8aacc11-9dcd-48f9-82b6-355c2a258dab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133997 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94531 "2 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f8e2e56-a1b5-4c3f-bdc7-efe57c8f2681) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114468 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/177df286-b58e-4372-b45a-73dbb77899b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36064 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30345 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184273 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142761 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45878 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38711 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46556 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111283 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37714 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118307 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45073 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8989 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44473 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44705 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->