### PR TITLE
[CMake] Don't apply the availability overlay to Swift on iOS

### DIFF
--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -82,7 +82,19 @@ file(WRITE "${_availability_overlay_yaml}.tmp"
 ")
 file(COPY_FILE "${_availability_overlay_yaml}.tmp" ${_availability_overlay_yaml} ONLY_IF_DIFFERENT)
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:SHELL:-ivfsoverlay ${_availability_overlay_yaml}>")
-add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${_availability_overlay_yaml}>")
+# The overlay strips API_UNAVAILABLE off SPI declarations, but the legacy
+# NS_CLASS_AVAILABLE/CF_AVAILABLE class attributes expand straight to
+# __attribute__((availability(ios,...))) and are not routed through any macro
+# the overlay stubs redefine. On iOS this leaves classes such as
+# CoreBluetooth's CBClassicPeer marked unavailable while their (now-available)
+# members reference them -- a hard error when the Swift ClangImporter emits the
+# framework's private module (e.g. CoreBluetooth_Private) against the internal
+# SDK. Keep the overlay off Swift on iOS, matching the non-Swift-only scoping
+# used before 316413@main; other Cocoa platforms are unaffected (the classic
+# Bluetooth classes are available on macOS).
+if (NOT CMAKE_OSX_SYSROOT MATCHES "iPhone")
+    add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${_availability_overlay_yaml}>")
+endif ()
 unset(_availability_overlay_dir)
 unset(_availability_overlay_yaml)
 


### PR DESCRIPTION
#### 68d1c3be9d607eec981c1ca61cf8d768beb1073d
<pre>
[CMake] Don&apos;t apply the availability overlay to Swift on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=318466">https://bugs.webkit.org/show_bug.cgi?id=318466</a>
<a href="https://rdar.apple.com/problem/181266073">rdar://problem/181266073</a>

Reviewed by NOBODY (OOPS!).

The availability overlay added in <a href="https://commits.webkit.org/316413@main">316413@main</a> stubs out &lt;Availability.h&gt;
and &lt;os/availability.h&gt; so that API_UNAVAILABLE(...) expands to nothing,
letting WebKit bind to SPI marked unavailable on the public SDK. It is
applied to both C++ and Swift, whereas the AvailabilityProhibitedInternal.h
mechanism it replaced was scoped to non-Swift only.

Restore the pre-<a href="https://commits.webkit.org/316413@main">316413@main</a> non-Swift-only scoping on iOS by gating the
Swift -vfsoverlay on a non-iPhone sysroot.

* Source/cmake/OptionsCocoa.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68d1c3be9d607eec981c1ca61cf8d768beb1073d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172294 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181746 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134007 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37439 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114478 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30351 "Failed to checkout and rebase branch from PR 68551") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3083 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184279 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33555 "Built successfully and passed tests") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142770 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45884 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142651 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46562 "Failed to checkout and rebase branch from PR 68551") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111289 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/46562 "Failed to checkout and rebase branch from PR 68551") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204972 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45079 "Failed to checkout and rebase branch from PR 68551") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8998 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54724 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44479 "Failed to checkout and rebase branch from PR 68551") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44538 "Failed to checkout and rebase branch from PR 68551") | | | | 
<!--EWS-Status-Bubble-End-->