### PR TITLE
[Site Isolation] Back navigation to an intermediate multi-process BFCache entry hangs when a cross-site iframe could not be cached

### DIFF
--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -79,7 +79,7 @@ public:
     void markPagesForCaptionPreferencesChanged();
 #endif
 
-    bool NODELETE isInBackForwardCache(BackForwardFrameItemIdentifier) const;
+    WEBCORE_EXPORT bool NODELETE isInBackForwardCache(BackForwardFrameItemIdentifier) const;
     bool hasCachedPageExpired(BackForwardFrameItemIdentifier) const;
 
 private:

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8909,7 +8909,7 @@ void WebPage::setIsSuspended(bool suspended, CompletionHandler<void(std::optiona
 void WebPage::suspendWithFrameItem(BackForwardFrameItemIdentifier identifier, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (m_isSuspended)
-        return completionHandler(true);
+        return completionHandler(BackForwardCache::singleton().isInBackForwardCache(identifier));
 
     RefPtr page = corePage();
     if (!page) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9386,6 +9386,48 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithCrossSiteIframe)
     checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheGoBackToIntermediateEntryDoesNotHang)
+{
+    // Same-site main-frame chain a -> b -> c, each hosting the same cross-site iframe. The iframe
+    // process is suspended when the first entry (a) is cached, so it cannot also cache the
+    // intermediate entry (b): its single live page is already suspended. Going back to b must
+    // therefore fall back to a normal load instead of attempting a back/forward-cache restore of
+    // iframe children that were never cached — which used to hang on a reload that never fired
+    // didFinishNavigation.
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/b"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/c"_s, { "<iframe src='https://b.com/frame'></iframe>"_s } },
+        { "/frame"_s, { "iframe content"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    EXPECT_EQ([webView backForwardList].backList.count, (NSUInteger)2);
+
+    // Back to the intermediate entry b. Must complete (not hang) and land on b.
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://a.com/b", [webView URL].absoluteString);
+
+    // The cross-site iframe subtree must be reconstructed after the fallback load — a regression
+    // that completed the main-frame navigation but dropped the iframe would otherwise pass.
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
+}
+
 TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithCrossSiteIframeMultipleCycles)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 22fa960e41397c6c2fd972209abfe04df4dfb6ae
<pre>
[Site Isolation] Back navigation to an intermediate multi-process BFCache entry hangs when a cross-site iframe could not be cached
<a href="https://bugs.webkit.org/show_bug.cgi?id=318475">https://bugs.webkit.org/show_bug.cgi?id=318475</a>
<a href="https://rdar.apple.com/181270033">rdar://181270033</a>

Reviewed by Sihui Liu.

Under Site Isolation with multi-process back/forward cache, a same-site
main-frame history chain (a -&gt; b -&gt; c) where each entry hosts a cross-site
iframe could hang when navigating back to an intermediate entry.

A cross-site subframe web process hosts a single WebPage with one
m_isSuspended flag, and BackForwardCache suspension operates on that one live
corePage(). When the first main-frame entry (a) is cached, the iframe process
suspends its single live page. When the UIProcess later asks it (via
SuspendWithFrameItem) to also cache the intermediate entry (b), the WebPage is
already suspended and its single live corePage() cannot be suspended again, so
b&apos;s iframe subframe is never added to that process&apos;s BackForwardCache.

WebPage::suspendWithFrameItem&apos;s already-suspended early-return replied
completionHandler(true) -- a false success -- so WebPageProxy::didCacheBackForwardItem
recorded b as having cached iframe children it never had. On back-navigation to
b, RestoreWithFrameItem -&gt; BackForwardCache::take returned NOT-FOUND, the restore
aggregator failed, and the UIProcess fell back to reload(ExpiredOnly), which
never fired didFinishNavigation, so the navigation hung until timing out.

Return the honest answer instead: whether this frame item is actually cached in
this process (isInBackForwardCache(identifier)). That is true for an idempotent
re-suspend of the same entry and false when the WebPage is suspended for a
different entry -- mirroring addIfCacheable&apos;s own return value. The false makes
the UIProcess discard b&apos;s unbacked entry, so back-to-b falls back to a normal
load that completes.

This is a targeted fix for the hang. The underlying limitation it works around
-- an iframe process can hold only one cached main-frame entry per WebPage --
still caps multi-entry BFCache coverage under Site Isolation and will be
addressed by a larger redesign (moving cached-entry ownership from the single
per-process WebPage down to a per-BFCache-entry frame snapshot), tracked in
<a href="https://bugs.webkit.org/show_bug.cgi?id=318474">https://bugs.webkit.org/show_bug.cgi?id=318474</a> (<a href="https://rdar.apple.com/181269874">rdar://181269874</a>).

* Source/WebCore/history/BackForwardCache.h: Export isInBackForwardCache.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::suspendWithFrameItem): Report whether the frame item is
actually cached rather than an unconditional success when already suspended.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST): Add MultiProcessBFCacheGoBackToIntermediateEntryDoesNotHang.

Canonical link: <a href="https://commits.webkit.org/316605@main">https://commits.webkit.org/316605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9363a66b3090506ad9d3e968c745d1ea4dd0fdb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181753 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129857 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9ae618b-af17-4dc1-ab8a-8c28399d1091) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134013 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94538 "1 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63572de1-9928-4fe2-a3a3-f5a729761fdd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114484 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8d1fbc8-5d70-4a87-91a6-0f1117e97edd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36074 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34411 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184286 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142774 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45891 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38646 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46569 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111296 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37722 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118320 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45086 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9005 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44545 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->