### PR TITLE
[Site Isolation] Web Inspector: main-frame subresource sometimes missing from Network under Site Isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain-expected.txt
@@ -1,0 +1,9 @@
+Test that a fetch triggered in the top-level main frame produces a WI.Resource attributed to the main frame under Site Isolation.
+
+
+== Running test suite: SiteIsolation.Network.MainFrame
+-- Running test case: SiteIsolation.Network.MainFrame.ResourceAddedForFetch
+PASS: Resource should be created.
+PASS: Resource URL should contain 'data.json'.
+PASS: Resource's parent frame should be the main frame.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain.html
@@ -1,0 +1,39 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script>
+function triggerMainFrameFetch() {
+    let url = "resources/data.json?" + Math.random();
+    fetch(url);
+}
+
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.MainFrame");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.MainFrame.ResourceAddedForFetch",
+        description: "A fetch triggered in the top-level main frame should produce a WI.Resource attributed to the main frame under Site Isolation (rdar://169739511).",
+        async test() {
+            // Listen for a resource to be added to any frame.
+            let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+
+            // Trigger the fetch from the main frame. Under Site Isolation the main frame runs in
+            // its own WebContent process; this asserts that its FrameNetworkAgentProxy is
+            // instrumented and its events route through ProxyingNetworkAgent to the frontend.
+            InspectorTest.evaluateInPage("triggerMainFrameFetch()");
+
+            let resourceEvent = await resourceAddedPromise;
+            let resource = resourceEvent.data.resource;
+
+            InspectorTest.expectThat(resource instanceof WI.Resource, "Resource should be created.");
+            InspectorTest.expectThat(resource.url.includes("data.json"), "Resource URL should contain 'data.json'.");
+            InspectorTest.expectEqual(resource.parentFrame, WI.networkManager.mainFrame, "Resource's parent frame should be the main frame.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that a fetch triggered in the top-level main frame produces a WI.Resource attributed to the main frame under Site Isolation.</p>
+</body>

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
@@ -126,14 +126,18 @@ Protocol::Network::LoaderId BackendIdentifierRegistry::loaderId(WebCore::Documen
 {
     if (!loader)
         return emptyString();
-    return m_loaderToIdentifier.ensure(loader, [protectedLoader = RefPtr { loader }] {
-        if (RefPtr frame = protectedLoader->frame()) {
-            if (RefPtr document = frame->document())
-                return protocolLoaderId(document->identifier());
-        }
-        // FIXME: Fallback for early instrumentation before document exists.
-        // This produces a legacy-format ID; deterministic ID will be assigned
-        // once the document is available. rdar://170087346
+
+    // Compute fresh from the current document rather than memoizing by raw DocumentLoader* which can go stale.
+    // protocolLoaderId() is deterministic in the document's ScriptExecutionContextIdentifier, so this matches
+    // the id network events report.
+    if (RefPtr frame = loader->frame()) {
+        if (RefPtr document = frame->document())
+            return protocolLoaderId(document->identifier());
+    }
+
+    // Fallback only when no document exists yet (early instrumentation): keep a stable per-loader
+    // id. This produces a legacy-format ID; a deterministic one is used once the document exists.
+    return m_loaderToIdentifier.ensure(loader, [] {
         return IdentifiersFactory::createIdentifier();
     }).iterator->value;
 }


### PR DESCRIPTION
#### 36e79ac25b963f8abeb3a6440e9df0008a217aaa
<pre>
[Site Isolation] Web Inspector: main-frame subresource sometimes missing from Network under Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=318472">https://bugs.webkit.org/show_bug.cgi?id=318472</a>

Reviewed by BJ Burg.

Under Site Isolation the inspector backend could report an inconsistent
loaderId for the main frame: the id in the Page.getResourceTree snapshot
did not match the id carried by the network events for resources loaded
by that same frame. Because of the mismatch, a subresource requested by
the main frame (for example via fetch()) could intermittently be handled
by the frontend as a provisional load and not attributed to the frame.

The frontend attributes a resource to a frame by matching loaderIds. A
resource gets its loaderId from the UIProcess ProxyingNetworkAgent,
which derives it freshly from the live document&apos;s
ScriptExecutionContextIdentifier. The frame gets its loaderId once,
from the page target&apos;s Page.getResourceTree snapshot, which came from
BackendIdentifierRegistry::loaderId() -- a value memoized in a map
keyed by the raw DocumentLoader*. That cached value could go stale
(minted while the loader was still provisional, or held against a
DocumentLoader* whose address was later reused), so getResourceTree
reported a loaderId that no longer matched the frame&apos;s live document.

When the two disagree, NetworkManager._addResourceToFrame treats the
resource as the start of a provisional navigation and hands it to
startProvisionalLoad() instead of adding it. Because staleness depended
on timing and pointer reuse, the failure was intermittent.

Fix BackendIdentifierRegistry::loaderId() to compute the id directly
from the loader&apos;s current document instead of memoizing.
protocolLoaderId() is a deterministic function of the document&apos;s
ScriptExecutionContextIdentifier, so it now always matches what network
events report; the map is kept only for the pre-document fallback. Its
sole caller under Site Isolation is
InspectorPageAgent::buildObjectForFrame() with the committed
documentLoader(), so frame-&gt;document() always reflects that loader&apos;s
own document. The pre-Site-Isolation LegacyIdentifierRegistry path is
unaffected.

Test: http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain.html
- Add the test we wanted to have, the main-frame variant of the sibling
  test cross-origin-iframe-resource-appears-in-network-domain.html,
  which would intermittently timing out without this patch.

* LayoutTests/http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/main-frame-resource-appears-in-network-domain.html: Added.
* Source/WebCore/inspector/InspectorIdentifierRegistry.cpp:
(Inspector::BackendIdentifierRegistry::loaderId):

Canonical link: <a href="https://commits.webkit.org/316758@main">https://commits.webkit.org/316758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f774fbcd6e45755692ba135a56391ee5e611e22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129859 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/654c9eec-99b8-4f74-af6a-5d3d00b0b366) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134014 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94540 "1 flakes 21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/203836e0-1946-430a-9ee7-dd7ac5ef7b8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37442 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154555 "Found 1 new API test failure: TestWebKitAPI.WebKit.MediaBufferingPolicy (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114485 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c3dd259-e27d-4dfd-a6c2-0ae8355c668e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36076 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34414 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30360 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184288 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142777 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142658 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46571 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111298 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37723 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118322 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45088 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9008 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44488 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44547 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->