### PR TITLE
Web Inspector: Network.setExtraHTTPHeaders should replace previously set headers instead of accumulating them

### DIFF
--- a/LayoutTests/http/tests/inspector/network/set-extra-http-headers-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/set-extra-http-headers-expected.txt
@@ -1,0 +1,9 @@
+Tests that Network.setExtraHTTPHeaders replaces previously set headers instead of accumulating them.
+
+
+== Running test suite: Network.setExtraHTTPHeaders
+-- Running test case: Network.setExtraHTTPHeaders.Replace
+PASS: First request should include "X-WebKit-Test-Header-A".
+PASS: Second request should include "X-WebKit-Test-Header-B".
+PASS: Second request should not include "X-WebKit-Test-Header-A" from the previous call.
+

--- a/LayoutTests/http/tests/inspector/network/set-extra-http-headers.html
+++ b/LayoutTests/http/tests/inspector/network/set-extra-http-headers.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function triggerFetch() {
+    fetch("resources/echo.py?content=test&r=" + Math.random());
+}
+
+function test()
+{
+    const headerA = "X-WebKit-Test-Header-A";
+    const valueA = "ValueA";
+    const headerB = "X-WebKit-Test-Header-B";
+    const valueB = "ValueB";
+
+    let suite = InspectorTest.createAsyncSuite("Network.setExtraHTTPHeaders");
+
+    async function loadAndGetResource() {
+        let [resourceWasAddedEvent] = await Promise.all([
+            WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded),
+            InspectorTest.evaluateInPage(`triggerFetch()`),
+        ]);
+        return resourceWasAddedEvent.data.resource;
+    }
+
+    suite.addTestCase({
+        name: "Network.setExtraHTTPHeaders.Replace",
+        description: "A subsequent Network.setExtraHTTPHeaders call replaces the previously set headers instead of accumulating them.",
+        async test() {
+            // First call sets header A.
+            await NetworkAgent.setExtraHTTPHeaders({[headerA]: valueA});
+            let firstResource = await loadAndGetResource();
+            InspectorTest.expectEqual(firstResource.requestHeaders.valueForCaseInsensitiveKey(headerA), valueA, `First request should include "${headerA}".`);
+
+            // Second call sets header B only. Header A must no longer be sent.
+            await NetworkAgent.setExtraHTTPHeaders({[headerB]: valueB});
+            let secondResource = await loadAndGetResource();
+            InspectorTest.expectEqual(secondResource.requestHeaders.valueForCaseInsensitiveKey(headerB), valueB, `Second request should include "${headerB}".`);
+            InspectorTest.expectThat(!secondResource.requestHeaders.valueForCaseInsensitiveKey(headerA), `Second request should not include "${headerA}" from the previous call.`);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that Network.setExtraHTTPHeaders replaces previously set headers instead of accumulating them.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -911,6 +911,8 @@ void InspectorNetworkAgent::continuePendingResponses()
 
 Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&& headers)
 {
+    m_extraRequestHeaders.clear();
+
     for (auto& entry : headers.get()) {
         auto stringValue = entry.value->asString();
         if (!!stringValue)


### PR DESCRIPTION
#### feb6c63a58b4ac76e95e02458ff696f389ef1f91
<pre>
Web Inspector: Network.setExtraHTTPHeaders should replace previously set headers instead of accumulating them
<a href="https://bugs.webkit.org/show_bug.cgi?id=318478">https://bugs.webkit.org/show_bug.cgi?id=318478</a>

Reviewed by Devin Rousso.

Network.setExtraHTTPHeaders merged each call&apos;s headers into the previously
stored set without clearing it first, so a header added by one call could
never be removed by a later call. Since each call fully specifies the extra
headers to send, clear the stored headers before applying the new ones.

* LayoutTests/http/tests/inspector/network/set-extra-http-headers.html: Added.
* LayoutTests/http/tests/inspector/network/set-extra-http-headers-expected.txt: Added.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::setExtraHTTPHeaders):

Canonical link: <a href="https://commits.webkit.org/316444@main">https://commits.webkit.org/316444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/412230626df3fda15ce96875d90e540c7c23b0c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134012 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37449 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114483 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30361 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184289 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142779 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45894 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154140 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142660 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46572 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111299 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37724 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45089 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9010 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->