### PR TITLE
Take 2: [iOS] Remove support for AVMediaSource from MediaDeviceRoute

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -39,7 +39,7 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
-OBJC_CLASS WebMediaSourceObserver;
+OBJC_CLASS WebPlaybackControlObserver;
 
 namespace WebCore {
 
@@ -91,9 +91,9 @@ public:
     virtual void timeRangeDidChange(MediaDeviceRoute&) { }
     virtual void readyDidChange(MediaDeviceRoute&) { }
     virtual void bufferingDidChange(MediaDeviceRoute&) { }
-    virtual void playbackErrorDidChange(MediaDeviceRoute&) { }
+    virtual void errorDidChange(MediaDeviceRoute&) { }
     virtual void audioOptionsDidChange(MediaDeviceRoute&) { }
-    virtual void currentPlaybackPositionDidChange(MediaDeviceRoute&) { }
+    virtual void playbackPositionDidChange(MediaDeviceRoute&) { }
     virtual void playingDidChange(MediaDeviceRoute&) { }
     virtual void playbackSpeedDidChange(MediaDeviceRoute&) { }
     virtual void scanSpeedDidChange(MediaDeviceRoute&) { }
@@ -120,16 +120,16 @@ public:
     MediaTimeRange timeRange() const;
     bool ready() const;
     bool buffering() const;
-    std::optional<MediaPlaybackSourceError> playbackError() const;
+    std::optional<MediaPlaybackSourceError> error() const;
     Vector<MediaSelectionOption> audioOptions() const;
-    MediaTime currentPlaybackPosition() const;
+    MediaTime playbackPosition() const;
     bool playing() const;
     float playbackSpeed() const;
     float scanSpeed() const;
     bool muted() const;
     float volume() const;
 
-    void setCurrentPlaybackPosition(MediaTime);
+    void setPlaybackPosition(MediaTime);
     void setPlaying(bool);
     void setPlaybackSpeed(float);
     void setScanSpeed(float);
@@ -141,7 +141,7 @@ private:
 
     WTF::UUID m_identifier;
     RetainPtr<WebMediaDevicePlatformRoute> m_platformRoute;
-    RetainPtr<WebMediaSourceObserver> m_mediaSourceObserver;
+    RetainPtr<WebPlaybackControlObserver> m_playbackControlObserver;
     WeakPtr<MediaDeviceRouteClient> m_client;
 #if HAVE(AVROUTING_FRAMEWORK)
     RetainPtr<WebMediaDevicePlatformRouteSession> m_routeSession;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -36,14 +36,16 @@
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
-#define FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
+#define FOR_EACH_READONLY_KEY_PATH(Macro) \
     Macro(timeRange, TimeRange, MediaTimeRange) \
     Macro(ready, Ready, bool) \
     Macro(buffering, Buffering, bool) \
     Macro(audioOptions, AudioOptions, Vector<MediaSelectionOption>) \
+    Macro(error, Error, std::optional<MediaPlaybackSourceError>) \
+    Macro(playbackPosition, PlaybackPosition, MediaTime) \
 \
 
-#define FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_READWRITE_KEY_PATH(Macro) \
     Macro(playing, Playing, bool) \
     Macro(playbackSpeed, PlaybackSpeed, float) \
     Macro(scanSpeed, ScanSpeed, float) \
@@ -51,43 +53,16 @@
     Macro(volume, Volume, float) \
 \
 
-#define FOR_EACH_COMMON_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
+#define FOR_EACH_KEY_PATH(Macro) \
+    FOR_EACH_READONLY_KEY_PATH(Macro) \
+    FOR_EACH_READWRITE_KEY_PATH(Macro) \
 \
 
-#define FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READONLY_KEY_PATH(Macro) \
-    Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
-\
-
-#define FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_READWRITE_KEY_PATH(Macro) \
-    Macro(currentPlaybackPosition, CurrentPlaybackPosition, MediaTime) \
-\
-
-#define FOR_EACH_MEDIA_SOURCE_KEY_PATH(Macro) \
-    FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH(Macro) \
-    FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH(Macro) \
-\
-
-#define FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(Macro) \
-    FOR_EACH_COMMON_KEY_PATH(Macro) \
-\
-
-#define ADD_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_mediaSource addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebMediaSourceObserverContext]; \
-\
-
-#define REMOVE_MEDIA_SOURCE_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_mediaSource removeObserver:self forKeyPath:@#KeyPath context:WebMediaSourceObserverContext]; \
-\
-
-#define ADD_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_playbackControl addObserver:self forKeyPath:@#KeyPath options:NSKeyValueObservingOptionInitial context:WebPlaybackControlObserverContext]; \
 \
 
-#define REMOVE_PLAYBACK_CONTROL_OBSERVER(KeyPath, SetterSuffix, Type) \
+#define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
     [_playbackControl removeObserver:self forKeyPath:@#KeyPath context:WebPlaybackControlObserverContext]; \
 \
 
@@ -108,37 +83,30 @@
 #define DEFINE_GETTER(KeyPath, SetterSuffix, Type) \
     Type MediaDeviceRoute::KeyPath() const \
     { \
-        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
-            return convert(playbackControl.get().KeyPath); \
-        return convert([m_mediaSourceObserver mediaSource].KeyPath); \
+        return convert([m_playbackControlObserver playbackControl].KeyPath); \
     } \
 \
 
 #define DEFINE_SETTER(KeyPath, SetterSuffix, Type) \
     void MediaDeviceRoute::set##SetterSuffix(Type KeyPath) \
     { \
-        if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) \
-            return [playbackControl set##SetterSuffix:convert(WTF::move(KeyPath))]; \
-        [[m_mediaSourceObserver mediaSource] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
+        [[m_playbackControlObserver playbackControl] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
     } \
 \
 
 NS_ASSUME_NONNULL_BEGIN
 
-static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
 static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverContext;
 
-@interface WebMediaSourceObserver : NSObject
+@interface WebPlaybackControlObserver : NSObject
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route NS_DESIGNATED_INITIALIZER;
-@property (nonatomic, nullable, strong) AVMediaSource *mediaSource;
 @property (nonatomic, nullable, strong) AVPlaybackControl *playbackControl;
 @end
 
-@implementation WebMediaSourceObserver {
+@implementation WebPlaybackControlObserver {
     WeakPtr<WebCore::MediaDeviceRoute> _route;
-    RetainPtr<AVMediaSource> _mediaSource;
     RetainPtr<AVPlaybackControl> _playbackControl;
 }
 
@@ -151,23 +119,6 @@ static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverCont
     return self;
 }
 
-- (AVMediaSource * _Nullable)mediaSource
-{
-    return _mediaSource.get();
-}
-
-- (void)setMediaSource:(AVMediaSource * _Nullable)mediaSource
-{
-    if (mediaSource)
-        self.playbackControl = nil;
-
-    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
-
-    _mediaSource = mediaSource;
-
-    FOR_EACH_MEDIA_SOURCE_KEY_PATH(ADD_MEDIA_SOURCE_OBSERVER)
-}
-
 - (AVPlaybackControl * _Nullable)playbackControl
 {
     return _playbackControl.get();
@@ -175,60 +126,29 @@ static void* WebPlaybackControlObserverContext = &WebPlaybackControlObserverCont
 
 - (void)setPlaybackControl:(AVPlaybackControl * _Nullable)playbackControl
 {
-    if (playbackControl)
-        self.mediaSource = nil;
-
-    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
 
     _playbackControl = playbackControl;
 
-    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(ADD_PLAYBACK_CONTROL_OBSERVER)
-    ADD_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
-    ADD_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+    FOR_EACH_KEY_PATH(ADD_OBSERVER)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context
 {
-    if (context != WebMediaSourceObserverContext && context != WebPlaybackControlObserverContext) {
+    if (context != WebPlaybackControlObserverContext) {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
 
     dispatch_async(mainDispatchQueueSingleton(), ^{
-        if (context == WebMediaSourceObserverContext) {
-            FOR_EACH_MEDIA_SOURCE_KEY_PATH(OBSERVE_VALUE)
-            ASSERT_NOT_REACHED();
-            return;
-        }
-
-        if ([keyPath isEqualToString:@"error"]) {
-            if (RefPtr route = _route.get()) {
-                if (RefPtr client = route->client())
-                    client->playbackErrorDidChange(*route);
-            }
-            return;
-        }
-        if ([keyPath isEqualToString:@"playbackPosition"]) {
-            if (RefPtr route = _route.get()) {
-                if (RefPtr client = route->client())
-                    client->currentPlaybackPositionDidChange(*route);
-            }
-            return;
-        }
-
-        FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(OBSERVE_VALUE)
+        FOR_EACH_KEY_PATH(OBSERVE_VALUE)
         ASSERT_NOT_REACHED();
     });
 }
 
 - (void)dealloc
 {
-    FOR_EACH_MEDIA_SOURCE_KEY_PATH(REMOVE_MEDIA_SOURCE_OBSERVER)
-    FOR_EACH_PLAYBACK_CONTROL_KEY_PATH(REMOVE_PLAYBACK_CONTROL_OBSERVER)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(error, Error, std::optional<MediaPlaybackSourceError>)
-    REMOVE_PLAYBACK_CONTROL_OBSERVER(playbackPosition, PlaybackPosition, AVPlaybackUserInterfacePlaybackPosition *)
+    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
     [super dealloc];
 }
 
@@ -258,6 +178,11 @@ static CMTime convert(MediaTime time)
 static MediaTime convert(CMTime time)
 {
     return PAL::toMediaTime(time);
+}
+
+static MediaTime convert(AVPlaybackUserInterfacePlaybackPosition *playbackPosition)
+{
+    return convert(playbackPosition.position);
 }
 
 static MediaTimeRange convert(CMTimeRange timeRange)
@@ -301,7 +226,7 @@ Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *plat
 MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
     : m_identifier { WTF::UUID::createVersion4() }
     , m_platformRoute { platformRoute }
-    , m_mediaSourceObserver { adoptNS([[WebMediaSourceObserver alloc] initWithRoute:*this]) }
+    , m_playbackControlObserver { adoptNS([[WebPlaybackControlObserver alloc] initWithRoute:*this]) }
 {
 }
 
@@ -315,29 +240,10 @@ WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
     return m_platformRoute.get();
 }
 
-std::optional<MediaPlaybackSourceError> MediaDeviceRoute::playbackError() const
+void MediaDeviceRoute::setPlaybackPosition(MediaTime playbackPosition)
 {
-    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
-        return convert(playbackControl.get().error);
-    return convert([m_mediaSourceObserver mediaSource].playbackError);
-}
-
-MediaTime MediaDeviceRoute::currentPlaybackPosition() const
-{
-    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl])
-        return convert(playbackControl.get().playbackPosition.position);
-    return convert([m_mediaSourceObserver mediaSource].currentPlaybackPosition);
-}
-
-void MediaDeviceRoute::setCurrentPlaybackPosition(MediaTime currentPlaybackPosition)
-{
-    if (RetainPtr playbackControl = [m_mediaSourceObserver playbackControl]) {
-        // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
-        [playbackControl seekToPosition:convert(WTF::move(currentPlaybackPosition)) tolerance:PAL::kCMTimeZero];
-        return;
-    }
-
-    [m_mediaSourceObserver mediaSource].currentPlaybackPosition = convert(WTF::move(currentPlaybackPosition));
+    // FIXME: We should introduce a proper seek-with-tolerance function on MediaDeviceRoute rather than assuming a zero tolerance here.
+    [[m_playbackControlObserver playbackControl] seekToPosition:convert(WTF::move(playbackPosition)) tolerance:PAL::kCMTimeZero];
 }
 
 MediaDeviceRoute::~MediaDeviceRoute()
@@ -347,22 +253,16 @@ MediaDeviceRoute::~MediaDeviceRoute()
 #endif
 }
 
-FOR_EACH_COMMON_KEY_PATH(DEFINE_GETTER)
-FOR_EACH_COMMON_READWRITE_KEY_PATH(DEFINE_SETTER)
+FOR_EACH_KEY_PATH(DEFINE_GETTER)
+FOR_EACH_READWRITE_KEY_PATH(DEFINE_SETTER)
 
 } // namespace WebCore
 
-#undef FOR_EACH_COMMON_READONLY_KEY_PATH
-#undef FOR_EACH_COMMON_READWRITE_KEY_PATH
-#undef FOR_EACH_COMMON_KEY_PATH
-#undef FOR_EACH_MEDIA_SOURCE_READONLY_KEY_PATH
-#undef FOR_EACH_MEDIA_SOURCE_READWRITE_KEY_PATH
-#undef FOR_EACH_MEDIA_SOURCE_KEY_PATH
-#undef FOR_EACH_PLAYBACK_CONTROL_KEY_PATH
-#undef ADD_MEDIA_SOURCE_OBSERVER
-#undef REMOVE_MEDIA_SOURCE_OBSERVER
-#undef ADD_PLAYBACK_CONTROL_OBSERVER
-#undef REMOVE_PLAYBACK_CONTROL_OBSERVER
+#undef FOR_EACH_READONLY_KEY_PATH
+#undef FOR_EACH_READWRITE_KEY_PATH
+#undef FOR_EACH_KEY_PATH
+#undef ADD_OBSERVER
+#undef REMOVE_OBSERVER
 #undef OBSERVE_VALUE
 #undef DEFINE_GETTER
 #undef DEFINE_SETTER

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -280,7 +280,7 @@ void MediaPlayerPrivateWirelessPlayback::seekToTarget(const SeekTarget& seekTarg
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, seekTarget);
-    route->setCurrentPlaybackPosition(seekTarget.time);
+    route->setPlaybackPosition(seekTarget.time);
 }
 
 bool MediaPlayerPrivateWirelessPlayback::paused() const
@@ -430,12 +430,12 @@ void MediaPlayerPrivateWirelessPlayback::readyDidChange(MediaDeviceRoute& route)
         setReadyState(MediaPlayerReadyState::HaveEnoughData);
 }
 
-void MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange(MediaDeviceRoute& route)
+void MediaPlayerPrivateWirelessPlayback::errorDidChange(MediaDeviceRoute& route)
 {
     ASSERT(&route == this->route());
-    ALWAYS_LOG(LOGIDENTIFIER, !!route.playbackError());
+    ALWAYS_LOG(LOGIDENTIFIER, !!route.error());
 
-    if (route.playbackError())
+    if (route.error())
         setNetworkState(route.ready() ? MediaPlayer::NetworkState::DecodeError : MediaPlayer::NetworkState::FormatError);
 }
 
@@ -448,14 +448,14 @@ void MediaPlayerPrivateWirelessPlayback::audioOptionsDidChange(MediaDeviceRoute&
         player->characteristicChanged();
 }
 
-void MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange(MediaDeviceRoute& route)
+void MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange(MediaDeviceRoute& route)
 {
     ASSERT(&route == this->route());
 
-    auto currentPlaybackPosition = route.currentPlaybackPosition();
-    ALWAYS_LOG(LOGIDENTIFIER, currentPlaybackPosition);
+    auto playbackPosition = route.playbackPosition();
+    ALWAYS_LOG(LOGIDENTIFIER, playbackPosition);
 
-    updateTimebaseTimeAndRate(currentPlaybackPosition, route.playing() ? route.playbackSpeed() : 0);
+    updateTimebaseTimeAndRate(playbackPosition, route.playing() ? route.playbackSpeed() : 0);
 
     auto currentTime = this->currentTime();
 
@@ -492,7 +492,7 @@ CMTimebaseRef MediaPlayerPrivateWirelessPlayback::ensureTimebase()
     dispatch_activate(m_timerSource.get());
 
     if (RefPtr route = this->route())
-        updateTimebaseTimeAndRate(route->currentPlaybackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
+        updateTimebaseTimeAndRate(route->playbackPosition() ?: MediaTime::zeroTime(), route->playing() ? route->playbackSpeed() : 0);
 
     return m_timebase.get();
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -129,9 +129,9 @@ private:
     // MediaDeviceRouteClient
     void timeRangeDidChange(MediaDeviceRoute&) final;
     void readyDidChange(MediaDeviceRoute&) final;
-    void playbackErrorDidChange(MediaDeviceRoute&) final;
+    void errorDidChange(MediaDeviceRoute&) final;
     void audioOptionsDidChange(MediaDeviceRoute&) final;
-    void currentPlaybackPositionDidChange(MediaDeviceRoute&) final;
+    void playbackPositionDidChange(MediaDeviceRoute&) final;
 
     CMTimebaseRef ensureTimebase();
     void destroyTimebase();


### PR DESCRIPTION
#### 2ebd30036b52f3f2999a12e54b2da051268b1895
<pre>
Take 2: [iOS] Remove support for AVMediaSource from MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=318481">https://bugs.webkit.org/show_bug.cgi?id=318481</a>
<a href="https://rdar.apple.com/181273446">rdar://181273446</a>

Reviewed by Jer Noble.

Removed support for AVMediaSource from MediaDeviceRoute and simplified the code now that an
AVPlaybackControl-conforming object is the only observee.

No new tests. Covered by existing tests.

* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRouteClient::errorDidChange):
(WebCore::MediaDeviceRouteClient::playbackPositionDidChange):
(WebCore::MediaDeviceRouteClient::playbackErrorDidChange): Deleted.
(WebCore::MediaDeviceRouteClient::currentPlaybackPositionDidChange): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebPlaybackControlObserver setPlaybackControl:]):
(-[WebPlaybackControlObserver observeValueForKeyPath:ofObject:change:context:]):
(-[WebPlaybackControlObserver dealloc]):
(WebCore::convert):
(WebCore::MediaDeviceRoute::setPlaybackPosition):
(-[WebMediaSourceObserver initWithRoute:]): Deleted.
(-[WebMediaSourceObserver mediaSource]): Deleted.
(-[WebMediaSourceObserver setMediaSource:]): Deleted.
(-[WebMediaSourceObserver playbackControl]): Deleted.
(-[WebMediaSourceObserver setPlaybackControl:]): Deleted.
(-[WebMediaSourceObserver observeValueForKeyPath:ofObject:change:context:]): Deleted.
(-[WebMediaSourceObserver dealloc]): Deleted.
(WebCore::MediaDeviceRoute::playbackError const): Deleted.
(WebCore::MediaDeviceRoute::currentPlaybackPosition const): Deleted.
(WebCore::MediaDeviceRoute::setCurrentPlaybackPosition): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::seekToTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::errorDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackPositionDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::ensureTimebase):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange): Deleted.
(WebCore::MediaPlayerPrivateWirelessPlayback::currentPlaybackPositionDidChange): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:

Canonical link: <a href="https://commits.webkit.org/316434@main">https://commits.webkit.org/316434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ec138b075d1b04b5d94997ee597f5c95eb0f2d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46227 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181761 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129865 "Failed to checkout and rebase branch from PR 68559") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4810f073-d22a-49b5-80f6-86d4353fe8b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45870 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/129865 "Failed to checkout and rebase branch from PR 68559") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/865f2e63-c23d-439f-90ad-7e27c3d4db25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114491 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f344ad6d-1b0e-4742-b727-82fbb951f67a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30366 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184294 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45899 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142664 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/38517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111304 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26152 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45094 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44494 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44553 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->