### PR TITLE
Web Inspector: Network.interceptWithRequest crashes if the request was already aborted

### DIFF
--- a/LayoutTests/inspector/network/intercept-aborted-request-expected.txt
+++ b/LayoutTests/inspector/network/intercept-aborted-request-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Fetch is aborted
 CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Fetch is aborted
+CONSOLE MESSAGE: Unhandled Promise Rejection: AbortError: Fetch is aborted
 Test request interception of the aborted request.
 
 
@@ -30,6 +31,21 @@ PASS: Should produce an exception.
     {
       "code": -32000,
       "message": "Unable to abort request, it has already been processed"
+    }
+  ]
+}
+
+-- Running test case: Network.InterceptAbortedRequest.Request
+Triggering load...
+Intercepting with request...
+PASS: Should produce an exception.
+{
+  "code": -32000,
+  "message": "Unable to intercept request, it has already been processed",
+  "data": [
+    {
+      "code": -32000,
+      "message": "Unable to intercept request, it has already been processed"
     }
   ]
 }

--- a/LayoutTests/inspector/network/intercept-aborted-request.html
+++ b/LayoutTests/inspector/network/intercept-aborted-request.html
@@ -74,6 +74,28 @@ function test()
         },
     });
 
+    suite.addTestCase({
+        name: "Network.InterceptAbortedRequest.Request",
+        description: "Tests request interception that continues an aborted request with a request",
+        async test() {
+            ProtocolTest.log("Triggering load...");
+            let [requestInterceptedEvent] = await Promise.all([
+                InspectorProtocol.awaitEvent({event: "Network.requestIntercepted"}),
+                ProtocolTest.evaluateInPage(`fetchAndAbort()`),
+            ]);
+
+            ProtocolTest.log("Intercepting with request...");
+            await ProtocolTest.expectException(async () => {
+                await InspectorProtocol.awaitCommand({
+                    method: "Network.interceptWithRequest",
+                    params: {
+                        requestId: requestInterceptedEvent.params.requestId,
+                    },
+                });
+            });
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1206,6 +1206,9 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithReq
         return makeUnexpected("Missing pending intercept request for given requestId"_s);
 
     Ref loader = *pendingRequest->m_loader;
+    if (loader->reachedTerminalState())
+        return makeUnexpected("Unable to intercept request, it has already been processed"_s);
+
     ResourceRequest request = loader->request();
     if (!!url)
         request.setURL(URL({ }, url));


### PR DESCRIPTION
#### 60dafe23e70a13d7e3489dba01050a936d6d6759
<pre>
Web Inspector: Network.interceptWithRequest crashes if the request was already aborted
<a href="https://bugs.webkit.org/show_bug.cgi?id=318482">https://bugs.webkit.org/show_bug.cgi?id=318482</a>

Reviewed by Devin Rousso.

Unlike Network.interceptRequestWithResponse and Network.interceptRequestWithError,
Network.interceptWithRequest did not check whether the intercepted loader had
already reached its terminal state. If the request was aborted while the intercept
was still pending, continuing it operated on a terminal loader and crashed. Add the
same reachedTerminalState() guard the sibling commands already use.

* LayoutTests/inspector/network/intercept-aborted-request-expected.txt:
* LayoutTests/inspector/network/intercept-aborted-request.html:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::interceptWithRequest):

Canonical link: <a href="https://commits.webkit.org/316445@main">https://commits.webkit.org/316445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24910dd4e9fc019c598f95c3d065485eff2a0843

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134016 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37454 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114487 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36088 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30367 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184295 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142784 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45900 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154142 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38531 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46578 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111305 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37726 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45095 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9012 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->