### PR TITLE
[Site Isolation] datalist-cross-origin-iframe.html is a constant timeout on iOS

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8542,7 +8542,6 @@ http/tests/cache/cancel-multiple-post-xhrs.html [ Pass Failure ] # rdar://178676
 http/tests/download/anchor-download-redirect-cross-origin.html [ Pass Crash ] # rdar://178214780
 http/tests/privateClickMeasurement/database-disabled-in-ephemeral-session.html [ Pass Timeout Crash ] # rdar://176608751, rdar://179387095
 http/tests/security/referrer-policy-header-invalid.html [ Pass Timeout ] # rdar://178168636
-http/tests/site-isolation/datalist-cross-origin-iframe.html [ Timeout ] # rdar://179387257
 http/tests/site-isolation/selection-focus.html [ ImageOnlyFailure ] # rdar://163216880
 http/tests/site-isolation/type-in-cross-origin-iframe.html [ Failure Timeout ] # rdar://178168718
 http/wpt/service-workers/persistent-modules.html [ Pass Failure ] # rdar://178676392

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -927,8 +927,16 @@ void WebPageProxy::elementDidFocus(IPC::Connection& connection, const FocusedEle
             if (!pageClient)
                 return;
 
+            bool focusedElementIsInRemoteFrame = convertedInfo.frame && !convertedInfo.frame->isMainFrame;
+
             pageClient->elementDidFocus(convertedInfo, userIsInteracting,
                 blurPreviousNode, activityStateChanges, userDataObject.get());
+
+            // Converting the rects of a remote frame element takes an IPC round trip, during which the
+            // post-layout EditorState for this focus usually arrives and is dropped because nothing was
+            // waiting for it yet. Ask for another one.
+            if (focusedElementIsInRemoteFrame && protectedThis->waitingForPostLayoutEditorStateUpdateAfterFocusingElement())
+                protectedThis->scheduleFullEditorStateUpdate();
         });
 }
 


### PR DESCRIPTION
#### 4cd241990dd995176a36fda18911e39e30125ba0
<pre>
[Site Isolation] datalist-cross-origin-iframe.html is a constant timeout on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=318484">https://bugs.webkit.org/show_bug.cgi?id=318484</a>
<a href="https://rdar.apple.com/179387257">rdar://179387257</a>

Reviewed by NOBODY (OOPS!).

The test taps the datalist indicator of an input inside a cross-origin iframe and
waits for the suggestions to be shown. -[WKDataListSuggestionsDropdown _showSuggestions]
defers presenting the suggestions menu with -[WKContentView
doAfterEditorStateUpdateAfterFocusingElement:], which waits for
WebPageProxy::dispatchDidUpdateEditorState() to observe the post-layout EditorState
computed for the newly focused element. Under site isolation that never happened, so the
suggestions were never presented and the test timed out.

The web process emits ElementDidFocus from WebPage::updateRendering() and commits the
post-layout EditorState in the same RemoteLayerTreeDrawingArea::flushLayers(), so the two
arrive back to back. When the focused element is in a remote frame, WebPageProxy::
elementDidFocus() first has to convert the element rects to main frame coordinates, which
is an IPC round trip through the parent frame&apos;s process, so PageClient::elementDidFocus()
(and with it setWaitingForPostLayoutEditorStateUpdateAfterFocusingElement(true)) only runs
after that round trip. The EditorState therefore lands while nothing is waiting for it,
dispatchDidUpdateEditorState() does nothing, and the wait is never satisfied because no
further post-layout update is scheduled. For a main frame focus the conversion completes
synchronously and the ordering works out, which is why this only reproduces under site
isolation.

Request another editor state update once the client has been told about a remote frame
focus and is waiting for the post-layout EditorState. Unmark the test as timing out.

Note that this also leaves RevealFocusedElementDeferralReason::EditorState unfulfilled, so
zooming to reveal a focused element in a remote frame was deferred forever as well.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::elementDidFocus):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cd241990dd995176a36fda18911e39e30125ba0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/140606 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66da1dc9-02d1-4289-8237-b3f0cfb74bd5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/51006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138217 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96311 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0398c44-f2df-4312-8d30-b22d9ca28647) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118682 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60dbe2a1-fa7c-4ed4-93e0-28ac6d4b43e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40376 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38753 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38463 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35430 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189391 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50963 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147308 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51646 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147100 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41819 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123861 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118199 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50154 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13441 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49550 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49790 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49612 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->