### PR TITLE
com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::createVideoInfoFromFormatDescription

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -100,19 +100,75 @@ static RetainPtr<CFStringRef> cfStringFromFourCC(FourCC fourCC)
     return adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, string.begin(), kCFStringEncodingASCII));
 }
 
+static Vector<std::pair<FourCC, Ref<SharedBuffer>>> parseExtensionAtomsDictionary(CFDictionaryRef atomDictionary, size_t indexStart = 0)
+{
+    CFIndex extensionCount = CFDictionaryGetCount(atomDictionary);
+    if (CFIndex(indexStart) >= extensionCount)
+        return { };
+
+    Vector<const void*, 1> keys(extensionCount);
+    Vector<const void*, 1> values(extensionCount);
+    CFDictionaryGetKeysAndValues(atomDictionary, keys.mutableSpan().data(), values.mutableSpan().data());
+    Vector<std::pair<FourCC, Ref<SharedBuffer>>> result;
+    result.reserveInitialCapacity(extensionCount - indexStart);
+    // Per CMFormatDescription.h, each value is either a CFData payload or a CFArray
+    // of CFData (multiple atoms of the same FourCC). Expand arrays into multiple
+    // entries sharing a FourCC.
+    for (CFIndex index = indexStart; index < extensionCount; ++index) {
+        auto fourCC = cfStringToFourCC(checked_cf_cast<CFStringRef>(keys[index]));
+        CFTypeRef value = static_cast<CFTypeRef>(values[index]);
+        if (RetainPtr data = dynamic_cf_cast<CFDataRef>(value))
+            result.append({ fourCC, SharedBuffer::create(data.get()) });
+        else if (RetainPtr array = dynamic_cf_cast<CFArrayRef>(value)) {
+            CFIndex arrayCount = CFArrayGetCount(array.get());
+            for (CFIndex arrayIndex = 0; arrayIndex < arrayCount; ++arrayIndex) {
+                if (RetainPtr entry = dynamic_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(array.get(), arrayIndex)))
+                    result.append({ fourCC, SharedBuffer::create(entry.get()) });
+            }
+        } else
+            RELEASE_LOG_ERROR(Media, "Unexpected value type in SampleDescriptionExtensionAtoms for FourCC %s", fourCC.string().begin());
+    }
+    return result;
+}
+
 static RetainPtr<CFDictionaryRef> createExtensionAtomsDictionary(const Vector<std::pair<FourCC, Ref<SharedBuffer>>>& configurations)
 {
-    Vector<RetainPtr<CFTypeRef>> configurationCFStringKeys = { configurations.size(), [&](auto index) {
-        return cfStringFromFourCC(configurations[index].first);
+    Vector<FourCC> orderedKeys;
+    Vector<Vector<RetainPtr<CFDataRef>>> groupedDatas;
+    orderedKeys.reserveInitialCapacity(configurations.size());
+    groupedDatas.reserveInitialCapacity(configurations.size());
+    for (auto& [fourCC, buffer] : configurations) {
+        size_t existingIndex = notFound;
+        for (size_t i = 0; i < orderedKeys.size(); ++i) {
+            if (orderedKeys[i] == fourCC) {
+                existingIndex = i;
+                break;
+            }
+        }
+        if (existingIndex == notFound) {
+            orderedKeys.append(fourCC);
+            groupedDatas.append({ buffer->createCFData() });
+        } else
+            groupedDatas[existingIndex].append(buffer->createCFData());
+    }
+
+    Vector<RetainPtr<CFTypeRef>> retainedKeys = { orderedKeys.size(), [&](auto index) -> RetainPtr<CFTypeRef> {
+        return cfStringFromFourCC(orderedKeys[index]);
     } };
-    Vector<RetainPtr<CFDataRef>> configurationValues = { configurations.size(), [&](auto index) {
-        return configurations[index].second->createCFData();
+    Vector<RetainPtr<CFTypeRef>> retainedValues = { groupedDatas.size(), [&](auto index) -> RetainPtr<CFTypeRef> {
+        auto& datas = groupedDatas[index];
+        if (datas.size() == 1)
+            return datas[0];
+        Vector<CFTypeRef> rawDatas(datas.size(), [&](auto j) {
+            return datas[j].get();
+        });
+        return adoptCF(CFArrayCreate(kCFAllocatorDefault, rawDatas.begin(), rawDatas.size(), &kCFTypeArrayCallBacks));
     } };
-    Vector<CFTypeRef> rawConfigurationKeys(configurationCFStringKeys.size(), [&](auto index) {
-        return configurationCFStringKeys[index].get();
+    Vector<CFTypeRef> rawConfigurationKeys(retainedKeys.size(), [&](auto index) {
+        return retainedKeys[index].get();
     });
-    Vector<CFTypeRef> rawConfigurationValues(configurationValues.size(), [&](auto index) {
-        return configurationValues[index].get();
+    Vector<CFTypeRef> rawConfigurationValues(retainedValues.size(), [&](auto index) {
+        return retainedValues[index].get();
     });
     ASSERT(rawConfigurationKeys.size() == rawConfigurationValues.size());
 
@@ -144,6 +200,16 @@ static std::optional<EncryptionDataCollection> getEncryptionDataCollection(CMFor
         encryptionOriginalFormat = plainTextCodecType;
     }
 
+    // For video, every atom in this dictionary (including any codec configuration atom) is
+    // already captured in full by VideoInfo::extensionAtoms(); encryptionInitDatas is left
+    // empty here for video so createExtensionsDictionary() sources these atoms from a single place.
+    if (PAL::CMFormatDescriptionGetMediaType(description) == kCMMediaType_Video) {
+        return EncryptionDataCollection {
+            .encryptionData = WTF::move(*encryptionData),
+            .encryptionOriginalFormat = encryptionOriginalFormat
+        };
+    }
+
     RetainPtr extensionAtoms = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(description, PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
     if (!extensionAtoms) {
         return EncryptionDataCollection {
@@ -152,22 +218,7 @@ static std::optional<EncryptionDataCollection> getEncryptionDataCollection(CMFor
         };
     }
 
-    // For video content, the first element of the dictionary is always the video's atomData.
-    size_t indexStart = PAL::CMFormatDescriptionGetMediaType(description) == kCMMediaType_Video;
-    size_t extensionsCount = CFDictionaryGetCount(extensionAtoms.get());
-    if (extensionsCount <= indexStart) {
-        return EncryptionDataCollection {
-            .encryptionData = WTF::move(*encryptionData),
-            .encryptionOriginalFormat = encryptionOriginalFormat
-        };
-    }
-
-    Vector<const void*, 2> keys(extensionsCount);
-    Vector<const void*, 2> values(extensionsCount);
-    CFDictionaryGetKeysAndValues(extensionAtoms.get(), keys.mutableSpan().data(), values.mutableSpan().data());
-    Vector<TrackInfoEncryptionInitData> encryptionInitDatas = { size_t(extensionsCount) - indexStart, [&](auto index) -> TrackInfoEncryptionInitData {
-        return { cfStringToFourCC(static_cast<CFStringRef>(keys[index + indexStart])), SharedBuffer::create(static_cast<CFDataRef>(values[index + indexStart])) };
-    } };
+    auto encryptionInitDatas = parseExtensionAtomsDictionary(extensionAtoms.get());
 
     return EncryptionDataCollection {
         .encryptionData = WTF::move(*encryptionData),
@@ -467,14 +518,8 @@ RefPtr<VideoInfo> createVideoInfoFromFormatDescription(CMFormatDescriptionRef de
         CFIndex extensionCount = CFDictionaryGetCount(atomDictionary.get());
         if (!extensionCount)
             RELEASE_LOG_INFO(Media, "kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms having %ld keys keys expected at least 1", extensionCount);
-        else {
-            Vector<const void*, 1> keys(extensionCount);
-            Vector<const void*, 1> values(extensionCount);
-            CFDictionaryGetKeysAndValues(atomDictionary.get(), keys.mutableSpan().data(), values.mutableSpan().data());
-            extensionAtoms = { size_t(extensionCount), [&](auto index) -> TrackInfo::AtomData {
-                return { cfStringToFourCC(checked_cf_cast<CFStringRef>(keys[index])), SharedBuffer::create(checked_cf_cast<CFDataRef>(values[index])) };
-            } };
-        }
+        else
+            extensionAtoms = parseExtensionAtomsDictionary(atomDictionary.get());
     } else
         RELEASE_LOG_ERROR(Media, "Couldn't retrieve extensionAtoms from CMFormatDescription");
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
@@ -35,9 +35,11 @@
 #import <WebCore/PlatformVideoColorSpace.h>
 #import <WebCore/PlatformVideoMatrixCoefficients.h>
 #import <WebCore/PlatformVideoTransferCharacteristics.h>
+#import <WebCore/SharedBuffer.h>
 #import <WebCore/TrackInfo.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cf/TypeCastsCF.h>
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
@@ -127,6 +129,158 @@ TEST(CMUtilities, GetKeyIDsWithActiveGigacage)
         for (size_t i = 0; i < 16; ++i)
             EXPECT_EQ(span[i], uint8_t(i));
     }
+}
+
+// Verifies that when a video format description carries both encryption extensions and
+// SampleDescriptionExtensionAtoms, each atom is emitted exactly once (as CFData) rather than
+// as a CFArray of duplicate entries.
+TEST(CMUtilities, EncryptedVideoExtensionAtomsRoundTripDoesNotDuplicate)
+{
+    constexpr uint8_t tencData[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+    };
+    constexpr uint8_t dvcCBuf[] = { 0x01, 0x02, 0x03 };
+    constexpr uint8_t hvcCBuf[] = { 0x0a, 0x0b };
+
+    WebCore::EncryptionDataCollection encryptionCollection {
+        .encryptionData = { WebCore::EncryptionBoxType::CommonEncryptionTrackEncryptionBox, WebCore::SharedBuffer::create(std::span<const uint8_t> { tencData, sizeof(tencData) }) },
+    };
+
+    auto videoInfo = WebCore::VideoInfo::create({
+        { .codecName = WebCore::FourCC('hvc1'), .encryptionData = WTF::move(encryptionCollection) }, {
+            .size = { 640, 480 },
+            .displaySize = { 640, 480 },
+            .extensionAtoms = {
+                { WebCore::FourCC('dvcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { dvcCBuf, sizeof(dvcCBuf) }) },
+                { WebCore::FourCC('hvcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { hvcCBuf, sizeof(hvcCBuf) }) },
+            },
+        }
+    });
+
+    auto desc = WebCore::createFormatDescriptionFromTrackInfo(videoInfo);
+    ASSERT_TRUE(desc);
+
+    RetainPtr atomDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(desc.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    ASSERT_TRUE(atomDict);
+    ASSERT_EQ(CFDictionaryGetCount(atomDict.get()), 2);
+
+    auto dvcCValue = CFDictionaryGetValue(atomDict.get(), CFSTR("dvcC"));
+    ASSERT_TRUE(dvcCValue);
+    EXPECT_EQ(CFGetTypeID(dvcCValue), CFDataGetTypeID());
+    ASSERT_EQ(CFDataGetLength(checked_cf_cast<CFDataRef>(dvcCValue)), 3);
+
+    auto hvcCValue = CFDictionaryGetValue(atomDict.get(), CFSTR("hvcC"));
+    ASSERT_TRUE(hvcCValue);
+    EXPECT_EQ(CFGetTypeID(hvcCValue), CFDataGetTypeID());
+    ASSERT_EQ(CFDataGetLength(checked_cf_cast<CFDataRef>(hvcCValue)), 2);
+}
+
+// Verifies the WebContent -> GPU-process round trip: parsing an encrypted CMFormatDescription
+// into a VideoInfo and rebuilding a CMFormatDescription from it preserves each extension atom
+// exactly once.
+TEST(CMUtilities, EncryptedVideoFormatDescriptionRoundTripDoesNotDuplicateAtoms)
+{
+    constexpr uint8_t tencData[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+    };
+    constexpr uint8_t dvcCBuf[] = { 0x01, 0x02, 0x03 };
+    constexpr uint8_t hvcCBuf[] = { 0x0a, 0x0b };
+    RetainPtr tencCFData = adoptCF(CFDataCreate(kCFAllocatorDefault, tencData, sizeof(tencData)));
+    NSData *dvcCData = [NSData dataWithBytes:dvcCBuf length:sizeof(dvcCBuf)];
+    NSData *hvcCData = [NSData dataWithBytes:hvcCBuf length:sizeof(hvcCBuf)];
+    NSDictionary *extensions = @{
+        (__bridge NSString *)PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms: @{ @"dvcC": dvcCData, @"hvcC": hvcCData },
+        @"CommonEncryptionTrackEncryptionBox": (__bridge NSData *)tencCFData.get(),
+    };
+    CMFormatDescriptionRef rawDesc = nullptr;
+    PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_HEVC, 1920, 1080, (__bridge CFDictionaryRef)extensions, &rawDesc);
+    RetainPtr desc = adoptCF(rawDesc);
+    ASSERT_TRUE(desc.get());
+
+    RefPtr videoInfo = WebCore::createVideoInfoFromFormatDescription(desc.get());
+    ASSERT_TRUE(videoInfo);
+    ASSERT_TRUE(videoInfo->encryptionDataCollection());
+    EXPECT_TRUE(videoInfo->encryptionDataCollection()->encryptionInitDatas.isEmpty());
+    ASSERT_EQ(videoInfo->extensionAtoms().size(), 2u);
+
+    RetainPtr reconstructed = WebCore::createFormatDescriptionFromTrackInfo(*videoInfo);
+    ASSERT_TRUE(reconstructed);
+
+    RetainPtr atomDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(reconstructed.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    ASSERT_TRUE(atomDict);
+    ASSERT_EQ(CFDictionaryGetCount(atomDict.get()), 2);
+
+    auto dvcCValue = CFDictionaryGetValue(atomDict.get(), CFSTR("dvcC"));
+    ASSERT_TRUE(dvcCValue);
+    EXPECT_EQ(CFGetTypeID(dvcCValue), CFDataGetTypeID());
+    ASSERT_EQ(CFDataGetLength(checked_cf_cast<CFDataRef>(dvcCValue)), 3);
+
+    auto hvcCValue = CFDictionaryGetValue(atomDict.get(), CFSTR("hvcC"));
+    ASSERT_TRUE(hvcCValue);
+    EXPECT_EQ(CFGetTypeID(hvcCValue), CFDataGetTypeID());
+    ASSERT_EQ(CFDataGetLength(checked_cf_cast<CFDataRef>(hvcCValue)), 2);
+}
+
+// Verifies that a genuinely duplicated FourCC (CFArray of multiple distinct atoms sharing
+// one key, e.g. 'avcC') round-trips through an encrypted video CMFormatDescription without
+// being merged into any other atom's data or multiplied beyond its original count.
+TEST(CMUtilities, EncryptedVideoWithDuplicateFourCCAtomsRoundTrip)
+{
+    constexpr uint8_t tencData[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+    };
+    constexpr uint8_t avcC1[] = { 0xAA };
+    constexpr uint8_t avcC2[] = { 0xBB, 0xBB };
+    constexpr uint8_t hvcCBuf[] = { 0x0a, 0x0b };
+    RetainPtr tencCFData = adoptCF(CFDataCreate(kCFAllocatorDefault, tencData, sizeof(tencData)));
+    NSData *avcCData1 = [NSData dataWithBytes:avcC1 length:sizeof(avcC1)];
+    NSData *avcCData2 = [NSData dataWithBytes:avcC2 length:sizeof(avcC2)];
+    NSData *hvcCData = [NSData dataWithBytes:hvcCBuf length:sizeof(hvcCBuf)];
+    NSDictionary *extensions = @{
+        (__bridge NSString *)PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms: @{ @"avcC": @[avcCData1, avcCData2], @"hvcC": hvcCData },
+        @"CommonEncryptionTrackEncryptionBox": (__bridge NSData *)tencCFData.get(),
+    };
+    CMFormatDescriptionRef rawDesc = nullptr;
+    PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_HEVC, 1920, 1080, (__bridge CFDictionaryRef)extensions, &rawDesc);
+    RetainPtr desc = adoptCF(rawDesc);
+    ASSERT_TRUE(desc.get());
+
+    RefPtr videoInfo = WebCore::createVideoInfoFromFormatDescription(desc.get());
+    ASSERT_TRUE(videoInfo);
+    ASSERT_TRUE(videoInfo->encryptionDataCollection());
+    EXPECT_TRUE(videoInfo->encryptionDataCollection()->encryptionInitDatas.isEmpty());
+    ASSERT_EQ(videoInfo->extensionAtoms().size(), 3u);
+
+    RetainPtr reconstructed = WebCore::createFormatDescriptionFromTrackInfo(*videoInfo);
+    ASSERT_TRUE(reconstructed.get());
+
+    RetainPtr atomDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(reconstructed.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    ASSERT_TRUE(atomDict);
+    ASSERT_EQ(CFDictionaryGetCount(atomDict.get()), 2);
+
+    auto avcCValue = CFDictionaryGetValue(atomDict.get(), CFSTR("avcC"));
+    ASSERT_TRUE(avcCValue);
+    EXPECT_EQ(CFGetTypeID(avcCValue), CFArrayGetTypeID());
+    auto avcCArray = checked_cf_cast<CFArrayRef>(avcCValue);
+    ASSERT_EQ(CFArrayGetCount(avcCArray), 2);
+    auto avcCEntry0 = checked_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(avcCArray, 0));
+    ASSERT_EQ(CFDataGetLength(avcCEntry0), 1);
+    EXPECT_EQ(CFDataGetBytePtr(avcCEntry0)[0], 0xAA);
+    auto avcCEntry1 = checked_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(avcCArray, 1));
+    ASSERT_EQ(CFDataGetLength(avcCEntry1), 2);
+    EXPECT_EQ(CFDataGetBytePtr(avcCEntry1)[0], 0xBB);
+    EXPECT_EQ(CFDataGetBytePtr(avcCEntry1)[1], 0xBB);
+
+    auto hvcCValue = CFDictionaryGetValue(atomDict.get(), CFSTR("hvcC"));
+    ASSERT_TRUE(hvcCValue);
+    EXPECT_EQ(CFGetTypeID(hvcCValue), CFDataGetTypeID());
+    ASSERT_EQ(CFDataGetLength(checked_cf_cast<CFDataRef>(hvcCValue)), 2);
 }
 
 #endif // ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
@@ -309,6 +463,196 @@ TEST(CMUtilities, MatrixCoefficientsRoundTrip)
     testMatrix(M::Bt2020NonconstantLuminance);
     testMatrix(M::Bt2020ConstantLuminance);
     testMatrix(M::Unspecified);
+}
+
+// ---- Extension Atoms (kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms) ----
+// Per <CoreMedia/CMFormatDescription.h>, each value is either a CFData payload or
+// a CFArray of CFData (multiple atoms sharing a FourCC).
+
+static RetainPtr<CMFormatDescriptionRef> makeVideoFormatDescriptionWithAtoms(NSDictionary *atomsDict)
+{
+    NSDictionary *extensions = @{
+        (__bridge NSString *)PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms: atomsDict,
+    };
+    CMFormatDescriptionRef desc = nullptr;
+    PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_H264, 1920, 1080, (__bridge CFDictionaryRef)extensions, &desc);
+    return adoptCF(desc);
+}
+
+TEST(CMUtilities, ExtensionAtomsCFArrayValueDoesNotCrash)
+{
+    constexpr uint8_t buf1[] = { 0x01, 0x02, 0x03 };
+    constexpr uint8_t buf2[] = { 0x0a, 0x0b };
+    NSData *data1 = [NSData dataWithBytes:buf1 length:sizeof(buf1)];
+    NSData *data2 = [NSData dataWithBytes:buf2 length:sizeof(buf2)];
+    auto desc = makeVideoFormatDescriptionWithAtoms(@{ @"avcC": @[data1, data2] });
+    ASSERT_TRUE(desc);
+
+    auto videoInfo = WebCore::createVideoInfoFromFormatDescription(desc.get());
+    ASSERT_TRUE(videoInfo);
+
+    auto& atoms = videoInfo->extensionAtoms();
+    ASSERT_EQ(atoms.size(), 2u);
+    EXPECT_EQ(atoms[0].first, WebCore::FourCC('avcC'));
+    EXPECT_EQ(atoms[1].first, WebCore::FourCC('avcC'));
+
+    auto span0 = atoms[0].second->span();
+    ASSERT_EQ(span0.size(), 3u);
+    EXPECT_EQ(span0[0], 0x01);
+    EXPECT_EQ(span0[1], 0x02);
+    EXPECT_EQ(span0[2], 0x03);
+    auto span1 = atoms[1].second->span();
+    ASSERT_EQ(span1.size(), 2u);
+    EXPECT_EQ(span1[0], 0x0a);
+    EXPECT_EQ(span1[1], 0x0b);
+}
+
+TEST(CMUtilities, ExtensionAtomsCFDataValueIngest)
+{
+    constexpr uint8_t buf[] = { 0xDE, 0xAD, 0xBE, 0xEF };
+    NSData *data = [NSData dataWithBytes:buf length:sizeof(buf)];
+    auto desc = makeVideoFormatDescriptionWithAtoms(@{ @"avcC": data });
+    ASSERT_TRUE(desc);
+
+    auto videoInfo = WebCore::createVideoInfoFromFormatDescription(desc.get());
+    ASSERT_TRUE(videoInfo);
+
+    auto& atoms = videoInfo->extensionAtoms();
+    ASSERT_EQ(atoms.size(), 1u);
+    EXPECT_EQ(atoms[0].first, WebCore::FourCC('avcC'));
+    auto span = atoms[0].second->span();
+    ASSERT_EQ(span.size(), 4u);
+    EXPECT_EQ(span[0], 0xDE);
+    EXPECT_EQ(span[1], 0xAD);
+    EXPECT_EQ(span[2], 0xBE);
+    EXPECT_EQ(span[3], 0xEF);
+}
+
+static Ref<WebCore::VideoInfo> makeVideoInfoWithAtoms(Vector<WebCore::TrackInfo::AtomData>&& atoms)
+{
+    return WebCore::VideoInfo::create({
+        { .codecName = WebCore::FourCC('avc1') }, {
+            .size = { 640, 480 },
+            .displaySize = { 640, 480 },
+            .extensionAtoms = WTF::move(atoms),
+        }
+    });
+}
+
+TEST(CMUtilities, CreateFormatDescriptionEmitsCFDataForSingleAtom)
+{
+    constexpr uint8_t buf[] = { 0x11, 0x22, 0x33 };
+    auto videoInfo = makeVideoInfoWithAtoms({
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { buf, sizeof(buf) }) },
+    });
+    auto desc = WebCore::createFormatDescriptionFromTrackInfo(videoInfo);
+    ASSERT_TRUE(desc);
+
+    RetainPtr atomDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(desc.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    ASSERT_TRUE(atomDict);
+
+    auto value = CFDictionaryGetValue(atomDict.get(), CFSTR("avcC"));
+    ASSERT_TRUE(value);
+    EXPECT_EQ(CFGetTypeID(value), CFDataGetTypeID());
+    auto cfData = checked_cf_cast<CFDataRef>(value);
+    ASSERT_EQ(CFDataGetLength(cfData), 3);
+    auto bytes = CFDataGetBytePtr(cfData);
+    EXPECT_EQ(bytes[0], 0x11);
+    EXPECT_EQ(bytes[1], 0x22);
+    EXPECT_EQ(bytes[2], 0x33);
+}
+
+TEST(CMUtilities, CreateFormatDescriptionEmitsCFArrayForMultipleAtomsSameFourCC)
+{
+    constexpr uint8_t a[] = { 0xAA };
+    constexpr uint8_t b[] = { 0xBB, 0xBB };
+    auto videoInfo = makeVideoInfoWithAtoms({
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { a, sizeof(a) }) },
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { b, sizeof(b) }) },
+    });
+    auto desc = WebCore::createFormatDescriptionFromTrackInfo(videoInfo);
+    ASSERT_TRUE(desc);
+
+    RetainPtr atomDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(desc.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    ASSERT_TRUE(atomDict);
+
+    auto value = CFDictionaryGetValue(atomDict.get(), CFSTR("avcC"));
+    ASSERT_TRUE(value);
+    EXPECT_EQ(CFGetTypeID(value), CFArrayGetTypeID());
+    auto cfArray = checked_cf_cast<CFArrayRef>(value);
+    ASSERT_EQ(CFArrayGetCount(cfArray), 2);
+
+    auto entry0 = checked_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(cfArray, 0));
+    ASSERT_EQ(CFDataGetLength(entry0), 1);
+    EXPECT_EQ(CFDataGetBytePtr(entry0)[0], 0xAA);
+
+    auto entry1 = checked_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(cfArray, 1));
+    ASSERT_EQ(CFDataGetLength(entry1), 2);
+    EXPECT_EQ(CFDataGetBytePtr(entry1)[0], 0xBB);
+    EXPECT_EQ(CFDataGetBytePtr(entry1)[1], 0xBB);
+}
+
+TEST(CMUtilities, CreateFormatDescriptionGroupsNonContiguousDuplicates)
+{
+    constexpr uint8_t a1[] = { 0x01 };
+    constexpr uint8_t b[]  = { 0x02 };
+    constexpr uint8_t a2[] = { 0x03 };
+    auto videoInfo = makeVideoInfoWithAtoms({
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { a1, sizeof(a1) }) },
+        { WebCore::FourCC('hvcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { b,  sizeof(b)  }) },
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { a2, sizeof(a2) }) },
+    });
+    auto desc = WebCore::createFormatDescriptionFromTrackInfo(videoInfo);
+    ASSERT_TRUE(desc);
+
+    RetainPtr atomDict = dynamic_cf_cast<CFDictionaryRef>(PAL::CMFormatDescriptionGetExtension(desc.get(), PAL::kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms));
+    ASSERT_TRUE(atomDict);
+
+    auto avccValue = CFDictionaryGetValue(atomDict.get(), CFSTR("avcC"));
+    ASSERT_TRUE(avccValue);
+    EXPECT_EQ(CFGetTypeID(avccValue), CFArrayGetTypeID());
+    auto avccArray = checked_cf_cast<CFArrayRef>(avccValue);
+    ASSERT_EQ(CFArrayGetCount(avccArray), 2);
+    EXPECT_EQ(CFDataGetBytePtr(checked_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(avccArray, 0)))[0], 0x01);
+    EXPECT_EQ(CFDataGetBytePtr(checked_cf_cast<CFDataRef>(CFArrayGetValueAtIndex(avccArray, 1)))[0], 0x03);
+
+    auto hvccValue = CFDictionaryGetValue(atomDict.get(), CFSTR("hvcC"));
+    ASSERT_TRUE(hvccValue);
+    EXPECT_EQ(CFGetTypeID(hvccValue), CFDataGetTypeID());
+    auto hvccData = checked_cf_cast<CFDataRef>(hvccValue);
+    ASSERT_EQ(CFDataGetLength(hvccData), 1);
+    EXPECT_EQ(CFDataGetBytePtr(hvccData)[0], 0x02);
+}
+
+TEST(CMUtilities, ExtensionAtomsRoundTripPreservesMultipleSameFourCC)
+{
+    constexpr uint8_t a[] = { 0x01, 0x02 };
+    constexpr uint8_t b[] = { 0x03, 0x04, 0x05 };
+    auto sourceInfo = makeVideoInfoWithAtoms({
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { a, sizeof(a) }) },
+        { WebCore::FourCC('avcC'), WebCore::SharedBuffer::create(std::span<const uint8_t> { b, sizeof(b) }) },
+    });
+    auto desc = WebCore::createFormatDescriptionFromTrackInfo(sourceInfo);
+    ASSERT_TRUE(desc);
+
+    auto roundTripped = WebCore::createVideoInfoFromFormatDescription(desc.get());
+    ASSERT_TRUE(roundTripped);
+
+    auto& atoms = roundTripped->extensionAtoms();
+    ASSERT_EQ(atoms.size(), 2u);
+    EXPECT_EQ(atoms[0].first, WebCore::FourCC('avcC'));
+    EXPECT_EQ(atoms[1].first, WebCore::FourCC('avcC'));
+
+    auto span0 = atoms[0].second->span();
+    ASSERT_EQ(span0.size(), 2u);
+    EXPECT_EQ(span0[0], 0x01);
+    EXPECT_EQ(span0[1], 0x02);
+
+    auto span1 = atoms[1].second->span();
+    ASSERT_EQ(span1.size(), 3u);
+    EXPECT_EQ(span1[0], 0x03);
+    EXPECT_EQ(span1[1], 0x04);
+    EXPECT_EQ(span1[2], 0x05);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 40f62db2b0a18f38fb7d9cd79fade5978e585fd6
<pre>
com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::createVideoInfoFromFormatDescription
<a href="https://bugs.webkit.org/show_bug.cgi?id=317652">https://bugs.webkit.org/show_bug.cgi?id=317652</a>
<a href="https://rdar.apple.com/175430748">rdar://175430748</a>

Reviewed by Eric Carlson.

Per CMFormatDescription documentation:
```
The extension is a CFDictionary mapping CFStrings of the four-char-code atom types
to either CFDatas containing the atom payload or (to represent multiple atoms of a
specific type) to CFArrays of CFData containing those payloads.
```

The conversion from CMVideoFormatDescription to VideoTrackInfo only handled
the first case, leading to a crash if the latter was used.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm

* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::parseExtensionAtomsDictionary):
(WebCore::createExtensionAtomsDictionary):
(WebCore::getEncryptionDataCollection):
(WebCore::createVideoInfoFromFormatDescription):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm:
(TestWebKitAPI::makeVideoFormatDescriptionWithAtoms):
(TestWebKitAPI::TEST(CMUtilities, ExtensionAtomsCFArrayValueDoesNotCrash)):
(TestWebKitAPI::TEST(CMUtilities, ExtensionAtomsCFDataValueIngest)):
(TestWebKitAPI::makeVideoInfoWithAtoms):
(TestWebKitAPI::TEST(CMUtilities, CreateFormatDescriptionEmitsCFDataForSingleAtom)):
(TestWebKitAPI::TEST(CMUtilities, CreateFormatDescriptionEmitsCFArrayForMultipleAtomsSameFourCC)):
(TestWebKitAPI::TEST(CMUtilities, CreateFormatDescriptionGroupsNonContiguousDuplicates)):
(TestWebKitAPI::TEST(CMUtilities, ExtensionAtomsRoundTripPreservesMultipleSameFourCC)):

Canonical link: <a href="https://commits.webkit.org/316464@main">https://commits.webkit.org/316464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8af82a06e7f9b4537f57273362e1b1dce334c541

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181767 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129871 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ec4a87a-22f9-4ec0-a286-1a06a35ad0ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134018 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5022815a-33da-4f0a-9fec-6913caf48eaf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59f92a2e-b9d9-411a-a3a2-dee394bcff37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36078 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30372 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184300 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36983 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142788 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45905 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142669 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38543 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46583 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111310 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37729 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118334 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45100 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9014 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44500 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44559 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->