### PR TITLE
Model does not change current src based on the media attribute

### DIFF
--- a/LayoutTests/model-element/model-element-source-media-expected.txt
+++ b/LayoutTests/model-element/model-element-source-media-expected.txt
@@ -1,0 +1,9 @@
+
+PASS A <source> whose media attribute matches is selected.
+PASS A <source> whose media attribute does not match is not selected.
+PASS A non-matching <source> is skipped in favor of a later matching <source>.
+PASS A <source> without a media attribute acts as a fallback when earlier <source>s do not match.
+PASS Changing a <source> media attribute to a matching value selects it.
+PASS Changing a <source> media attribute to a non-matching value deselects it.
+PASS A <source> must satisfy both its media attribute and a supported type to be selected.
+

--- a/LayoutTests/model-element/model-element-source-media.html
+++ b/LayoutTests/model-element/model-element-source-media.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script>
+
+// The media attribute is evaluated against the screen media type, so "screen"
+// and "all" always match while "print" never does. Using media-type queries
+// (rather than viewport features) keeps the results deterministic regardless of
+// the test window size.
+const makeSource = (src, media, type) => {
+    const source = document.createElement("source");
+    source.src = src;
+    if (media !== undefined)
+        source.media = media;
+    if (type)
+        source.type = type;
+    return source;
+}
+
+test(() => {
+    const model = document.createElement("model");
+    const source = model.appendChild(makeSource("model.usdz", "all"));
+    assert_equals(model.currentSrc, source.src);
+}, "A <source> whose media attribute matches is selected.");
+
+test(() => {
+    const model = document.createElement("model");
+    model.appendChild(makeSource("model.usdz", "print"));
+    assert_equals(model.currentSrc, "");
+}, "A <source> whose media attribute does not match is not selected.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-1.usdz", "print"));
+    const secondSource = model.appendChild(makeSource("model-2.usdz", "screen"));
+    assert_equals(model.currentSrc, secondSource.src);
+}, "A non-matching <source> is skipped in favor of a later matching <source>.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-1.usdz", "print"));
+    const secondSource = model.appendChild(makeSource("model-2.usdz"));
+    assert_equals(model.currentSrc, secondSource.src);
+}, "A <source> without a media attribute acts as a fallback when earlier <source>s do not match.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-1.usdz", "print"));
+    const secondSource = model.appendChild(makeSource("model-2.usdz", "print"));
+    assert_equals(model.currentSrc, "");
+
+    firstSource.media = "screen";
+    assert_equals(model.currentSrc, firstSource.src);
+}, "Changing a <source> media attribute to a matching value selects it.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-1.usdz", "screen"));
+    const secondSource = model.appendChild(makeSource("model-2.usdz", "screen"));
+    assert_equals(model.currentSrc, firstSource.src);
+
+    firstSource.media = "print";
+    assert_equals(model.currentSrc, secondSource.src);
+}, "Changing a <source> media attribute to a non-matching value deselects it.");
+
+test(() => {
+    const model = document.createElement("model");
+    const firstSource = model.appendChild(makeSource("model-1.usdz", "screen", "model/unknown"));
+    const secondSource = model.appendChild(makeSource("model-2.usdz", "screen", "model/vnd.usdz+zip"));
+    assert_equals(model.currentSrc, secondSource.src);
+}, "A <source> must satisfy both its media attribute and a supported type to be selected.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -31,6 +31,7 @@
 
 #include "ARKitBadgeSystemImage.h"
 #include "AbortSignal.h"
+#include "CommonAtomStrings.h"
 #include "ContainerNodeInlines.h"
 #include "DOMMatrixReadOnly.h"
 #include "DOMPointReadOnly.h"
@@ -69,6 +70,7 @@
 #include "LegacySchemeRegistry.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
+#include "MediaQueryEvaluator.h"
 #include "Model.h"
 #include "ModelPlayer.h"
 #include "ModelPlayerAnimationState.h"
@@ -229,8 +231,13 @@ URL HTMLModelElement::selectModelSource() const
     if (auto src = getNonEmptyURLAttribute(srcAttr); src.isValid())
         return src;
 
+    Ref document = this->document();
     for (Ref element : childrenOfType<HTMLSourceElement>(*this)) {
         if (!isSupportedModelType(element->attributeWithoutSynchronization(typeAttr)))
+            continue;
+
+        auto& queries = element->parsedMediaAttribute(document);
+        if (!queries.isEmpty() && !MQ::MediaQueryEvaluator { screenAtom(), document }.evaluate(queries))
             continue;
 
         if (auto src = element->getNonEmptyURLAttribute(srcAttr); src.isValid())

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -184,6 +184,12 @@ void HTMLSourceElement::attributeChanged(const QualifiedName& name, const AtomSt
         RefPtr parent = parentElement();
         if (m_shouldCallSourcesChanged && parent)
             downcast<HTMLPictureElement>(*parent).sourcesChanged();
+#if ENABLE(MODEL_ELEMENT)
+        if (name == mediaAttr) {
+            if (RefPtr parentModelElement = dynamicDowncast<HTMLModelElement>(parent.get()))
+                parentModelElement->sourcesChanged();
+        }
+#endif
         break;
     }
     case AttributeNames::widthAttr:


### PR DESCRIPTION
#### 27f39d2af63b080177a28aab15cde66714cc1c7a
<pre>
Model does not change current src based on the media attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=318468">https://bugs.webkit.org/show_bug.cgi?id=318468</a>
<a href="https://rdar.apple.com/172688994">rdar://172688994</a>

Reviewed by Mike Wyrzykowski.

Honor the &lt;source&gt; media attribute when selecting a &lt;model&gt;&apos;s source,
matching HTMLMediaElement (&lt;video&gt;) resource selection: the media query
is evaluated at selection time only — on load and on explicit source/
attribute changes — not dynamically on viewport changes like &lt;picture&gt;.
The dynamic approach is intentionally avoided due to memory concerns.

* LayoutTests/model-element/model-element-source-media-expected.txt: Added.
* LayoutTests/model-element/model-element-source-media.html: Added.
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::selectModelSource const):
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/316452@main">https://commits.webkit.org/316452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6368936e7e4248fc81c845d08bd20ff4880a573d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129872 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b042f25c-56ca-47bc-8cba-0ee1845b769b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134023 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca06fda2-f6c0-4aef-b0af-b72b7c8d6ce7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37447 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114494 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/980741fb-71e6-46cd-a887-06c5e578a109) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36081 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30373 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184301 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45906 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142671 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38537 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46584 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111311 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37730 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45101 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9015 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44501 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44560 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->