### PR TITLE
Block local IPs with credentials in iframes and redirects from public pages.

### DIFF
--- a/LayoutTests/http/tests/security/block-iframe-with-credentials-to-private-ip-expected.txt
+++ b/LayoutTests/http/tests/security/block-iframe-with-credentials-to-private-ip-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Not allowed to load local network address with credentials: http://login:password@127.0.0.1:8000/security/resources/target.html
+
+This sets up an iframe with a public address space (only IP literals count as local), which attempts to load an iframe with credentials from a local IP address, which should be blocked.

--- a/LayoutTests/http/tests/security/block-iframe-with-credentials-to-private-ip.html
+++ b/LayoutTests/http/tests/security/block-iframe-with-credentials-to-private-ip.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<iframe src="http://localhost:8000/security/resources/public-iframe-with-credentialed-local-ip.html"></iframe>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+    }
+</script>
+<p>This sets up an iframe with a public address space (only IP literals count as local), which attempts to load an iframe with credentials from a local IP address, which should be blocked.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/public-iframe-with-credentialed-local-ip.html
+++ b/LayoutTests/http/tests/security/resources/public-iframe-with-credentialed-local-ip.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<iframe src="http://login:password@127.0.0.1:8000/security/resources/target.html"></iframe>
+</body>
+</html>

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -715,6 +715,13 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
             cancelMainResourceLoad(protect(frameLoader())->blockedError(newRequest));
             return completionHandler(WTF::move(newRequest));
         }
+        if (newRequest.url().hasCredentials() && isLocalIPAddressSpace(newRequest.url()) && !isLocalIPAddressSpace(redirectResponse.url())) {
+            DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - redirecting to a URL with a disallowed IP address with credentials");
+            if (frame)
+                FrameLoader::reportBlockedCredentialedLocalLoadFailed(*frame, newRequest.url());
+            cancelMainResourceLoad(protect(frameLoader())->blockedError(newRequest));
+            return completionHandler(WTF::move(newRequest));
+        }
     }
 
     ASSERT(frame);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2058,6 +2058,12 @@ void FrameLoader::reportBlockedLoadFailed(LocalFrame& frame, const URL& url)
     protect(frame.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
 }
 
+void FrameLoader::reportBlockedCredentialedLocalLoadFailed(LocalFrame& frame, const URL& url)
+{
+    ASSERT(!url.isEmpty());
+    protect(frame.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Not allowed to load local network address with credentials: "_s, url.string()));
+}
+
 bool FrameLoader::willLoadMediaElementURL(URL& url, Node& initiatorNode)
 {
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -158,6 +158,7 @@ public:
 
     static void reportLocalLoadFailed(LocalFrame*, const String& url);
     static void reportBlockedLoadFailed(LocalFrame&, const URL&);
+    static void reportBlockedCredentialedLocalLoadFailed(LocalFrame&, const URL&);
 
     // FIXME: These are all functions which stop loads. We have too many.
     void stopAllLoadersAndCheckCompleteness();

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -310,6 +310,11 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
         return nullptr;
     }
 
+    if (url.hasCredentials() && isLocalIPAddressSpace(url) && !isLocalIPAddressSpace(document->url())) {
+        FrameLoader::reportBlockedCredentialedLocalLoadFailed(frame, url);
+        return nullptr;
+    }
+
     if (!SubframeLoadingDisabler::canLoadFrame(ownerElement))
         return nullptr;
 


### PR DESCRIPTION
#### 07ff1b50bf1b147f1767597a8fd6a1c0e4101397
<pre>
Block local IPs with credentials in iframes and redirects from public pages.
<a href="https://rdar.apple.com/24575445">rdar://24575445</a>

Reviewed by NOBODY (OOPS!).

Both embedded credentials and access to local IP addresses can be used maliciously, but fully eliminating either is controversial. Using both together from a public address space should have virtually no legitimate use and should be blocked.

Test: http/tests/security/block-iframe-with-credentials-to-private-ip.html

* LayoutTests/http/tests/security/block-iframe-with-credentials-to-private-ip-expected.txt: Added.
* LayoutTests/http/tests/security/block-iframe-with-credentials-to-private-ip.html: Added.
* LayoutTests/http/tests/security/resources/public-iframe-with-credentialed-local-ip.html: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest): Block public addresses redirecting to URLs that embed credentials and target local IP addresses.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::reportBlockedCredentialedLocalLoadFailed): Add new error message for this block reason.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadSubframe): Block iframes from public addresses loading URLs that embed credentials and target local IP addresses.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07ff1b50bf1b147f1767597a8fd6a1c0e4101397

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134630 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95053 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155776 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115099 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36691 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35024 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31196 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185133 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143476 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31885 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112491 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38304 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119166 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45923 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10224 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->