### PR TITLE
Drop vestigial -expected.checksum support

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test.py
@@ -38,7 +38,6 @@ class Test(object):
     test_path = attr.ib(type=str)
     expected_text_path = attr.ib(default=None, type=str)
     expected_image_path = attr.ib(default=None, type=str)
-    expected_checksum_path = attr.ib(default=None, type=str)
     expected_audio_path = attr.ib(default=None, type=str)
     reference_files = attr.ib(default=None, type=list)
     is_http_test = attr.ib(default=False, type=bool)

--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py
@@ -183,7 +183,7 @@ def get_test_baselines(test_file, test_config):
     all_platforms_port = AllPlatformsPort(host)
 
     all_test_baselines = {}
-    for baseline_extension in ('.txt', '.checksum', '.png'):
+    for baseline_extension in ('.txt', '.png'):
         test_baselines = test_config.test_port.expected_baselines(test_file, baseline_extension)
         baselines = all_platforms_port.expected_baselines(test_file, baseline_extension, all_baselines=True)
         for platform_directory, expected_filename in baselines:
@@ -266,13 +266,9 @@ class RebaselineHTTPRequestHandler(ReflectionHandler):
             file_name = test_name + '-expected.png'
         elif mode == 'actual-image':
             file_name = test_name + '-actual.png'
-        if mode == 'expected-checksum':
-            file_name = test_name + '-expected.checksum'
-        elif mode == 'actual-checksum':
-            file_name = test_name + '-actual.checksum'
         elif mode == 'diff-image':
             file_name = test_name + '-diff.png'
-        if mode == 'expected-text':
+        elif mode == 'expected-text':
             file_name = test_name + '-expected.txt'
         elif mode == 'actual-text':
             file_name = test_name + '-actual.txt'

--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py
@@ -97,7 +97,6 @@ class RebaselineTestTest(unittest.TestCase):
         self._assertRebaseline(
             test_files=(
                 'fast/text-expected.txt',
-                'platform/mac/fast/text-expected.checksum',
             ),
             results_files=(
                 'fast/text-actual.txt',
@@ -108,8 +107,6 @@ class RebaselineTestTest(unittest.TestCase):
             expected_success=True,
             expected_log=[
                 'Rebaselining fast/text...',
-                '  Moving current mac baselines to mac-leopard',
-                '    No current baselines to move',
                 '  Updating baselines for mac',
                 '    Updated text-expected.txt',
             ])
@@ -141,11 +138,9 @@ class RebaselineTestTest(unittest.TestCase):
                 'fast/image-expected.txt',
                 'platform/mac/fast/image-expected.txt',
                 'platform/mac/fast/image-expected.png',
-                'platform/mac/fast/image-expected.checksum',
             ),
             results_files=(
                 'fast/image-actual.png',
-                'fast/image-actual.checksum',
             ),
             test_name='fast/image.html',
             baseline_target='mac',
@@ -154,10 +149,8 @@ class RebaselineTestTest(unittest.TestCase):
             expected_log=[
                 'Rebaselining fast/image...',
                 '  Moving current mac baselines to mac-leopard',
-                '    Moved image-expected.checksum',
                 '    Moved image-expected.png',
                 '  Updating baselines for mac',
-                '    Updated image-expected.checksum',
                 '    Updated image-expected.png',
             ])
 
@@ -186,11 +179,9 @@ class RebaselineTestTest(unittest.TestCase):
             test_files=(
                 'fast/image-expected.txt',
                 'platform/mac/fast/image-expected.png',
-                'platform/mac/fast/image-expected.checksum',
             ),
             results_files=(
                 'fast/image-actual.png',
-                'fast/image-actual.checksum',
             ),
             test_name='fast/image.html',
             baseline_target='mac',
@@ -199,7 +190,6 @@ class RebaselineTestTest(unittest.TestCase):
             expected_log=[
                 'Rebaselining fast/image...',
                 '  Updating baselines for mac',
-                '    Updated image-expected.checksum',
                 '    Updated image-expected.png',
             ])
 
@@ -263,15 +253,13 @@ class GetBaselinesTest(unittest.TestCase):
             test_files=(
                 'fast/image-expected.txt',
                 'platform/mac/fast/image-expected.png',
-                'platform/mac/fast/image-expected.checksum',
                 'platform/win/fast/image-expected.png',
-                'platform/win/fast/image-expected.checksum',
             ),
             test_name='fast/image.html',
             expected_baselines={
                 'base': {'.txt': True},
-                'mac': {'.checksum': True, '.png': True},
-                'win': {'.checksum': False, '.png': False},
+                'mac': {'.png': True},
+                'win': {'.png': False},
             })
 
     def test_extra_baselines(self):


### PR DESCRIPTION
#### d05841cdd84b31a026de98351bbdffc55f53bfaf
<pre>
Drop vestigial -expected.checksum support
<a href="https://bugs.webkit.org/show_bug.cgi?id=318486">https://bugs.webkit.org/show_bug.cgi?id=318486</a>
<a href="https://rdar.apple.com/181275486">rdar://181275486</a>

Reviewed by Elliott Williams.

Standalone .checksum baseline files haven&apos;t been written since
75298@main (May 2011), which removed write_image_hashes() from
TestResultWriter. Checksums have instead been embedded as tEXt chunks
inside PNGs, with reading support added in 72081@main (Marh 2011).

* Tools/Scripts/webkitpy/layout_tests/models/test.py:
(Test):
* Tools/Scripts/webkitpy/tool/servers/rebaselineserver.py:
(get_test_baselines):
(RebaselineHTTPRequestHandler.test_result):
* Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py:
(RebaselineTestTest.test_text_rebaseline_move_no_op_2):
(RebaselineTestTest.test_text_rebaseline_move_only_images):
(RebaselineTestTest.test_image_rebaseline):
(GetBaselinesTest.test_image_and_text_baselines):

Canonical link: <a href="https://commits.webkit.org/316623@main">https://commits.webkit.org/316623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7634710b2abd0da337b3919c4723c7625ba183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130489 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/524457da-2fba-4b5b-b2ba-583057205c7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/e1710add-0881-43b1-8a3b-632176ee60f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/8c127670-b156-4c03-acd1-fc9ba7ffe3a0/e9a386c3-f73d-4660-a360-8891042208f3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172254 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36532 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34859 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30991 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34565 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184927 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143305 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46523 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38658 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47201 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112205 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38160 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45718 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9508 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45119 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45351 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45177 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->