### PR TITLE
[Web Inspector] InspectorAuditResourcesObject::getResources() is O(n²) due to linear reverse lookup

### DIFF
--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -61,8 +61,10 @@ InspectorAuditResourcesObject::InspectorAuditResourcesObject(InspectorAuditAgent
 
 InspectorAuditResourcesObject::~InspectorAuditResourcesObject()
 {
-    for (RefPtr cachedResource : m_resources.values())
-        cachedResource->removeClient(clientForResource(*cachedResource));
+    for (auto& weakResource : m_resources.values()) {
+        if (RefPtr cachedResource = weakResource.get())
+            cachedResource->removeClient(clientForResource(*cachedResource));
+    }
 }
 
 ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResourcesObject::getResources(Document& document)
@@ -80,19 +82,14 @@ ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResou
         resource.url = cachedResource->url().string();
         resource.mimeType = cachedResource->mimeType();
 
-        bool exists = false;
-        for (const auto& entry : m_resources) {
-            if (entry.value == cachedResource) {
-                resource.id = entry.key;
-                exists = true;
-                break;
-            }
-        }
-        if (!exists) {
+        if (auto identifier = m_resourceIdentifiers.getOptional(*cachedResource))
+            resource.id = WTF::move(*identifier);
+        else {
             cachedResource->addClient(clientForResource(*cachedResource));
 
             resource.id = String::number(m_resources.size() + 1);
             m_resources.add(resource.id, cachedResource);
+            m_resourceIdentifiers.add(*cachedResource, resource.id);
         }
 
         resources.append(WTF::move(resource));

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.h
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.h
@@ -36,6 +36,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -163,7 +164,8 @@ private:
     };
     InspectorAuditCachedStyleSheetClient m_cachedStyleSheetClient;
 
-    MemoryCompactRobinHoodHashMap<String, CachedResource*> m_resources;
+    MemoryCompactRobinHoodHashMap<String, WeakPtr<CachedResource>> m_resources;
+    WeakHashMap<CachedResource, String> m_resourceIdentifiers;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 5f7ab40afc2d8c7dd20253955edbe834a91db32e
<pre>
[Web Inspector] InspectorAuditResourcesObject::getResources() is O(n²) due to linear reverse lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=318425">https://bugs.webkit.org/show_bug.cgi?id=318425</a>
<a href="https://rdar.apple.com/181206139">rdar://181206139</a>

Reviewed by Devin Rousso.

getResources() maps each CachedResource to a previously-assigned string
identifier. m_resources is a forward map (identifier -&gt; CachedResource),
so the reverse lookup (&quot;do I already have this resource, and what is its
id?&quot;) was done by linearly scanning the entire map for every resource
returned by cachedResourcesForFrame(). That is O(n) per resource, or
O(n²) per call. Because m_resources is never pruned, it accumulates every
resource seen across all getResources() calls for the object&apos;s lifetime,
so the scan grows unboundedly across repeated audit calls.

Add a reverse map m_resourceIdentifiers (CachedResource -&gt; identifier)
kept in sync on insertion, turning the reverse lookup into O(1). Because
CachedResource is RefCountedAndCanMakeWeakPtr, this uses a WeakHashMap
rather than a raw-pointer key, matching how ResourceTimingInformation
keys CachedResource and satisfying the SaferCPP prohibition on raw
pointer map keys.

While here, change the forward map to hold WeakPtr&lt;CachedResource&gt;
instead of a raw CachedResource*. Clients are non-owning and
~CachedResource neither asserts on nor notifies outstanding clients, so a
resource could be destroyed while this (never-pruned) map still held a
raw pointer to it, leaving the destructor&apos;s removeClient() and
getResourceContent()&apos;s lookup as latent use-after-frees. Weak pointers
make both sites null-check safely and, as a bonus, prevent a reused
address from ever false-matching a stale entry. Identifier numbering is
unchanged: dead entries remain in the map as null weak pointers, so
size()-based ids stay unique.

* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::~InspectorAuditResourcesObject):
(WebCore::InspectorAuditResourcesObject::getResources):
(WebCore::InspectorAuditResourcesObject::getResourceContent):
* Source/WebCore/inspector/InspectorAuditResourcesObject.h:

Canonical link: <a href="https://commits.webkit.org/317967@main">https://commits.webkit.org/317967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16df1ce391a19e0ecad7b00a51d3ae7c94be1fea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186497 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e67302b8-70c4-49c4-980f-16a76c731e2c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137813 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29f42fb1-fb42-46d1-a2c8-fb52d8b980bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158603 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118287 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4aa7fe3c-e9e7-4374-965c-2ccc8d0dd14a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39977 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38346 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38102 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34964 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42577 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50498 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39492 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51181 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146688 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41452 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123389 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117630 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49686 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13083 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49085 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49321 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49146 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->