### PR TITLE
[GFC] Visually overflowing content may not get painted in certain circumstances.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-below-container-is-painted-ref.html">
+<meta name="assert" content="A grid item in a zero-height grid container overflows its bottom edge and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 100px;
+    height: 0;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  }
+  .item {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-in-both-axes-is-painted-ref.html">
+<meta name="assert" content="A grid item in a zero-width, zero-height grid container overflows both the right and bottom edges and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 0;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  }
+  .item {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 40px;
+    top: 40px;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 40px;
+    top: 40px;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-in-nonstart-cell-is-painted-ref.html">
+<meta name="assert" content="A grid item placed in a non-start row and column of a zero-width, zero-height grid overflows both the right and bottom edges and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 0;
+    display: grid;
+    grid-template-columns: 40px 40px;
+    grid-template-rows: 40px 40px;
+  }
+  .item {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .square {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="square"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-item-right-of-container-is-painted-ref.html">
+<meta name="assert" content="A grid item in a zero-width grid container overflows its right edge and must still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 100px;
+    display: grid;
+    grid-template-columns: auto;
+    grid-template-rows: auto;
+  }
+  .item {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="item"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .a {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 30px;
+    background-color: green;
+  }
+  .b {
+    position: absolute;
+    left: 40px;
+    top: 40px;
+    width: 30px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="a"></div>
+<div class="b"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+  body {
+    margin: 0;
+  }
+  .a {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 30px;
+    background-color: green;
+  }
+  .b {
+    position: absolute;
+    left: 40px;
+    top: 40px;
+    width: 30px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="a"></div>
+<div class="b"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid/">
+<link rel="help" href="https://drafts.csswg.org/css-overflow/#scrollable">
+<link rel="match" href="grid-overflowing-multiple-items-are-painted-ref.html">
+<meta name="assert" content="Multiple grid items placed in different cells of a zero-width, zero-height grid overflow different edges and must all still be painted.">
+<style>
+  body {
+    margin: 0;
+  }
+  .grid {
+    width: 0;
+    height: 0;
+    display: grid;
+    grid-template-columns: 40px 40px;
+    grid-template-rows: 40px 40px;
+  }
+  .a {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+    width: 100px;
+    height: 30px;
+    background-color: green;
+  }
+  .b {
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    width: 30px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<div class="grid">
+  <div class="a"></div>
+  <div class="b"></div>
+</div>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -213,6 +213,30 @@ void GridLayout::layout()
     updateGridItemRenderers();
     updateFormattingContextRootRenderer(gridLayoutConstraints, usedTrackSizes);
     layoutOutOfFlowBoxes(usedTrackSizes);
+
+    CheckedRef renderGrid = gridBoxRenderer();
+    renderGrid->updateLogicalHeight();
+    updateOverflow(renderGrid);
+}
+
+void GridLayout::updateOverflow(RenderGrid& renderGrid)
+{
+    ASSERT(renderGrid.style().isOverflowVisible());
+    renderGrid.clearOverflow();
+
+    CheckedRef layoutState = this->layoutState();
+    auto& gridBoxGeometry = layoutState->geometryForBox(gridBox());
+    auto contentBoxOffset = LayoutSize { gridBoxGeometry.contentBoxLeft(), gridBoxGeometry.contentBoxTop() };
+
+    auto gridItemsOverflowRect = LayoutRect { };
+    for (CheckedRef layoutBox : formattingContextBoxes(gridBox())) {
+        LayoutRect gridItemBorderBoxRect = Layout::BoxGeometry::borderBoxRect(layoutState->geometryForBox(layoutBox));
+        gridItemBorderBoxRect.move(contentBoxOffset);
+        gridItemsOverflowRect.unite(gridItemBorderBoxRect);
+    }
+
+    if (!renderGrid.borderBoxRect().contains(gridItemsOverflowRect))
+        renderGrid.addVisualOverflow(gridItemsOverflowRect);
 }
 
 void GridLayout::layoutOutOfFlowBoxes(const Layout::UsedTrackSizes& usedTrackSizes)

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -66,6 +66,7 @@ private:
     void updateGridItemRenderers();
     void updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints&, const Layout::UsedTrackSizes&);
     void layoutOutOfFlowBoxes(const Layout::UsedTrackSizes&);
+    void updateOverflow(RenderGrid&);
     void populateGridPositionsForOutOfFlowLayout(const Layout::UsedTrackSizes&);
 
     const Layout::ElementBox& gridBox() const { return *m_gridBox; }

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -583,7 +583,6 @@ bool RenderGrid::layoutUsingGridFormattingContext()
     gridLayout.updateFormattingContextGeometries();
 
     gridLayout.layout();
-    updateLogicalHeight();
     return true;
 }
 


### PR DESCRIPTION
#### aaf1bb8a51dc510c7c95a5f63067024d191b99fe
<pre>
[GFC] Visually overflowing content may not get painted in certain circumstances.
<a href="https://bugs.webkit.org/show_bug.cgi?id=318489">https://bugs.webkit.org/show_bug.cgi?id=318489</a>
<a href="https://rdar.apple.com/problem/181277780">rdar://problem/181277780</a>

Reviewed by Alan Baradlay.

RenderBlock::paint has an early return that will exit the function if
the visual content is clipped out with respect to the painting rect.
This is done by checking to see if the visual overflow rect intersects
with the painting rect. In the scenario where there is no visual
overflow visualOverflowRect() will just return the border box rect of
the renderer.

Currently, we do not report any sort of visual overflow for GFC content
so RenderBlock::paint always grabs the border box rect. In the cases
where the border box rect has a width of height is 0, since intersects()
checks for empty rects, we end up early returning even if the grid has
visual content.

We can fix this by collecting any sort of visual overflow at the end of
layout inside of integration and set it on the RenderGrid if there is
any.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-below-container-is-painted.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-both-axes-is-painted.html: Added.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-in-nonstart-cell-is-painted.html: Added.
Checks to make sure that we still properly report visual overflow if the
overflowing content does not start at the content box origin of the grid.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-item-right-of-container-is-painted.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-overflowing-multiple-items-are-painted.html: Added.

Canonical link: <a href="https://commits.webkit.org/316668@main">https://commits.webkit.org/316668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f151d15946a2b3d60bc5cb41ac61300ec8f2340d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172829 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46748 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130385 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134413 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94882 "22 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114882 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36459 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34772 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30886 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146882 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34476 "Found 1 new test failure: imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-corner-shape-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184833 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143224 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143096 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38692 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47097 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112099 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38091 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118857 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45614 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9419 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45015 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45247 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->