### PR TITLE
Web Inspector: Site Isolation: Network domain sourceMappingURL forwarding

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url-expected.txt
@@ -1,0 +1,16 @@
+Test that Network.loadingFinished forwards the sourceMapURL for cross-origin iframe stylesheets under Site Isolation, from both the SourceMap response header and an inline sourceMappingURL comment.
+
+
+Installing hook for downloadSourceMap.
+
+== Running test suite: SiteIsolation.Network.CrossOriginIFrameSourceMapURL
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.SourceMapURLFromHeader
+PASS: Resource should be created.
+PASS: Resource should be a stylesheet.
+PASS: loadingFinished should carry the SourceMap header value.
+
+-- Running test case: SiteIsolation.Network.CrossOriginIFrame.SourceMapURLFromInlineComment
+PASS: Resource should be created.
+PASS: Resource should be a stylesheet.
+PASS: loadingFinished should carry the inline sourceMappingURL comment value.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url.html
@@ -1,0 +1,62 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.CrossOriginIFrameSourceMapURL");
+
+    // Spy on downloadSourceMap to capture the sourceMapURL that Network.loadingFinished
+    // forwards, without performing the (flaky, network-dependent) source map download.
+    InspectorTest.log("Installing hook for downloadSourceMap.");
+    let capturedSourceMapURL;
+    WI.networkManager.downloadSourceMap = function(sourceMapURL) {
+        capturedSourceMapURL = sourceMapURL;
+    };
+
+    // Load a stylesheet in the cross-origin iframe and return the resource plus the
+    // sourceMapURL captured from Network.loadingFinished.
+    async function loadStylesheet(href) {
+        let frameTarget = await frameTargetForURLContaining("iframe-with-stylesheet.html");
+        InspectorTest.assert(frameTarget instanceof WI.FrameTarget, "Cross-origin stylesheet iframe frame target should exist.");
+        await waitForExpressionInTarget(frameTarget, "typeof loadStylesheet === 'function'");
+
+        capturedSourceMapURL = undefined;
+        let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+        await frameTarget.RuntimeAgent.evaluate.invoke({expression: `loadStylesheet(${JSON.stringify(href)})`, objectGroup: "test"});
+        let resourceEvent = await resourceAddedPromise;
+        let resource = resourceEvent.data.resource;
+        if (!resource.finished)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+        return {resource, sourceMapURL: capturedSourceMapURL};
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.SourceMapURLFromHeader",
+        description: "loadingFinished for a cross-origin iframe stylesheet should carry the SourceMap response header value.",
+        async test() {
+            let {resource, sourceMapURL} = await loadStylesheet("stylesheet-with-source-map-header.py?" + Math.random());
+            InspectorTest.expectThat(resource instanceof WI.Resource, "Resource should be created.");
+            InspectorTest.expectEqual(resource.type, WI.Resource.Type.StyleSheet, "Resource should be a stylesheet.");
+            InspectorTest.expectEqual(sourceMapURL, "stylesheet-header.css.map", "loadingFinished should carry the SourceMap header value.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.CrossOriginIFrame.SourceMapURLFromInlineComment",
+        description: "loadingFinished for a cross-origin iframe stylesheet with no header should carry the inline sourceMappingURL comment value.",
+        async test() {
+            let {resource, sourceMapURL} = await loadStylesheet("stylesheet-with-inline-source-map.css?" + Math.random());
+            InspectorTest.expectThat(resource instanceof WI.Resource, "Resource should be created.");
+            InspectorTest.expectEqual(resource.type, WI.Resource.Type.StyleSheet, "Resource should be a stylesheet.");
+            InspectorTest.expectEqual(sourceMapURL, "stylesheet-inline.css.map", "loadingFinished should carry the inline sourceMappingURL comment value.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Network.loadingFinished forwards the sourceMapURL for cross-origin iframe stylesheets under Site Isolation, from both the SourceMap response header and an inline sourceMappingURL comment.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-stylesheet.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/iframe-with-stylesheet.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/iframe-with-stylesheet.html
@@ -1,0 +1,10 @@
+<p>Cross-origin iframe that loads a stylesheet on demand.</p>
+
+<script>
+function loadStylesheet(href) {
+    let link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    document.head.appendChild(link);
+}
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-inline-source-map.css
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-inline-source-map.css
@@ -1,0 +1,2 @@
+body { color: blue; }
+/*# sourceMappingURL=stylesheet-inline.css.map */

--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header.py
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write('Content-Type: text/css\r\n')
+sys.stdout.write('Cache-Control: no-store\r\n')
+sys.stdout.write('SourceMap: stylesheet-header.css.map\r\n')
+sys.stdout.write('\r\n')
+sys.stdout.flush()
+
+sys.stdout.write('body { color: green; }\n')

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp
@@ -27,6 +27,7 @@
 #include "BackendResourceDataStore.h"
 
 #include <WebCore/CertificateInfo.h>
+#include <WebCore/HTTPHeaderNames.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/ResourceResponse.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -182,6 +183,12 @@ void BackendResourceDataStore::responseReceived(ResourceLoaderIdentifier resourc
     resourceData->setType(type);
     resourceData->setMIMEType(response.mimeType());
     resourceData->m_responseTimestamp = WallTime::now();
+
+    // Capture the source map URL header now, since the response is not retained.
+    String sourceMapURL = response.httpHeaderField(HTTPHeaderName::SourceMap);
+    if (sourceMapURL.isEmpty())
+        sourceMapURL = response.httpHeaderField(HTTPHeaderName::XSourceMap);
+    resourceData->setSourceMapURL(sourceMapURL);
 
     if (ResourceUtilities::shouldTreatAsText(response.mimeType()))
         resourceData->setDecoder(ResourceUtilities::createTextDecoder(response.mimeType(), response.textEncodingName()));

--- a/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
+++ b/Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h
@@ -81,6 +81,9 @@ public:
         const String& textEncodingName() const LIFETIME_BOUND { return m_textEncodingName; }
         void setTextEncodingName(const String& textEncodingName) { m_textEncodingName = textEncodingName; }
 
+        const String& sourceMapURL() const LIFETIME_BOUND { return m_sourceMapURL; }
+        void setSourceMapURL(const String& sourceMapURL) { m_sourceMapURL = sourceMapURL; }
+
         int httpStatusCode() const { return m_httpStatusCode; }
         void setHTTPStatusCode(int code) { m_httpStatusCode = code; }
 
@@ -120,6 +123,7 @@ public:
         String m_url;
         String m_mimeType;
         String m_textEncodingName;
+        String m_sourceMapURL;
         String m_content;
         String m_httpStatusText;
         RefPtr<WebCore::TextResourceDecoder> m_decoder;

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -35,6 +35,7 @@
 #include "ProxyingNetworkAgentMessages.h"
 #include "WebPage.h"
 #include "WebProcess.h"
+#include <JavaScriptCore/ContentSearchUtilities.h>
 #include <WebCore/CachedResource.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentInlines.h>
@@ -286,10 +287,21 @@ void FrameNetworkAgentProxy::didFinishLoading(ResourceLoaderIdentifier resourceI
     if (!page)
         return;
 
+    // The Network domain's sourceMapURL is CSS-only by design; scripts flow through
+    // the Debugger domain. Mirror ResourceUtilities::sourceMapURLForResource: prefer the
+    // SourceMap/X-SourceMap response header (captured at response time), then fall back to
+    // a "/*# sourceMappingURL=... */" comment in the decoded stylesheet text.
+    String sourceMapURL;
+    if (auto* resourceData = m_resourcesData->data(resourceID); resourceData && resourceData->type() == ResourceType::StyleSheet) {
+        sourceMapURL = resourceData->sourceMapURL();
+        if (sourceMapURL.isEmpty() && resourceData->hasContent() && !resourceData->base64Encoded())
+            sourceMapURL = ContentSearchUtilities::findStylesheetSourceMapURL(resourceData->content());
+    }
+
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
-        Messages::ProxyingNetworkAgent::LoadingFinished(qualifyResourceID(resourceID), timestamp, String()),
+        Messages::ProxyingNetworkAgent::LoadingFinished(qualifyResourceID(resourceID), timestamp, sourceMapURL),
         page->identifier());
 }
 
@@ -336,6 +348,9 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
     if (ResourceUtilities::cachedResourceContent(cachedResource, &content, &base64Encoded))
         m_resourcesData->setResourceContent(resourceID, content, base64Encoded);
 
+    // FIXME: Unlike the network path (didFinishLoading), the CSS sourceMappingURL is not
+    // forwarded for memory-cached stylesheets: it is neither computed from the CachedResource
+    // here nor carried by the RequestServedFromMemoryCache message. Tracked in webkit.org/b/??????.
     auto timestamp = MonotonicTime::now().secondsSinceEpoch().value();
     auto documentURL = protectedLoader->url().string();
 


### PR DESCRIPTION
#### 7b30931aae73c8bbbff647740c7f66a97376b2e5
<pre>
Web Inspector: Site Isolation: Network domain sourceMappingURL forwarding
<a href="https://bugs.webkit.org/show_bug.cgi?id=310251">https://bugs.webkit.org/show_bug.cgi?id=310251</a>
<a href="https://rdar.apple.com/172894304">rdar://172894304</a>

Reviewed by BJ Burg.

Under Site Isolation, network events for cross-origin iframe
resources are reported by FrameNetworkAgentProxy (WebProcess) to
ProxyingNetworkAgent (UIProcess), bypassing the legacy in-WebProcess
InspectorNetworkAgent (which early-returns from enable() under SI).
FrameNetworkAgentProxy::didFinishLoading was sending an empty
sourceMappingURL, so source maps for stylesheets loaded inside
cross-origin iframes did not auto-link in the Network tab.

Mirror the legacy ResourceUtilities::sourceMapURLForResource
behavior, which is CSS-only by design: script source maps flow
through the Debugger domain (scriptParsed) and are unaffected here.

Because BackendResourceDataStore does not retain the
ResourceResponse, capture the SourceMap (then X-SourceMap) header
when the response is received. At didFinishLoading, for stylesheets,
use that header value, falling back to a &quot;/*# sourceMappingURL=... */&quot;
comment in the decoded stylesheet text, and send the resolved URL in
the LoadingFinished IPC message. ProxyingNetworkAgent::loadingFinished
and the frontend already forward and consume this value, so no
UIProcess or frontend changes are needed.

The memory-cache path (Network.CachedResource.sourceMapURL via
RequestServedFromMemoryCache) is not covered by this change. Tracking
it as a follow-up in webkit.org/b/318740.

Test: http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url.html

* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/cross-origin-iframe-network-source-map-url.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/iframe-with-stylesheet.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-inline-source-map.css: Added.
(body):
* LayoutTests/http/tests/site-isolation/inspector/network/resources/stylesheet-with-source-map-header.py: Added.
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.cpp:
(WebKit::BackendResourceDataStore::responseReceived):
* Source/WebKit/WebProcess/Inspector/BackendResourceDataStore.h:
(WebKit::BackendResourceDataStore::ResourceData::setSourceMapURL):
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::FrameNetworkAgentProxy::didFinishLoading):
(WebKit::FrameNetworkAgentProxy::didLoadResourceFromMemoryCache):

Canonical link: <a href="https://commits.webkit.org/316764@main">https://commits.webkit.org/316764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad7c46d56938d749ead5b18aac5c7e68e420db36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173369 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/47301 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46983 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/182942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/176327 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/182942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46983 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/31427 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/38234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46983 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/185367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46969 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/185367 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47648 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26331 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47648 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/46154 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/45556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->