### PR TITLE
[Site Isolation] Web Inspector: Network domain emulations/headers not forwarded to web process

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/network/resources/cacheable-resource.py
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/resources/cacheable-resource.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import sys
+
+# A cacheable resource: with a long max-age, a repeated same-URL load is served from the cache unless
+# the inspector has disabled resource caching for the page.
+sys.stdout.write('Content-Type: text/plain\r\n')
+sys.stdout.write('Cache-Control: max-age=3600\r\n')
+sys.stdout.write('Access-Control-Allow-Origin: *\r\n')
+sys.stdout.write('\r\n')
+sys.stdout.write('cacheable resource body')

--- a/LayoutTests/http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled-expected.txt
@@ -1,0 +1,11 @@
+Test that Network.setEmulatedConditions and Network.setResourceCachingDisabled are forwarded to the WebContent process(es) under Site Isolation.
+
+
+
+== Running test suite: SiteIsolation.Network.SetEmulatedConditionsAndResourceCachingDisabled
+-- Running test case: SiteIsolation.Network.SetResourceCachingDisabled.CrossOriginIFrameBypassesCache
+PASS: With caching enabled, the first load should come from the network.
+PASS: With caching enabled, the second load should be served from the cache.
+PASS: With caching disabled, the first load should come from the network.
+PASS: With caching disabled, the second load should NOT be served from the cache.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled.html
@@ -1,0 +1,97 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.SetEmulatedConditionsAndResourceCachingDisabled");
+
+    // Load a resource inside the cross-origin iframe and resolve to the resulting resource's
+    // responseSource, so we can observe whether it was served from the cache.
+    async function fetchResponseSource(frameTarget, url) {
+        let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+        await frameTarget.RuntimeAgent.evaluate.invoke({
+            expression: `fetch("${url}").then((response) => response.text())`,
+            objectGroup: "test",
+            awaitPromise: true,
+        });
+        let resource = (await resourceAddedPromise).data.resource;
+        if (!resource.finished && !resource.failed)
+            await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+        return resource.responseSource;
+    }
+
+    function isFromCache(responseSource) {
+        return responseSource === WI.Resource.ResponseSource.MemoryCache
+            || responseSource === WI.Resource.ResponseSource.DiskCache;
+    }
+
+    // Give each phase a unique cache key so its first load is guaranteed to miss any entry left by a
+    // previous test run; only a repeat within the same phase (same key) can be a genuine cache hit.
+    function uniqueCacheableURL() {
+        return `cacheable-resource.py?key=${Math.random()}`;
+    }
+
+    // FIXME: Network.setEmulatedConditions is gated on ENABLE_INSPECTOR_NETWORK_THROTTLING, which is
+    // disabled by default (rdar://122224142), so the command is not generated on current builds.
+    // Guarded on hasCommand so this case self-enables once network throttling ships.
+    if (InspectorBackend.hasCommand("Network.setEmulatedConditions")) {
+        suite.addTestCase({
+            name: "SiteIsolation.Network.SetEmulatedConditions.SucceedsUnderSiteIsolation",
+            description: "Network.setEmulatedConditions should succeed under Site Isolation (previously returned \"Not supported\").",
+            async test() {
+                // setEmulatedConditions is hosted by ProxyingNetworkAgent on the web-page (backend)
+                // target; it drives the throttle session-wide via the WebsiteDataStore.
+                await WI.backendTarget.NetworkAgent.setEmulatedConditions(1024);
+                InspectorTest.pass("setEmulatedConditions with a byte limit should succeed under Site Isolation.");
+
+                // Reset so we don't throttle the resource loads in the next test case.
+                await WI.backendTarget.NetworkAgent.setEmulatedConditions();
+                InspectorTest.pass("setEmulatedConditions reset should succeed under Site Isolation.");
+            }
+        });
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.SetResourceCachingDisabled.CrossOriginIFrameBypassesCache",
+        description: "Network.setResourceCachingDisabled should be forwarded to the WebContent process so a cross-origin iframe's repeated load is not served from the cache.",
+        async test() {
+            let frameTarget = await frameTargetForURLContaining("iframe-with-fetch.html");
+            InspectorTest.assert(frameTarget instanceof WI.FrameTarget, "Cross-origin iframe frame target should exist.");
+            await waitForExpressionInTarget(frameTarget, "typeof triggerFetch === 'function'");
+
+            InspectorTest.assert(WI.backendTarget.hasCommand("Network.setResourceCachingDisabled"), "Backend target should expose Network.setResourceCachingDisabled.");
+
+            // Control: with caching enabled, a repeated load of a cacheable resource is served from
+            // the cache. This establishes that the resource is cacheable in the first place.
+            const enabledURL = uniqueCacheableURL();
+            await WI.backendTarget.NetworkAgent.setResourceCachingDisabled(false);
+            await frameTarget.RuntimeAgent.evaluate.invoke({expression: "internals.clearMemoryCache()", objectGroup: "test"});
+
+            let firstEnabledSource = await fetchResponseSource(frameTarget, enabledURL);
+            InspectorTest.expectEqual(firstEnabledSource, WI.Resource.ResponseSource.Network, "With caching enabled, the first load should come from the network.");
+            let secondEnabledSource = await fetchResponseSource(frameTarget, enabledURL);
+            InspectorTest.expectThat(isFromCache(secondEnabledSource), "With caching enabled, the second load should be served from the cache.");
+
+            // Treatment: with caching disabled, the same repeated load must go to the network.
+            const disabledURL = uniqueCacheableURL();
+            await WI.backendTarget.NetworkAgent.setResourceCachingDisabled(true);
+            await frameTarget.RuntimeAgent.evaluate.invoke({expression: "internals.clearMemoryCache()", objectGroup: "test"});
+
+            let firstDisabledSource = await fetchResponseSource(frameTarget, disabledURL);
+            InspectorTest.expectEqual(firstDisabledSource, WI.Resource.ResponseSource.Network, "With caching disabled, the first load should come from the network.");
+            let secondDisabledSource = await fetchResponseSource(frameTarget, disabledURL);
+            InspectorTest.expectFalse(isFromCache(secondDisabledSource), "With caching disabled, the second load should NOT be served from the cache.");
+
+            // Reset.
+            await WI.backendTarget.NetworkAgent.setResourceCachingDisabled(false);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Network.setEmulatedConditions and Network.setResourceCachingDisabled are forwarded to the WebContent process(es) under Site Isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-fetch.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/network/set-extra-http-headers-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/set-extra-http-headers-expected.txt
@@ -1,0 +1,8 @@
+Test that Network.setExtraHTTPHeaders is forwarded to the WebContent process and applied to requests from a cross-origin iframe under Site Isolation.
+
+
+
+== Running test suite: SiteIsolation.Network.SetExtraHTTPHeaders
+-- Running test case: SiteIsolation.Network.SetExtraHTTPHeaders.AppliedToCrossOriginIFrameRequest
+PASS: The cross-origin iframe's request should carry the inspector's extra HTTP header.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/network/set-extra-http-headers.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/network/set-extra-http-headers.html
@@ -1,0 +1,60 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Network.SetExtraHTTPHeaders");
+
+    // HTTP header names are case-insensitive; the request headers reported by the Network domain may
+    // not preserve the exact casing the inspector supplied.
+    function headerValueIgnoringCase(headers, name) {
+        let lowered = name.toLowerCase();
+        for (let key in headers) {
+            if (key.toLowerCase() === lowered)
+                return headers[key];
+        }
+        return undefined;
+    }
+
+    suite.addTestCase({
+        name: "SiteIsolation.Network.SetExtraHTTPHeaders.AppliedToCrossOriginIFrameRequest",
+        description: "Network.setExtraHTTPHeaders should be forwarded to the WebContent process and applied to requests made from a cross-origin iframe.",
+        async test() {
+            let frameTarget = await frameTargetForURLContaining("iframe-with-fetch.html");
+            InspectorTest.assert(frameTarget instanceof WI.FrameTarget, "Cross-origin iframe frame target should exist.");
+            await waitForExpressionInTarget(frameTarget, "typeof triggerFetch === 'function'");
+
+            const headerName = "X-WebKit-Inspector-Test";
+            const headerValue = "site-isolation-header-value";
+
+            // setExtraHTTPHeaders is a Network-domain command hosted by ProxyingNetworkAgent on the
+            // web-page (backend) target under Site Isolation, not on the per-frame target.
+            InspectorTest.assert(WI.backendTarget.hasCommand("Network.setExtraHTTPHeaders"), "Backend target should expose Network.setExtraHTTPHeaders.");
+            await WI.backendTarget.NetworkAgent.setExtraHTTPHeaders({[headerName]: headerValue});
+
+            // The command completes in the UIProcess after dispatching the header map to each
+            // WebContent process; that dispatch is asynchronous relative to the frame target's own
+            // command channel, so poll by triggering fetches from the iframe until a request carries
+            // the header. Each request's headers are reported (post-application) via requestWillBeSent.
+            let observedValue;
+            for (let attempt = 0; attempt < 20 && observedValue !== headerValue; ++attempt) {
+                let resourceAddedPromise = WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+                await frameTarget.RuntimeAgent.evaluate.invoke({expression: "triggerFetch()", objectGroup: "test"});
+                let resource = (await resourceAddedPromise).data.resource;
+                observedValue = headerValueIgnoringCase(resource.requestHeaders, headerName);
+                if (observedValue !== headerValue)
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+            }
+
+            InspectorTest.expectEqual(observedValue, headerValue, "The cross-origin iframe's request should carry the inspector's extra HTTP header.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that Network.setExtraHTTPHeaders is forwarded to the WebContent process and applied to requests from a cross-origin iframe under Site Isolation.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/network/resources/iframe-with-fetch.html"></iframe>
+</body>

--- a/Source/JavaScriptCore/inspector/protocol/Network.json
+++ b/Source/JavaScriptCore/inspector/protocol/Network.json
@@ -195,7 +195,7 @@
         {
             "name": "setExtraHTTPHeaders",
             "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
-            "targetTypes": ["page"],
+            "targetTypes": ["page", "web-page"],
             "parameters": [
                 { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
             ]
@@ -356,7 +356,7 @@
         {
             "name": "setEmulatedConditions",
             "description": "Emulate various network conditions (e.g. bytes per second, latency, etc.).",
-            "targetTypes": ["page"],
+            "targetTypes": ["page", "web-page"],
             "condition": "defined(ENABLE_INSPECTOR_NETWORK_THROTTLING) && ENABLE_INSPECTOR_NETWORK_THROTTLING",
             "parameters": [
                 { "name": "bytesPerSecondLimit", "type": "integer", "optional": true, "description": "Limits the bytes per second of requests if positive. Removes any limits if zero or not provided." }

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -37,7 +37,9 @@
 #include "WebInspectorBackendMessages.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
+#include "WebsiteDataStore.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorIdentifierRegistry.h>
 #include <WebCore/ProcessQualified.h>
 
@@ -203,6 +205,12 @@ void ProxyingNetworkAgent::enableInstrumentationForProcess(WebKit::WebProcessPro
     });
     webProcess.addMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID, *this);
     webProcess.send(Messages::WebInspectorBackend::EnableNetworkInstrumentation { }, pageID);
+
+    // Catch a newly-instrumented process up to the latched network overrides.
+    if (!m_extraRequestHeaders.isEmpty())
+        webProcess.send(Messages::WebInspectorBackend::SetExtraHTTPHeaders { m_extraRequestHeaders }, pageID);
+    if (m_resourceCachingDisabled)
+        webProcess.send(Messages::WebInspectorBackend::SetResourceCachingDisabled { m_resourceCachingDisabled }, pageID);
 }
 
 void ProxyingNetworkAgent::disableInstrumentationForProcess(WebKit::WebProcessProxy& webProcess, WebCore::PageIdentifier pageID)
@@ -279,12 +287,37 @@ CommandResult<void> ProxyingNetworkAgent::disable()
     }
     removeAllRegisteredReceivers();
 
+    // Reset latched Network overrides. This agent outlives frontend disconnect/reconnect, so a
+    // future frontend must not inherit stale state; the WebProcess side is undone by the
+    // DisableNetworkInstrumentation messages above. Mirrors InspectorNetworkAgent::disable().
+    m_extraRequestHeaders = { };
+    m_resourceCachingDisabled = false;
+#if ENABLE(INSPECTOR_NETWORK_THROTTLING)
+    if (RefPtr inspectedPage = m_inspectedPage.get())
+        inspectedPage->websiteDataStore().setEmulatedConditions(std::nullopt);
+#endif
+
     return { };
 }
 
-CommandResult<void> ProxyingNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&&)
+CommandResult<void> ProxyingNetworkAgent::setExtraHTTPHeaders(Ref<JSON::Object>&& headers)
 {
-    // FIXME: Forward to all WebContent processes.
+    HTTPHeaderMap headerMap;
+    for (auto& entry : headers.get()) {
+        Ref value = entry.value;
+        if (auto stringValue = value->asString(); !!stringValue)
+            headerMap.set(entry.key, stringValue);
+    }
+    m_extraRequestHeaders = WTF::move(headerMap);
+
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage)
+        return { };
+
+    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebInspectorBackend::SetExtraHTTPHeaders { m_extraRequestHeaders }, pageID);
+    });
+
     return { };
 }
 
@@ -330,9 +363,18 @@ void ProxyingNetworkAgent::getResponseBody(const Protocol::Network::RequestId& r
         *targetPageID);
 }
 
-CommandResult<void> ProxyingNetworkAgent::setResourceCachingDisabled(bool)
+CommandResult<void> ProxyingNetworkAgent::setResourceCachingDisabled(bool disabled)
 {
-    // FIXME: Forward to all WebContent processes.
+    m_resourceCachingDisabled = disabled;
+
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage)
+        return { };
+
+    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebInspectorBackend::SetResourceCachingDisabled { disabled }, pageID);
+    });
+
     return { };
 }
 
@@ -401,9 +443,18 @@ CommandResult<void> ProxyingNetworkAgent::interceptRequestWithError(const Protoc
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-CommandResult<void> ProxyingNetworkAgent::setEmulatedConditions(std::optional<int>&&)
+CommandResult<void> ProxyingNetworkAgent::setEmulatedConditions(std::optional<int>&& bytesPerSecondLimit)
 {
-    return makeUnexpected("Not supported"_s);
+    RefPtr inspectedPage = m_inspectedPage.get();
+    if (!inspectedPage)
+        return makeUnexpected("Inspected page is gone"_s);
+
+    std::optional<int64_t> limit;
+    if (bytesPerSecondLimit)
+        limit = *bytesPerSecondLimit;
+
+    inspectedPage->websiteDataStore().setEmulatedConditions(WTF::move(limit));
+    return { };
 }
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendDispatchers.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
@@ -116,6 +117,9 @@ private:
 
     bool m_enabled { false };
     HashMap<std::pair<WebCore::ProcessIdentifier, WebCore::PageIdentifier>, unsigned> m_instrumentedProcessPageCounts;
+
+    WebCore::HTTPHeaderMap m_extraRequestHeaders;
+    bool m_resourceCachingDisabled { false };
 
     // Pin each instrumented WebProcessProxy alive while we hold an IPC message
     // receiver registration on it. Without this, the process can be destructed

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -42,6 +42,7 @@
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
+#include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/InstrumentingAgents.h>
@@ -64,10 +65,11 @@ static ScopedResourceLoaderIdentifier qualifyResourceID(ResourceLoaderIdentifier
     return { resourceID, Process::identifier() };
 }
 
-FrameNetworkAgentProxy::FrameNetworkAgentProxy(WebAgentContext& context, WebPage& page, BackendResourceDataStore& store)
+FrameNetworkAgentProxy::FrameNetworkAgentProxy(WebAgentContext& context, WebPage& page, BackendResourceDataStore& store, const HTTPHeaderMap& extraRequestHeaders)
     : NetworkAgentInstrumentation(context)
     , m_page(page)
     , m_resourcesData(store)
+    , m_extraRequestHeaders(extraRequestHeaders)
 {
 }
 
@@ -164,6 +166,11 @@ void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID
     if (!loader || !loader->frame() || !loader->frame()->document())
         return;
 
+    // Apply the inspector's extra request headers to the mutable outgoing request, like the legacy
+    // InspectorNetworkAgent::willSendRequest.
+    for (auto& header : m_extraRequestHeaders)
+        request.setHTTPHeaderField(header.key, header.value);
+
     RefPtr protectedLoader = loader;
     RefPtr page = m_page.get();
     if (!page)
@@ -195,6 +202,11 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
 {
     if (!loader || !loader->frame() || !loader->frame()->document())
         return;
+
+    // Apply the inspector's extra request headers here too, so Ping/Beacon loads carry them like
+    // the legacy path (InspectorNetworkAgent funnels both willSendRequest paths through one core).
+    for (auto& header : m_extraRequestHeaders)
+        request.setHTTPHeaderField(header.key, header.value);
 
     RefPtr protectedLoader = loader;
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.h
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.h
@@ -44,6 +44,7 @@ class CachedResource;
 class Document;
 class DocumentLoader;
 class DocumentThreadableLoader;
+class HTTPHeaderMap;
 class LocalFrame;
 class NetworkLoadMetrics;
 class ResourceError;
@@ -65,7 +66,7 @@ class FrameNetworkAgentProxy : public Inspector::NetworkAgentInstrumentation, pu
     WTF_MAKE_NONCOPYABLE(FrameNetworkAgentProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameNetworkAgentProxy);
 public:
-    FrameNetworkAgentProxy(WebCore::WebAgentContext&, WebPage&, BackendResourceDataStore&);
+    FrameNetworkAgentProxy(WebCore::WebAgentContext&, WebPage&, BackendResourceDataStore&, const WebCore::HTTPHeaderMap& extraRequestHeaders);
     ~FrameNetworkAgentProxy() override;
 
     // AbstractCanMakeCheckedPtr overrides
@@ -100,6 +101,9 @@ public:
 private:
     WeakRef<WebPage> m_page;
     CheckedRef<BackendResourceDataStore> const m_resourcesData;
+
+    // Owned by the WebInspectorBackend that owns this proxy; applied in willSendRequest.
+    const WebCore::HTTPHeaderMap& m_extraRequestHeaders;
 
     bool m_enabled { false };
 };

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -360,7 +360,7 @@ void WebInspectorBackend::ensureNetworkInstrumentationForFrame(LocalFrame& frame
     };
 
     CheckedRef resourceDataStore = m_resourceDataStore.get();
-    auto proxy = makeUnique<FrameNetworkAgentProxy>(webContext, *page, resourceDataStore.get());
+    auto proxy = makeUnique<FrameNetworkAgentProxy>(webContext, *page, resourceDataStore.get(), m_extraRequestHeaders);
     proxy->enable();
     m_frameNetworkAgentProxies.add(frameID, WTF::move(proxy));
 }
@@ -393,11 +393,19 @@ void WebInspectorBackend::disableNetworkInstrumentation()
     m_frameNetworkAgentProxies.clear();
     m_networkInstrumentationEnabled = false;
 
+    // Reset latched Network overrides so nothing persists past inspection. The caching flag lives
+    // on the Page and would otherwise stay disabled with no inspector attached. Mirrors
+    // InspectorNetworkAgent::disable().
+    m_extraRequestHeaders.clear();
+    m_resourceCachingDisabled = false;
+
     if (!m_page)
         return;
 
-    if (RefPtr corePage = m_page->corePage())
+    if (RefPtr corePage = m_page->corePage()) {
+        corePage->setResourceCachingDisabledByWebInspector(false);
         corePage->inspectorController().disconnectRemoteInstrumentation();
+    }
 }
 
 void WebInspectorBackend::removeInstrumentationForFrame(FrameIdentifier frameID)
@@ -572,6 +580,23 @@ void WebInspectorBackend::searchInFramesAndRequests(Vector<WebCore::FrameIdentif
     });
 
     completionHandler(WTF::move(results));
+}
+
+void WebInspectorBackend::setExtraHTTPHeaders(WebCore::HTTPHeaderMap&& headers)
+{
+    // Each FrameNetworkAgentProxy reads this in willSendRequest, so frames created after this
+    // arrives also apply it.
+    m_extraRequestHeaders = WTF::move(headers);
+}
+
+void WebInspectorBackend::setResourceCachingDisabled(bool disabled)
+{
+    m_resourceCachingDisabled = disabled;
+
+    // The flag lives on the Page, so one application covers every frame in this process.
+    RefPtr page = m_page.get();
+    if (RefPtr corePage = page ? page->corePage() : nullptr)
+        corePage->setResourceCachingDisabledByWebInspector(disabled);
 }
 
 void WebInspectorBackend::ensurePageInstrumentationForFrame(LocalFrame& frame)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -29,6 +29,7 @@
 #include "Connection.h"
 #include "MessageReceiver.h"
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/HTTPHeaderMap.h>
 #include <WebCore/InspectorBackendClient.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <wtf/HashMap.h>
@@ -100,6 +101,9 @@ public:
     void disableNetworkInstrumentation();
     void getResponseBody(WebCore::ResourceLoaderIdentifier, CompletionHandler<void(String content, bool base64Encoded, String errorString)>&&);
 
+    void setExtraHTTPHeaders(WebCore::HTTPHeaderMap&&);
+    void setResourceCachingDisabled(bool);
+
     void enablePageInstrumentation();
     void disablePageInstrumentation();
     void getFrameResourceData(Vector<WebCore::FrameIdentifier>&& frameIDs, CompletionHandler<void(Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>>&&)>&&);
@@ -143,6 +147,11 @@ private:
 
     bool m_attached { false };
     bool m_previousCanAttach { false };
+
+    // Must outlive m_frameNetworkAgentProxies below: each proxy holds a reference to
+    // m_extraRequestHeaders and reads it in willSendRequest.
+    WebCore::HTTPHeaderMap m_extraRequestHeaders;
+    bool m_resourceCachingDisabled { false };
 
     HashMap<WebCore::FrameIdentifier, std::unique_ptr<FrameNetworkAgentProxy>> m_frameNetworkAgentProxies;
     UniqueRef<BackendResourceDataStore> m_resourceDataStore;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -46,6 +46,10 @@ messages -> WebInspectorBackend {
     EnableNetworkInstrumentation()
     DisableNetworkInstrumentation()
 
+    # Network overrides forwarded from the UIProcess ProxyingNetworkAgent. See rdar://181060656.
+    SetExtraHTTPHeaders(WebCore::HTTPHeaderMap headers)
+    SetResourceCachingDisabled(bool disabled)
+
     EnablePageInstrumentation()
     DisablePageInstrumentation()
 


### PR DESCRIPTION
#### 65ee250042a1b2c540c5aa68095410b1024ab47a
<pre>
[Site Isolation] Web Inspector: Network domain emulations/headers not forwarded to web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=318493">https://bugs.webkit.org/show_bug.cgi?id=318493</a>

Reviewed by BJ Burg.

Under Site Isolation the per-WebProcess WebCore inspector agents
(InspectorNetworkAgent / PageNetworkAgent) early-return from enable(), so
they no longer hold or apply the Network domain&apos;s extra request headers or
the resource-caching-disabled flag. The UIProcess ProxyingNetworkAgent, the
only Network agent active under Site Isolation, stubbed setExtraHTTPHeaders,
setResourceCachingDisabled, and setEmulatedConditions. This re-hosts that
state in the Site Isolation classes.

setEmulatedConditions is applied session-wide at the NetworkSession level,
which is shared by every WebContent process of the page, so
ProxyingNetworkAgent (UIProcess) drives WebsiteDataStore directly with no
IPC, mirroring the legacy WebInspectorUIProxy::setEmulatedConditions hop.

setExtraHTTPHeaders and setResourceCachingDisabled need the WebProcess, so
each is a latch-and-fan-out on the UIProcess side: ProxyingNetworkAgent
stores the value and sends it to every WebContent process, and re-sends it
in enableInstrumentationForProcess() so processes that join later (process
swaps, new cross-origin iframes) pick up the current value. In the
WebProcess, WebInspectorBackend latches the value; the extra headers are
applied to the mutable outgoing request in
FrameNetworkAgentProxy::willSendRequest and willSendRequestOfType (each
proxy holds a reference to the shared map), and the caching flag is applied
to the process&apos;s Page.

On disable the latched state is reset in both processes, mirroring
InspectorNetworkAgent::disable(): ProxyingNetworkAgent outlives frontend
disconnect/reconnect so it must not leak stale headers into a later
frontend, and WebInspectorBackend must clear the Page&apos;s
resource-caching-disabled flag so it does not persist with no inspector
attached.

setExtraHTTPHeaders and setEmulatedConditions were gated to the &quot;page&quot;
target only, so they were not exposed on the &quot;web-page&quot; multiplexing target
where ProxyingNetworkAgent lives; both now also list &quot;web-page&quot;.
setResourceCachingDisabled was already ungated.

setEmulatedConditions cannot be layout-tested because
ENABLE_INSPECTOR_NETWORK_THROTTLING is disabled by default. Its test
case is guarded on InspectorBackend.hasCommand() so it self-enables
once network throttling ships.

Tests: http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled.html
       http/tests/site-isolation/inspector/network/set-extra-http-headers.html

* LayoutTests/http/tests/site-isolation/inspector/network/resources/cacheable-resource.py: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/set-emulated-conditions-and-resource-caching-disabled.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/set-extra-http-headers-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/network/set-extra-http-headers.html: Added.
* Source/JavaScriptCore/inspector/protocol/Network.json:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::enableInstrumentationForProcess):
(Inspector::ProxyingNetworkAgent::disable):
(Inspector::ProxyingNetworkAgent::setExtraHTTPHeaders):
(Inspector::ProxyingNetworkAgent::setResourceCachingDisabled):
(Inspector::ProxyingNetworkAgent::setEmulatedConditions):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::FrameNetworkAgentProxy::FrameNetworkAgentProxy):
(WebKit::FrameNetworkAgentProxy::willSendRequest):
(WebKit::FrameNetworkAgentProxy::willSendRequestOfType):
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::ensureNetworkInstrumentationForFrame):
(WebKit::WebInspectorBackend::disableNetworkInstrumentation):
(WebKit::WebInspectorBackend::setExtraHTTPHeaders):
(WebKit::WebInspectorBackend::setResourceCachingDisabled):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:

Canonical link: <a href="https://commits.webkit.org/316819@main">https://commits.webkit.org/316819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79cdb4a998285bba97d958a2b40630f5fd0abc9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130943 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bd3f9a3a-2543-4714-9482-cabc7e67ea10) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10544f99-df24-4b2d-bfd5-db6f6cb80ffb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9fda3846-6d4d-4d32-bfdc-e269036274c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36881 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35233 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31445 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3997 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185385 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34649 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38255 "Found 1026 new failures in b3/B3Value.h, b3/testb3_7.cpp, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39435 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/core/float_exprs.wast.js.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143683 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143547 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47666 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112769 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26363 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38497 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119415 "Built successfully") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46172 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9927 "") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->