### PR TITLE
Add a test page for unit tests

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -274,6 +274,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/svg/graphics"
     "${WEBCORE_DIR}/svg/graphics/filters"
     "${WEBCORE_DIR}/svg/properties"
+    "${WEBCORE_DIR}/testing"
     "${WEBCORE_DIR}/websockets"
     "${WEBCORE_DIR}/workers"
     "${WEBCORE_DIR}/workers/service"
@@ -2277,7 +2278,11 @@ endif ()
 
 set(WebCoreTestSupport_FRAMEWORKS ${WebCore_FRAMEWORKS})
 set(WebCoreTestSupport_DEPENDENCIES WebCoreTestSupportBindings)
-set(WebCoreTestSupport_PRIVATE_HEADERS testing/js/WebCoreTestSupport.h)
+set(WebCoreTestSupport_PRIVATE_HEADERS
+    testing/TestPage.h
+
+    testing/js/WebCoreTestSupport.h
+)
 
 if (ENABLE_LEGACY_ENCRYPTED_MEDIA)
     list(APPEND WebCore_SOURCES
@@ -2613,6 +2618,7 @@ list(APPEND WebCoreTestSupport_SOURCES
     testing/MockPageOverlay.cpp
     testing/MockPageOverlayClient.cpp
     testing/ServiceWorkerInternals.cpp
+    testing/TestPage.cpp
     testing/js/WebCoreTestSupport.cpp
 )
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1462,7 +1462,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/messageports/MessageWithMessagePorts.h
     dom/messageports/TransferredMessagePort.h
 
-
+    editing/CachedMatchFinder.h
     editing/CharacterRange.h
     editing/ClipboardAccessPolicy.h
     editing/CompositionHighlight.h
@@ -3579,7 +3579,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     testing/MockGamepadProvider.h
     testing/MockParentalControlsURLFilter.h
     testing/MockWebAuthenticationConfiguration.h
-
     testing/js/WebCoreTestSupport.h
 
     workers/FetchingWorkerIdentifier.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2181,6 +2181,8 @@
 		51714EA81CF4E4B1004723C4 /* IDBActiveDOMObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 51714EA71CF4DE87004723C4 /* IDBActiveDOMObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51714EAC1CF65951004723C4 /* GCObservation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51714EA91CF65899004723C4 /* GCObservation.cpp */; };
 		51714EAD1CF65951004723C4 /* GCObservation.h in Headers */ = {isa = PBXBuildFile; fileRef = 51714EAA1CF65899004723C4 /* GCObservation.h */; };
+		0A11FACE2F6A00A3009B51B0 /* TestPage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A11FACE2F6A00A1009B51B0 /* TestPage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0A11FACE2F6A00A4009B51B0 /* TestPage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A11FACE2F6A00A2009B51B0 /* TestPage.cpp */; };
 		51714EB11CF665CE004723C4 /* JSGCObservation.h in Headers */ = {isa = PBXBuildFile; fileRef = 51714EAF1CF6654A004723C4 /* JSGCObservation.h */; };
 		51741D0F0B07259A00ED442C /* BackForwardClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 51741D0B0B07259A00ED442C /* BackForwardClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51741D110B07259A00ED442C /* HistoryItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 51741D0D0B07259A00ED442C /* HistoryItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6271,7 +6273,7 @@
 		D6489D26166FFCF1007C031B /* JSHTMLTemplateElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D6489D24166FFCF1007C031B /* JSHTMLTemplateElement.h */; };
 		D66817FB166FE6D700FA07B4 /* HTMLTemplateElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EFC0BC1666DF7A003D291E /* HTMLTemplateElement.h */; };
 		D669F992A34B36EDA5435687 /* UnifiedSource19-header-RenderStyleGetters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5250A569CD8198C008B831C9 /* UnifiedSource19-header-RenderStyleGetters.cpp */; };
-		D6E082672F5A3AED009B51B0 /* CachedMatchFinder.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E082652F5A3AD7009B51B0 /* CachedMatchFinder.h */; };
+		D6E082672F5A3AED009B51B0 /* CachedMatchFinder.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E082652F5A3AD7009B51B0 /* CachedMatchFinder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D6E276B014637455001D280A /* MutationObserverRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E276AE14637455001D280A /* MutationObserverRegistration.h */; };
 		D6E528A4149A926D00EFE1F3 /* MutationObserverInterestGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E528A2149A926D00EFE1F3 /* MutationObserverInterestGroup.h */; };
 		D70AD65813E1342B005B50B4 /* RenderFragmentContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = D70AD65613E1342B005B50B4 /* RenderFragmentContainer.h */; };
@@ -12747,6 +12749,8 @@
 		51714EA71CF4DE87004723C4 /* IDBActiveDOMObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IDBActiveDOMObject.h; sourceTree = "<group>"; };
 		51714EA91CF65899004723C4 /* GCObservation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GCObservation.cpp; sourceTree = "<group>"; };
 		51714EAA1CF65899004723C4 /* GCObservation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCObservation.h; sourceTree = "<group>"; };
+		0A11FACE2F6A00A1009B51B0 /* TestPage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestPage.h; sourceTree = "<group>"; };
+		0A11FACE2F6A00A2009B51B0 /* TestPage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestPage.cpp; sourceTree = "<group>"; };
 		51714EAB1CF65899004723C4 /* GCObservation.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = GCObservation.idl; sourceTree = "<group>"; };
 		51714EAE1CF6654A004723C4 /* JSGCObservation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSGCObservation.cpp; sourceTree = "<group>"; };
 		51714EAF1CF6654A004723C4 /* JSGCObservation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGCObservation.h; sourceTree = "<group>"; };
@@ -27451,6 +27455,8 @@
 				417F0D7E1FFEE14E008EF303 /* ServiceWorkerInternals.h */,
 				417F0D811FFEE150008EF303 /* ServiceWorkerInternals.idl */,
 				41D41C652256859200697942 /* ServiceWorkerInternals.mm */,
+				0A11FACE2F6A00A2009B51B0 /* TestPage.cpp */,
+				0A11FACE2F6A00A1009B51B0 /* TestPage.h */,
 				EB081CD81696084400553730 /* TypeConversions.h */,
 				EB081CD91696084400553730 /* TypeConversions.idl */,
 				E18D83E9243F71D3009247D6 /* WebFakeXRDevice.cpp */,
@@ -43882,6 +43888,7 @@
 				A140618C1E2ECA0A0032B34E /* MockPreviewLoaderClient.h in Headers */,
 				5715610B234C1B49008FC7AB /* MockWebAuthenticationConfiguration.h in Headers */,
 				AA5F3B8D16CC33D100455EB0 /* PlatformSpeechSynthesizerMock.h in Headers */,
+				0A11FACE2F6A00A3009B51B0 /* TestPage.h in Headers */,
 				A1763F3F1E205234001D58DE /* WebArchiveDumpSupport.h in Headers */,
 				41815C1F138319830057AAA4 /* WebCoreTestSupport.h in Headers */,
 				A13AB0802EE7AF53003C1ED5 /* WebMockMediaDeviceRoute.h in Headers */,
@@ -50776,6 +50783,7 @@
 				A140618B1E2ECA0A0032B34E /* MockPreviewLoaderClient.cpp in Sources */,
 				417F0D821FFEE979008EF303 /* ServiceWorkerInternals.cpp in Sources */,
 				41D41C672256874F00697942 /* ServiceWorkerInternals.mm in Sources */,
+				0A11FACE2F6A00A4009B51B0 /* TestPage.cpp in Sources */,
 				DE7710861FA2F0D600460016 /* WebArchiveDumpSupport.mm in Sources */,
 				41815C1E138319830057AAA4 /* WebCoreTestSupport.cpp in Sources */,
 				5273CC9025637F6700850007 /* WebFakeXRDevice.cpp in Sources */,

--- a/Source/WebCore/editing/CachedMatchFinder.h
+++ b/Source/WebCore/editing/CachedMatchFinder.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "FindOptions.h"
-#include "SimpleRange.h"
+#include <WebCore/FindOptions.h>
+#include <WebCore/SimpleRange.h>
 #include <wtf/Expected.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
@@ -42,13 +42,13 @@ class ShadowRoot;
 class CachedMatchFinder {
     WTF_MAKE_TZONE_ALLOCATED(CachedMatchFinder);
 public:
-    explicit CachedMatchFinder(Document&);
+    WEBCORE_EXPORT explicit CachedMatchFinder(Document&);
 
     enum class CacheUnusable : bool { Oversized };
 
     Expected<std::optional<SimpleRange>, CacheUnusable> findMatchFrom(const std::optional<SimpleRange>&, const String& target, FindOptions);
     Expected<Vector<SimpleRange>, CacheUnusable> findMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
-    Expected<unsigned, CacheUnusable> countMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
+    WEBCORE_EXPORT Expected<unsigned, CacheUnusable> countMatches(const std::optional<SimpleRange>&, const String& target, FindOptions, std::optional<unsigned> limit = std::nullopt);
 
     WEBCORE_EXPORT static void setMaximumRunCountForTesting(std::optional<unsigned>);
 

--- a/Source/WebCore/loader/DocumentWriter.h
+++ b/Source/WebCore/loader/DocumentWriter.h
@@ -48,10 +48,10 @@ public:
 
     void replaceDocumentWithResultOfExecutingJavascriptURL(const String&, Document* ownerDocument);
 
-    bool begin();
+    WEBCORE_EXPORT bool begin();
     bool begin(const URL&, bool dispatchWindowObjectAvailable = true, Document* ownerDocument = nullptr, std::optional<ScriptExecutionContextIdentifier> = std::nullopt, const NavigationAction* triggeringAction = nullptr);
     void addData(const SharedBuffer&);
-    void insertDataSynchronously(const String&); // For an internal use only to prevent the parser from yielding.
+    WEBCORE_EXPORT void insertDataSynchronously(const String&); // For an internal use only to prevent the parser from yielding.
     WEBCORE_EXPORT void end();
 
     void NODELETE setFrame(LocalFrame&);

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -103,7 +103,7 @@ public:
     friend class RenderView;
 
     WEBCORE_EXPORT static Ref<LocalFrameView> create(LocalFrame&);
-    static Ref<LocalFrameView> create(LocalFrame&, const IntSize& initialSize);
+    WEBCORE_EXPORT static Ref<LocalFrameView> create(LocalFrame&, const IntSize& initialSize);
 
     virtual ~LocalFrameView();
 

--- a/Source/WebCore/testing/TestPage.cpp
+++ b/Source/WebCore/testing/TestPage.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestPage.h"
+
+#include "Document.h"
+#include "DocumentLoader.h"
+#include "DocumentWriter.h"
+#include "EmptyClients.h"
+#include "FrameLoader.h"
+#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
+#include "LocalFrameView.h"
+#include "Page.h"
+#include "PageConfiguration.h"
+#include "ProcessWarming.h"
+#include "Settings.h"
+#include <pal/SessionID.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+Ref<Page> createTestPage(const TestPageOptions& options)
+{
+    static bool prewarmed = [] {
+        ProcessWarming::prewarmGlobally();
+        return true;
+    }();
+    UNUSED_VARIABLE(prewarmed);
+
+    Ref page = Page::create(pageConfigurationWithEmptyClients(std::nullopt, PAL::SessionID::defaultSessionID()));
+
+    page->settings().setScriptEnabled(false);
+    page->settings().setAcceleratedCompositingEnabled(false);
+#if ENABLE(VIDEO)
+    page->settings().setMediaEnabled(false);
+#endif
+    if (options.configureSettings)
+        options.configureSettings(page->settings());
+
+    RefPtr frame = page->localMainFrame();
+    RELEASE_ASSERT(frame);
+
+    frame->setView(LocalFrameView::create(*frame, options.viewportSize));
+    frame->init();
+
+    return page;
+}
+
+void loadHTMLIntoTestPage(LocalFrame& frame, const String& html)
+{
+    RefPtr activeDocumentLoader = frame.loader().activeDocumentLoader();
+    ASSERT(activeDocumentLoader);
+    auto& writer = activeDocumentLoader->writer();
+    writer.setMIMEType("text/html"_s);
+    writer.begin();
+    writer.insertDataSynchronously(html);
+    writer.end();
+
+    if (RefPtr document = frame.document())
+        document->updateLayoutIgnorePendingStylesheets();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/testing/TestPage.h
+++ b/Source/WebCore/testing/TestPage.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/IntSize.h>
+#include <WebCore/PlatformExportMacros.h>
+#include <wtf/Forward.h>
+#include <wtf/Function.h>
+#include <wtf/Ref.h>
+
+namespace WebCore {
+
+class LocalFrame;
+class Page;
+class Settings;
+
+struct TestPageOptions {
+    IntSize viewportSize { 800, 600 };
+    Function<void(Settings&)> configureSettings;
+};
+
+// Tests should use TestPageHarness rather than calling these directly.
+WEBCORE_TESTSUPPORT_EXPORT Ref<Page> createTestPage(const TestPageOptions& = { });
+WEBCORE_TESTSUPPORT_EXPORT void loadHTMLIntoTestPage(LocalFrame&, const String& html);
+
+} // namespace WebCore

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -216,6 +216,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/AudioSampleFormat.cpp
         Tests/WebCore/CSSParser.cpp
         Tests/WebCore/CSSTokenizerTests.cpp
+        Tests/WebCore/CachedMatchFinder.cpp
         Tests/WebCore/ColorTests.cpp
         Tests/WebCore/ComplexTextController.cpp
         Tests/WebCore/ContextMenuAction.cpp
@@ -257,6 +258,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/SharedBuffer.cpp
         Tests/WebCore/SharedBufferTest.cpp
         Tests/WebCore/StyleGradient.cpp
+        Tests/WebCore/TestPlatformStrategies.cpp
         Tests/WebCore/TextIterator.cpp
         Tests/WebCore/TimeRanges.cpp
         Tests/WebCore/TransformationMatrix.cpp
@@ -272,6 +274,7 @@ if (ENABLE_WEBCORE)
     endif ()
 
     set(TestWebCore_LIBRARIES
+        WebKit::WebCoreTestSupport
         WebKit::gtest
     )
     set(TestWebCore_FRAMEWORKS

--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -183,6 +183,8 @@ list(APPEND TestWebKit_SOURCES
     Helpers/mac/GamepadMappings/SunLightApplicationGenericNES.mm
 
     Tests/WebCore/ASN1Utilities.cpp
+    Tests/WebCore/CachedMatchFinder.cpp
+    Tests/WebCore/TestPlatformStrategies.cpp
 
     Tests/WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -16,15 +16,6 @@
 			name = "Derived Sources";
 			productName = "Derived Sources";
 		};
-		537CF84322EFD64100C6EBB3 /* Apply Configuration to XCFileLists */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 537CF84622EFD64100C6EBB3 /* Build configuration list for PBXAggregateTarget "Apply Configuration to XCFileLists" */;
-			buildPhases = (
-				537CF84722EFD65000C6EBB3 /* Run Sublaunch Script */,
-			);
-			name = "Apply Configuration to XCFileLists";
-			productName = "Apply Configuration to XCFileLists";
-		};
 		07A11A5702F9C0FE00000001 /* Testing.framework Overlays */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 07A11A5702F9C0FE00000002 /* Build configuration list for PBXAggregateTarget "Testing.framework Overlays" */;
@@ -33,6 +24,15 @@
 			);
 			name = "Testing.framework Overlays";
 			productName = "Testing.framework Overlays";
+		};
+		537CF84322EFD64100C6EBB3 /* Apply Configuration to XCFileLists */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 537CF84622EFD64100C6EBB3 /* Build configuration list for PBXAggregateTarget "Apply Configuration to XCFileLists" */;
+			buildPhases = (
+				537CF84722EFD65000C6EBB3 /* Run Sublaunch Script */,
+			);
+			name = "Apply Configuration to XCFileLists";
+			productName = "Apply Configuration to XCFileLists";
 		};
 		5C9D921422D7DA02008E9266 /* Generate Unified Sources */ = {
 			isa = PBXAggregateTarget;
@@ -197,20 +197,6 @@
 			remoteGlobalIDString = 0723A7492F80357300CB96E7;
 			remoteInfo = "Derived Sources";
 		};
-		07A11A5702F9C0FE00000005 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 07A11A5702F9C0FE00000001;
-			remoteInfo = "Testing.framework Overlays";
-		};
-		07A11A5702F9C0FE00000006 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 07A11A5702F9C0FE00000001;
-			remoteInfo = "Testing.framework Overlays";
-		};
 		0723A7562F80359900CB96E7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
@@ -245,6 +231,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 0723A7492F80357300CB96E7;
 			remoteInfo = "Derived Sources";
+		};
+		07A11A5702F9C0FE00000005 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07A11A5702F9C0FE00000001;
+			remoteInfo = "Testing.framework Overlays";
+		};
+		07A11A5702F9C0FE00000006 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07A11A5702F9C0FE00000001;
+			remoteInfo = "Testing.framework Overlays";
 		};
 		3A5DDAFB28D3F2A7004DA950 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -689,6 +689,7 @@
 				WebCore/ApplicationManifestParser.cpp,
 				WebCore/ASN1Utilities.cpp,
 				WebCore/AudioSampleFormat.cpp,
+				WebCore/CachedMatchFinder.cpp,
 				WebCore/CARingBufferTest.cpp,
 				WebCore/CBORReaderTest.cpp,
 				WebCore/CBORValueTest.cpp,
@@ -802,6 +803,7 @@
 				WebCore/STUNMessageParsingTest.cpp,
 				WebCore/StyleGradient.cpp,
 				WebCore/SVGImageCasts.cpp,
+				WebCore/TestPlatformStrategies.cpp,
 				WebCore/TextBoundaries.cpp,
 				WebCore/TextCodec.cpp,
 				WebCore/TextIterator.cpp,
@@ -2506,16 +2508,6 @@
 			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
 			targetProxy = 0723A7542F80358F00CB96E7 /* PBXContainerItemProxy */;
 		};
-		07A11A5702F9C0FE00000007 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 07A11A5702F9C0FE00000001 /* Testing.framework Overlays */;
-			targetProxy = 07A11A5702F9C0FE00000005 /* PBXContainerItemProxy */;
-		};
-		07A11A5702F9C0FE00000008 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 07A11A5702F9C0FE00000001 /* Testing.framework Overlays */;
-			targetProxy = 07A11A5702F9C0FE00000006 /* PBXContainerItemProxy */;
-		};
 		0723A7572F80359900CB96E7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
@@ -2540,6 +2532,16 @@
 			isa = PBXTargetDependency;
 			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
 			targetProxy = 0723A75E2F8035B400CB96E7 /* PBXContainerItemProxy */;
+		};
+		07A11A5702F9C0FE00000007 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 07A11A5702F9C0FE00000001 /* Testing.framework Overlays */;
+			targetProxy = 07A11A5702F9C0FE00000005 /* PBXContainerItemProxy */;
+		};
+		07A11A5702F9C0FE00000008 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 07A11A5702F9C0FE00000001 /* Testing.framework Overlays */;
+			targetProxy = 07A11A5702F9C0FE00000006 /* PBXContainerItemProxy */;
 		};
 		3A5DDAFC28D3F2A7004DA950 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2617,6 +2619,14 @@
 			};
 			name = Debug;
 		};
+		0723A74B2F80357300CB96E7 /* Release configuration for PBXAggregateTarget "Derived Sources" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		07A11A5702F9C0FE00000003 /* Debug configuration for PBXAggregateTarget "Testing.framework Overlays" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2626,14 +2636,6 @@
 			name = Debug;
 		};
 		07A11A5702F9C0FE00000004 /* Release configuration for PBXAggregateTarget "Testing.framework Overlays" */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		0723A74B2F80357300CB96E7 /* Release configuration for PBXAggregateTarget "Derived Sources" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;

--- a/Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestPageHarness.h"
+
+#include <WebCore/CachedMatchFinder.h>
+#include <WebCore/Element.h>
+#include <WebCore/FindOptions.h>
+#include <WebCore/HTMLCollection.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(CachedMatchFinder, CountMatchesFindsMatches)
+{
+    auto testPage = TestPageHarness::create();
+    testPage.loadHTML("<p>The quick brown fox jumped over the brown dog.</p>"_s);
+
+    CachedMatchFinder finder(testPage.document());
+    auto result = finder.countMatches(std::nullopt, "brown"_s, { });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 2u);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TestPlatformStrategies.h"
+#include <JavaScriptCore/InitializeThreading.h>
+#include <WebCore/Document.h>
+#include <WebCore/LocalFrame.h>
+#include <WebCore/Page.h>
+#include <WebCoreTestSupport/TestPage.h>
+#include <wtf/MainThread.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+class TestPageHarness {
+public:
+    static TestPageHarness create(WebCore::TestPageOptions options = { })
+    {
+        JSC::initialize();
+        WTF::initializeMainThread();
+        ensureTestPlatformStrategiesInstalled();
+        return TestPageHarness(WebCore::createTestPage(options));
+    }
+
+    WebCore::Page& page() { return m_page.get(); }
+    WebCore::LocalFrame& frame() { return *m_page->localMainFrame(); }
+    WebCore::Document& document() { return *m_page->localTopDocument(); }
+
+    void loadHTML(const String& html) { WebCore::loadHTMLIntoTestPage(frame(), html); }
+
+private:
+    explicit TestPageHarness(Ref<WebCore::Page>&& page)
+        : m_page(WTF::move(page))
+    {
+    }
+
+    Ref<WebCore::Page> m_page;
+};
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestPlatformStrategies.h"
+
+#include <WebCore/BlobRegistry.h>
+#include <WebCore/Color.h>
+#include <WebCore/LoaderStrategy.h>
+#include <WebCore/MediaStrategy.h>
+#include <WebCore/PasteboardItemInfo.h>
+#include <WebCore/PasteboardStrategy.h>
+#include <WebCore/PlatformStrategies.h>
+#include <WebCore/ResourceError.h>
+#include <WebCore/SharedBuffer.h>
+#include <mutex>
+#include <wtf/URL.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+namespace {
+
+// Every method here is a stub. These are never expected to be called.
+class TestLoaderStrategy final : public LoaderStrategy {
+public:
+    void loadResource(LocalFrame&, CachedResource&, ResourceRequest&&, const ResourceLoaderOptions&, CompletionHandler<void(RefPtr<SubresourceLoader>&&)>&&) final { }
+    void loadResourceSynchronously(FrameLoader&, ResourceLoaderIdentifier, const ResourceRequest&, ClientCredentialPolicy, const FetchOptions&, const HTTPHeaderMap&, ResourceError&, ResourceResponse&, Vector<uint8_t>&) final { }
+    void pageLoadCompleted(Page&) final { }
+    void browsingContextRemoved(LocalFrame&) final { }
+    void remove(ResourceLoader*) final { }
+    void setDefersLoading(ResourceLoader&, bool) final { }
+    void crossOriginRedirectReceived(ResourceLoader*, const URL&) final { }
+    void servePendingRequests(ResourceLoadPriority) final { }
+    void suspendPendingRequests() final { }
+    void resumePendingRequests() final { }
+    void startPingLoad(LocalFrame&, ResourceRequest&, const HTTPHeaderMap&, const FetchOptions&, ContentSecurityPolicyImposition, PingLoadCompletionHandler&&) final { }
+    void preconnectTo(FrameLoader&, ResourceRequest&&, StoredCredentialsPolicy, ShouldPreconnectAsFirstParty, PreconnectCompletionHandler&&) final { }
+    void setCaptureExtraNetworkLoadMetricsEnabled(bool) final { }
+    bool isOnLine() const final { return true; }
+    void addOnlineStateChangeListener(Function<void(bool)>&&) final { }
+    void isResourceLoadFinished(CachedResource&, CompletionHandler<void(bool)>&&) final { }
+
+    ResourceError cancelledError(const ResourceRequest&) const final { return { }; }
+    ResourceError blockedError(const ResourceRequest&) const final { return { }; }
+    bool isBlockedError(const ResourceError&) const final { return false; }
+    ResourceError blockedByContentBlockerError(const ResourceRequest&) const final { return { }; }
+    ResourceError cannotShowURLError(const ResourceRequest&) const final { return { }; }
+    ResourceError interruptedForPolicyChangeError(const ResourceRequest&) const final { return { }; }
+#if ENABLE(CONTENT_FILTERING)
+    ResourceError blockedByContentFilterError(const ResourceRequest&) const final { return { }; }
+#endif
+    ResourceError cannotShowMIMETypeError(const ResourceResponse&) const final { return { }; }
+    ResourceError fileDoesNotExistError(const ResourceResponse&) const final { return { }; }
+    ResourceError httpsUpgradeRedirectLoopError(const ResourceRequest&) const final { return { }; }
+    ResourceError httpNavigationWithHTTPSOnlyError(const ResourceRequest&) const final { return { }; }
+    bool isHttpNavigationWithHTTPSOnlyError(const ResourceError&) const final { return false; }
+    ResourceError pluginWillHandleLoadError(const ResourceResponse&) const final { return { }; }
+};
+
+class TestPasteboardStrategy final : public PasteboardStrategy {
+public:
+#if PLATFORM(IOS_FAMILY)
+    void writeToPasteboard(const PasteboardURL&, const String&, const PasteboardContext*) final { }
+    void writeToPasteboard(const PasteboardWebContent&, const String&, const PasteboardContext*) final { }
+    void writeToPasteboard(const PasteboardImage&, const String&, const PasteboardContext*) final { }
+    void writeToPasteboard(const String&, const String&, const String&, const PasteboardContext*) final { }
+    void updateSupportedTypeIdentifiers(const Vector<String>&, const String&, const PasteboardContext*) final { }
+#endif
+#if PLATFORM(COCOA)
+    void getTypes(Vector<String>&, const String&, const PasteboardContext*) final { }
+    RefPtr<SharedBuffer> bufferForType(const String&, const String&, const PasteboardContext*) final { return nullptr; }
+    void getPathnamesForType(Vector<String>&, const String&, const String&, const PasteboardContext*) final { }
+    String stringForType(const String&, const String&, const PasteboardContext*) final { return { }; }
+    Vector<String> allStringsForType(const String&, const String&, const PasteboardContext*) final { return { }; }
+    int64_t changeCount(const String&, const PasteboardContext*) final { return 0; }
+    Color color(const String&, const PasteboardContext*) final { return { }; }
+    URL url(const String&, const PasteboardContext*) final { return { }; }
+    int getNumberOfFiles(const String&, const PasteboardContext*) final { return 0; }
+    int64_t addTypes(const Vector<String>&, const String&, const PasteboardContext*) final { return 0; }
+    int64_t setTypes(const Vector<String>&, const String&, const PasteboardContext*) final { return 0; }
+    int64_t setBufferForType(SharedBuffer*, const String&, const String&, const PasteboardContext*) final { return 0; }
+    int64_t setURL(const PasteboardURL&, const String&, const PasteboardContext*) final { return 0; }
+    int64_t setColor(const Color&, const String&, const PasteboardContext*) final { return 0; }
+    int64_t setStringForType(const String&, const String&, const String&, const PasteboardContext*) final { return 0; }
+    int64_t writeWebArchive(LegacyWebArchive&, const String&) final { return 0; }
+    bool containsURLStringSuitableForLoading(const String&, const PasteboardContext*) final { return false; }
+    String urlStringSuitableForLoading(const String&, String&, const PasteboardContext*) final { return { }; }
+#endif
+    String readStringFromPasteboard(size_t, const String&, const String&, const PasteboardContext*) final { return { }; }
+    RefPtr<SharedBuffer> readBufferFromPasteboard(std::optional<size_t>, const String&, const String&, const PasteboardContext*) final { return nullptr; }
+    URL readURLFromPasteboard(size_t, const String&, String&, const PasteboardContext*) final { return { }; }
+    std::optional<PasteboardItemInfo> informationForItemAtIndex(size_t, const String&, int64_t, const PasteboardContext*) final { return std::nullopt; }
+    std::optional<Vector<PasteboardItemInfo>> allPasteboardItemInfo(const String&, int64_t, const PasteboardContext*) final { return std::nullopt; }
+    int getPasteboardItemsCount(const String&, const PasteboardContext*) final { return 0; }
+    Vector<String> typesSafeForDOMToReadAndWrite(const String&, const String&, const PasteboardContext*) final { return { }; }
+    int64_t writeCustomData(const Vector<PasteboardCustomData>&, const String&, const PasteboardContext*) final { return 0; }
+    bool containsStringSafeForDOMToReadForType(const String&, const String&, const PasteboardContext*) final { return false; }
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    Vector<String> types(const String&) final { return { }; }
+    String readTextFromClipboard(const String&, const String&) final { return { }; }
+    Vector<String> readFilePathsFromClipboard(const String&) final { return { }; }
+    RefPtr<SharedBuffer> readBufferFromClipboard(const String&, const String&) final { return nullptr; }
+    void writeToClipboard(const String&, SelectionData&&) final { }
+    void clearClipboard(const String&) final { }
+    int64_t changeCount(const String&) final { return 0; }
+#elif USE(LIBWPE)
+    void getTypes(Vector<String>&) final { }
+    void writeToPasteboard(const PasteboardWebContent&) final { }
+    void writeToPasteboard(const String&, const String&) final { }
+#endif
+};
+
+class TestBlobRegistry final : public BlobRegistry {
+public:
+    void registerInternalFileBlobURL(const URL&, Ref<BlobDataFileReference>&&, const String&, const String&) final { }
+    void registerInternalBlobURL(const URL&, Vector<BlobPart>&&, const String&) final { }
+    void registerBlobURL(const URL&, const URL&, const PolicyContainer&, const std::optional<SecurityOriginData>&) final { }
+    void registerInternalBlobURLOptionallyFileBacked(const URL&, const URL&, RefPtr<BlobDataFileReference>&&, const String&) final { }
+    void registerInternalBlobURLForSlice(const URL&, const URL&, long long, long long, const String&) final { }
+    void unregisterBlobURL(const URL&, const std::optional<SecurityOriginData>&) final { }
+    void registerBlobURLHandle(const URL&, const std::optional<SecurityOriginData>&) final { }
+    void unregisterBlobURLHandle(const URL&, const std::optional<SecurityOriginData>&) final { }
+    String blobType(const URL&) final { return emptyString(); }
+    unsigned long long blobSize(const URL&) final { return 0; }
+    void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>&, CompletionHandler<void(Vector<String>&&)>&&) final { }
+};
+
+class TestMediaStrategy final : public MediaStrategy {
+public:
+#if ENABLE(WEB_AUDIO)
+    Ref<AudioDestination> createAudioDestination(const AudioDestinationCreationOptions&) final { RELEASE_ASSERT_NOT_REACHED(); }
+#endif
+};
+
+class TestPlatformStrategies final : public PlatformStrategies {
+private:
+    LoaderStrategy* createLoaderStrategy() final { return new TestLoaderStrategy; }
+    PasteboardStrategy* createPasteboardStrategy() final { return new TestPasteboardStrategy; }
+    MediaStrategy* createMediaStrategy() final { return new TestMediaStrategy; }
+    BlobRegistry* createBlobRegistry() final { return new TestBlobRegistry; }
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    PushStrategy* createPushStrategy() final { return nullptr; }
+#endif
+};
+
+} // anonymous namespace
+
+void ensureTestPlatformStrategiesInstalled()
+{
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        setPlatformStrategies(new TestPlatformStrategies);
+    });
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.h
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace TestWebKitAPI {
+
+void ensureTestPlatformStrategiesInstalled();
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### eaf77a3bea205399e1e83395b5b20cc2fac8f347
<pre>
Add a test page for unit tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=318499">https://bugs.webkit.org/show_bug.cgi?id=318499</a>
<a href="https://rdar.apple.com/181282877">rdar://181282877</a>

Reviewed by Sammy Gill.

TestPageHarness creates a headless WebCore::Page (with a LocalFrame,
LocalFrameView, and Document) for unit testing WebCore code that
depends on layout, e.g. anything that needs a Document, Frame, or
Page to operate on.

Basic usage:

     auto testPage = TestPageHarness::create();
     testPage.loadHTML(&quot;&lt;p&gt;Hello, world.&lt;/p&gt;&quot;_s);
     SomeClassUnderTest instance(testPage.document());

By default, script, accelerated compositing, and media are disabled,
and the viewport is 800x600. Pass a WebCore::TestPageOptions to
override these settings.

Call loadHTML() again on an existing harness to load new content into
the same Page/Frame/Settings.

You can test behavior across multiple loads without paying for a new
Page each time.

Now, components/classes/functions that need a document, page, or
frame can effectively be unit tested.

This pattern should be used in place of exposing internal structures
via Internals.idl. This is quicker and more ergonomic than a layout
test in this case.

Tests: Tools/TestWebKitAPI/Tests/WebCore/TestPageExample.cpp
       Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h
       Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp
       Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.h

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/CachedMatchFinder.h:
* Source/WebCore/loader/DocumentWriter.h:
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/testing/TestPage.cpp: Added.
(WebCore::createTestPage):
(WebCore::loadHTMLIntoTestPage):
* Source/WebCore/testing/TestPage.h: Added.
(WebCore::createTestPage):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformMac.cmake:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/CachedMatchFinder.cpp: Added.
(TestWebKitAPI::TEST(CachedMatchFinder, CountMatchesFindsMatches)):
* Tools/TestWebKitAPI/Tests/WebCore/TestPageHarness.h: Added.
(TestWebKitAPI::TestPageHarness::create):
(TestWebKitAPI::TestPageHarness::page):
(TestWebKitAPI::TestPageHarness::frame):
(TestWebKitAPI::TestPageHarness::document):
(TestWebKitAPI::TestPageHarness::loadHTML):
(TestWebKitAPI::TestPageHarness::TestPageHarness):
* Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.cpp: Added.
(TestWebKitAPI::ensureTestPlatformStrategiesInstalled):
* Tools/TestWebKitAPI/Tests/WebCore/TestPlatformStrategies.h: Added.

Canonical link: <a href="https://commits.webkit.org/316845@main">https://commits.webkit.org/316845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/535ee97f5d82666e157da27359f60b32e9063da4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130954 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb5c1704-faa6-4ee9-8153-7382b72991c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134834 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b1d564fc-5b0a-4ec0-a8b7-c64ef3e6ad29) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115310 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36891 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35243 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31456 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185396 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143692 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46998 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38776 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47677 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112780 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38499 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119426 "Found 847 new failures in WebProcess/Network/WebResourceLoader.cpp, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm, WebProcess/WebPage/WebPage.cpp, testing/LegacyMockCDM.cpp, WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm, Shared/WebBackForwardListFrameItem.cpp ...") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46183 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9937 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->