### PR TITLE
Out-of-bounds read in InspectorAnimationAgent when parsedKeyframes is shorter than blendingKeyframes

### DIFF
--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -149,7 +149,7 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
                 .release();
 
             RefPtr<const TimingFunction> timingFunction;
-            if (!parsedKeyframes.isEmpty())
+            if (i < parsedKeyframes.size())
                 timingFunction = parsedKeyframes[i].timingFunction;
             if (!timingFunction)
                 timingFunction = blendingKeyframe.timingFunction();


### PR DESCRIPTION
#### 122493b27e92dedc613240fe169122d2896624c1
<pre>
Out-of-bounds read in InspectorAnimationAgent when parsedKeyframes is shorter than blendingKeyframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318501">https://bugs.webkit.org/show_bug.cgi?id=318501</a>
<a href="https://rdar.apple.com/181283194">rdar://181283194</a>

Reviewed by Devin Rousso.

buildObjectForKeyframes() in InspectorAnimationAgent.cpp iterates over
blendingKeyframes.size() but indexes parsedKeyframes[i] guarded only by
!parsedKeyframes.isEmpty(). KeyframeEffect stores these as two independent
vectors populated by separate paths: m_parsedKeyframes is set via the Web
Animations API (setKeyframes), while m_blendingKeyframes is recomputed from
the CSS rule (computeCSSAnimationBlendingKeyframes). For a style-originated
(CSS) animation whose keyframes were re-set through the Web Animations API
and later recomputed from the CSS rule, parsedKeyframes.size() can be smaller
than blendingKeyframes.size(). Inspecting such an animation in the Web
Inspector Animations panel then reads past the end of parsedKeyframes.

Guard the access with a bounds check (i &lt; parsedKeyframes.size()) instead of
the emptiness check, matching the pattern already used by
KeyframeEffect::timingFunctionForKeyframeAtIndex(). When the index is out of
range the code falls through to the existing blendingKeyframe.timingFunction()
and backing-animation fallbacks, so well-sized keyframes are unaffected.

* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):

Canonical link: <a href="https://commits.webkit.org/316470@main">https://commits.webkit.org/316470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb0ffa7c1decdc8f3d243c1177e3aa137b50d844

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129922 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65a91fe6-c248-483d-9b60-191db1134a03) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134058 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df7b12bd-af6b-49dd-acb7-d960dd8d99ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114530 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/030d4f16-ad80-42a1-b664-cb376c64ce08) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36119 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30423 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184353 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142830 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45956 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142711 "Found 1 new API test failure: WebKitGTK/TestDOMElement:/webkit/WebKitDOMElement/auto-fill (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38547 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46634 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111361 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37760 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118385 "Failed to checkout and rebase branch from PR 68579") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45151 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9041 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44783 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44610 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->