### PR TITLE
roland.com: Double search icon in search field (works in Chrome)

### DIFF
--- a/LayoutTests/fast/forms/box-shadow-override.html
+++ b/LayoutTests/fast/forms/box-shadow-override.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/forms/change-input-type-and-submit-form-crash.html
+++ b/LayoutTests/fast/forms/change-input-type-and-submit-form-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/forms/disabled-search-input.html
+++ b/LayoutTests/fast/forms/disabled-search-input.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/fast/forms/ios/form-control-refresh/search/search-decoration-appearance-expected-mismatch.html
+++ b/LayoutTests/fast/forms/ios/form-control-refresh/search/search-decoration-appearance-expected-mismatch.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/forms/ios/form-control-refresh/search/search-decoration-appearance.html
+++ b/LayoutTests/fast/forms/ios/form-control-refresh/search/search-decoration-appearance.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/forms/placeholder-position.html
+++ b/LayoutTests/fast/forms/placeholder-position.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <style>
 .center::placeholder {
     text-align: center;

--- a/LayoutTests/fast/forms/search-abs-pos-cancel-button.html
+++ b/LayoutTests/fast/forms/search-abs-pos-cancel-button.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
     <title>Search Field with Transform</title>

--- a/LayoutTests/fast/forms/search-field-buttons-do-not-have-focus-rings-expected.html
+++ b/LayoutTests/fast/forms/search-field-buttons-do-not-have-focus-rings-expected.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/forms/search-field-buttons-do-not-have-focus-rings.html
+++ b/LayoutTests/fast/forms/search-field-buttons-do-not-have-focus-rings.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/forms/search-input-rtl.html
+++ b/LayoutTests/fast/forms/search-input-rtl.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/fast/forms/search-rtl.html
+++ b/LayoutTests/fast/forms/search-rtl.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">

--- a/LayoutTests/fast/forms/search-styled.html
+++ b/LayoutTests/fast/forms/search-styled.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">

--- a/LayoutTests/fast/forms/search-transformed.html
+++ b/LayoutTests/fast/forms/search-transformed.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">

--- a/LayoutTests/fast/forms/search-zoomed.html
+++ b/LayoutTests/fast/forms/search-zoomed.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">

--- a/LayoutTests/fast/forms/search/search-padding-cancel-results-buttons.html
+++ b/LayoutTests/fast/forms/search/search-padding-cancel-results-buttons.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/forms/search/search-recent-searches.html
+++ b/LayoutTests/fast/forms/search/search-recent-searches.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
 <script src="../../../resources/js-test.js"></script>

--- a/LayoutTests/fast/forms/search/search-results-attribute-disabled-by-default-expected.txt
+++ b/LayoutTests/fast/forms/search/search-results-attribute-disabled-by-default-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS results=N saved-searches button is not constructed by default
+PASS cancel button is unaffected by the SearchInputResultsAttributeEnabled gate
+

--- a/LayoutTests/fast/forms/search/search-results-attribute-disabled-by-default.html
+++ b/LayoutTests/fast/forms/search/search-results-attribute-disabled-by-default.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<title>rdar://179949639: <input type=search> results=N attribute is disabled by default for newly-linked apps and full web browsers</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<!-- No webkit-test-runner [ SearchInputResultsAttributeEnabled=... ] header is set on this test
+     deliberately. Layout tests run under WebKitTestRunner, which counts as
+     "running test" inside isFullWebBrowserOrRunningTest(); combined with the
+     WebCore-default of false, the SearchInputResultsAttributeEnabled setting
+     defaults to false and the saved-searches shadow element must NOT be created.
+
+     This is the structural fix for the Roland double-magnifying-glass bug
+     (rdar://179949639): no shadow element means no native icon to clash with
+     the site's CSS background-image. -->
+
+<input id="resultsButton" type="search" results="10">
+<input id="cancelButton"  type="search" value="x">
+
+<script>
+function shadowPart(input, partName) {
+    if (!window.internals)
+        throw new Error('This test requires window.internals (run-webkit-tests).');
+    const root = internals.shadowRoot(input);
+    return root.querySelector(`[useragentpart='${partName}']`);
+}
+
+test(() => {
+    const input = document.getElementById('resultsButton');
+    assert_equals(shadowPart(input, '-webkit-search-results-button'), null,
+        '::-webkit-search-results-button shadow element must not exist when SearchInputResultsAttributeEnabled is false');
+    assert_equals(shadowPart(input, '-webkit-search-decoration'), null,
+        '::-webkit-search-decoration shadow element must not exist when SearchInputResultsAttributeEnabled is false');
+    assert_equals(shadowPart(input, '-webkit-search-results-decoration'), null,
+        '::-webkit-search-results-decoration shadow element must not exist when SearchInputResultsAttributeEnabled is false');
+}, 'results=N saved-searches button is not constructed by default');
+
+test(() => {
+    const input = document.getElementById('cancelButton');
+    assert_not_equals(shadowPart(input, '-webkit-search-cancel-button'), null,
+        '::-webkit-search-cancel-button shadow element must always exist (web-platform-relevant; not gated by the setting)');
+}, 'cancel button is unaffected by the SearchInputResultsAttributeEnabled gate');
+</script>

--- a/LayoutTests/fast/forms/search/search-results-hidden-crash.html
+++ b/LayoutTests/fast/forms/search/search-results-hidden-crash.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 
 <head>

--- a/LayoutTests/fast/forms/search/search-size-with-decorations.html
+++ b/LayoutTests/fast/forms/search/search-size-with-decorations.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <!doctype html>
 <html>
     <head>

--- a/LayoutTests/fast/replaced/width100percent-searchfield.html
+++ b/LayoutTests/fast/replaced/width100percent-searchfield.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <html>
 <head>
 <style>

--- a/LayoutTests/imported/blink/fast/forms/search-popup-crasher.html
+++ b/LayoutTests/imported/blink/fast/forms/search-popup-crasher.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <HTML>
 <HEAD>
 <script>

--- a/LayoutTests/pdf/crash-with-embed-hidden.html
+++ b/LayoutTests/pdf/crash-with-embed-hidden.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ SearchInputResultsAttributeEnabled=true ] -->
 <p>This test should not crash.</p>
 <script>
 if (testRunner)

--- a/LayoutTests/platform/gtk/fast/css/focus-ring-exists-for-search-field-expected.txt
+++ b/LayoutTests/platform/gtk/fast/css/focus-ring-exists-for-search-field-expected.txt
@@ -10,9 +10,8 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,52) size 784x24
         RenderTextControl {INPUT} at (0,0) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (0,0) size 0x0
 layer at (11,63) size 170x18
   RenderBlock {DIV} at (0,0) size 170x18
-caret: position 0 of child 0 {DIV} of child 1 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body
+caret: position 0 of child 0 {DIV} of child 0 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body

--- a/LayoutTests/platform/gtk/fast/css/input-search-padding-expected.txt
+++ b/LayoutTests/platform/gtk/fast/css/input-search-padding-expected.txt
@@ -5,7 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTextControl {INPUT} at (0,0) size 461x80 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 455x45
-          RenderBlock {DIV} at (0,22) size 0x0
           RenderBlock {DIV} at (0,0) size 415x45
       RenderBR {BR} at (461,25) size 0x18
       RenderTextControl {INPUT} at (0,80) size 461x80 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/gtk/fast/css/text-input-with-webkit-border-radius-expected.txt
+++ b/LayoutTests/platform/gtk/fast/css/text-input-with-webkit-border-radius-expected.txt
@@ -17,7 +17,6 @@ layer at (0,0) size 800x138
       RenderBlock {DIV} at (0,68) size 163x46 [bgcolor=#888888]
         RenderTextControl {INPUT} at (11,9) size 133x24 [bgcolor=#00FF00] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 127x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 111x18
         RenderText {#text} at (0,0) size 0x0
 layer at (22,97) size 111x18

--- a/LayoutTests/platform/gtk/fast/css/text-overflow-input-expected.txt
+++ b/LayoutTests/platform/gtk/fast/css/text-overflow-input-expected.txt
@@ -15,7 +15,6 @@ layer at (0,0) size 800x392
           text run at (192,21) width 4: " "
         RenderTextControl {INPUT} at (196,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (388,21) size 4x18
           text run at (388,21) width 4: " "
@@ -24,7 +23,6 @@ layer at (0,0) size 800x392
           text run at (584,21) width 4: " "
         RenderTextControl {INPUT} at (588,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,42) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -36,7 +34,6 @@ layer at (0,0) size 800x392
           text run at (191,69) width 4: " "
         RenderTextControl {INPUT} at (195,66) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 185x18
-            RenderBlock {DIV} at (185,9) size 0x0
             RenderBlock {DIV} at (16,0) size 169x18
         RenderText {#text} at (386,69) size 4x18
           text run at (386,69) width 4: " "
@@ -45,7 +42,6 @@ layer at (0,0) size 800x392
           text run at (581,69) width 4: " "
         RenderTextControl {INPUT} at (585,66) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 185x18
-            RenderBlock {DIV} at (185,9) size 0x0
             RenderBlock {DIV} at (16,0) size 169x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,90) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -61,7 +57,6 @@ layer at (0,0) size 800x392
           text run at (192,21) width 4: " "
         RenderTextControl {INPUT} at (196,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (388,21) size 4x18
           text run at (388,21) width 4: " "
@@ -70,7 +65,6 @@ layer at (0,0) size 800x392
           text run at (584,21) width 4: " "
         RenderTextControl {INPUT} at (588,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,42) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -82,7 +76,6 @@ layer at (0,0) size 800x392
           text run at (191,69) width 4: " "
         RenderTextControl {INPUT} at (195,66) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 185x18
-            RenderBlock {DIV} at (185,9) size 0x0
             RenderBlock {DIV} at (16,0) size 169x18
         RenderText {#text} at (386,69) size 4x18
           text run at (386,69) width 4: " "
@@ -91,7 +84,6 @@ layer at (0,0) size 800x392
           text run at (581,69) width 4: " "
         RenderTextControl {INPUT} at (585,66) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 185x18
-            RenderBlock {DIV} at (185,9) size 0x0
             RenderBlock {DIV} at (16,0) size 169x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,90) size 191x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/gtk/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/control-restrict-line-height-expected.txt
@@ -18,7 +18,6 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (374,56) size 0x18
       RenderTextControl {INPUT} at (0,83) size 192x34 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 186x27
-          RenderBlock {DIV} at (0,13) size 0x0
           RenderBlock {DIV} at (0,0) size 170x27
       RenderText {#text} at (0,0) size 0x0
 layer at (11,95) size 170x27 backgroundClip at (11,95) size 170x26 clip at (11,95) size 170x26 scrollWidth 359

--- a/LayoutTests/platform/gtk/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/input-appearance-height-expected.txt
@@ -81,7 +81,6 @@ layer at (0,0) size 800x600
           text run at (0,261) width 44: "search "
         RenderTextControl {INPUT} at (44,257) size 192x25 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (0,0) size 0x0
 layer at (47,29) size 186x18

--- a/LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt
@@ -11,7 +11,6 @@ layer at (0,0) size 800x600
         text run at (192,21) width 4: " "
       RenderTextControl {INPUT} at (196,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 186x18
-          RenderBlock {DIV} at (0,9) size 0x0
           RenderBlock {DIV} at (0,0) size 170x18
       RenderText {#text} at (388,21) size 4x18
         text run at (388,21) width 4: " "

--- a/LayoutTests/platform/gtk/fast/forms/search-cancel-button-style-sharing-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/search-cancel-button-style-sharing-expected.txt
@@ -9,13 +9,11 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,34) size 784x24
         RenderTextControl {INPUT} at (0,0) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (192,3) size 4x18
           text run at (192,3) width 4: " "
         RenderTextControl {INPUT} at (196,0) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 170x18
         RenderText {#text} at (0,0) size 0x0
 layer at (11,45) size 170x18

--- a/LayoutTests/platform/gtk/fast/forms/search-display-none-cancel-button-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/search-display-none-cancel-button-expected.txt
@@ -8,7 +8,6 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (499,0) size 0x18
       RenderTextControl {INPUT} at (0,18) size 192x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 186x18
-          RenderBlock {DIV} at (0,9) size 0x0
           RenderBlock {DIV} at (0,0) size 186x18
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 186x18

--- a/LayoutTests/platform/gtk/fast/forms/search-vertical-alignment-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/search-vertical-alignment-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,52) size 784x45
         RenderTextControl {INPUT} at (0,0) size 192x45 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 186x39
-            RenderBlock {DIV} at (16,10) size 154x19
+            RenderBlock {DIV} at (0,10) size 170x19
         RenderText {#text} at (192,14) size 4x17
           text run at (192,14) width 4: " "
         RenderTextControl {INPUT} at (196,0) size 192x45 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,113) size 784x18
         RenderTextControl {INPUT} at (0,1) size 192x17 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 186x16
-            RenderBlock {DIV} at (16,3) size 154x10
+            RenderBlock {DIV} at (0,3) size 170x10
         RenderText {#text} at (192,0) size 4x18
           text run at (192,0) width 4: " "
         RenderTextControl {INPUT} at (196,1) size 192x16 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -29,44 +29,38 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,147) size 784x18
         RenderTextControl {INPUT} at (0,5) size 192x13 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 186x12
-            RenderBlock {DIV} at (16,3) size 154x6
+            RenderBlock {DIV} at (0,3) size 170x6
         RenderText {#text} at (192,0) size 4x18
           text run at (192,0) width 4: " "
         RenderTextControl {INPUT} at (196,3) size 192x12 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
-layer at (27,74) size 154x18
-  RenderBlock {DIV} at (0,0) size 154x18
+layer at (11,74) size 170x18
+  RenderBlock {DIV} at (0,0) size 170x18
     RenderText {#text} at (0,0) size 30x18
       text run at (0,0) width 30: "Text"
 layer at (207,74) size 186x18
   RenderBlock {DIV} at (3,13) size 186x19
     RenderText {#text} at (0,0) size 30x18
       text run at (0,0) width 30: "Text"
-layer at (27,126) size 154x10 scrollHeight 18
-  RenderBlock {DIV} at (0,0) size 154x10
+layer at (11,126) size 170x10 scrollHeight 18
+  RenderBlock {DIV} at (0,0) size 170x10
     RenderText {#text} at (0,0) size 30x18
       text run at (0,0) width 30: "Text"
 layer at (207,121) size 186x18
   RenderBlock {DIV} at (3,-1) size 186x18
     RenderText {#text} at (0,0) size 30x18
       text run at (0,0) width 30: "Text"
-layer at (27,164) size 154x6 scrollHeight 18
-  RenderBlock {DIV} at (0,0) size 154x6
+layer at (11,164) size 170x6 scrollHeight 18
+  RenderBlock {DIV} at (0,0) size 170x6
     RenderText {#text} at (0,0) size 30x18
       text run at (0,0) width 30: "Text"
 layer at (207,155) size 186x18
   RenderBlock {DIV} at (3,-3) size 186x18
     RenderText {#text} at (0,0) size 30x18
       text run at (0,0) width 30: "Text"
-layer at (11,75) size 16x16
-  RenderBlock {DIV} at (0,11) size 16x17 [bgcolor=#000000]
 layer at (181,75) size 16x16
   RenderBlock {DIV} at (170,11) size 16x17 [bgcolor=#000000]
-layer at (11,123) size 16x16
-  RenderBlock {DIV} at (0,0) size 16x16 [bgcolor=#000000]
 layer at (181,123) size 16x16
   RenderBlock {DIV} at (170,0) size 16x16 [bgcolor=#000000]
-layer at (11,161) size 16x16
-  RenderBlock {DIV} at (0,0) size 16x16 [bgcolor=#000000]
 layer at (181,161) size 16x16
   RenderBlock {DIV} at (170,0) size 16x16 [bgcolor=#000000]

--- a/LayoutTests/platform/gtk/fast/forms/searchfield-heights-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/searchfield-heights-expected.txt
@@ -8,19 +8,16 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (368,0) size 0x18
       RenderTextControl {INPUT} at (0,122) size 69x6 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,0) size 63x6
-          RenderBlock {DIV} at (0,3) size 0x0
           RenderBlock {DIV} at (0,0) size 57x6
       RenderText {#text} at (69,113) size 4x17
         text run at (69,113) width 4: " "
       RenderTextControl {INPUT} at (73,101) size 173x41 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 167x34
-          RenderBlock {DIV} at (0,17) size 0x0
           RenderBlock {DIV} at (0,8) size 152x18
       RenderText {#text} at (246,113) size 4x17
         text run at (246,113) width 4: " "
       RenderTextControl {INPUT} at (250,18) size 316x200 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 310x194
-          RenderBlock {DIV} at (0,97) size 0x0
           RenderBlock {DIV} at (0,81) size 283x32
       RenderText {#text} at (0,0) size 0x0
 layer at (11,130) size 57x6

--- a/LayoutTests/platform/ios/fast/css/focus-ring-exists-for-search-field-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/focus-ring-exists-for-search-field-expected.txt
@@ -10,10 +10,9 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,56) size 784x20
         RenderTextControl {INPUT} at (0,0) size 154x20 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (29,67) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
-caret: position 0 of child 0 {DIV} of child 1 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body
+layer at (14,67) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
+caret: position 0 of child 0 {DIV} of child 0 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body

--- a/LayoutTests/platform/ios/fast/css/input-search-padding-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/input-search-padding-expected.txt
@@ -5,7 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTextControl {INPUT} at (0,0) size 537x89 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
         RenderFlexibleBox {DIV} at (21,9) size 495x49
-          RenderBlock {DIV} at (0,24) size 0x0
           RenderBlock {DIV} at (0,0) size 495x49
           RenderBlock {DIV} at (494,24) size 0x0
       RenderBR {BR} at (536,33) size 1x19

--- a/LayoutTests/platform/ios/fast/css/text-input-with-webkit-border-radius-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/text-input-with-webkit-border-radius-expected.txt
@@ -17,7 +17,6 @@ layer at (0,0) size 800x141
       RenderBlock {DIV} at (0,72) size 163x45 [bgcolor=#888888]
         RenderTextControl {INPUT} at (11,9) size 133x22 [bgcolor=#00FF00] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 121x15
-            RenderBlock {DIV} at (0,7) size 0x0
             RenderBlock {DIV} at (0,0) size 120x14
             RenderBlock {DIV} at (120,7) size 0x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/css/text-overflow-input-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/text-overflow-input-expected.txt
@@ -15,8 +15,7 @@ layer at (0,0) size 800x332
           text run at (153,20) width 5: " "
         RenderTextControl {INPUT} at (157,21) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (311,20) size 5x20
           text run at (311,20) width 5: " "
@@ -25,8 +24,7 @@ layer at (0,0) size 800x332
           text run at (469,20) width 5: " "
         RenderTextControl {INPUT} at (473,21) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,43) size 154x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
@@ -38,8 +36,7 @@ layer at (0,0) size 800x332
           text run at (151,63) width 5: " "
         RenderTextControl {INPUT} at (155,64) size 153x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 140x14
-            RenderBlock {DIV} at (128,1) size 12x12
-            RenderBlock {DIV} at (0,0) size 125x14
+            RenderBlock {DIV} at (0,0) size 140x14
             RenderBlock {DIV} at (0,7) size 0x0
         RenderText {#text} at (307,63) size 5x20
           text run at (307,63) width 5: " "
@@ -48,8 +45,7 @@ layer at (0,0) size 800x332
           text run at (463,63) width 5: " "
         RenderTextControl {INPUT} at (467,64) size 153x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 140x14
-            RenderBlock {DIV} at (128,1) size 12x12
-            RenderBlock {DIV} at (0,0) size 125x14
+            RenderBlock {DIV} at (0,0) size 140x14
             RenderBlock {DIV} at (0,7) size 0x0
         RenderText {#text} at (619,63) size 5x20
           text run at (619,63) width 5: " "
@@ -66,8 +62,7 @@ layer at (0,0) size 800x332
           text run at (153,20) width 5: " "
         RenderTextControl {INPUT} at (157,21) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (311,20) size 5x20
           text run at (311,20) width 5: " "
@@ -76,8 +71,7 @@ layer at (0,0) size 800x332
           text run at (469,20) width 5: " "
         RenderTextControl {INPUT} at (473,21) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,43) size 154x20 [bgcolor=#FFFFFF] [border: (1px solid #3C3C4399)]
@@ -89,8 +83,7 @@ layer at (0,0) size 800x332
           text run at (151,63) width 5: " "
         RenderTextControl {INPUT} at (155,64) size 153x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 140x14
-            RenderBlock {DIV} at (128,1) size 12x12
-            RenderBlock {DIV} at (0,0) size 125x14
+            RenderBlock {DIV} at (0,0) size 140x14
             RenderBlock {DIV} at (0,7) size 0x0
         RenderText {#text} at (307,63) size 5x20
           text run at (307,63) width 5: " "
@@ -99,8 +92,7 @@ layer at (0,0) size 800x332
           text run at (463,63) width 5: " "
         RenderTextControl {INPUT} at (467,64) size 153x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 140x14
-            RenderBlock {DIV} at (128,1) size 12x12
-            RenderBlock {DIV} at (0,0) size 125x14
+            RenderBlock {DIV} at (0,0) size 140x14
             RenderBlock {DIV} at (0,7) size 0x0
         RenderText {#text} at (619,63) size 5x20
           text run at (619,63) width 5: " "
@@ -134,18 +126,18 @@ layer at (14,77) size 142x14 scrollWidth 288
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (14,77) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
-layer at (187,77) size 127x14 scrollWidth 288
-  RenderBlock {DIV} at (20,3) size 128x14 [color=#A9A9A9]
+layer at (172,77) size 142x14 scrollWidth 288
+  RenderBlock {DIV} at (6,3) size 142x14 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 288x14
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (187,77) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (172,77) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
 layer at (330,77) size 142x14 scrollWidth 290
   RenderBlock {DIV} at (6,3) size 142x14
     RenderText {#text} at (0,0) size 288x14
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (503,77) size 127x14 scrollWidth 290
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (488,77) size 142x14 scrollWidth 290
+  RenderBlock {DIV} at (0,0) size 142x14
     RenderText {#text} at (0,0) size 288x14
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (14,98) size 142x14 scrollWidth 387
@@ -172,26 +164,26 @@ layer at (14,120) size 140x14 scrollX 148 scrollWidth 288
       text run at (123,0) width 17: "elit"
 layer at (14,120) size 140x14
   RenderBlock {DIV} at (6,3) size 140x14
-layer at (170,120) size 125x14 scrollX 163 scrollWidth 288
-  RenderBlock {DIV} at (6,3) size 125x14 [color=#A9A9A9]
-    RenderText {#text} at (-163,0) size 288x14
-      text run at (-162,0) width 32: "Lorem"
-      text run at (-130,0) width 3: " "
-      text run at (-127,0) width 32: "ipsum"
-      text run at (-95,0) width 3: " "
-      text run at (-92,0) width 27: "dolor"
-      text run at (-65,0) width 3: " "
-      text run at (-62,0) width 13: "sit"
-      text run at (-49,0) width 3: " "
-      text run at (-46,0) width 30: "amet,"
-      text run at (-16,0) width 3: " "
-      text run at (-13,0) width 63: "consectetur"
-      text run at (49,0) width 4: " "
-      text run at (52,0) width 54: "adipiscing"
-      text run at (105,0) width 4: " "
-      text run at (108,0) width 17: "elit"
-layer at (170,120) size 125x14
-  RenderBlock {DIV} at (0,0) size 125x14
+layer at (170,120) size 140x14 scrollX 148 scrollWidth 288
+  RenderBlock {DIV} at (6,3) size 140x14 [color=#A9A9A9]
+    RenderText {#text} at (-148,0) size 288x14
+      text run at (-147,0) width 32: "Lorem"
+      text run at (-115,0) width 3: " "
+      text run at (-112,0) width 32: "ipsum"
+      text run at (-80,0) width 3: " "
+      text run at (-77,0) width 27: "dolor"
+      text run at (-50,0) width 3: " "
+      text run at (-47,0) width 13: "sit"
+      text run at (-34,0) width 3: " "
+      text run at (-31,0) width 30: "amet,"
+      text run at (-1,0) width 3: " "
+      text run at (1,0) width 64: "consectetur"
+      text run at (64,0) width 4: " "
+      text run at (67,0) width 54: "adipiscing"
+      text run at (120,0) width 4: " "
+      text run at (123,0) width 17: "elit"
+layer at (170,120) size 140x14
+  RenderBlock {DIV} at (0,0) size 140x14
 layer at (326,120) size 140x14 scrollX 148 scrollWidth 288
   RenderBlock {DIV} at (6,3) size 140x14
     RenderText {#text} at (-148,0) size 288x14
@@ -210,24 +202,24 @@ layer at (326,120) size 140x14 scrollX 148 scrollWidth 288
       text run at (67,0) width 54: "adipiscing"
       text run at (120,0) width 4: " "
       text run at (123,0) width 17: "elit"
-layer at (482,120) size 125x14 scrollX 163 scrollWidth 288
-  RenderBlock {DIV} at (0,0) size 125x14
-    RenderText {#text} at (-163,0) size 288x14
-      text run at (-162,0) width 32: "Lorem"
-      text run at (-130,0) width 3: " "
-      text run at (-127,0) width 32: "ipsum"
-      text run at (-95,0) width 3: " "
-      text run at (-92,0) width 27: "dolor"
-      text run at (-65,0) width 3: " "
-      text run at (-62,0) width 13: "sit"
-      text run at (-49,0) width 3: " "
-      text run at (-46,0) width 30: "amet,"
-      text run at (-16,0) width 3: " "
-      text run at (-13,0) width 63: "consectetur"
-      text run at (49,0) width 4: " "
-      text run at (52,0) width 54: "adipiscing"
-      text run at (105,0) width 4: " "
-      text run at (108,0) width 17: "elit"
+layer at (482,120) size 140x14 scrollX 148 scrollWidth 288
+  RenderBlock {DIV} at (0,0) size 140x14
+    RenderText {#text} at (-148,0) size 288x14
+      text run at (-147,0) width 32: "Lorem"
+      text run at (-115,0) width 3: " "
+      text run at (-112,0) width 32: "ipsum"
+      text run at (-80,0) width 3: " "
+      text run at (-77,0) width 27: "dolor"
+      text run at (-50,0) width 3: " "
+      text run at (-47,0) width 13: "sit"
+      text run at (-34,0) width 3: " "
+      text run at (-31,0) width 30: "amet,"
+      text run at (-1,0) width 3: " "
+      text run at (1,0) width 64: "consectetur"
+      text run at (64,0) width 4: " "
+      text run at (67,0) width 54: "adipiscing"
+      text run at (120,0) width 4: " "
+      text run at (123,0) width 17: "elit"
 layer at (638,120) size 142x14 backgroundClip at (638,120) size 141x14 clip at (638,120) size 141x14 scrollWidth 387
   RenderBlock {DIV} at (0,0) size 142x14
     RenderText {#text} at (0,0) size 385x14
@@ -238,18 +230,18 @@ layer at (14,177) size 142x14 scrollWidth 288
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (14,177) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
-layer at (187,177) size 127x14 scrollWidth 288
-  RenderBlock {DIV} at (20,3) size 128x14 [color=#A9A9A9]
+layer at (172,177) size 142x14 scrollWidth 288
+  RenderBlock {DIV} at (6,3) size 142x14 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 288x14
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (187,177) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (172,177) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
 layer at (330,177) size 142x14 scrollWidth 290
   RenderBlock {DIV} at (6,3) size 142x14
     RenderText {#text} at (0,0) size 288x14
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (503,177) size 127x14 scrollWidth 290
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (488,177) size 142x14 scrollWidth 290
+  RenderBlock {DIV} at (0,0) size 142x14
     RenderText {#text} at (0,0) size 288x14
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (14,199) size 142x14 scrollWidth 387
@@ -276,26 +268,26 @@ layer at (14,220) size 140x14 scrollX 148 scrollWidth 288
       text run at (123,0) width 17: "elit"
 layer at (14,220) size 140x14
   RenderBlock {DIV} at (6,3) size 140x14
-layer at (170,220) size 125x14 scrollX 163 scrollWidth 288
-  RenderBlock {DIV} at (6,3) size 125x14 [color=#A9A9A9]
-    RenderText {#text} at (-163,0) size 288x14
-      text run at (-162,0) width 32: "Lorem"
-      text run at (-130,0) width 3: " "
-      text run at (-127,0) width 32: "ipsum"
-      text run at (-95,0) width 3: " "
-      text run at (-92,0) width 27: "dolor"
-      text run at (-65,0) width 3: " "
-      text run at (-62,0) width 13: "sit"
-      text run at (-49,0) width 3: " "
-      text run at (-46,0) width 30: "amet,"
-      text run at (-16,0) width 3: " "
-      text run at (-13,0) width 63: "consectetur"
-      text run at (49,0) width 4: " "
-      text run at (52,0) width 54: "adipiscing"
-      text run at (105,0) width 4: " "
-      text run at (108,0) width 17: "elit"
-layer at (170,220) size 125x14
-  RenderBlock {DIV} at (0,0) size 125x14
+layer at (170,220) size 140x14 scrollX 148 scrollWidth 288
+  RenderBlock {DIV} at (6,3) size 140x14 [color=#A9A9A9]
+    RenderText {#text} at (-148,0) size 288x14
+      text run at (-147,0) width 32: "Lorem"
+      text run at (-115,0) width 3: " "
+      text run at (-112,0) width 32: "ipsum"
+      text run at (-80,0) width 3: " "
+      text run at (-77,0) width 27: "dolor"
+      text run at (-50,0) width 3: " "
+      text run at (-47,0) width 13: "sit"
+      text run at (-34,0) width 3: " "
+      text run at (-31,0) width 30: "amet,"
+      text run at (-1,0) width 3: " "
+      text run at (1,0) width 64: "consectetur"
+      text run at (64,0) width 4: " "
+      text run at (67,0) width 54: "adipiscing"
+      text run at (120,0) width 4: " "
+      text run at (123,0) width 17: "elit"
+layer at (170,220) size 140x14
+  RenderBlock {DIV} at (0,0) size 140x14
 layer at (326,220) size 140x14 scrollX 148 scrollWidth 288
   RenderBlock {DIV} at (6,3) size 140x14
     RenderText {#text} at (-148,0) size 288x14
@@ -314,24 +306,24 @@ layer at (326,220) size 140x14 scrollX 148 scrollWidth 288
       text run at (67,0) width 54: "adipiscing"
       text run at (120,0) width 4: " "
       text run at (123,0) width 17: "elit"
-layer at (482,220) size 125x14 scrollX 163 scrollWidth 288
-  RenderBlock {DIV} at (0,0) size 125x14
-    RenderText {#text} at (-163,0) size 288x14
-      text run at (-162,0) width 32: "Lorem"
-      text run at (-130,0) width 3: " "
-      text run at (-127,0) width 32: "ipsum"
-      text run at (-95,0) width 3: " "
-      text run at (-92,0) width 27: "dolor"
-      text run at (-65,0) width 3: " "
-      text run at (-62,0) width 13: "sit"
-      text run at (-49,0) width 3: " "
-      text run at (-46,0) width 30: "amet,"
-      text run at (-16,0) width 3: " "
-      text run at (-13,0) width 63: "consectetur"
-      text run at (49,0) width 4: " "
-      text run at (52,0) width 54: "adipiscing"
-      text run at (105,0) width 4: " "
-      text run at (108,0) width 17: "elit"
+layer at (482,220) size 140x14 scrollX 148 scrollWidth 288
+  RenderBlock {DIV} at (0,0) size 140x14
+    RenderText {#text} at (-148,0) size 288x14
+      text run at (-147,0) width 32: "Lorem"
+      text run at (-115,0) width 3: " "
+      text run at (-112,0) width 32: "ipsum"
+      text run at (-80,0) width 3: " "
+      text run at (-77,0) width 27: "dolor"
+      text run at (-50,0) width 3: " "
+      text run at (-47,0) width 13: "sit"
+      text run at (-34,0) width 3: " "
+      text run at (-31,0) width 30: "amet,"
+      text run at (-1,0) width 3: " "
+      text run at (1,0) width 64: "consectetur"
+      text run at (64,0) width 4: " "
+      text run at (67,0) width 54: "adipiscing"
+      text run at (120,0) width 4: " "
+      text run at (123,0) width 17: "elit"
 layer at (638,220) size 142x14 backgroundClip at (638,220) size 141x14 clip at (638,220) size 141x14 scrollWidth 387
   RenderBlock {DIV} at (0,0) size 142x14
     RenderText {#text} at (0,0) size 385x14

--- a/LayoutTests/platform/ios/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/control-restrict-line-height-expected.txt
@@ -18,11 +18,10 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (294,43) size 1x20
       RenderTextControl {INPUT} at (0,68) size 154x34 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
         RenderFlexibleBox {DIV} at (6,3) size 142x27
-          RenderBlock {DIV} at (0,7) size 11x12
-          RenderBlock {DIV} at (14,0) size 128x27
+          RenderBlock {DIV} at (0,0) size 142x27
           RenderBlock {DIV} at (141,13) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (29,80) size 127x27 backgroundClip at (29,80) size 127x26 clip at (29,80) size 127x26 scrollWidth 272
-  RenderBlock {DIV} at (0,0) size 127x27
+layer at (14,80) size 142x27 backgroundClip at (14,80) size 142x26 clip at (14,80) size 142x26 scrollWidth 272
+  RenderBlock {DIV} at (0,0) size 142x27
     RenderText {#text} at (0,6) size 271x15
       text run at (0,6) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/ios/fast/forms/datalist/datalist-searchinput-appearance-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/datalist/datalist-searchinput-appearance-expected.txt
@@ -5,12 +5,11 @@ layer at (0,0) size 800x40
     RenderBody {BODY} at (8,8) size 784x24
       RenderTextControl {INPUT} at (0,1) size 152x23 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
         RenderFlexibleBox {DIV} at (6,3) size 140x16
-          RenderBlock {DIV} at (0,2) size 11x12
-          RenderBlock {DIV} at (14,0) size 105x16
+          RenderBlock {DIV} at (0,0) size 119x16
           RenderBlock {DIV} at (118,8) size 0x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (29,13) size 103x16
-  RenderBlock {DIV} at (0,0) size 104x16
+layer at (14,13) size 118x16
+  RenderBlock {DIV} at (0,0) size 119x16
 layer at (125,6) size 36x30
   RenderBlock (relative positioned) {DIV} at (111,-7) size 36x30

--- a/LayoutTests/platform/ios/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/input-appearance-height-expected.txt
@@ -81,8 +81,7 @@ layer at (0,0) size 800x600
           text run at (0,237) width 45: "search "
         RenderTextControl {INPUT} at (44,238) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (0,0) size 0x0
 layer at (51,33) size 142x14
@@ -93,5 +92,5 @@ layer at (64,227) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
 layer at (78,248) size 142x14
   RenderBlock {DIV} at (0,0) size 142x14
-layer at (74,270) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (59,270) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14

--- a/LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt
@@ -11,8 +11,7 @@ layer at (0,0) size 800x600
         text run at (153,20) width 5: " "
       RenderTextControl {INPUT} at (157,21) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
         RenderFlexibleBox {DIV} at (6,3) size 142x14
-          RenderBlock {DIV} at (0,1) size 11x12
-          RenderBlock {DIV} at (14,0) size 128x14
+          RenderBlock {DIV} at (0,0) size 142x14
           RenderBlock {DIV} at (141,7) size 0x0
       RenderText {#text} at (311,20) size 5x20
         text run at (311,20) width 5: " "
@@ -33,12 +32,12 @@ layer at (14,33) size 142x14
       text run at (0,0) width 21: "text"
 layer at (14,33) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14
-layer at (187,33) size 127x14
-  RenderBlock {DIV} at (20,3) size 128x14 [color=#640000]
+layer at (172,33) size 142x14
+  RenderBlock {DIV} at (6,3) size 142x14 [color=#640000]
     RenderText {#text} at (0,0) size 36x14
       text run at (0,0) width 36: "search"
-layer at (187,33) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (172,33) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
 layer at (330,33) size 142x14
   RenderBlock {DIV} at (6,3) size 142x14 [color=#640000]
     RenderText {#text} at (0,0) size 51x14

--- a/LayoutTests/platform/ios/fast/forms/search-cancel-button-style-sharing-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/search-cancel-button-style-sharing-expected.txt
@@ -9,20 +9,18 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,36) size 784x22
         RenderTextControl {INPUT} at (0,1) size 154x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (153,0) size 5x20
           text run at (153,0) width 5: " "
         RenderTextControl {INPUT} at (157,1) size 155x21 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
           RenderFlexibleBox {DIV} at (6,3) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x12
-            RenderBlock {DIV} at (14,0) size 128x14
+            RenderBlock {DIV} at (0,0) size 142x14
             RenderBlock {DIV} at (141,7) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (29,49) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
-layer at (187,49) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (14,49) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
+layer at (172,49) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
     RenderText {#text} at (0,0) size 42x14
       text run at (0,0) width 42: "this one"

--- a/LayoutTests/platform/ios/fast/forms/search-display-none-cancel-button-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/search-display-none-cancel-button-expected.txt
@@ -8,10 +8,9 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (510,0) size 1x20
       RenderTextControl {INPUT} at (0,20) size 154x20 [bgcolor=#EEEEEF] [border: (1px solid #FFFFFF)]
         RenderFlexibleBox {DIV} at (6,3) size 142x14
-          RenderBlock {DIV} at (0,1) size 11x12
-          RenderBlock {DIV} at (14,0) size 128x14
+          RenderBlock {DIV} at (0,0) size 142x14
       RenderText {#text} at (0,0) size 0x0
-layer at (29,31) size 127x14
-  RenderBlock {DIV} at (0,0) size 127x14
+layer at (14,31) size 142x14
+  RenderBlock {DIV} at (0,0) size 142x14
     RenderText {#text} at (0,0) size 21x14
       text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/css/focus-ring-exists-for-search-field-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/css/focus-ring-exists-for-search-field-expected.txt
@@ -10,10 +10,9 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,52) size 784x19
         RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (0,0) size 0x0
-layer at (19,63) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
-caret: position 0 of child 0 {DIV} of child 1 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body
+layer at (11,63) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
+caret: position 0 of child 0 {DIV} of child 0 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/css/text-input-with-webkit-border-radius-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/css/text-input-with-webkit-border-radius-expected.txt
@@ -17,7 +17,6 @@ layer at (0,0) size 800x137
       RenderBlock {DIV} at (0,68) size 163x45 [bgcolor=#888888]
         RenderTextControl {INPUT} at (11,9) size 133x25 [bgcolor=#00FF00] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 127x19
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,3) size 108x13
             RenderBlock {DIV} at (108,0) size 19x19
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/css/text-overflow-input-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/css/text-overflow-input-expected.txt
@@ -15,8 +15,7 @@ layer at (0,0) size 800x268
           text run at (147,18) width 5: " "
         RenderTextControl {INPUT} at (151,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (299,18) size 5x18
           text run at (299,18) width 5: " "
@@ -25,8 +24,7 @@ layer at (0,0) size 800x268
           text run at (451,18) width 5: " "
         RenderTextControl {INPUT} at (455,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (603,18) size 5x18
           text run at (603,18) width 5: " "
@@ -39,8 +37,7 @@ layer at (0,0) size 800x268
           text run at (145,37) width 5: " "
         RenderTextControl {INPUT} at (149,37) size 147x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 140x19
-            RenderBlock {DIV} at (131,0) size 9x19
-            RenderBlock {DIV} at (19,3) size 113x13
+            RenderBlock {DIV} at (19,3) size 121x13
             RenderBlock {DIV} at (0,0) size 19x19
         RenderText {#text} at (295,37) size 5x19
           text run at (295,37) width 5: " "
@@ -49,8 +46,7 @@ layer at (0,0) size 800x268
           text run at (445,37) width 5: " "
         RenderTextControl {INPUT} at (449,37) size 147x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 140x19
-            RenderBlock {DIV} at (131,0) size 9x19
-            RenderBlock {DIV} at (19,3) size 113x13
+            RenderBlock {DIV} at (19,3) size 121x13
             RenderBlock {DIV} at (0,0) size 19x19
         RenderText {#text} at (595,37) size 5x19
           text run at (595,37) width 5: " "
@@ -67,8 +63,7 @@ layer at (0,0) size 800x268
           text run at (147,18) width 5: " "
         RenderTextControl {INPUT} at (151,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (299,18) size 5x18
           text run at (299,18) width 5: " "
@@ -77,8 +72,7 @@ layer at (0,0) size 800x268
           text run at (451,18) width 5: " "
         RenderTextControl {INPUT} at (455,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (603,18) size 5x18
           text run at (603,18) width 5: " "
@@ -91,8 +85,7 @@ layer at (0,0) size 800x268
           text run at (145,37) width 5: " "
         RenderTextControl {INPUT} at (149,37) size 147x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 140x19
-            RenderBlock {DIV} at (131,0) size 9x19
-            RenderBlock {DIV} at (19,3) size 113x13
+            RenderBlock {DIV} at (19,3) size 121x13
             RenderBlock {DIV} at (0,0) size 19x19
         RenderText {#text} at (295,37) size 5x19
           text run at (295,37) width 5: " "
@@ -101,8 +94,7 @@ layer at (0,0) size 800x268
           text run at (445,37) width 5: " "
         RenderTextControl {INPUT} at (449,37) size 147x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 140x19
-            RenderBlock {DIV} at (131,0) size 9x19
-            RenderBlock {DIV} at (19,3) size 113x13
+            RenderBlock {DIV} at (19,3) size 121x13
             RenderBlock {DIV} at (0,0) size 19x19
         RenderText {#text} at (595,37) size 5x19
           text run at (595,37) width 5: " "
@@ -136,18 +128,18 @@ layer at (11,71) size 142x13 scrollWidth 288
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (11,71) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13
-layer at (171,71) size 115x13 scrollWidth 288
-  RenderBlock {DIV} at (11,3) size 115x13 [color=#A9A9A9]
+layer at (163,71) size 123x13 scrollWidth 288
+  RenderBlock {DIV} at (3,3) size 123x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (171,71) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (163,71) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
 layer at (315,71) size 142x13 scrollWidth 290
   RenderBlock {DIV} at (3,3) size 142x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (475,71) size 115x13 scrollWidth 290
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (467,71) size 123x13 scrollWidth 290
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (619,71) size 142x13 backgroundClip at (619,71) size 141x13 clip at (619,71) size 141x13 scrollWidth 387
@@ -174,26 +166,26 @@ layer at (11,91) size 140x13 scrollX 148 scrollWidth 288
       text run at (123,0) width 17: "elit"
 layer at (11,91) size 140x13
   RenderBlock {DIV} at (3,3) size 140x13
-layer at (180,91) size 113x13 scrollX 175 scrollWidth 288
-  RenderBlock {DIV} at (22,3) size 113x13 [color=#A9A9A9]
-    RenderText {#text} at (-175,0) size 288x13
-      text run at (-174,0) width 32: "Lorem"
-      text run at (-142,0) width 3: " "
-      text run at (-139,0) width 32: "ipsum"
-      text run at (-107,0) width 3: " "
-      text run at (-104,0) width 27: "dolor"
-      text run at (-77,0) width 3: " "
-      text run at (-74,0) width 13: "sit"
-      text run at (-61,0) width 3: " "
-      text run at (-58,0) width 30: "amet,"
-      text run at (-28,0) width 3: " "
-      text run at (-25,0) width 63: "consectetur"
-      text run at (37,0) width 4: " "
-      text run at (40,0) width 54: "adipiscing"
-      text run at (93,0) width 4: " "
-      text run at (96,0) width 17: "elit"
-layer at (180,91) size 113x13
-  RenderBlock {DIV} at (0,0) size 113x13
+layer at (180,91) size 121x13 scrollX 167 scrollWidth 288
+  RenderBlock {DIV} at (22,3) size 121x13 [color=#A9A9A9]
+    RenderText {#text} at (-167,0) size 288x13
+      text run at (-166,0) width 32: "Lorem"
+      text run at (-134,0) width 3: " "
+      text run at (-131,0) width 32: "ipsum"
+      text run at (-99,0) width 3: " "
+      text run at (-96,0) width 27: "dolor"
+      text run at (-69,0) width 3: " "
+      text run at (-66,0) width 13: "sit"
+      text run at (-53,0) width 3: " "
+      text run at (-50,0) width 30: "amet,"
+      text run at (-20,0) width 3: " "
+      text run at (-17,0) width 63: "consectetur"
+      text run at (45,0) width 4: " "
+      text run at (48,0) width 54: "adipiscing"
+      text run at (101,0) width 4: " "
+      text run at (104,0) width 17: "elit"
+layer at (180,91) size 121x13
+  RenderBlock {DIV} at (0,0) size 121x13
 layer at (311,91) size 140x13 scrollX 148 scrollWidth 288
   RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (-148,0) size 288x13
@@ -212,24 +204,24 @@ layer at (311,91) size 140x13 scrollX 148 scrollWidth 288
       text run at (67,0) width 54: "adipiscing"
       text run at (120,0) width 4: " "
       text run at (123,0) width 17: "elit"
-layer at (480,91) size 113x13 scrollX 175 scrollWidth 288
-  RenderBlock {DIV} at (0,0) size 113x13
-    RenderText {#text} at (-175,0) size 288x13
-      text run at (-174,0) width 32: "Lorem"
-      text run at (-142,0) width 3: " "
-      text run at (-139,0) width 32: "ipsum"
-      text run at (-107,0) width 3: " "
-      text run at (-104,0) width 27: "dolor"
-      text run at (-77,0) width 3: " "
-      text run at (-74,0) width 13: "sit"
-      text run at (-61,0) width 3: " "
-      text run at (-58,0) width 30: "amet,"
-      text run at (-28,0) width 3: " "
-      text run at (-25,0) width 63: "consectetur"
-      text run at (37,0) width 4: " "
-      text run at (40,0) width 54: "adipiscing"
-      text run at (93,0) width 4: " "
-      text run at (96,0) width 17: "elit"
+layer at (480,91) size 121x13 scrollX 167 scrollWidth 288
+  RenderBlock {DIV} at (0,0) size 121x13
+    RenderText {#text} at (-167,0) size 288x13
+      text run at (-166,0) width 32: "Lorem"
+      text run at (-134,0) width 3: " "
+      text run at (-131,0) width 32: "ipsum"
+      text run at (-99,0) width 3: " "
+      text run at (-96,0) width 27: "dolor"
+      text run at (-69,0) width 3: " "
+      text run at (-66,0) width 13: "sit"
+      text run at (-53,0) width 3: " "
+      text run at (-50,0) width 30: "amet,"
+      text run at (-20,0) width 3: " "
+      text run at (-17,0) width 63: "consectetur"
+      text run at (45,0) width 4: " "
+      text run at (48,0) width 54: "adipiscing"
+      text run at (101,0) width 4: " "
+      text run at (104,0) width 17: "elit"
 layer at (611,91) size 140x13 backgroundClip at (611,91) size 139x13 clip at (611,91) size 139x13 scrollX 245 scrollWidth 385
   RenderBlock {DIV} at (0,0) size 140x13
     RenderText {#text} at (-245,0) size 385x13
@@ -240,18 +232,18 @@ layer at (11,144) size 142x13 scrollWidth 288
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (11,144) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13
-layer at (171,144) size 115x13 scrollWidth 288
-  RenderBlock {DIV} at (11,3) size 115x13 [color=#A9A9A9]
+layer at (163,144) size 123x13 scrollWidth 288
+  RenderBlock {DIV} at (3,3) size 123x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (171,144) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (163,144) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
 layer at (315,144) size 142x13 scrollWidth 290
   RenderBlock {DIV} at (3,3) size 142x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (475,144) size 115x13 scrollWidth 290
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (467,144) size 123x13 scrollWidth 290
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (619,144) size 142x13 backgroundClip at (619,144) size 141x13 clip at (619,144) size 141x13 scrollWidth 387
@@ -278,26 +270,26 @@ layer at (11,163) size 140x13 scrollX 148 scrollWidth 288
       text run at (123,0) width 17: "elit"
 layer at (11,163) size 140x13
   RenderBlock {DIV} at (3,3) size 140x13
-layer at (180,163) size 113x13 scrollX 175 scrollWidth 288
-  RenderBlock {DIV} at (22,3) size 113x13 [color=#A9A9A9]
-    RenderText {#text} at (-175,0) size 288x13
-      text run at (-174,0) width 32: "Lorem"
-      text run at (-142,0) width 3: " "
-      text run at (-139,0) width 32: "ipsum"
-      text run at (-107,0) width 3: " "
-      text run at (-104,0) width 27: "dolor"
-      text run at (-77,0) width 3: " "
-      text run at (-74,0) width 13: "sit"
-      text run at (-61,0) width 3: " "
-      text run at (-58,0) width 30: "amet,"
-      text run at (-28,0) width 3: " "
-      text run at (-25,0) width 63: "consectetur"
-      text run at (37,0) width 4: " "
-      text run at (40,0) width 54: "adipiscing"
-      text run at (93,0) width 4: " "
-      text run at (96,0) width 17: "elit"
-layer at (180,163) size 113x13
-  RenderBlock {DIV} at (0,0) size 113x13
+layer at (180,163) size 121x13 scrollX 167 scrollWidth 288
+  RenderBlock {DIV} at (22,3) size 121x13 [color=#A9A9A9]
+    RenderText {#text} at (-167,0) size 288x13
+      text run at (-166,0) width 32: "Lorem"
+      text run at (-134,0) width 3: " "
+      text run at (-131,0) width 32: "ipsum"
+      text run at (-99,0) width 3: " "
+      text run at (-96,0) width 27: "dolor"
+      text run at (-69,0) width 3: " "
+      text run at (-66,0) width 13: "sit"
+      text run at (-53,0) width 3: " "
+      text run at (-50,0) width 30: "amet,"
+      text run at (-20,0) width 3: " "
+      text run at (-17,0) width 63: "consectetur"
+      text run at (45,0) width 4: " "
+      text run at (48,0) width 54: "adipiscing"
+      text run at (101,0) width 4: " "
+      text run at (104,0) width 17: "elit"
+layer at (180,163) size 121x13
+  RenderBlock {DIV} at (0,0) size 121x13
 layer at (311,163) size 140x13 scrollX 148 scrollWidth 288
   RenderBlock {DIV} at (3,3) size 140x13
     RenderText {#text} at (-148,0) size 288x13
@@ -316,24 +308,24 @@ layer at (311,163) size 140x13 scrollX 148 scrollWidth 288
       text run at (67,0) width 54: "adipiscing"
       text run at (120,0) width 4: " "
       text run at (123,0) width 17: "elit"
-layer at (480,163) size 113x13 scrollX 175 scrollWidth 288
-  RenderBlock {DIV} at (0,0) size 113x13
-    RenderText {#text} at (-175,0) size 288x13
-      text run at (-174,0) width 32: "Lorem"
-      text run at (-142,0) width 3: " "
-      text run at (-139,0) width 32: "ipsum"
-      text run at (-107,0) width 3: " "
-      text run at (-104,0) width 27: "dolor"
-      text run at (-77,0) width 3: " "
-      text run at (-74,0) width 13: "sit"
-      text run at (-61,0) width 3: " "
-      text run at (-58,0) width 30: "amet,"
-      text run at (-28,0) width 3: " "
-      text run at (-25,0) width 63: "consectetur"
-      text run at (37,0) width 4: " "
-      text run at (40,0) width 54: "adipiscing"
-      text run at (93,0) width 4: " "
-      text run at (96,0) width 17: "elit"
+layer at (480,163) size 121x13 scrollX 167 scrollWidth 288
+  RenderBlock {DIV} at (0,0) size 121x13
+    RenderText {#text} at (-167,0) size 288x13
+      text run at (-166,0) width 32: "Lorem"
+      text run at (-134,0) width 3: " "
+      text run at (-131,0) width 32: "ipsum"
+      text run at (-99,0) width 3: " "
+      text run at (-96,0) width 27: "dolor"
+      text run at (-69,0) width 3: " "
+      text run at (-66,0) width 13: "sit"
+      text run at (-53,0) width 3: " "
+      text run at (-50,0) width 30: "amet,"
+      text run at (-20,0) width 3: " "
+      text run at (-17,0) width 63: "consectetur"
+      text run at (45,0) width 4: " "
+      text run at (48,0) width 54: "adipiscing"
+      text run at (101,0) width 4: " "
+      text run at (104,0) width 17: "elit"
 layer at (611,163) size 140x13 backgroundClip at (611,163) size 139x13 clip at (611,163) size 139x13 scrollX 245 scrollWidth 385
   RenderBlock {DIV} at (0,0) size 140x13
     RenderText {#text} at (-245,0) size 385x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/control-restrict-line-height-expected.txt
@@ -18,11 +18,10 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (286,41) size 1x19
       RenderTextControl {INPUT} at (0,67) size 148x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderFlexibleBox {DIV} at (3,0) size 142x19
-          RenderBlock {DIV} at (0,0) size 8x19
-          RenderBlock {DIV} at (8,3) size 115x13
+          RenderBlock {DIV} at (0,3) size 123x13
           RenderBlock {DIV} at (122,0) size 20x19
       RenderText {#text} at (0,0) size 0x0
-layer at (19,79) size 115x13 scrollWidth 272
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (11,79) size 123x13 scrollWidth 272
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 271x13
       text run at (0,0) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/datalist/datalist-searchinput-appearance-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/datalist/datalist-searchinput-appearance-expected.txt
@@ -5,10 +5,9 @@ layer at (0,0) size 800x35
     RenderBody {BODY} at (8,8) size 784x20
       RenderTextControl {INPUT} at (0,0) size 148x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderFlexibleBox {DIV} at (3,0) size 142x19
-          RenderBlock {DIV} at (0,0) size 8x19
-          RenderBlock {DIV} at (8,3) size 103x13
+          RenderBlock {DIV} at (0,3) size 111x13
           RenderBlock {DIV} at (110,0) size 20x19
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (19,11) size 103x13
-  RenderBlock {DIV} at (0,0) size 103x13
+layer at (11,11) size 111x13
+  RenderBlock {DIV} at (0,0) size 111x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-appearance-height-expected.txt
@@ -81,8 +81,7 @@ layer at (0,0) size 800x600
           text run at (0,214) width 45: "search "
         RenderTextControl {INPUT} at (44,214) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (0,0) size 0x0
 layer at (48,29) size 142x13
@@ -93,5 +92,5 @@ layer at (61,205) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13
 layer at (75,224) size 142x13
   RenderBlock {DIV} at (0,0) size 142x13
-layer at (64,244) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (56,244) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/placeholder-pseudo-style-expected.txt
@@ -11,8 +11,7 @@ layer at (0,0) size 800x600
         text run at (147,18) width 5: " "
       RenderTextControl {INPUT} at (151,18) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
         RenderFlexibleBox {DIV} at (3,0) size 142x19
-          RenderBlock {DIV} at (0,0) size 8x19
-          RenderBlock {DIV} at (8,3) size 115x13
+          RenderBlock {DIV} at (0,3) size 123x13
           RenderBlock {DIV} at (122,0) size 20x19
       RenderText {#text} at (299,18) size 5x18
         text run at (299,18) width 5: " "
@@ -34,12 +33,12 @@ layer at (11,29) size 142x13
       text run at (0,0) width 21: "text"
 layer at (11,29) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13
-layer at (171,29) size 115x13
-  RenderBlock {DIV} at (11,3) size 115x13 [color=#640000]
+layer at (163,29) size 123x13
+  RenderBlock {DIV} at (3,3) size 123x13 [color=#640000]
     RenderText {#text} at (0,0) size 36x13
       text run at (0,0) width 36: "search"
-layer at (171,29) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (163,29) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
 layer at (315,29) size 142x13
   RenderBlock {DIV} at (3,3) size 142x13 [color=#640000]
     RenderText {#text} at (0,0) size 51x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-cancel-button-style-sharing-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-cancel-button-style-sharing-expected.txt
@@ -9,20 +9,18 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,34) size 784x20
         RenderTextControl {INPUT} at (0,0) size 148x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (147,0) size 5x18
           text run at (147,0) width 5: " "
         RenderTextControl {INPUT} at (151,0) size 149x20 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (0,0) size 0x0
-layer at (19,45) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
-layer at (171,45) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (11,45) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
+layer at (163,45) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 42x13
       text run at (0,0) width 42: "this one"

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-display-none-cancel-button-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-display-none-cancel-button-expected.txt
@@ -7,11 +7,10 @@ layer at (0,0) size 800x600
         text run at (0,0) width 510: "This tests that the display:none style will work on a search field's cancel button."
       RenderBR {BR} at (509,0) size 1x18
       RenderTextControl {INPUT} at (0,18) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
-        RenderFlexibleBox {DIV} at (3,0) size 142x19
-          RenderBlock {DIV} at (0,0) size 8x19
-          RenderBlock {DIV} at (8,3) size 134x13
+        RenderFlexibleBox {DIV} at (3,3) size 142x13
+          RenderBlock {DIV} at (0,0) size 142x13
       RenderText {#text} at (0,0) size 0x0
-layer at (19,29) size 134x13
-  RenderBlock {DIV} at (0,0) size 134x13
+layer at (11,29) size 142x13
+  RenderBlock {DIV} at (0,0) size 142x13
     RenderText {#text} at (0,0) size 21x13
       text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-vertical-alignment-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-vertical-alignment-expected.txt
@@ -13,8 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,52) size 784x45
         RenderTextControl {INPUT} at (0,0) size 148x45 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 142x39
-            RenderBlock {DIV} at (0,10) size 17x19
-            RenderBlock {DIV} at (17,13) size 106x13
+            RenderBlock {DIV} at (0,13) size 123x13
             RenderBlock {DIV} at (122,10) size 20x19
         RenderText {#text} at (147,12) size 5x19
           text run at (147,12) width 5: " "
@@ -23,8 +22,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,113) size 784x18
         RenderTextControl {INPUT} at (0,1) size 148x17 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 142x16
-            RenderBlock {DIV} at (0,0) size 17x19
-            RenderBlock {DIV} at (17,1) size 106x14
+            RenderBlock {DIV} at (0,1) size 123x14
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (147,0) size 5x18
           text run at (147,0) width 5: " "
@@ -33,31 +31,30 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,147) size 784x18
         RenderTextControl {INPUT} at (0,5) size 148x12 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 142x12
-            RenderBlock {DIV} at (0,0) size 17x19
-            RenderBlock {DIV} at (17,3) size 106x6
+            RenderBlock {DIV} at (0,3) size 123x6
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (147,0) size 5x18
           text run at (147,0) width 5: " "
         RenderTextControl {INPUT} at (151,3) size 149x13 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
-layer at (28,76) size 106x13
-  RenderBlock {DIV} at (0,0) size 106x13
+layer at (11,76) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
 layer at (163,76) size 142x13
   RenderBlock {DIV} at (3,16) size 142x13
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
-layer at (28,124) size 106x13
-  RenderBlock {DIV} at (0,0) size 106x13
+layer at (11,124) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
 layer at (163,124) size 142x13
   RenderBlock {DIV} at (3,1) size 142x14
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
-layer at (28,163) size 106x6 scrollHeight 13
-  RenderBlock {DIV} at (0,0) size 106x6
+layer at (11,163) size 123x6 scrollHeight 13
+  RenderBlock {DIV} at (0,0) size 123x6
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
 layer at (163,158) size 142x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/repaint/search-field-cancel-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/repaint/search-field-cancel-expected.txt
@@ -14,11 +14,10 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,34) size 784x19
         RenderTextControl {INPUT} at (0,0) size 148x19 [bgcolor=#FFFFFF] [border: (2px inset #000000)]
           RenderFlexibleBox {DIV} at (3,0) size 142x19
-            RenderBlock {DIV} at (0,0) size 8x19
-            RenderBlock {DIV} at (8,3) size 115x13
+            RenderBlock {DIV} at (0,3) size 123x13
             RenderBlock {DIV} at (122,0) size 20x19
         RenderText {#text} at (0,0) size 0x0
-layer at (19,45) size 115x13
-  RenderBlock {DIV} at (0,0) size 115x13
+layer at (11,45) size 123x13
+  RenderBlock {DIV} at (0,0) size 123x13
     RenderText {#text} at (0,0) size 52x13
       text run at (0,0) width 52: "some text"

--- a/LayoutTests/platform/mac-wk2/fast/css/focus-ring-exists-for-search-field-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/css/focus-ring-exists-for-search-field-expected.txt
@@ -10,10 +10,9 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,52) size 784x21
         RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (0,0) size 0x0
-layer at (30,64) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
-caret: position 0 of child 0 {DIV} of child 1 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body
+layer at (15,64) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
+caret: position 0 of child 0 {DIV} of child 0 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body

--- a/LayoutTests/platform/mac-wk2/fast/css/text-input-with-webkit-border-radius-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/css/text-input-with-webkit-border-radius-expected.txt
@@ -17,7 +17,6 @@ layer at (0,0) size 800x137
       RenderBlock {DIV} at (0,68) size 163x45 [bgcolor=#888888]
         RenderTextControl {INPUT} at (11,9) size 133x19 [bgcolor=#00FF00] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 127x13
-            RenderBlock {DIV} at (0,6) size 0x0
             RenderBlock {DIV} at (0,0) size 116x13
             RenderBlock {DIV} at (116,1) size 11x11
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-wk2/fast/css/text-overflow-input-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/css/text-overflow-input-expected.txt
@@ -15,8 +15,7 @@ layer at (0,0) size 800x362
           text run at (155,18) width 5: " "
         RenderTextControl {INPUT} at (159,18) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (315,18) size 5x19
           text run at (315,18) width 5: " "
@@ -25,8 +24,7 @@ layer at (0,0) size 800x362
           text run at (475,18) width 5: " "
         RenderTextControl {INPUT} at (479,18) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,39) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -38,8 +36,7 @@ layer at (0,0) size 800x362
           text run at (153,60) width 5: " "
         RenderTextControl {INPUT} at (157,60) size 155x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 140x13
-            RenderBlock {DIV} at (128,1) size 12x11
-            RenderBlock {DIV} at (11,0) size 114x13
+            RenderBlock {DIV} at (11,0) size 129x13
             RenderBlock {DIV} at (0,1) size 11x11
         RenderText {#text} at (311,60) size 5x19
           text run at (311,60) width 5: " "
@@ -48,8 +45,7 @@ layer at (0,0) size 800x362
           text run at (469,60) width 5: " "
         RenderTextControl {INPUT} at (473,60) size 155x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 140x13
-            RenderBlock {DIV} at (128,1) size 12x11
-            RenderBlock {DIV} at (11,0) size 114x13
+            RenderBlock {DIV} at (11,0) size 129x13
             RenderBlock {DIV} at (0,1) size 11x11
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,81) size 154x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -65,8 +61,7 @@ layer at (0,0) size 800x362
           text run at (155,18) width 5: " "
         RenderTextControl {INPUT} at (159,18) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (315,18) size 5x19
           text run at (315,18) width 5: " "
@@ -75,8 +70,7 @@ layer at (0,0) size 800x362
           text run at (475,18) width 5: " "
         RenderTextControl {INPUT} at (479,18) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,39) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -88,8 +82,7 @@ layer at (0,0) size 800x362
           text run at (153,60) width 5: " "
         RenderTextControl {INPUT} at (157,60) size 155x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 140x13
-            RenderBlock {DIV} at (128,1) size 12x11
-            RenderBlock {DIV} at (11,0) size 114x13
+            RenderBlock {DIV} at (11,0) size 129x13
             RenderBlock {DIV} at (0,1) size 11x11
         RenderText {#text} at (311,60) size 5x19
           text run at (311,60) width 5: " "
@@ -98,8 +91,7 @@ layer at (0,0) size 800x362
           text run at (469,60) width 5: " "
         RenderTextControl {INPUT} at (473,60) size 155x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 140x13
-            RenderBlock {DIV} at (128,1) size 12x11
-            RenderBlock {DIV} at (11,0) size 114x13
+            RenderBlock {DIV} at (11,0) size 129x13
             RenderBlock {DIV} at (0,1) size 11x11
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,81) size 154x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -132,18 +124,18 @@ layer at (15,72) size 142x13 scrollWidth 288
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (15,72) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
-layer at (190,72) size 116x13 scrollWidth 288
-  RenderBlock {DIV} at (21,4) size 117x13 [color=#A9A9A9]
+layer at (175,72) size 131x13 scrollWidth 288
+  RenderBlock {DIV} at (7,4) size 131x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (190,72) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (175,72) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
 layer at (335,72) size 142x13 scrollWidth 290
   RenderBlock {DIV} at (7,4) size 142x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (510,72) size 116x13 scrollWidth 290
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (495,72) size 131x13 scrollWidth 290
+  RenderBlock {DIV} at (0,0) size 131x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (15,93) size 142x13 scrollWidth 387
@@ -170,26 +162,26 @@ layer at (15,114) size 140x13 scrollX 148 scrollWidth 288
       text run at (123,0) width 17: "elit"
 layer at (15,114) size 140x13
   RenderBlock {DIV} at (7,4) size 140x13
-layer at (184,114) size 114x13 scrollX 174 scrollWidth 288
-  RenderBlock {DIV} at (18,4) size 114x13 [color=#A9A9A9]
-    RenderText {#text} at (-174,0) size 288x13
-      text run at (-173,0) width 32: "Lorem"
-      text run at (-141,0) width 3: " "
-      text run at (-138,0) width 32: "ipsum"
-      text run at (-106,0) width 3: " "
-      text run at (-103,0) width 27: "dolor"
-      text run at (-76,0) width 3: " "
-      text run at (-73,0) width 13: "sit"
-      text run at (-60,0) width 3: " "
-      text run at (-57,0) width 30: "amet,"
-      text run at (-27,0) width 3: " "
-      text run at (-24,0) width 63: "consectetur"
-      text run at (38,0) width 4: " "
-      text run at (41,0) width 54: "adipiscing"
-      text run at (94,0) width 4: " "
-      text run at (97,0) width 17: "elit"
-layer at (184,114) size 114x13
-  RenderBlock {DIV} at (0,0) size 114x13
+layer at (184,114) size 129x13 scrollX 159 scrollWidth 288
+  RenderBlock {DIV} at (18,4) size 129x13 [color=#A9A9A9]
+    RenderText {#text} at (-159,0) size 288x13
+      text run at (-158,0) width 32: "Lorem"
+      text run at (-126,0) width 3: " "
+      text run at (-123,0) width 32: "ipsum"
+      text run at (-91,0) width 3: " "
+      text run at (-88,0) width 27: "dolor"
+      text run at (-61,0) width 3: " "
+      text run at (-58,0) width 13: "sit"
+      text run at (-45,0) width 3: " "
+      text run at (-42,0) width 30: "amet,"
+      text run at (-12,0) width 3: " "
+      text run at (-9,0) width 63: "consectetur"
+      text run at (53,0) width 4: " "
+      text run at (56,0) width 54: "adipiscing"
+      text run at (109,0) width 4: " "
+      text run at (112,0) width 17: "elit"
+layer at (184,114) size 129x13
+  RenderBlock {DIV} at (0,0) size 129x13
 layer at (331,114) size 140x13 scrollX 148 scrollWidth 288
   RenderBlock {DIV} at (7,4) size 140x13
     RenderText {#text} at (-148,0) size 288x13
@@ -208,24 +200,24 @@ layer at (331,114) size 140x13 scrollX 148 scrollWidth 288
       text run at (67,0) width 54: "adipiscing"
       text run at (120,0) width 4: " "
       text run at (123,0) width 17: "elit"
-layer at (500,114) size 114x13 scrollX 174 scrollWidth 288
-  RenderBlock {DIV} at (0,0) size 114x13
-    RenderText {#text} at (-174,0) size 288x13
-      text run at (-173,0) width 32: "Lorem"
-      text run at (-141,0) width 3: " "
-      text run at (-138,0) width 32: "ipsum"
-      text run at (-106,0) width 3: " "
-      text run at (-103,0) width 27: "dolor"
-      text run at (-76,0) width 3: " "
-      text run at (-73,0) width 13: "sit"
-      text run at (-60,0) width 3: " "
-      text run at (-57,0) width 30: "amet,"
-      text run at (-27,0) width 3: " "
-      text run at (-24,0) width 63: "consectetur"
-      text run at (38,0) width 4: " "
-      text run at (41,0) width 54: "adipiscing"
-      text run at (94,0) width 4: " "
-      text run at (97,0) width 17: "elit"
+layer at (500,114) size 129x13 scrollX 159 scrollWidth 288
+  RenderBlock {DIV} at (0,0) size 129x13
+    RenderText {#text} at (-159,0) size 288x13
+      text run at (-158,0) width 32: "Lorem"
+      text run at (-126,0) width 3: " "
+      text run at (-123,0) width 32: "ipsum"
+      text run at (-91,0) width 3: " "
+      text run at (-88,0) width 27: "dolor"
+      text run at (-61,0) width 3: " "
+      text run at (-58,0) width 13: "sit"
+      text run at (-45,0) width 3: " "
+      text run at (-42,0) width 30: "amet,"
+      text run at (-12,0) width 3: " "
+      text run at (-9,0) width 63: "consectetur"
+      text run at (53,0) width 4: " "
+      text run at (56,0) width 54: "adipiscing"
+      text run at (109,0) width 4: " "
+      text run at (112,0) width 17: "elit"
 layer at (15,135) size 140x13 scrollX 245 scrollWidth 385
   RenderBlock {DIV} at (0,0) size 140x13
     RenderText {#text} at (-245,0) size 385x13
@@ -236,18 +228,18 @@ layer at (15,190) size 142x13 scrollWidth 288
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (15,190) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
-layer at (190,190) size 116x13 scrollWidth 288
-  RenderBlock {DIV} at (21,4) size 117x13 [color=#A9A9A9]
+layer at (175,190) size 131x13 scrollWidth 288
+  RenderBlock {DIV} at (7,4) size 131x13 [color=#A9A9A9]
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (190,190) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (175,190) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
 layer at (335,190) size 142x13 scrollWidth 290
   RenderBlock {DIV} at (7,4) size 142x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-layer at (510,190) size 116x13 scrollWidth 290
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (495,190) size 131x13 scrollWidth 290
+  RenderBlock {DIV} at (0,0) size 131x13
     RenderText {#text} at (0,0) size 288x13
       text run at (0,0) width 288: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 layer at (15,211) size 142x13 scrollWidth 387
@@ -274,26 +266,26 @@ layer at (15,232) size 140x13 scrollX 148 scrollWidth 288
       text run at (123,0) width 17: "elit"
 layer at (15,232) size 140x13
   RenderBlock {DIV} at (7,4) size 140x13
-layer at (184,232) size 114x13 scrollX 174 scrollWidth 288
-  RenderBlock {DIV} at (18,4) size 114x13 [color=#A9A9A9]
-    RenderText {#text} at (-174,0) size 288x13
-      text run at (-173,0) width 32: "Lorem"
-      text run at (-141,0) width 3: " "
-      text run at (-138,0) width 32: "ipsum"
-      text run at (-106,0) width 3: " "
-      text run at (-103,0) width 27: "dolor"
-      text run at (-76,0) width 3: " "
-      text run at (-73,0) width 13: "sit"
-      text run at (-60,0) width 3: " "
-      text run at (-57,0) width 30: "amet,"
-      text run at (-27,0) width 3: " "
-      text run at (-24,0) width 63: "consectetur"
-      text run at (38,0) width 4: " "
-      text run at (41,0) width 54: "adipiscing"
-      text run at (94,0) width 4: " "
-      text run at (97,0) width 17: "elit"
-layer at (184,232) size 114x13
-  RenderBlock {DIV} at (0,0) size 114x13
+layer at (184,232) size 129x13 scrollX 159 scrollWidth 288
+  RenderBlock {DIV} at (18,4) size 129x13 [color=#A9A9A9]
+    RenderText {#text} at (-159,0) size 288x13
+      text run at (-158,0) width 32: "Lorem"
+      text run at (-126,0) width 3: " "
+      text run at (-123,0) width 32: "ipsum"
+      text run at (-91,0) width 3: " "
+      text run at (-88,0) width 27: "dolor"
+      text run at (-61,0) width 3: " "
+      text run at (-58,0) width 13: "sit"
+      text run at (-45,0) width 3: " "
+      text run at (-42,0) width 30: "amet,"
+      text run at (-12,0) width 3: " "
+      text run at (-9,0) width 63: "consectetur"
+      text run at (53,0) width 4: " "
+      text run at (56,0) width 54: "adipiscing"
+      text run at (109,0) width 4: " "
+      text run at (112,0) width 17: "elit"
+layer at (184,232) size 129x13
+  RenderBlock {DIV} at (0,0) size 129x13
 layer at (331,232) size 140x13 scrollX 148 scrollWidth 288
   RenderBlock {DIV} at (7,4) size 140x13
     RenderText {#text} at (-148,0) size 288x13
@@ -312,24 +304,24 @@ layer at (331,232) size 140x13 scrollX 148 scrollWidth 288
       text run at (67,0) width 54: "adipiscing"
       text run at (120,0) width 4: " "
       text run at (123,0) width 17: "elit"
-layer at (500,232) size 114x13 scrollX 174 scrollWidth 288
-  RenderBlock {DIV} at (0,0) size 114x13
-    RenderText {#text} at (-174,0) size 288x13
-      text run at (-173,0) width 32: "Lorem"
-      text run at (-141,0) width 3: " "
-      text run at (-138,0) width 32: "ipsum"
-      text run at (-106,0) width 3: " "
-      text run at (-103,0) width 27: "dolor"
-      text run at (-76,0) width 3: " "
-      text run at (-73,0) width 13: "sit"
-      text run at (-60,0) width 3: " "
-      text run at (-57,0) width 30: "amet,"
-      text run at (-27,0) width 3: " "
-      text run at (-24,0) width 63: "consectetur"
-      text run at (38,0) width 4: " "
-      text run at (41,0) width 54: "adipiscing"
-      text run at (94,0) width 4: " "
-      text run at (97,0) width 17: "elit"
+layer at (500,232) size 129x13 scrollX 159 scrollWidth 288
+  RenderBlock {DIV} at (0,0) size 129x13
+    RenderText {#text} at (-159,0) size 288x13
+      text run at (-158,0) width 32: "Lorem"
+      text run at (-126,0) width 3: " "
+      text run at (-123,0) width 32: "ipsum"
+      text run at (-91,0) width 3: " "
+      text run at (-88,0) width 27: "dolor"
+      text run at (-61,0) width 3: " "
+      text run at (-58,0) width 13: "sit"
+      text run at (-45,0) width 3: " "
+      text run at (-42,0) width 30: "amet,"
+      text run at (-12,0) width 3: " "
+      text run at (-9,0) width 63: "consectetur"
+      text run at (53,0) width 4: " "
+      text run at (56,0) width 54: "adipiscing"
+      text run at (109,0) width 4: " "
+      text run at (112,0) width 17: "elit"
 layer at (15,253) size 140x13 scrollX 245 scrollWidth 385
   RenderBlock {DIV} at (0,0) size 140x13
     RenderText {#text} at (-245,0) size 385x13

--- a/LayoutTests/platform/mac-wk2/fast/forms/datalist/datalist-searchinput-appearance-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/datalist/datalist-searchinput-appearance-expected.txt
@@ -5,12 +5,11 @@ layer at (0,0) size 800x39
     RenderBody {BODY} at (8,8) size 784x23
       RenderTextControl {INPUT} at (0,0) size 154x23 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (7,4) size 140x15
-          RenderBlock {DIV} at (0,2) size 11x11
-          RenderBlock {DIV} at (14,0) size 94x15
+          RenderBlock {DIV} at (0,0) size 108x15
           RenderBlock {DIV} at (107,2) size 12x11
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,12) size 92x15
-  RenderBlock {DIV} at (0,0) size 93x15
+layer at (15,12) size 107x15
+  RenderBlock {DIV} at (0,0) size 108x15
 layer at (133,12) size 22x15
   RenderBlock (relative positioned) {DIV} at (118,0) size 22x15

--- a/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/input-appearance-height-expected.txt
@@ -81,8 +81,7 @@ layer at (0,0) size 800x600
           text run at (0,220) width 45: "search "
         RenderTextControl {INPUT} at (44,220) size 157x22 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (0,0) size 0x0
 layer at (52,30) size 142x13
@@ -93,5 +92,5 @@ layer at (65,208) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
 layer at (79,229) size 142x13
   RenderBlock {DIV} at (0,0) size 142x13
-layer at (75,250) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (60,250) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13

--- a/LayoutTests/platform/mac-wk2/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/placeholder-pseudo-style-expected.txt
@@ -11,8 +11,7 @@ layer at (0,0) size 800x600
         text run at (155,18) width 5: " "
       RenderTextControl {INPUT} at (159,18) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (7,4) size 142x13
-          RenderBlock {DIV} at (0,1) size 11x11
-          RenderBlock {DIV} at (14,0) size 117x13
+          RenderBlock {DIV} at (0,0) size 131x13
           RenderBlock {DIV} at (130,1) size 12x11
       RenderText {#text} at (315,18) size 5x19
         text run at (315,18) width 5: " "
@@ -34,12 +33,12 @@ layer at (15,30) size 142x13
       text run at (0,0) width 21: "text"
 layer at (15,30) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13
-layer at (190,30) size 116x13
-  RenderBlock {DIV} at (21,4) size 117x13 [color=#640000]
+layer at (175,30) size 131x13
+  RenderBlock {DIV} at (7,4) size 131x13 [color=#640000]
     RenderText {#text} at (0,0) size 36x13
       text run at (0,0) width 36: "search"
-layer at (190,30) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (175,30) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
 layer at (335,30) size 142x13
   RenderBlock {DIV} at (7,4) size 142x13 [color=#640000]
     RenderText {#text} at (0,0) size 51x13

--- a/LayoutTests/platform/mac-wk2/fast/forms/search-cancel-button-style-sharing-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/search-cancel-button-style-sharing-expected.txt
@@ -9,20 +9,18 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,34) size 784x21
         RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (155,0) size 5x19
           text run at (155,0) width 5: " "
         RenderTextControl {INPUT} at (159,0) size 157x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (0,0) size 0x0
-layer at (30,46) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
-layer at (190,46) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (15,46) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
+layer at (175,46) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
     RenderText {#text} at (0,0) size 42x13
       text run at (0,0) width 42: "this one"

--- a/LayoutTests/platform/mac-wk2/fast/forms/search-display-none-cancel-button-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/search-display-none-cancel-button-expected.txt
@@ -8,10 +8,9 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (509,0) size 1x18
       RenderTextControl {INPUT} at (0,18) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (7,4) size 142x13
-          RenderBlock {DIV} at (0,1) size 11x11
-          RenderBlock {DIV} at (14,0) size 128x13
+          RenderBlock {DIV} at (0,0) size 142x13
       RenderText {#text} at (0,0) size 0x0
-layer at (30,30) size 127x13
-  RenderBlock {DIV} at (0,0) size 127x13
+layer at (15,30) size 142x13
+  RenderBlock {DIV} at (0,0) size 142x13
     RenderText {#text} at (0,0) size 21x13
       text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/mac-wk2/fast/forms/search-vertical-alignment-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/forms/search-vertical-alignment-expected.txt
@@ -13,8 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,52) size 784x45
         RenderTextControl {INPUT} at (0,0) size 148x45 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 142x39
-            RenderBlock {DIV} at (0,14) size 11x11
-            RenderBlock {DIV} at (14,13) size 117x13
+            RenderBlock {DIV} at (0,13) size 131x13
             RenderBlock {DIV} at (130,14) size 12x11
         RenderText {#text} at (147,12) size 5x19
           text run at (147,12) width 5: " "
@@ -23,8 +22,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,113) size 784x18
         RenderTextControl {INPUT} at (0,1) size 148x17 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,1) size 142x14
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (147,0) size 5x18
           text run at (147,0) width 5: " "
@@ -33,31 +31,30 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,147) size 784x18
         RenderTextControl {INPUT} at (0,5) size 148x12 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 142x12
-            RenderBlock {DIV} at (0,0) size 11x12
-            RenderBlock {DIV} at (14,3) size 117x6
+            RenderBlock {DIV} at (0,3) size 131x6
             RenderBlock {DIV} at (130,0) size 12x12
         RenderText {#text} at (147,0) size 5x18
           text run at (147,0) width 5: " "
         RenderTextControl {INPUT} at (151,3) size 149x13 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
-layer at (26,76) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (11,76) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
 layer at (163,76) size 142x13
   RenderBlock {DIV} at (3,16) size 142x13
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
-layer at (26,124) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (11,124) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
 layer at (163,124) size 142x13
   RenderBlock {DIV} at (3,1) size 142x14
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
-layer at (26,163) size 116x6 scrollHeight 13
-  RenderBlock {DIV} at (0,0) size 116x6
+layer at (11,163) size 131x6 scrollHeight 13
+  RenderBlock {DIV} at (0,0) size 131x6
     RenderText {#text} at (0,0) size 22x13
       text run at (0,0) width 22: "Text"
 layer at (163,158) size 142x13

--- a/LayoutTests/platform/mac-wk2/fast/repaint/search-field-cancel-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/repaint/search-field-cancel-expected.txt
@@ -14,11 +14,10 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,34) size 784x21
         RenderTextControl {INPUT} at (0,0) size 156x21 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (7,4) size 142x13
-            RenderBlock {DIV} at (0,1) size 11x11
-            RenderBlock {DIV} at (14,0) size 117x13
+            RenderBlock {DIV} at (0,0) size 131x13
             RenderBlock {DIV} at (130,1) size 12x11
         RenderText {#text} at (0,0) size 0x0
-layer at (30,46) size 116x13
-  RenderBlock {DIV} at (0,0) size 116x13
+layer at (15,46) size 131x13
+  RenderBlock {DIV} at (0,0) size 131x13
     RenderText {#text} at (0,0) size 52x13
       text run at (0,0) width 52: "some text"

--- a/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt
@@ -18,11 +18,10 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (286,43) size 1x19
       RenderTextControl {INPUT} at (0,69) size 156x36 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (7,4) size 142x27
-          RenderBlock {DIV} at (0,7) size 11x12
-          RenderBlock {DIV} at (14,0) size 117x27
+          RenderBlock {DIV} at (0,0) size 131x27
           RenderBlock {DIV} at (130,7) size 12x12
       RenderText {#text} at (0,0) size 0x0
-layer at (30,82) size 116x27 backgroundClip at (30,82) size 116x26 clip at (30,82) size 116x26 scrollWidth 272
-  RenderBlock {DIV} at (0,0) size 116x27
+layer at (15,82) size 131x27 backgroundClip at (15,82) size 131x26 clip at (15,82) size 131x26 scrollWidth 272
+  RenderBlock {DIV} at (0,0) size 131x27
     RenderText {#text} at (0,6) size 271x14
       text run at (0,6) width 271: "This text should be centered vertically in the button"

--- a/LayoutTests/platform/wpe/fast/css/focus-ring-exists-for-search-field-expected.txt
+++ b/LayoutTests/platform/wpe/fast/css/focus-ring-exists-for-search-field-expected.txt
@@ -10,9 +10,8 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,52) size 784x24
         RenderTextControl {INPUT} at (0,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (0,0) size 0x0
 layer at (11,63) size 151x18
   RenderBlock {DIV} at (0,0) size 151x18
-caret: position 0 of child 0 {DIV} of child 1 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body
+caret: position 0 of child 0 {DIV} of child 0 {DIV} of child 0 {DIV} of {#document-fragment} of child 3 {INPUT} of body

--- a/LayoutTests/platform/wpe/fast/css/input-search-padding-expected.txt
+++ b/LayoutTests/platform/wpe/fast/css/input-search-padding-expected.txt
@@ -5,7 +5,6 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderTextControl {INPUT} at (0,0) size 423x82 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 417x47
-          RenderBlock {DIV} at (0,23) size 0x0
           RenderBlock {DIV} at (0,0) size 377x47
       RenderBR {BR} at (423,26) size 0x17
       RenderTextControl {INPUT} at (0,82) size 423x82 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/wpe/fast/css/text-input-with-webkit-border-radius-expected.txt
+++ b/LayoutTests/platform/wpe/fast/css/text-input-with-webkit-border-radius-expected.txt
@@ -17,7 +17,6 @@ layer at (0,0) size 800x138
       RenderBlock {DIV} at (0,68) size 163x46 [bgcolor=#888888]
         RenderTextControl {INPUT} at (11,9) size 133x24 [bgcolor=#00FF00] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 127x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 111x18
         RenderText {#text} at (0,0) size 0x0
 layer at (22,97) size 111x18

--- a/LayoutTests/platform/wpe/fast/css/text-overflow-input-expected.txt
+++ b/LayoutTests/platform/wpe/fast/css/text-overflow-input-expected.txt
@@ -15,7 +15,6 @@ layer at (0,0) size 800x392
           text run at (173,21) width 4: " "
         RenderTextControl {INPUT} at (177,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (350,21) size 4x18
           text run at (350,21) width 4: " "
@@ -24,7 +23,6 @@ layer at (0,0) size 800x392
           text run at (527,21) width 4: " "
         RenderTextControl {INPUT} at (531,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,42) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -36,7 +34,6 @@ layer at (0,0) size 800x392
           text run at (172,69) width 4: " "
         RenderTextControl {INPUT} at (176,66) size 172x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 166x18
-            RenderBlock {DIV} at (166,9) size 0x0
             RenderBlock {DIV} at (16,0) size 150x18
         RenderText {#text} at (348,69) size 4x18
           text run at (348,69) width 4: " "
@@ -45,7 +42,6 @@ layer at (0,0) size 800x392
           text run at (524,69) width 4: " "
         RenderTextControl {INPUT} at (528,66) size 172x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 166x18
-            RenderBlock {DIV} at (166,9) size 0x0
             RenderBlock {DIV} at (16,0) size 150x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,90) size 172x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -61,7 +57,6 @@ layer at (0,0) size 800x392
           text run at (173,21) width 4: " "
         RenderTextControl {INPUT} at (177,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (350,21) size 4x18
           text run at (350,21) width 4: " "
@@ -70,7 +65,6 @@ layer at (0,0) size 800x392
           text run at (527,21) width 4: " "
         RenderTextControl {INPUT} at (531,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,42) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -82,7 +76,6 @@ layer at (0,0) size 800x392
           text run at (172,69) width 4: " "
         RenderTextControl {INPUT} at (176,66) size 172x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 166x18
-            RenderBlock {DIV} at (166,9) size 0x0
             RenderBlock {DIV} at (16,0) size 150x18
         RenderText {#text} at (348,69) size 4x18
           text run at (348,69) width 4: " "
@@ -91,7 +84,6 @@ layer at (0,0) size 800x392
           text run at (524,69) width 4: " "
         RenderTextControl {INPUT} at (528,66) size 172x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 166x18
-            RenderBlock {DIV} at (166,9) size 0x0
             RenderBlock {DIV} at (16,0) size 150x18
         RenderText {#text} at (0,0) size 0x0
         RenderTextControl {INPUT} at (0,90) size 172x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]

--- a/LayoutTests/platform/wpe/fast/forms/control-restrict-line-height-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/control-restrict-line-height-expected.txt
@@ -18,7 +18,6 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (338,56) size 0x18
       RenderTextControl {INPUT} at (0,83) size 173x34 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 167x27
-          RenderBlock {DIV} at (0,13) size 0x0
           RenderBlock {DIV} at (0,0) size 151x27
       RenderText {#text} at (0,0) size 0x0
 layer at (11,95) size 151x27 backgroundClip at (11,95) size 151x26 clip at (11,95) size 151x26 scrollWidth 323

--- a/LayoutTests/platform/wpe/fast/forms/input-appearance-height-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/input-appearance-height-expected.txt
@@ -81,7 +81,6 @@ layer at (0,0) size 800x600
           text run at (0,261) width 44: "search "
         RenderTextControl {INPUT} at (44,257) size 173x25 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (0,0) size 0x0
 layer at (47,29) size 167x18

--- a/LayoutTests/platform/wpe/fast/forms/placeholder-pseudo-style-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/placeholder-pseudo-style-expected.txt
@@ -11,7 +11,6 @@ layer at (0,0) size 800x600
         text run at (173,21) width 4: " "
       RenderTextControl {INPUT} at (177,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 167x18
-          RenderBlock {DIV} at (0,9) size 0x0
           RenderBlock {DIV} at (0,0) size 151x18
       RenderText {#text} at (350,21) size 4x18
         text run at (350,21) width 4: " "

--- a/LayoutTests/platform/wpe/fast/forms/search-cancel-button-style-sharing-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/search-cancel-button-style-sharing-expected.txt
@@ -9,13 +9,11 @@ layer at (0,0) size 800x600
       RenderBlock (anonymous) at (0,34) size 784x24
         RenderTextControl {INPUT} at (0,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (173,3) size 4x18
           text run at (173,3) width 4: " "
         RenderTextControl {INPUT} at (177,0) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x18
-            RenderBlock {DIV} at (0,9) size 0x0
             RenderBlock {DIV} at (0,0) size 151x18
         RenderText {#text} at (0,0) size 0x0
 layer at (11,45) size 151x18

--- a/LayoutTests/platform/wpe/fast/forms/search-display-none-cancel-button-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/search-display-none-cancel-button-expected.txt
@@ -8,7 +8,6 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (499,0) size 0x18
       RenderTextControl {INPUT} at (0,18) size 173x24 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 167x18
-          RenderBlock {DIV} at (0,9) size 0x0
           RenderBlock {DIV} at (0,0) size 167x18
       RenderText {#text} at (0,0) size 0x0
 layer at (11,29) size 167x18

--- a/LayoutTests/platform/wpe/fast/forms/search-vertical-alignment-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/search-vertical-alignment-expected.txt
@@ -13,7 +13,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,52) size 784x45
         RenderTextControl {INPUT} at (0,0) size 173x45 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,3) size 167x39
-            RenderBlock {DIV} at (16,10) size 135x19
+            RenderBlock {DIV} at (0,10) size 151x19
         RenderText {#text} at (173,14) size 4x17
           text run at (173,14) width 4: " "
         RenderTextControl {INPUT} at (177,0) size 173x45 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -21,7 +21,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,113) size 784x18
         RenderTextControl {INPUT} at (0,1) size 173x17 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 167x16
-            RenderBlock {DIV} at (16,3) size 135x10
+            RenderBlock {DIV} at (0,3) size 151x10
         RenderText {#text} at (173,0) size 4x18
           text run at (173,0) width 4: " "
         RenderTextControl {INPUT} at (177,1) size 173x16 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
@@ -29,44 +29,38 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,147) size 784x18
         RenderTextControl {INPUT} at (0,5) size 173x13 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
           RenderFlexibleBox {DIV} at (3,0) size 167x12
-            RenderBlock {DIV} at (16,3) size 135x6
+            RenderBlock {DIV} at (0,3) size 151x6
         RenderText {#text} at (173,0) size 4x18
           text run at (173,0) width 4: " "
         RenderTextControl {INPUT} at (177,3) size 173x12 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderText {#text} at (0,0) size 0x0
-layer at (27,74) size 135x18
-  RenderBlock {DIV} at (0,0) size 135x18
+layer at (11,74) size 151x18
+  RenderBlock {DIV} at (0,0) size 151x18
     RenderText {#text} at (0,0) size 28x18
       text run at (0,0) width 28: "Text"
 layer at (188,74) size 167x18
   RenderBlock {DIV} at (3,13) size 167x19
     RenderText {#text} at (0,0) size 28x18
       text run at (0,0) width 28: "Text"
-layer at (27,126) size 135x10 scrollHeight 18
-  RenderBlock {DIV} at (0,0) size 135x10
+layer at (11,126) size 151x10 scrollHeight 18
+  RenderBlock {DIV} at (0,0) size 151x10
     RenderText {#text} at (0,0) size 28x18
       text run at (0,0) width 28: "Text"
 layer at (188,121) size 167x18
   RenderBlock {DIV} at (3,-1) size 167x18
     RenderText {#text} at (0,0) size 28x18
       text run at (0,0) width 28: "Text"
-layer at (27,164) size 135x6 scrollHeight 18
-  RenderBlock {DIV} at (0,0) size 135x6
+layer at (11,164) size 151x6 scrollHeight 18
+  RenderBlock {DIV} at (0,0) size 151x6
     RenderText {#text} at (0,0) size 28x18
       text run at (0,0) width 28: "Text"
 layer at (188,155) size 167x18
   RenderBlock {DIV} at (3,-3) size 167x18
     RenderText {#text} at (0,0) size 28x18
       text run at (0,0) width 28: "Text"
-layer at (11,75) size 16x16
-  RenderBlock {DIV} at (0,11) size 16x17 [bgcolor=#000000]
 layer at (162,75) size 16x16
   RenderBlock {DIV} at (151,11) size 16x17 [bgcolor=#000000]
-layer at (11,123) size 16x16
-  RenderBlock {DIV} at (0,0) size 16x16 [bgcolor=#000000]
 layer at (162,123) size 16x16
   RenderBlock {DIV} at (151,0) size 16x16 [bgcolor=#000000]
-layer at (11,161) size 16x16
-  RenderBlock {DIV} at (0,0) size 16x16 [bgcolor=#000000]
 layer at (162,161) size 16x16
   RenderBlock {DIV} at (151,0) size 16x16 [bgcolor=#000000]

--- a/LayoutTests/platform/wpe/fast/forms/searchfield-heights-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/searchfield-heights-expected.txt
@@ -8,19 +8,16 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (368,0) size 0x18
       RenderTextControl {INPUT} at (0,122) size 69x6 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,0) size 63x6
-          RenderBlock {DIV} at (0,3) size 0x0
           RenderBlock {DIV} at (0,0) size 57x6
       RenderText {#text} at (69,113) size 4x17
         text run at (69,113) width 4: " "
       RenderTextControl {INPUT} at (73,102) size 172x40 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 166x34
-          RenderBlock {DIV} at (0,17) size 0x0
           RenderBlock {DIV} at (0,8) size 151x18
       RenderText {#text} at (245,113) size 4x17
         text run at (245,113) width 4: " "
       RenderTextControl {INPUT} at (249,18) size 297x200 [bgcolor=#FFFFFF] [border: (2px inset #808080)]
         RenderFlexibleBox {DIV} at (3,3) size 291x194
-          RenderBlock {DIV} at (0,97) size 0x0
           RenderBlock {DIV} at (0,81) size 264x32
       RenderText {#text} at (0,0) size 0x0
 layer at (11,130) size 57x6

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7383,6 +7383,20 @@ ScrollingPerformanceTestingEnabled:
     WebCore:
       default: false
 
+SearchInputResultsAttributeEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "<input type=search> results=N attribute"
+  humanReadableDescription: "Enable the legacy WebKit-only ::-webkit-search-results-button saved-searches dropdown opt-in"
+  defaultValue:
+    WebKitLegacy:
+      "PLATFORM(COCOA)" : WebKit::defaultSearchInputResultsAttributeEnabled()
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 SecureContextChecksEnabled:
   type: bool
   status: internal

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -52,6 +52,7 @@ enum class SDKAlignedBehavior {
     DefaultsToExcludingBackgroundsWhenPrinting,
     DefaultsToPassiveTouchListenersOnDocument,
     DefaultsToPassiveWheelListenersOnDocument,
+    DisableNonStandardSearchInputResultsAttribute,
     DoesNotDrainTheMicrotaskQueueWhenCallingObjC,
     DoesNotParseStringEndingWithFullStopAsFloatingPointNumber,
     DoesNotAddIntrinsicMarginsToFormControls,

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -850,7 +850,8 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     }
     case AttributeNames::resultsAttr:
-        m_maxResults = newValue.isNull() ? -1 : std::min(parseHTMLInteger(newValue).value_or(0), maxSavedResults);
+        if (document().settings().searchInputResultsAttributeEnabled())
+            m_maxResults = newValue.isNull() ? -1 : std::min(parseHTMLInteger(newValue).value_or(0), maxSavedResults);
         break;
     case AttributeNames::autosaveAttr:
         invalidateStyleForSubtree();

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -47,6 +47,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderSearchField.h"
 #include "ScriptDisallowedScope.h"
+#include "Settings.h"
 #include "ShadowRoot.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StylePreferredSize.h"
@@ -299,10 +300,12 @@ void SearchInputType::createShadowSubtree()
     ASSERT(container);
     ASSERT(textWrapper);
 
-    Ref resultsButton = SearchFieldResultsButtonElement::create(document);
-    container->insertBefore(resultsButton, textWrapper.copyRef());
-    updateResultButtonPseudoType(resultsButton, element()->maxResults());
-    m_resultsButton = WTF::move(resultsButton);
+    if (document->settings().searchInputResultsAttributeEnabled()) {
+        Ref resultsButton = SearchFieldResultsButtonElement::create(document);
+        container->insertBefore(resultsButton, textWrapper.copyRef());
+        updateResultButtonPseudoType(resultsButton, element()->maxResults());
+        m_resultsButton = WTF::move(resultsButton);
+    }
 
     Ref cancelButton = SearchFieldCancelButtonElement::create(document);
     container->insertBefore(cancelButton, protect(textWrapper->nextSibling()));

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -95,8 +95,6 @@ void RenderSearchField::showPopup()
     if (m_searchPopupIsVisible)
         return;
 
-
-
     if (!m_searchPopup)
         m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*inputElement().inputType()));
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -386,6 +386,17 @@ bool defaultIFrameResourceMonitoringEnabled()
 }
 #endif
 
+bool defaultSearchInputResultsAttributeEnabled()
+{
+#if PLATFORM(COCOA)
+    static bool result = !isFullWebBrowserOrRunningTest()
+        && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DisableNonStandardSearchInputResultsAttribute);
+    return result;
+#else
+    return false;
+#endif
+}
+
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
 bool defaultPreferSpatialAudioExperience()
 {

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -196,6 +196,8 @@ bool defaultScreenTimeEnabled();
 bool defaultIFrameResourceMonitoringEnabled();
 #endif
 
+bool defaultSearchInputResultsAttributeEnabled();
+
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
 bool defaultPreferSpatialAudioExperience();
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -153,6 +153,8 @@ void WebPreferences::platformInitializeStore()
         m_store.setBoolValueForKey(WebPreferencesKey::iFrameResourceMonitoringEnabledKey(), defaultIFrameResourceMonitoringEnabled());
 #endif
 
+        m_store.setBoolValueForKey(WebPreferencesKey::searchInputResultsAttributeEnabledKey(), defaultSearchInputResultsAttributeEnabled());
+
 #define INITIALIZE_DEFAULT_OVERRIDABLE_PREFERENCE_FROM_NSUSERDEFAULTS(KeyUpper, KeyLower, TypeName, Type, DefaultValue, HumanReadableName, HumanReadableDescription) \
         setDebug##TypeName##ValueIfInUserDefaults(m_identifier, m_keyPrefix, m_globalDebugKeyPrefix, WebPreferencesKey::KeyLower##Key(), m_store);
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
@@ -58,6 +58,8 @@ bool defaultNeedsKeyboardEventDisambiguationQuirks();
 bool defaultHTMLEnhancedSelectParsingQuirkEnabled();
 #endif
 
+bool defaultSearchInputResultsAttributeEnabled();
+
 bool defaultMutationEventsEnabled();
 bool defaultAttachmentElementEnabled();
 bool defaultShouldRestrictBaseURLSchemes();

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -172,6 +172,12 @@ bool defaultMutationEventsEnabled()
     return WTF::CocoaApplication::isAppleApplication() || !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::MutationEventsDisabledByDefault);
 }
 
+bool defaultSearchInputResultsAttributeEnabled()
+{
+    static bool result = !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DisableNonStandardSearchInputResultsAttribute);
+    return result;
+}
+
 bool defaultAttachmentElementEnabled()
 {
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 2fa9993ac40a62d9529a164d6a5559b5f7d0d8a5
<pre>
roland.com: Double search icon in search field (works in Chrome)
<a href="https://bugs.webkit.org/show_bug.cgi?id=317437">https://bugs.webkit.org/show_bug.cgi?id=317437</a>
&lt;<a href="https://rdar.apple.com/problem/179949639">rdar://problem/179949639</a>&gt;

Reviewed by Tim Nguyen.

Reland 316422@main after resolving the debug assertion that forced us to revert.

The Roland support site (static.roland.com) shows two magnifying glass icons in Safari&apos;s
search field where Chrome shows only one.

The HTML is:

  &lt;input class=&quot;form-control&quot; type=&quot;search&quot; name=&quot;q&quot; results=&quot;10&quot; ...&gt;

with CSS `appearance: none` and a `background-image: url(search.svg)` that paints the
site&apos;s own magnifying glass. The legacy WebKit-only `results=N` attribute opts the input
into ::-webkit-search-results-button, which caused WebKit to paint a search icon.

The fix is to match Chrome and Firefox behavior by removing the `results=N` feature
when WebKit is used for web browsing. We retain it for backwards compatibility with
apps that may depend on it.

We gate the deprecation on a Linked-On-Or-After check so we avoid changing behavior
unexpectedly. Developers can re-enable the feature using the new feature flag.

I have also rebaselined the tests that were not specifically testing this deprecated
feature, but had layout impact now that the deprecated decoration is no longer automatically
added to search fields.

Test: fast/forms/search/search-results-attribute-disabled-by-default.html

* LayoutTests/fast/forms/box-shadow-override.html:
* LayoutTests/fast/forms/change-input-type-and-submit-form-crash.html:
* LayoutTests/fast/forms/disabled-search-input.html:
* LayoutTests/fast/forms/ios/form-control-refresh/search/search-decoration-appearance-expected-mismatch.html:
* LayoutTests/fast/forms/ios/form-control-refresh/search/search-decoration-appearance.html:
* LayoutTests/fast/forms/placeholder-position.html:
* LayoutTests/fast/forms/search-abs-pos-cancel-button.html:
* LayoutTests/fast/forms/search-field-buttons-do-not-have-focus-rings-expected.html:
* LayoutTests/fast/forms/search-field-buttons-do-not-have-focus-rings.html:
* LayoutTests/fast/forms/search-input-rtl.html:
* LayoutTests/fast/forms/search-rtl.html:
* LayoutTests/fast/forms/search-styled.html:
* LayoutTests/fast/forms/search-transformed.html:
* LayoutTests/fast/forms/search-zoomed.html:
* LayoutTests/fast/forms/search/search-padding-cancel-results-buttons.html:
* LayoutTests/fast/forms/search/search-recent-searches.html:
* LayoutTests/fast/forms/search/search-results-attribute-disabled-by-default-expected.txt: Added.
* LayoutTests/fast/forms/search/search-results-attribute-disabled-by-default.html: Added.
* LayoutTests/fast/forms/search/search-results-hidden-crash.html:
* LayoutTests/fast/forms/search/search-size-with-decorations.html:
* LayoutTests/fast/replaced/width100percent-searchfield.html:
* LayoutTests/imported/blink/fast/forms/search-popup-crasher.html:
* LayoutTests/pdf/crash-with-embed-hidden.html:
* LayoutTests/platform/gtk/fast/css/focus-ring-exists-for-search-field-expected.txt:
* LayoutTests/platform/gtk/fast/css/input-search-padding-expected.txt:
* LayoutTests/platform/gtk/fast/css/text-input-with-webkit-border-radius-expected.txt:
* LayoutTests/platform/gtk/fast/css/text-overflow-input-expected.txt:
* LayoutTests/platform/gtk/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/gtk/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/gtk/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/gtk/fast/forms/search-cancel-button-style-sharing-expected.txt:
* LayoutTests/platform/gtk/fast/forms/search-display-none-cancel-button-expected.txt:
* LayoutTests/platform/gtk/fast/forms/search-vertical-alignment-expected.txt:
* LayoutTests/platform/gtk/fast/forms/searchfield-heights-expected.txt:
* LayoutTests/platform/ios/fast/css/focus-ring-exists-for-search-field-expected.txt:
* LayoutTests/platform/ios/fast/css/input-search-padding-expected.txt:
* LayoutTests/platform/ios/fast/css/text-input-with-webkit-border-radius-expected.txt:
* LayoutTests/platform/ios/fast/css/text-overflow-input-expected.txt:
* LayoutTests/platform/ios/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/ios/fast/forms/datalist/datalist-searchinput-appearance-expected.txt:
* LayoutTests/platform/ios/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/ios/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/ios/fast/forms/search-cancel-button-style-sharing-expected.txt:
* LayoutTests/platform/ios/fast/forms/search-display-none-cancel-button-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/css/focus-ring-exists-for-search-field-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/css/text-input-with-webkit-border-radius-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/css/text-overflow-input-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/datalist/datalist-searchinput-appearance-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-cancel-button-style-sharing-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-display-none-cancel-button-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/search-vertical-alignment-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/repaint/search-field-cancel-expected.txt:
* LayoutTests/platform/mac-wk2/fast/css/focus-ring-exists-for-search-field-expected.txt:
* LayoutTests/platform/mac-wk2/fast/css/text-input-with-webkit-border-radius-expected.txt:
* LayoutTests/platform/mac-wk2/fast/css/text-overflow-input-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/datalist/datalist-searchinput-appearance-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/search-cancel-button-style-sharing-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/search-display-none-cancel-button-expected.txt:
* LayoutTests/platform/mac-wk2/fast/forms/search-vertical-alignment-expected.txt:
* LayoutTests/platform/mac-wk2/fast/repaint/search-field-cancel-expected.txt:
* LayoutTests/platform/mac/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/wpe/fast/css/focus-ring-exists-for-search-field-expected.txt:
* LayoutTests/platform/wpe/fast/css/input-search-padding-expected.txt:
* LayoutTests/platform/wpe/fast/css/text-input-with-webkit-border-radius-expected.txt:
* LayoutTests/platform/wpe/fast/css/text-overflow-input-expected.txt:
* LayoutTests/platform/wpe/fast/forms/control-restrict-line-height-expected.txt:
* LayoutTests/platform/wpe/fast/forms/input-appearance-height-expected.txt:
* LayoutTests/platform/wpe/fast/forms/placeholder-pseudo-style-expected.txt:
* LayoutTests/platform/wpe/fast/forms/search-cancel-button-style-sharing-expected.txt:
* LayoutTests/platform/wpe/fast/forms/search-display-none-cancel-button-expected.txt:
* LayoutTests/platform/wpe/fast/forms/search-vertical-alignment-expected.txt:
* LayoutTests/platform/wpe/fast/forms/searchfield-heights-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::createShadowSubtree):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::showPopup):
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultSearchInputResultsAttributeEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::WebPreferences::platformInitializeStore):
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm:
(WebKit::defaultSearchInputResultsAttributeEnabled):

Canonical link: <a href="https://commits.webkit.org/316837@main">https://commits.webkit.org/316837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44464f4bcf7e9bb8fd6f640cf34f714dd1465251

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182927 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130910 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fd8045e2-eb8b-42c3-986a-095d971cb443) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134798 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b2f22cf-3db9-4b5e-89e4-a96940605779) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115273 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fbe46ed9-7c89-4624-ab23-d59eb8475c4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35206 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31412 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3971 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185351 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34616 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143657 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38773 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47633 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112735 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38468 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46139 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9901 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45772 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->