### PR TITLE
Web Inspector: Site Isolation: Page.frameNavigated should include loaderId from document identifier

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Test that under Site Isolation a cross-origin iframe's Page.frameNavigated loaderId matches the Network.requestWillBeSent loaderId for its main resource.
+
+
+
+== Running test suite: SiteIsolation.Page.FrameNavigatedLoaderIdMatchesNetwork
+-- Running test case: SiteIsolation.Page.FrameNavigated.LoaderIdMatchesNetworkMainResource
+PASS: Cross-origin child frame should be in the frame model.
+PASS: Network.requestWillBeSent (Document) should fire for the child's navigation.
+PASS: Page.frameNavigated should fire for the child's navigation.
+PASS: Page.frameNavigated loaderId should equal the Network.requestWillBeSent loaderId for the same main-resource load.
+PASS: Child frame's main resource should be the newly navigated document.
+PASS: Child frame should be committed with the navigation's loaderId.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe.html
@@ -1,0 +1,82 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    const NAV_URL_SUFFIX = "/resource-tree-frame-with-subresource.html";
+
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Page.FrameNavigatedLoaderIdMatchesNetwork");
+
+    suite.addTestCase({
+        name: "SiteIsolation.Page.FrameNavigated.LoaderIdMatchesNetworkMainResource",
+        description: "Under Site Isolation, a cross-origin iframe's Page.frameNavigated loaderId should equal the Network.requestWillBeSent loaderId reported for that navigation's main (Document) resource. Both are derived from the same DocumentLoader (via the hosting process's IdentifierRegistry), so they must be identical -- which is what lets the frontend correlate a navigation's main-resource network events with its frame. The statically-declared iframe is navigated once (post-connect) so both events can be observed live.",
+        async test() {
+            // The cross-origin iframe is declared statically, so it has already committed in its own
+            // process. frameTargetForURLContaining() returns the real (committed) frame target -- not
+            // the parent-process placeholder a single-shot TargetAdded would catch.
+            let frameTarget = await frameTargetForURLContaining("resource-tree-frame.html");
+            InspectorTest.assert(frameTarget instanceof WI.FrameTarget, "Cross-origin iframe frame target should exist.");
+
+            // Capture the raw loaderIds carried by the navigation, keyed on the target URL (reliable
+            // across the process boundary): the loaderId on the main-resource Network.requestWillBeSent
+            // (routed through resourceRequestWillBeSent) and the loaderId on Page.frameNavigated (routed
+            // through frameDidNavigate). These are the two streams the fix makes consistent.
+            let capturedNetworkDocumentLoaderId = null;
+            let capturedPageLoaderId = null;
+
+            let originalResourceRequestWillBeSent = WI.networkManager.resourceRequestWillBeSent;
+            WI.networkManager.resourceRequestWillBeSent = function(requestIdentifier, frameIdentifier, loaderIdentifier, request, type) {
+                if (type === InspectorBackend.Enum.Page.ResourceType.Document && request && request.url && request.url.endsWith(NAV_URL_SUFFIX))
+                    capturedNetworkDocumentLoaderId = loaderIdentifier;
+                return originalResourceRequestWillBeSent.apply(this, arguments);
+            };
+
+            let originalFrameDidNavigate = WI.networkManager.frameDidNavigate;
+            WI.networkManager.frameDidNavigate = function(framePayload) {
+                if (framePayload && framePayload.url && framePayload.url.endsWith(NAV_URL_SUFFIX))
+                    capturedPageLoaderId = framePayload.loaderId;
+                return originalFrameDidNavigate.apply(this, arguments);
+            };
+
+            let child = null;
+            try {
+                // Navigate the child within its own process (same-origin relative navigation) so both the
+                // main-resource Network.requestWillBeSent and the Page.frameNavigated commit fire live.
+                // Not awaited: the navigation may tear down the runtime before the reply arrives.
+                frameTarget.RuntimeAgent.evaluate.invoke({expression: `location.href = "${NAV_URL_SUFFIX.slice(1)}"`, objectGroup: "test"}).catch(() => {});
+
+                // Wait until both loaderIds are observed and the frame model reflects the navigation. The
+                // cross-origin child is identified as the main frame's child (its model URL can lag).
+                for (let attempt = 0; attempt < 100; ++attempt) {
+                    child = WI.networkManager.mainFrame ? WI.networkManager.frames.find((frame) => frame.parentFrame === WI.networkManager.mainFrame) : null;
+                    if (capturedPageLoaderId && capturedNetworkDocumentLoaderId && child && child.mainResource && child.mainResource.url.endsWith(NAV_URL_SUFFIX))
+                        break;
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+                }
+            } finally {
+                WI.networkManager.resourceRequestWillBeSent = originalResourceRequestWillBeSent;
+                WI.networkManager.frameDidNavigate = originalFrameDidNavigate;
+            }
+
+            InspectorTest.expectThat(!!child, "Cross-origin child frame should be in the frame model.");
+            InspectorTest.expectThat(!!capturedNetworkDocumentLoaderId, "Network.requestWillBeSent (Document) should fire for the child's navigation.");
+            InspectorTest.expectThat(!!capturedPageLoaderId, "Page.frameNavigated should fire for the child's navigation.");
+
+            // The core of the fix. (loaderId strings embed a process id, so compare for equality rather
+            // than logging the raw values.)
+            InspectorTest.expectThat(capturedNetworkDocumentLoaderId === capturedPageLoaderId, "Page.frameNavigated loaderId should equal the Network.requestWillBeSent loaderId for the same main-resource load.");
+
+            // The frame model reflects the navigation and adopts that same loaderId as its committed one.
+            InspectorTest.expectThat(child && child.mainResource && child.mainResource.url.endsWith(NAV_URL_SUFFIX), "Child frame's main resource should be the newly navigated document.");
+            InspectorTest.expectThat(child && child.loaderIdentifier === capturedPageLoaderId, "Child frame should be committed with the navigation's loaderId.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<body onload="runTest()">
+<p>Test that under Site Isolation a cross-origin iframe's Page.frameNavigated loaderId matches the Network.requestWillBeSent loaderId for its main resource.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/page/resources/resource-tree-frame.html"></iframe>
+</body>

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
@@ -30,6 +30,7 @@
 #include "DocumentLoader.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrameInlines.h"
+#include "NavigationIdentifier.h"
 #include "ProcessIdentifier.h"
 #include "RemoteFrame.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
@@ -127,16 +128,16 @@ Protocol::Network::LoaderId BackendIdentifierRegistry::loaderId(WebCore::Documen
     if (!loader)
         return emptyString();
 
-    // Compute fresh from the current document rather than memoizing by raw DocumentLoader* which can go stale.
-    // protocolLoaderId() is deterministic in the document's ScriptExecutionContextIdentifier, so this matches
-    // the id network events report.
-    if (RefPtr frame = loader->frame()) {
-        if (RefPtr document = frame->document())
-            return protocolLoaderId(document->identifier());
-    }
+    // Derive the id from the loader's navigationID, which is assigned at provisional-load start and
+    // stays fixed for the load. The Network stream computes this at the main resource's
+    // willSendRequest (before commit) and the Page stream at frameNavigated (after commit); anchoring
+    // on navigationID makes both arrive at the same string. It is process-local, so qualify it with
+    // the hosting process.
+    if (auto navigationID = loader->navigationID())
+        return makeString("loader-"_s, WebCore::Process::identifier().toUInt64(), '.', navigationID->toUInt64());
 
-    // Fallback only when no document exists yet (early instrumentation): keep a stable per-loader
-    // id. This produces a legacy-format ID; a deterministic one is used once the document exists.
+    // Fallback only when no navigationID exists yet (early instrumentation / non-navigation loads):
+    // keep a stable per-loader id. This produces a legacy-format ID.
     return m_loaderToIdentifier.ensure(loader, [] {
         return IdentifiersFactory::createIdentifier();
     }).iterator->value;

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.h
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.h
@@ -29,7 +29,6 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
-#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RobinHoodHashMap.h>
@@ -169,11 +168,6 @@ public:
             ObjectIdentifier<WebCore::ProcessIdentifierType>(*pidValue),
             WebCore::FrameIdentifier(*frameValue)
         };
-    }
-
-    static inline String protocolLoaderId(WebCore::ScriptExecutionContextIdentifier contextID)
-    {
-        return makeString("loader-"_s, contextID.processIdentifier().toUInt64(), '.', contextID.object().toString());
     }
 };
 

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -30,7 +30,6 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
-#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -68,10 +67,10 @@ struct FrameResource {
 };
 
 // Per-frame data gathered from a frame's hosting WebContent process: the committed document's
-// loaderId (carried as a ScriptExecutionContextIdentifier and converted to the protocol loaderId
-// string at the UIProcess boundary) and the frame's cached subresources.
+// protocol loaderId string (computed by that process so it matches the live Network events) and
+// the frame's cached subresources.
 struct FrameResourceData {
-    std::optional<WebCore::ScriptExecutionContextIdentifier> loaderId;
+    String loaderId;
     Vector<FrameResource> resources;
 };
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -668,7 +668,7 @@ WI.NetworkManager = class NetworkManager extends WI.Object
 
         if (framePayload.loaderId === frame.provisionalLoaderIdentifier) {
             // There was a provisional load in progress, commit it.
-            frame.commitProvisionalLoad(framePayload.securityOrigin);
+            frame.commitProvisionalLoad(framePayload.name, framePayload.securityOrigin);
         } else {
             let mainResource = null;
             if (frame.mainResource.url !== framePayload.url || frame.loaderIdentifier !== framePayload.loaderId) {

--- a/Source/WebInspectorUI/UserInterface/Models/Frame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Frame.js
@@ -108,16 +108,18 @@ WI.Frame = class Frame extends WI.Object
         this.dispatchEventToListeners(WI.Frame.Event.ProvisionalLoadStarted);
     }
 
-    commitProvisionalLoad(securityOrigin)
+    commitProvisionalLoad(name, securityOrigin)
     {
         console.assert(this._provisionalMainResource);
         console.assert(this._provisionalLoaderIdentifier);
         if (!this._provisionalLoaderIdentifier)
             return;
 
+        var oldName = this._name;
         var oldSecurityOrigin = this._securityOrigin;
         var oldMainResource = this._mainResource;
 
+        this._name = name || null;
         this._securityOrigin = securityOrigin || null;
         this._loaderIdentifier = this._provisionalLoaderIdentifier;
         this._mainResource = this._provisionalMainResource;
@@ -145,6 +147,9 @@ WI.Frame = class Frame extends WI.Object
 
         if (this._securityOrigin !== oldSecurityOrigin)
             this.dispatchEventToListeners(WI.Frame.Event.SecurityOriginDidChange, {oldSecurityOrigin});
+
+        if (this._name !== oldName)
+            this.dispatchEventToListeners(WI.Frame.Event.NameDidChange, {oldName});
     }
 
     clearProvisionalLoad(skipProvisionalLoadClearedEvent)

--- a/Source/WebKit/Shared/InspectorPageTypes.serialization.in
+++ b/Source/WebKit/Shared/InspectorPageTypes.serialization.in
@@ -33,7 +33,7 @@ header: <WebCore/InspectorResourceUtilities.h>
 };
 
 [CustomHeader] struct Inspector::FrameResourceData {
-    std::optional<WebCore::ScriptExecutionContextIdentifier> loaderId;
+    String loaderId;
     Vector<Inspector::FrameResource> resources;
 };
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -461,14 +461,13 @@ CommandResult<void> ProxyingNetworkAgent::setEmulatedConditions(std::optional<in
 
 // IPC message handlers from WebProcess FrameNetworkAgentProxy.
 
-void ProxyingNetworkAgent::requestWillBeSent(ResourceID resourceID, FrameID frameID, ContextID contextID, const String& targetID, const String& documentURL, const ResourceRequest& request, std::optional<ResourceResponse>&& redirectResponse, ResourceType resourceType, double timestamp, double walltime)
+void ProxyingNetworkAgent::requestWillBeSent(ResourceID resourceID, FrameID frameID, const String& loaderId, const String& targetID, const String& documentURL, const ResourceRequest& request, std::optional<ResourceResponse>&& redirectResponse, ResourceType resourceType, double timestamp, double walltime)
 {
     if (!m_enabled)
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
     auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
-    auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
     auto requestObject = buildObjectForResourceRequest(request);
 
     // FIXME: Build Initiator object once we have stack trace IPC.
@@ -483,14 +482,13 @@ void ProxyingNetworkAgent::requestWillBeSent(ResourceID resourceID, FrameID fram
     m_frontendDispatcher->requestWillBeSent(requestId, frameIdString, loaderId, documentURL, WTF::move(requestObject), timestamp, walltime, WTF::move(initiatorObject), WTF::move(redirectResponseObject), toProtocolResourceType(resourceType), targetID);
 }
 
-void ProxyingNetworkAgent::responseReceived(ResourceID resourceID, FrameID frameID, ContextID contextID, const ResourceResponse& response, ResourceType resourceType, double timestamp)
+void ProxyingNetworkAgent::responseReceived(ResourceID resourceID, FrameID frameID, const String& loaderId, const ResourceResponse& response, ResourceType resourceType, double timestamp)
 {
     if (!m_enabled)
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
     auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
-    auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
     auto responseObject = buildObjectForResourceResponse(response);
 
     if (responseObject)
@@ -525,15 +523,13 @@ void ProxyingNetworkAgent::loadingFailed(ResourceID resourceID, double timestamp
     m_frontendDispatcher->loadingFailed(requestId, timestamp, errorText, canceled);
 }
 
-void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, FrameID frameID, ContextID contextID, const String& documentURL, const ResourceResponse& response, ResourceType resourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp)
+void ProxyingNetworkAgent::requestServedFromMemoryCache(ResourceID resourceID, FrameID frameID, const String& loaderId, const String& documentURL, const ResourceResponse& response, ResourceType resourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp)
 {
     if (!m_enabled)
         return;
 
     auto requestId = IdentifierRegistry::protocolRequestId(resourceID.processIdentifier(), resourceID.object());
     auto frameIdString = IdentifierRegistry::protocolFrameId(frameID, resourceID.processIdentifier());
-    auto loaderId = IdentifierRegistry::protocolLoaderId(contextID);
-
     auto cachedResourceObject = Protocol::Network::CachedResource::create()
         .setUrl(response.url().string())
         .setType(toProtocolResourceType(resourceType))

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -37,7 +37,6 @@
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
-#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -53,7 +52,6 @@ namespace Inspector {
 
 using ResourceID = WebCore::ScopedResourceLoaderIdentifier;
 using FrameID = WebCore::FrameIdentifier;
-using ContextID = WebCore::ScriptExecutionContextIdentifier;
 
 class ProxyingNetworkAgent : public RefCounted<ProxyingNetworkAgent>, public WebKit::InspectorAgentBase, public NetworkBackendDispatcherHandler, public IPC::MessageReceiver, public CanMakeCheckedPtr<ProxyingNetworkAgent> {
     WTF_MAKE_TZONE_ALLOCATED(ProxyingNetworkAgent);
@@ -102,12 +100,12 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // IPC message handlers from WebProcess FrameNetworkAgentProxy
-    void requestWillBeSent(ResourceID, FrameID, ContextID, const String& targetID, const String& documentURL, const WebCore::ResourceRequest&, std::optional<WebCore::ResourceResponse>&&, ResourceType, double timestamp, double walltime);
-    void responseReceived(ResourceID, FrameID, ContextID, const WebCore::ResourceResponse&, ResourceType, double timestamp);
+    void requestWillBeSent(ResourceID, FrameID, const String& loaderId, const String& targetID, const String& documentURL, const WebCore::ResourceRequest&, std::optional<WebCore::ResourceResponse>&&, ResourceType, double timestamp, double walltime);
+    void responseReceived(ResourceID, FrameID, const String& loaderId, const WebCore::ResourceResponse&, ResourceType, double timestamp);
     void dataReceived(ResourceID, int dataLength, int encodedDataLength, double timestamp);
     void loadingFinished(ResourceID, double timestamp, const String& sourceMapURL);
     void loadingFailed(ResourceID, double timestamp, const String& errorText, bool canceled);
-    void requestServedFromMemoryCache(ResourceID, FrameID, ContextID, const String& documentURL, const WebCore::ResourceResponse&, ResourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp);
+    void requestServedFromMemoryCache(ResourceID, FrameID, const String& loaderId, const String& documentURL, const WebCore::ResourceResponse&, ResourceType, const String& sourceMapURL, uint64_t bodySize, double timestamp);
 
     void removeAllRegisteredReceivers();
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in
@@ -26,9 +26,9 @@
     DispatchedTo=UI
 ]
 messages -> Inspector::ProxyingNetworkAgent {
-    RequestWillBeSent(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ScriptExecutionContextIdentifier contextID, String targetID, String documentURL, WebCore::ResourceRequest request, std::optional<WebCore::ResourceResponse> redirectResponse, Inspector::ResourceType resourceType, double timestamp, double walltime)
+    RequestWillBeSent(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, String loaderId, String targetID, String documentURL, WebCore::ResourceRequest request, std::optional<WebCore::ResourceResponse> redirectResponse, Inspector::ResourceType resourceType, double timestamp, double walltime)
 
-    ResponseReceived(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ScriptExecutionContextIdentifier contextID, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, double timestamp)
+    ResponseReceived(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, String loaderId, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, double timestamp)
 
     DataReceived(WebCore::ScopedResourceLoaderIdentifier resourceID, int dataLength, int encodedDataLength, double timestamp)
 
@@ -36,5 +36,5 @@ messages -> Inspector::ProxyingNetworkAgent {
 
     LoadingFailed(WebCore::ScopedResourceLoaderIdentifier resourceID, double timestamp, String errorText, bool canceled)
 
-    RequestServedFromMemoryCache(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, WebCore::ScriptExecutionContextIdentifier contextID, String documentURL, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, String sourceMapURL, uint64_t bodySize, double timestamp)
+    RequestServedFromMemoryCache(WebCore::ScopedResourceLoaderIdentifier resourceID, WebCore::FrameIdentifier frameID, String loaderId, String documentURL, WebCore::ResourceResponse response, Inspector::ResourceType resourceType, String sourceMapURL, uint64_t bodySize, double timestamp)
 }

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp
@@ -94,7 +94,7 @@ static String protocolFrameIdForFrameID(FrameIdentifier frameID)
     return IdentifierRegistry::protocolFrameId(frameID);
 }
 
-void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, const String& mimeType, SecurityOriginData&& securityOrigin, std::optional<FrameIdentifier> parentFrameID, const String& name, WebCore::ScriptExecutionContextIdentifier loaderId)
+void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, const String& mimeType, SecurityOriginData&& securityOrigin, std::optional<FrameIdentifier> parentFrameID, const String& name, const String& loaderId)
 {
     // Cache the committing frame's real document info so getResourceTree()/buildFrameTree()
     // can report it for cross-origin children, whose commit the inspectedPage's WebFrameProxy
@@ -103,7 +103,7 @@ void ProxyingPageAgent::frameNavigated(FrameIdentifier frameID, const URL& url, 
 
     auto frameObject = Protocol::Page::Frame::create()
         .setId(protocolFrameIdForFrameID(frameID))
-        .setLoaderId(IdentifierRegistry::protocolLoaderId(loaderId))
+        .setLoaderId(loaderId)
         .setUrl(url.string())
         .setMimeType(mimeType)
         .setSecurityOrigin(securityOrigin.toString())
@@ -282,7 +282,7 @@ Ref<Protocol::Page::FrameResourceTree> ProxyingPageAgent::buildFrameTree(const W
     URL url = frame.url();
     SecurityOriginData securityOrigin = frame.documentSecurityOriginData();
     String mimeType = frame.mimeType();
-    std::optional<WebCore::ScriptExecutionContextIdentifier> loaderId;
+    String loaderId;
     if (auto it = m_cachedFrameDocumentInfo.find(frame.frameID()); it != m_cachedFrameDocumentInfo.end()) {
         url = it->value.url;
         securityOrigin = it->value.securityOrigin;
@@ -298,7 +298,7 @@ Ref<Protocol::Page::FrameResourceTree> ProxyingPageAgent::buildFrameTree(const W
     // before the inspector connected (e.g. the main frame), whose live frameNavigated wasn't cached.
     auto resources = JSON::ArrayOf<Protocol::Page::FrameResource>::create();
     if (auto it = resourcesByFrame.find(frame.frameID()); it != resourcesByFrame.end()) {
-        if (!loaderId)
+        if (loaderId.isEmpty())
             loaderId = it->value.loaderId;
         for (auto& resource : it->value.resources)
             resources->addItem(ResourceUtilities::buildResourceObject(resource));
@@ -306,7 +306,7 @@ Ref<Protocol::Page::FrameResourceTree> ProxyingPageAgent::buildFrameTree(const W
 
     auto frameObject = Protocol::Page::Frame::create()
         .setId(protocolId)
-        .setLoaderId(loaderId ? IdentifierRegistry::protocolLoaderId(*loaderId) : String())
+        .setLoaderId(loaderId)
         .setUrl(url.string())
         .setMimeType(mimeType.isEmpty() ? "text/html"_s : mimeType)
         .setSecurityOrigin(securityOrigin.toString())

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h
@@ -33,7 +33,6 @@
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
-#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
@@ -108,7 +107,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // IPC message handlers from WebProcess PageAgentProxy
-    void frameNavigated(WebCore::FrameIdentifier, const URL&, const String& mimeType, WebCore::SecurityOriginData&&, std::optional<WebCore::FrameIdentifier> parentFrameID, const String& name, WebCore::ScriptExecutionContextIdentifier loaderId);
+    void frameNavigated(WebCore::FrameIdentifier, const URL&, const String& mimeType, WebCore::SecurityOriginData&&, std::optional<WebCore::FrameIdentifier> parentFrameID, const String& name, const String& loaderId);
     void domContentEventFired(double timestamp);
     void loadEventFired(double timestamp);
     void frameDetached(WebCore::FrameIdentifier);
@@ -139,7 +138,7 @@ private:
         URL url;
         String mimeType;
         WebCore::SecurityOriginData securityOrigin;
-        std::optional<WebCore::ScriptExecutionContextIdentifier> loaderId;
+        String loaderId;
     };
     HashMap<WebCore::FrameIdentifier, CachedFrameDocumentInfo> m_cachedFrameDocumentInfo;
 };

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.messages.in
@@ -31,7 +31,7 @@
 ]
 messages -> Inspector::ProxyingPageAgent {
     # Page lifecycle events
-    FrameNavigated(WebCore::FrameIdentifier frameID, URL url, String mimeType, WebCore::SecurityOriginData securityOrigin, std::optional<WebCore::FrameIdentifier> parentFrameID, String name, WebCore::ScriptExecutionContextIdentifier loaderId)
+    FrameNavigated(WebCore::FrameIdentifier frameID, URL url, String mimeType, WebCore::SecurityOriginData securityOrigin, std::optional<WebCore::FrameIdentifier> parentFrameID, String name, String loaderId)
     DomContentEventFired(double timestamp)
     LoadEventFired(double timestamp)
     FrameDetached(WebCore::FrameIdentifier frameID)

--- a/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp
@@ -43,11 +43,13 @@
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTTPHeaderMap.h>
+#include <WebCore/InspectorIdentifierRegistry.h>
 #include <WebCore/InspectorResourceType.h>
 #include <WebCore/InspectorResourceUtilities.h>
 #include <WebCore/InstrumentingAgents.h>
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/Page.h>
+#include <WebCore/PageInspectorController.h>
 #include <WebCore/ProcessQualified.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -111,14 +113,16 @@ CommandResult<void> FrameNetworkAgentProxy::disable()
     return { };
 }
 
-static std::optional<ScriptExecutionContextIdentifier> contextIdentifier(DocumentLoader* loader)
+// The loaderId for a resource's DocumentLoader. The registry memoizes one string per loader, so
+// this network path and PageAgentProxy::frameNavigated report the identical id for a navigation.
+static String loaderIdForLoader(WebPage& page, DocumentLoader* loader)
 {
-    if (!loader || !loader->frame())
-        return std::nullopt;
-    auto* document = loader->frame()->document();
-    if (!document)
-        return std::nullopt;
-    return document->identifier();
+    RefPtr corePage = page.corePage();
+    if (!corePage)
+        return { };
+    Ref registry = corePage->inspectorController().identifierRegistry();
+    RefPtr protectedLoader = loader;
+    return registry->loaderId(protectedLoader.get());
 }
 
 static std::optional<FrameIdentifier> frameIdentifier(DocumentLoader* loader)
@@ -176,7 +180,7 @@ void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID
     if (!page)
         return;
 
-    auto contextID = protectedLoader->frame()->document()->identifier();
+    auto loaderId = loaderIdForLoader(*page, protectedLoader.get());
     auto frameID = frameIdentifier(protectedLoader.get());
     auto resourceType = resourceTypeForRequest(request, protectedLoader.get(), cachedResource);
     if (!frameID)
@@ -193,7 +197,7 @@ void FrameNetworkAgentProxy::willSendRequest(ResourceLoaderIdentifier resourceID
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::RequestWillBeSent(
-            qualifyResourceID(resourceID), *frameID, contextID, String(), documentURL, request,
+            qualifyResourceID(resourceID), *frameID, loaderId, String(), documentURL, request,
             WTF::move(optionalRedirectResponse), resourceType, timestamp, walltime),
         page->identifier());
 }
@@ -213,9 +217,9 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
     if (!page)
         return;
 
-    auto contextID = contextIdentifier(protectedLoader.get());
+    auto loaderId = loaderIdForLoader(*page, protectedLoader.get());
     auto frameID = frameIdentifier(protectedLoader.get());
-    if (!contextID || !frameID)
+    if (!frameID)
         return;
 
     // FIXME: Map from UncachedLoadType to a more specific ResourceType.
@@ -228,7 +232,7 @@ void FrameNetworkAgentProxy::willSendRequestOfType(ResourceLoaderIdentifier reso
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::RequestWillBeSent(
-            qualifyResourceID(resourceID), *frameID, *contextID, String(), documentURL, request,
+            qualifyResourceID(resourceID), *frameID, loaderId, String(), documentURL, request,
             std::nullopt, ResourceType::Other, timestamp, walltime),
         page->identifier());
 }
@@ -243,7 +247,7 @@ void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourc
     if (!page)
         return;
 
-    auto contextID = protectedLoader->frame()->document()->identifier();
+    auto loaderId = loaderIdForLoader(*page, protectedLoader.get());
     auto frameID = frameIdentifier(protectedLoader.get());
     if (!frameID)
         return;
@@ -257,7 +261,7 @@ void FrameNetworkAgentProxy::didReceiveResponse(ResourceLoaderIdentifier resourc
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::ResponseReceived(
-            qualifyResourceID(resourceID), *frameID, contextID, response, resourceType, timestamp),
+            qualifyResourceID(resourceID), *frameID, loaderId, response, resourceType, timestamp),
         page->identifier());
 }
 
@@ -344,7 +348,7 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
         return;
 
     auto resourceID = ResourceLoaderIdentifier::generate();
-    auto contextID = protectedLoader->frame()->document()->identifier();
+    auto loaderId = loaderIdForLoader(*page, protectedLoader.get());
     auto frameID = frameIdentifier(protectedLoader.get());
     auto resourceType = ResourceUtilities::inspectorResourceType(cachedResource);
     if (!frameID)
@@ -371,7 +375,7 @@ void FrameNetworkAgentProxy::didLoadResourceFromMemoryCache(DocumentLoader* load
 
     protect(WebProcess::singleton().parentProcessConnection())->send(
         Messages::ProxyingNetworkAgent::RequestServedFromMemoryCache(
-            qualifyResourceID(resourceID), *frameID, contextID, documentURL,
+            qualifyResourceID(resourceID), *frameID, loaderId, documentURL,
             cachedResource.response(), resourceType, sourceMapURL, bodySize, timestamp),
         page->identifier());
 }

--- a/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp
@@ -36,9 +36,11 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Document.h>
+#include <WebCore/DocumentLoader.h>
 #include <WebCore/ElementInlines.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameInlines.h>
+#include <WebCore/FrameLoader.h>
 #include <WebCore/FrameTree.h>
 #include <WebCore/HTMLFrameOwnerElement.h>
 #include <WebCore/HTMLNames.h>
@@ -148,11 +150,12 @@ void PageAgentProxy::frameNavigated(LocalFrame& frame)
             name = ownerElement->attributeWithoutSynchronization(WebCore::HTMLNames::idAttr);
     }
 
-    // Send the committed document's ScriptExecutionContextIdentifier as the loaderId; the
-    // UIProcess derives the deterministic, hosting-process-qualified protocol loaderId string
-    // from it (consistent across processes, unlike the per-process IdentifierRegistry loaderId).
-    // See webkit.org/b/308895.
-    auto loaderId = document->identifier();
+    // Send the loaderId for the just-committed DocumentLoader. The registry memoizes one string
+    // per loader, so this matches the id the network path already reported for the same loader.
+    Ref inspectedPage = m_inspectedPage.get();
+    Ref registry = inspectedPage->inspectorController().identifierRegistry();
+    RefPtr documentLoader = frame.loader().documentLoader();
+    auto loaderId = registry->loaderId(documentLoader.get());
 
     RefPtr connection = WebProcess::singleton().parentProcessConnection();
     if (!connection)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/Chrome.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>
+#include <WebCore/DocumentPage.h>
 #include <WebCore/DocumentView.h>
 #include <WebCore/FrameInspectorController.h>
 #include <WebCore/FrameLoadRequest.h>
@@ -679,12 +680,12 @@ void WebInspectorBackend::disablePageInstrumentation()
 void WebInspectorBackend::getFrameResourceData(Vector<WebCore::FrameIdentifier>&& frameIDs, CompletionHandler<void(Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>>&&)>&& completionHandler)
 {
     // Return, for each requested frame that is local to this WebContent process, its committed
-    // document's loaderId (as a ScriptExecutionContextIdentifier) and cached subresources. The
-    // UIProcess ProxyingPageAgent walks the authoritative cross-process frame tree, groups frame
-    // IDs by hosting process, and asks each process only for the frames it hosts; it then builds
-    // the Page.getResourceTree protocol objects from this typed data under Site Isolation. Frames
-    // not local to this process are silently skipped (another process answers for them).
-    // See webkit.org/b/308896.
+    // document's protocol loaderId string (computed here via IdentifierRegistry so it matches the
+    // live Network/Page events) and cached subresources. The UIProcess ProxyingPageAgent walks the
+    // authoritative cross-process frame tree, groups frame IDs by hosting process, and asks each
+    // process only for the frames it hosts; it then builds the Page.getResourceTree protocol objects
+    // from this typed data under Site Isolation. Frames not local to this process are silently
+    // skipped (another process answers for them). See webkit.org/b/308896.
     Vector<std::pair<WebCore::FrameIdentifier, Inspector::FrameResourceData>> resourcesByFrame;
     resourcesByFrame.reserveInitialCapacity(frameIDs.size());
 
@@ -697,8 +698,11 @@ void WebInspectorBackend::getFrameResourceData(Vector<WebCore::FrameIdentifier>&
             continue;
 
         Inspector::FrameResourceData frameData;
-        if (RefPtr document = localFrame->document())
-            frameData.loaderId = document->identifier();
+        if (RefPtr framePage = localFrame->page()) {
+            Ref registry = framePage->inspectorController().identifierRegistry();
+            RefPtr documentLoader = localFrame->loader().documentLoader();
+            frameData.loaderId = registry->loaderId(documentLoader.get());
+        }
         frameData.resources = Inspector::ResourceUtilities::buildResourceDataForFrame(*localFrame);
         resourcesByFrame.append({ frameID, WTF::move(frameData) });
     }


### PR DESCRIPTION
#### d4e3ca88a09ecc5a89c467bb8a75906d2ecc6f02
<pre>
Web Inspector: Site Isolation: Page.frameNavigated should include loaderId from document identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=308895">https://bugs.webkit.org/show_bug.cgi?id=308895</a>
<a href="https://rdar.apple.com/171780771">rdar://171780771</a>

Reviewed by BJ Burg.

Under Site Isolation the loaderId reported on Page.frameNavigated and
Page.getResourceTree did not match the loaderId the Network domain emits
for the same navigation&apos;s main resource. The frontend uses loaderId
purely as a correlation key between the Network and Page event streams
(NetworkManager.js): when a main-resource Network.requestWillBeSent
whose loaderId differs from the frame&apos;s committed loaderIdentifier
arrives, it starts a provisional load, and Page.frameNavigated commits
that load only when the event&apos;s loaderId equals the recorded provisional
loaderId. When the two disagree, the real main-resource load is
discarded and a fresh, empty main resource is synthesized in its place.

Root cause: the loaderId was derived from the frame&apos;s current document,
which changes across a navigation&apos;s commit. The Network stream computes
it at the main resource&apos;s willSendRequest -- before commit, when the
frame still shows the previous document -- while the Page stream
computes it at frameNavigated, after the new document has committed.
Deriving from frame-&gt;document()-&gt;identifier() therefore yields two
different strings for one load: the previous document&apos;s id on the
network event and the new document&apos;s id on the navigation. The frontend
never correlated them, so it discarded the real main resource for the
synthesized empty one.

Fix: derive the loaderId from the DocumentLoader&apos;s navigationID
(BackendIdentifierRegistry::loaderId). navigationID is assigned when the
load starts, while still provisional, and stays fixed for the load, so
the Network stream&apos;s pre-commit computation and the Page stream&apos;s
post-commit computation produce the identical string. It is
process-local, so it is qualified with the hosting process
(&quot;loader-&lt;pid&gt;.&lt;navigationID&gt;&quot;).

The id can only be computed in the frame&apos;s hosting WebContent process --
the UIProcess has neither the DocumentLoader nor its navigationID -- so
both proxy paths compute it there (FrameNetworkAgentProxy on the network
side, PageAgentProxy::frameNavigated on the page side) and send the
resulting string over IPC, rather than shipping a raw
ScriptExecutionContextIdentifier and converting it in the UIProcess. A
DocumentLoader never spans processes, so this is consistent.

The obvious alternatives don&apos;t work: frame-&gt;document()-&gt;identifier() is
the source of the bug above, and DocumentLoader::resultingClientId() --
the id the about-to-commit document will adopt -- is populated only for
service-worker-eligible loads, so it is unavailable for the common
navigation.

Because the loaderIds now agree, the frontend takes the provisional-load
commit path (WI.Frame.commitProvisionalLoad) for a cross-origin
navigation instead of synthesizing a fresh main resource via
WI.Frame.initialize. commitProvisionalLoad did not propagate the frame&apos;s
name, so make it adopt and dispatch the navigation&apos;s name like
initialize does; otherwise a window.name change reported on the
committing navigation would no longer reach the frame model.

Test: http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/page/frame-navigated-loader-id-matches-network-cross-origin-iframe.html: Added.
* Source/WebCore/inspector/InspectorResourceUtilities.h:
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.frameDidNavigate):
* Source/WebInspectorUI/UserInterface/Models/Frame.js:
(WI.Frame.prototype.commitProvisionalLoad):
* Source/WebKit/Shared/InspectorPageTypes.serialization.in:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::requestWillBeSent):
(Inspector::ProxyingNetworkAgent::responseReceived):
(Inspector::ProxyingNetworkAgent::requestServedFromMemoryCache):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.messages.in:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.cpp:
(Inspector::ProxyingPageAgent::frameNavigated):
(Inspector::ProxyingPageAgent::buildFrameTree const):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingPageAgent.messages.in:
* Source/WebKit/WebProcess/Inspector/FrameNetworkAgentProxy.cpp:
(WebKit::loaderIdForLoader):
(WebKit::FrameNetworkAgentProxy::willSendRequest):
(WebKit::FrameNetworkAgentProxy::willSendRequestOfType):
(WebKit::FrameNetworkAgentProxy::didReceiveResponse):
(WebKit::FrameNetworkAgentProxy::didLoadResourceFromMemoryCache):
(WebKit::contextIdentifier): Deleted.
* Source/WebKit/WebProcess/Inspector/PageAgentProxy.cpp:
(WebKit::PageAgentProxy::frameNavigated):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::getFrameResourceData):
* Source/WebCore/inspector/InspectorIdentifierRegistry.cpp:
(Inspector::BackendIdentifierRegistry::loaderId):
* Source/WebCore/inspector/InspectorIdentifierRegistry.h:
(Inspector::IdentifierRegistry::parseProtocolFrameId):
(Inspector::IdentifierRegistry::protocolLoaderId): Deleted.

Canonical link: <a href="https://commits.webkit.org/317864@main">https://commits.webkit.org/317864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e86769ea3a8b0557050ccc2179f77afbacd5334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/131483 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0da43b7c-4f3f-4523-a78a-7ea695ca6ddc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134997 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95255 "3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98818573-1c82-446c-9b67-583f5ec51a48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/08ace110-8b6b-4c1c-89b6-7e974c264bd7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37064 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35428 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35203 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31673 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38622 "Found 1026 new failures in b3/testb3_7.cpp, b3/B3Value.h, WebProcess/Network/WebResourceLoader.cpp, jit/OperationResult.h, UIProcess/WebProcessPool.cpp, Shared/Cocoa/WKNSArray.mm, heap/WeakSet.h, API/tests/Regress141275.mm, Shared/SessionState.cpp, NetworkProcess/NetworkResourceLoadParameters.cpp ...") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185614 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47215 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39424 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47894 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143738 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38675 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119764 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113068 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46400 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10156 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45802 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45861 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->