### PR TITLE
Add missing serialization.in enum values

### DIFF
--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in
@@ -40,6 +40,7 @@ enum class WebKit::PCM::MessageType : uint8_t {
     SetPrivateClickMeasurementAppBundleIDForTesting,
     DestroyStoreForTesting,
     AllowTLSCertificateChainForLocalPCMTesting
+    FetchRegistrableDomains
 }
 
 enum class WebKit::PrivateClickMeasurementAttributionType : bool

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1577,9 +1577,8 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
                     if valid_value.condition is not None:
                         result.append('#endif')
             result.append('        return true;')
-            result.append('    default:')
-            result.append('        return false;')
             result.append('    }')
+            result.append('    return false;')
         result.append('}')
         if enum.condition is not None:
             result.append('#endif')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -1630,9 +1630,8 @@ template<> bool isValidEnum<EnumNamespace::BoolEnumType>(bool value)
     case 0:
     case 1:
         return true;
-    default:
-        return false;
     }
+    return false;
 }
 #endif
 
@@ -1643,9 +1642,8 @@ template<> bool isValidEnum<EnumWithoutNamespace>(uint8_t value)
     case EnumWithoutNamespace::Value2:
     case EnumWithoutNamespace::Value3:
         return true;
-    default:
-        return false;
     }
+    return false;
 }
 
 #if ENABLE(UINT16_ENUM)
@@ -1657,9 +1655,8 @@ template<> bool isValidEnum<EnumNamespace::EnumType>(uint16_t value)
     case EnumNamespace::EnumType::SecondValue:
 #endif
         return true;
-    default:
-        return false;
     }
+    return false;
 }
 #endif
 
@@ -1730,9 +1727,8 @@ template<> bool isValidEnum<EnumNamespace::InnerEnumType>(uint8_t value)
     case EnumNamespace::InnerEnumType::OtherInnerInnerValue:
 #endif
         return true;
-    default:
-        return false;
     }
+    return false;
 }
 #endif
 
@@ -1743,9 +1739,8 @@ template<> bool isValidEnum<EnumNamespace::InnerBoolType>(bool value)
     case 0:
     case 1:
         return true;
-    default:
-        return false;
     }
+    return false;
 }
 #endif
 

--- a/Source/WebKit/Shared/JavaScriptCore.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptCore.serialization.in
@@ -22,6 +22,7 @@
 
 header: <JavaScriptCore/ConsoleTypes.h>
 enum class JSC::MessageSource : uint8_t {
+    Accessibility,
     XML,
     JS,
     Network,
@@ -83,4 +84,5 @@ enum class Inspector::InspectorTargetType : uint8_t {
     Page,
     DedicatedWorker,
     ServiceWorker,
+    Frame,
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -149,6 +149,7 @@ enum class WebCore::PermissionName : uint8_t {
     Push,
     ScreenWakeLock,
     SpeakerSelection
+    StorageAccess
 };
 
 header: <WebCore/PermissionQuerySource.h>
@@ -2475,11 +2476,13 @@ enum class WebCore::AllowsContentJavaScript : bool
 enum class WebCore::ViolationReportType : uint8_t {
     COEPInheritenceViolation,
     CORPViolation,
+    CSPHashReport
     ContentSecurityPolicy,
     CrossOriginOpenerPolicy,
     Deprecation,
     StandardReportingAPIViolation,
     Test
+    IntegrityPolicy
 };
 
 enum class WebCore::COEPDisposition : bool;

--- a/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in
@@ -435,6 +435,9 @@ enum class WebCore::MediaConstraintType : uint8_t {
     WhiteBalanceMode,
     Zoom,
     Torch,
+    FocusDistance,
+    BackgroundBlur,
+    PowerEfficient,
 };
 
 header: <WebCore/MediaConstraints.h>
@@ -558,6 +561,7 @@ class WebCore::RealtimeMediaSourceSettings {
     Screen,
     Window,
     SystemAudio
+    Canvas
 };
 
 class WebCore::CaptureDevice {

--- a/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
@@ -1004,6 +1004,8 @@ enum class WebCore::ReferrerPolicy : uint8_t {
 enum class WebCore::StyleAppearance : uint8_t {
     None,
     Auto,
+    Base,
+    BaseSelect,
     Checkbox,
     Radio,
     PushButton,


### PR DESCRIPTION
#### ed59e5db11a87df7a4b2718067a42b657e32850f
<pre>
Add missing serialization.in enum values
<a href="https://bugs.webkit.org/show_bug.cgi?id=318504">https://bugs.webkit.org/show_bug.cgi?id=318504</a>
<a href="https://rdar.apple.com/181285283">rdar://181285283</a>

Reviewed by Alexey Proskuryakov.

When receiving an integer over IPC that is supposed to be an enum,
if it isn&apos;t a valid enum value from a serialization.in file, we assume
the process is compromised and terminate it.  That means we need to have
all valid values in serialization.in files.

This adds the missing values, and removes the default from the generated
switch statement so we see a warning if we have missed any.

* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in:
* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(WTF::isValidEnum&lt;EnumNamespace::BoolEnumType&gt;):
(WTF::isValidEnum&lt;EnumWithoutNamespace&gt;):
(WTF::isValidEnum&lt;EnumNamespace::EnumType&gt;):
(WTF::isValidEnum&lt;EnumNamespace::InnerEnumType&gt;):
(WTF::isValidEnum&lt;EnumNamespace::InnerBoolType&gt;):
* Source/WebKit/Shared/JavaScriptCore.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCodersMedia.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316562@main">https://commits.webkit.org/316562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ab4c0386f2132625d3fa56dab77c920d3700672

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129946 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5ab4f3e-3fba-417a-8660-b48aa3518731) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134076 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94589 "4 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f910bcbb-b55c-4d53-ba3c-32fd4cca135b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114548 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08852533-efdc-4903-afdb-79c053658cca) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/171711 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36136 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34410 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30447 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3144 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184377 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33651 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142848 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45980 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142729 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46658 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30959 "Found 2 new test failures: http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html http/tests/xmlhttprequest/abort-should-cancel-load.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111386 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37774 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118409 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205068 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45175 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9061 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54749 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44575 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->