### PR TITLE
Update arch detection in run-jsc-stress-tests

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -514,46 +514,38 @@ def determineArchitectureFromMachOBinary
 end
 
 def determineArchitectureFromELFBinary
-    f = File.open($jscPath.to_s)
+    f = File.open($jscPath.to_s, "rb")
     data = f.read(20)
 
-    if !(data[0,4] == "\x7F\x45\x4C\x46")
+    if data[0, 4].bytes != [0x7F, 0x45, 0x4C, 0x46]
         $stderr.puts "Warning: Missing ELF magic in file #{Shellwords.shellescape($jscPath.to_s)}"
         return nil
     end
 
     # MIPS and PowerPC may be either big- or little-endian. S390 (which includes
     # S390x) is big-endian. The rest are little-endian.
-    # For RISC-V, to avoid encoding problems, construct the comparison string
-    # by packing a char array matching the ELF's RISC-V machine value.
-    code = data[18, 20]
+    code = data[18, 2].bytes
     case code
-    when "\x03\0"
+    when [0x03, 0]
         "x86"
-    when "\x08\0"
+    when [0x08, 0], [0, 0x08]
         "mips"
-    when "\0\x08"
-        "mips"
-    when "\x14\0"
+    when [0x14, 0], [0, 0x14]
         "powerpc"
-    when "\0\x14"
-        "powerpc"
-    when "\x15\0"
+    when [0x15, 0], [0, 0x15]
         "powerpc64"
-    when "\0\x15"
-        "powerpc64"
-    when "\0\x16"
+    when [0, 0x16]
         "s390"
-    when "\x28\0"
+    when [0x28, 0]
         "arm"
-    when "\x3E\0"
+    when [0x3E, 0]
         "x86_64"
-    when "\xB7\0"
+    when [0xB7, 0]
         "arm64"
-    when [243, 0].pack("cc")
+    when [0xF3, 0]
         "riscv64"
     else
-        $stderr.puts "Warning: unable to determine architecture from code: #{code}"
+        $stderr.puts "Warning: unable to determine architecture from code: #{code.inspect}"
         nil
     end
 end


### PR DESCRIPTION
#### 7d6af3d9a4c32f222156e42195fbd60af85d61d6
<pre>
Update arch detection in run-jsc-stress-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=318505">https://bugs.webkit.org/show_bug.cgi?id=318505</a>

Reviewed by Yusuke Suzuki.

arm64 and riscv64 have arch identifiers that don&apos;t look like ascii.
Let&apos;s compare them as bytes instead to avoid string encoding headaches.

Canonical link: <a href="https://commits.webkit.org/316479@main">https://commits.webkit.org/316479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33254fc5a5b3efbdc7d0abff4e04c9795da64828

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129930 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134063 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36133 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34401 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30431 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3131 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184361 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33635 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142835 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45964 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46642 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111370 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37763 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205052 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45159 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9048 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54744 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44559 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->