### PR TITLE
[JSC] Skip Latin-1 single-character atomization in `s.split('')`

### DIFF
--- a/JSTests/microbenchmarks/string-split-empty-long.js
+++ b/JSTests/microbenchmarks/string-split-empty-long.js
@@ -1,0 +1,20 @@
+const strings = [];
+for (let i = 0; i < 16; ++i) {
+    let s = "";
+    for (let j = 0; j < 99; ++j)
+        s += String.fromCharCode(32 + ((i + j) % 95));
+    strings.push(s);
+}
+
+function test(s) {
+    return s.split("");
+}
+noInline(test);
+
+let sum = 0;
+for (let i = 0; i < 1e5; ++i) {
+    const arr = test(strings[i & 15]);
+    sum += arr.length;
+}
+if (sum !== 1e5 * 99)
+    throw new Error("bad sum: " + sum);

--- a/JSTests/microbenchmarks/string-split-empty-short.js
+++ b/JSTests/microbenchmarks/string-split-empty-short.js
@@ -1,0 +1,20 @@
+const strings = [];
+for (let i = 0; i < 64; ++i) {
+    let s = "";
+    for (let j = 0; j < 16; ++j)
+        s += String.fromCharCode(97 + ((i + j) % 26));
+    strings.push(s);
+}
+
+function test(s) {
+    return s.split("");
+}
+noInline(test);
+
+let sum = 0;
+for (let i = 0; i < 5e5; ++i) {
+    const arr = test(strings[i & 63]);
+    sum += arr.length;
+}
+if (sum !== 5e5 * 16)
+    throw new Error("bad sum: " + sum);

--- a/JSTests/stress/string-split-empty-single-character-index-of.js
+++ b/JSTests/stress/string-split-empty-single-character-index-of.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+function indexOfTest(array, search) {
+    return array.indexOf(search);
+}
+noInline(indexOfTest);
+
+// Dynamically built (non-atom) subject, Latin-1.
+let dynamic = "";
+for (let i = 0; i < 20; ++i)
+    dynamic += String.fromCharCode(97 + i);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    let array = dynamic.split("");
+    shouldBe(array.length, 20);
+    shouldBe(indexOfTest(array, "c"), 2);
+    shouldBe(indexOfTest(array, String.fromCharCode(99, 100).substring(0, 1)), 2);
+    shouldBe(indexOfTest(array, "z"), -1);
+    shouldBe(indexOfTest(array, "Z"), -1);
+    shouldBe(indexOfTest(array, "aa"), -1);
+}
+
+// Atom (literal) subject: stringSplitCache path.
+for (let i = 0; i < testLoopCount; ++i) {
+    let array = "greedisgood".split("");
+    shouldBe(indexOfTest(array, "s"), 6);
+    shouldBe(indexOfTest(array, "z"), -1);
+    shouldBe(array.join(""), "greedisgood");
+}
+
+// Latin-1 boundary characters: 0x00, 0xFF, and just above (0x100).
+let edge = ("x" + String.fromCharCode(0, 255, 256, 65)).substring(1);
+let edgeArray = edge.split("");
+shouldBe(edgeArray.length, 4);
+shouldBe(indexOfTest(edgeArray, String.fromCharCode(0)), 0);
+shouldBe(indexOfTest(edgeArray, String.fromCharCode(255)), 1);
+shouldBe(indexOfTest(edgeArray, String.fromCharCode(256)), 2);
+shouldBe(indexOfTest(edgeArray, "A"), 3);
+shouldBe(indexOfTest(edgeArray, String.fromCharCode(1)), -1);
+
+// Non-Latin-1 (16-bit) and mixed 8/16-bit subjects.
+let unicode = ("x" + "あいうえお￿").substring(1);
+let unicodeArray = unicode.split("");
+shouldBe(unicodeArray.length, 6);
+shouldBe(indexOfTest(unicodeArray, "う"), 2);
+shouldBe(indexOfTest(unicodeArray, "￿"), 5);
+shouldBe(indexOfTest(unicodeArray, "か"), -1);
+shouldBe(indexOfTest(unicodeArray, "a"), -1);
+
+let mixed = ("x" + "aあb").substring(1);
+let mixedArray = mixed.split("");
+shouldBe(indexOfTest(mixedArray, "a"), 0);
+shouldBe(indexOfTest(mixedArray, "あ"), 1);
+shouldBe(indexOfTest(mixedArray, "b"), 2);
+
+// GC must not invalidate single-character lookups.
+gc();
+let postGCArray = dynamic.split("");
+shouldBe(indexOfTest(postGCArray, "e"), 4);
+shouldBe(indexOfTest(postGCArray, "Z"), -1);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5298,7 +5298,8 @@ JSC_DEFINE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32
         OPERATION_RETURN_IF_EXCEPTION(scope, 0);
 
         UCPUStrictInt32 result = toUCPUStrictInt32(-1);
-        if (vm.atomStringToJSStringMap.contains(search.data)) {
+        bool mayContainSearch = (search.data->length() == 1 && search.data->at(0) <= maxSingleCharacterString) || vm.atomStringToJSStringMap.contains(search.data);
+        if (mayContainSearch) {
             int32_t length = butterfly->publicLength();
             auto data = butterfly->contiguous().data();
             for (int32_t i = index; i < length; ++i) {

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1359,7 +1359,8 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncIndexOf, (JSGlobalObject* globalObject, C
             RETURN_IF_EXCEPTION(scope, { });
 
             JSValue result = jsNumber(-1);
-            if (vm.atomStringToJSStringMap.contains(search.data)) {
+            bool mayContainSearch = (search.data->length() == 1 && search.data->at(0) <= maxSingleCharacterString) || vm.atomStringToJSStringMap.contains(search.data);
+            if (mayContainSearch) {
                 auto data = butterfly->contiguous().data();
                 for (unsigned i = index; i < length; ++i) {
                     JSValue value = data[i].get();

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1178,8 +1178,9 @@ JSCell* stringSplitFast(JSGlobalObject* globalObject, JSString* thisString, JSSt
             }
 
             for (unsigned i = 0; i < resultSize; ++i) {
-                auto* string = jsSingleCharacterString(vm, input[i]);
-                if (makeAtomStringsArray) {
+                char16_t character = input[i];
+                auto* string = jsSingleCharacterString(vm, character);
+                if (makeAtomStringsArray && character > maxSingleCharacterString) [[unlikely]] {
                     Identifier identifier = string->toIdentifier(globalObject);
                     RETURN_IF_EXCEPTION(scope, { });
                     DeferGC defer(vm);


### PR DESCRIPTION
#### 02b44f2ad986575436f69f51863b556cbd460180
<pre>
[JSC] Skip Latin-1 single-character atomization in `s.split(&apos;&apos;)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318510">https://bugs.webkit.org/show_bug.cgi?id=318510</a>

Reviewed by Yusuke Suzuki.

The empty-separator fast path of s.split(&quot;&quot;) atomizes every resulting
character through toIdentifier / DeferGC / atomStringToJSStringMap
.ensureValue, even though Latin-1 single characters are already
atom-backed SmallStrings cells. This patch skips that block for Latin-1
characters.

Skipping alone would break the Array.prototype.indexOf onlyAtomStrings
fast path, which treats absence from atomStringToJSStringMap as absence
from the array. To prevent that, indexOf now treats a single Latin-1
character search as potentially present and falls through to the
pointer-comparison scan.

string-split-empty-long     45.4817+-1.1086  ^  14.8687+-0.3740  ^ definitely 3.0589x faster
string-split-empty-short    38.2363+-1.1574  ^  16.1969+-0.1237  ^ definitely 2.3607x faster

No regression on the indexOf microbenchmarks that now always scan:

atom-string-array-split-empty-index-of-not-found   0.8349+-0.0327     0.8123+-0.0378   might be 1.0278x faster
atom-string-array-split-empty-index-of-found       1.0105+-0.0291  ^  0.9138+-0.0307   ^ definitely 1.1058x faster

Tests: JSTests/microbenchmarks/string-split-empty-long.js
       JSTests/microbenchmarks/string-split-empty-short.js
       JSTests/stress/string-split-empty-single-character-index-of.js

* JSTests/microbenchmarks/string-split-empty-long.js: Added.
(test):
* JSTests/microbenchmarks/string-split-empty-short.js: Added.
(test):
* JSTests/stress/string-split-empty-single-character-index-of.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::stringSplitFast):

Canonical link: <a href="https://commits.webkit.org/316465@main">https://commits.webkit.org/316465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2bc0405010b4a3dd062e7feadcc5226e7b3259b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134078 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37497 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36132 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30441 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3140 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184371 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33645 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142844 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45974 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142725 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38545 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46652 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111380 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37768 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205062 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45169 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9057 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54747 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->