### PR TITLE
[JSC] LICM should skip tuple consumers

### DIFF
--- a/JSTests/stress/dfg-licm-hoist-tuple-node.js
+++ b/JSTests/stress/dfg-licm-hoist-tuple-node.js
@@ -1,0 +1,43 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=318366
+//
+// DFG/FTL LICM would hoist a loop-invariant tuple node (MapIteratorNext, produced by
+// array-destructuring of a Set) out of a loop and re-run its abstract effects through the
+// single-value accessors of AtTailAbstractState, hitting ASSERT(!node->isTuple()). Hoisting
+// such a tuple node is legitimate (its inputs are loop-invariant and it does not write), so
+// AtTailAbstractState::clearForNode must tolerate the tuple node's own slot, and LICM must
+// skip only the ExtractFromTuple consumer (whose child is an edge to the tuple node).
+
+function f(s, n) {
+    let v2 = -1;
+    while (n) {
+        [, v2] = s;
+        n--;
+    }
+    return v2;
+}
+noInline(f);
+
+const s = new Set([10, 20, 30]);
+for (let j = 0; j < testLoopCount; j++) {
+    const result = f(s, 3);
+    // Destructuring [, v2] = s takes the second element of the fresh iterator each time.
+    if (result !== 20)
+        throw new Error(`Bad result: ${result}`);
+}
+
+// The unbounded form from the bug report reaches the same hoisting path via loop OSR entry.
+function g() {
+    const v1 = new Set();
+    let v2 = 0;
+    let i = 0;
+    while (8) {
+        [, v2] = v1;
+        if (++i >= testLoopCount)
+            break;
+    }
+    return v2;
+}
+noInline(g);
+
+if (g() !== undefined)
+    throw new Error("Bad result from g");

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
@@ -54,9 +54,8 @@ void AtTailAbstractState::createValueForNode(NodeFlowProjection node)
     m_valuesAtTailMap.at(m_block).add(node, AbstractValue());
 }
 
-AbstractValue& AtTailAbstractState::forNode(NodeFlowProjection node)
+AbstractValue& AtTailAbstractState::forNodeImpl(NodeFlowProjection node)
 {
-    ASSERT(!node->isTuple());
     auto& valuesAtTail = m_valuesAtTailMap.at(m_block);
     UncheckedKeyHashMap<NodeFlowProjection, AbstractValue>::iterator iter = valuesAtTail.find(node);
     DFG_ASSERT(m_graph, node.node(), iter != valuesAtTail.end());

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
@@ -53,7 +53,12 @@ public:
     
     AbstractValue& fastForward(AbstractValue& value) { return value; }
     
-    AbstractValue& forNode(NodeFlowProjection);
+    AbstractValue& forNode(NodeFlowProjection node)
+    {
+        ASSERT(!node->isTuple());
+        return forNodeImpl(node);
+    }
+
     AbstractValue& forNode(Edge edge)
     {
         ASSERT(!edge.node()->isTuple());
@@ -75,13 +80,13 @@ public:
     {
         return value.filter(type);
     }
-    
+
     ALWAYS_INLINE void clearForNode(NodeFlowProjection node)
     {
-        ASSERT(!node->isTuple());
-        forNode(node).clear();
+        // Intentionally handle tuples too.
+        forNodeImpl(node).clear();
     }
-    
+
     ALWAYS_INLINE void clearForNode(Edge edge)
     {
         clearForNode(edge.node());
@@ -267,6 +272,8 @@ public:
     }
 
 private:
+    AbstractValue& forNodeImpl(NodeFlowProjection);
+
     Graph& m_graph;
     IndexMap<BasicBlock*, UncheckedKeyHashMap<NodeFlowProjection, AbstractValue>> m_valuesAtTailMap;
     IndexMap<BasicBlock*, Vector<AbstractValue>> m_tupleAbstractValues;

--- a/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
@@ -238,6 +238,13 @@ private:
         Node* node = nodeRef;
         LoopData& data = m_data[loop->index()];
 
+        // Currently safeToExecute does not support children having a tuple, and ExtractFromTuple is the only one node which
+        // does it (and guaranteed since we need to extract a value from a tuple).
+        if (node->op() == ExtractFromTuple) {
+            dataLogLnIf(verbose, "    Not hoisting ", node, " because its children are tuples.");
+            return false;
+        }
+
         if (!data.preHeader) {
             dataLogLnIf(verbose, "    Not hoisting ", node, " because the pre-header is invalid.");
             return false;


### PR DESCRIPTION
#### d90bb919af460a6d1e21164d745363b32e5e5d1e
<pre>
[JSC] LICM should skip tuple consumers
<a href="https://bugs.webkit.org/show_bug.cgi?id=318513">https://bugs.webkit.org/show_bug.cgi?id=318513</a>
<a href="https://rdar.apple.com/181175678">rdar://181175678</a>

Reviewed by Sosuke Suzuki.

DFG LICM is running AbstractInterpreter and safeToExecute with
DFGAtTailAbstractState, but

1. DFG LICM&apos;s safeToExecute is not correctly handling tuple children,
   while the current code is harmless, ASSERT hits.
2. DFG LICM&apos;s AbstractInterpreter run hits ASSERT because of clearForNode
   for Tuple returning DFG node, but this clearing is necessary and legit
   as it is introduced in 264281@main.

So,

1. DFGAtTailAbstractState should allow tuple returning node with clearForNode,
   as the other AbstractStates allow.
2. Let&apos;s disable LICM for ExtractFromTuple. Realistically, it has zero
   value as tuple extraction is almost no-op hint operation.

Test: JSTests/stress/dfg-licm-hoist-tuple-node.js

* JSTests/stress/dfg-licm-hoist-tuple-node.js: Added.
(f):
(g):
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp:
(JSC::DFG::AtTailAbstractState::forNodeImpl):
(JSC::DFG::AtTailAbstractState::forNode): Deleted.
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h:
(JSC::DFG::AtTailAbstractState::forNode):
(JSC::DFG::AtTailAbstractState::clearForNode):
* Source/JavaScriptCore/dfg/DFGLICMPhase.cpp:
(JSC::DFG::LICMPhase::attemptHoist):

Canonical link: <a href="https://commits.webkit.org/316463@main">https://commits.webkit.org/316463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb91e8cf6ff16014bdf4e5d2d183da3d46992bf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129948 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3240d10f-ebcf-4abe-87b9-6a12ba42aa24) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134077 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad3f1d85-27b2-4e84-879f-2cd04aeac7ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37505 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a971dba8-0192-4e20-bf9f-d9ec956f1234) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36140 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30449 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3143 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184379 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33653 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142849 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45982 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142730 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46660 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111388 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37775 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205070 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45177 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9060 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54750 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44577 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44809 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->