### PR TITLE
[JSC] Prove resolved values non-thenable for `NewResolvedPromise` in DFG constant folding

### DIFF
--- a/JSTests/microbenchmarks/async-function-return-number-no-await.js
+++ b/JSTests/microbenchmarks/async-function-return-number-no-await.js
@@ -1,0 +1,25 @@
+// Async functions without await returning a primitive should fulfill the result
+// promise inline; proving non-thenable-ness in constant folding also removes the
+// world clobber around the promise allocation.
+
+async function compute(x) {
+    return x * 2 + 1;
+}
+
+function kernel(count) {
+    let last;
+    for (let i = 0; i < count; i++)
+        last = compute(i);
+    return last;
+}
+noInline(kernel);
+
+let last;
+for (let r = 0; r < 5; r++)
+    last = kernel(2e6);
+
+last.then((value) => {
+    if (value !== (2e6 - 1) * 2 + 1)
+        throw new Error("bad result");
+});
+drainMicrotasks();

--- a/JSTests/microbenchmarks/async-function-return-object-no-await.js
+++ b/JSTests/microbenchmarks/async-function-return-object-no-await.js
@@ -1,0 +1,29 @@
+// Async functions without await returning an object literal should fulfill the
+// result promise inline once constant folding proves the resolved value is not
+// a thenable, instead of calling operationNewResolvedPromise every time.
+
+const rows = [];
+for (let j = 0; j < 16; j++)
+    rows.push({ id: j, first: 'A' + j, last: 'B' + j, score: j * 3 });
+
+async function toDTO(row) {
+    return { id: row.id, name: row.first, score: row.score, ok: true };
+}
+
+function kernel(count) {
+    let last;
+    for (let i = 0; i < count; i++)
+        last = toDTO(rows[i & 15]);
+    return last;
+}
+noInline(kernel);
+
+let last;
+for (let r = 0; r < 5; r++)
+    last = kernel(8e5);
+
+last.then((dto) => {
+    if (dto.score !== rows[(8e5 - 1) & 15].score)
+        throw new Error("bad result");
+});
+drainMicrotasks();

--- a/JSTests/stress/async-function-return-non-thenable-folding.js
+++ b/JSTests/stress/async-function-return-non-thenable-folding.js
@@ -1,0 +1,235 @@
+// Verifies observable behavior of async functions without await when constant
+// folding proves the returned value is not a thenable. All promise resolution
+// semantics (thenable adoption, "then" getter observability, microtask ordering,
+// watchpoint invalidation) must be unchanged.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "bad value: " + actual + ", expected: " + expected);
+}
+
+const log = [];
+
+// Phase 1: plain object return -- value identity, async fulfillment.
+{
+    async function toDTO(row) {
+        return { id: row.id, name: row.first, score: row.score, ok: true };
+    }
+    const rows = [];
+    for (let j = 0; j < 16; j++)
+        rows.push({ id: j, first: 'A' + j, last: 'B' + j, score: j * 3 });
+
+    let sum = 0;
+    for (let i = 0; i < 2e5; i++) {
+        toDTO(rows[i & 15]).then((dto) => { sum += dto.score; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    let expected = 0;
+    for (let i = 0; i < 2e5; i++)
+        expected += (i & 15) * 3;
+    shouldBe(sum, expected, "phase1 sum");
+
+    // Fulfillment must be asynchronous even when fast-pathed.
+    let syncCheck = "pending";
+    toDTO(rows[0]).then(() => { syncCheck = "fulfilled"; });
+    shouldBe(syncCheck, "pending", "phase1 no sync fulfillment");
+    drainMicrotasks();
+    shouldBe(syncCheck, "fulfilled", "phase1 fulfilled after drain");
+    log.push("phase1 ok");
+}
+
+// Phase 2: primitive returns.
+{
+    async function compute(x) {
+        return x * 2 + 1;
+    }
+    let last = 0;
+    for (let i = 0; i < 2e5; i++)
+        compute(i).then((v) => { last = v; });
+    drainMicrotasks();
+    shouldBe(last, (2e5 - 1) * 2 + 1, "phase2 last");
+    log.push("phase2 ok");
+}
+
+// Phase 3: thenable with own "then" method -- must be adopted, called once per resolve.
+{
+    let thenCalls = 0;
+    async function makeThenable(i) {
+        return { then(resolve, reject) { thenCalls++; resolve(i * 10); } };
+    }
+    let got = -1;
+    for (let i = 0; i < 2e5; i++) {
+        makeThenable(i).then((v) => { got = v; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(thenCalls, 2e5, "phase3 then call count");
+    shouldBe(got, (2e5 - 1) * 10, "phase3 adopted value");
+    log.push("phase3 ok");
+}
+
+// Phase 4: "then" accessor on the prototype -- the Get must remain observable,
+// exactly once per resolution, with the resolved object as receiver.
+{
+    let getterCalls = 0;
+    let lastReceiverId = -1;
+    class DTOWithAccessor {
+        constructor(id) { this.id = id; }
+        get then() { getterCalls++; lastReceiverId = this.id; return undefined; }
+    }
+    async function makeAccessorDTO(i) {
+        return new DTOWithAccessor(i);
+    }
+    let gotId = -1;
+    for (let i = 0; i < 2e5; i++) {
+        makeAccessorDTO(i).then((v) => { gotId = v.id; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(getterCalls, 2e5, "phase4 getter call count");
+    shouldBe(lastReceiverId, 2e5 - 1, "phase4 receiver");
+    shouldBe(gotId, 2e5 - 1, "phase4 fulfilled with object");
+    log.push("phase4 ok");
+}
+
+// Phase 5: "then" getter that throws -- promise must reject.
+{
+    const poison = {};
+    Object.defineProperty(poison, "then", { get() { throw new Error("poisoned"); } });
+    async function returnPoison() {
+        return poison;
+    }
+    let rejected = null;
+    returnPoison().then(() => { rejected = "fulfilled"; }, (e) => { rejected = e.message; });
+    drainMicrotasks();
+    shouldBe(rejected, "poisoned", "phase5 rejection");
+    log.push("phase5 ok");
+}
+
+// Phase 6: returning a promise -- must create a fresh promise that adopts it.
+{
+    async function passThrough(p) {
+        return p;
+    }
+    const inner = Promise.resolve(42);
+    const outer = passThrough(inner);
+    shouldBe(outer === inner, false, "phase6 fresh promise");
+    let got = -1;
+    outer.then((v) => { got = v; });
+    drainMicrotasks();
+    shouldBe(got, 42, "phase6 adopted value");
+
+    // Microtask tick ordering when returning a promise must be unchanged.
+    const order = [];
+    async function g() { return Promise.resolve("g"); }
+    g().then((v) => order.push(v));
+    Promise.resolve().then(() => order.push("t1")).then(() => order.push("t2")).then(() => order.push("t3")).then(() => order.push("t4"));
+    drainMicrotasks();
+    log.push("phase6 order: " + order.join(","));
+}
+
+// Phase 7: microtask tick ordering for plain object return must be unchanged.
+{
+    const order = [];
+    async function h() { return { v: "h" }; }
+    h().then((o) => order.push(o.v));
+    Promise.resolve().then(() => order.push("t1")).then(() => order.push("t2")).then(() => order.push("t3"));
+    drainMicrotasks();
+    log.push("phase7 order: " + order.join(","));
+}
+
+// Phase 8: polymorphic DTO shapes.
+{
+    async function poly(o) {
+        return o.flip ? { a: o.id, kind: "x" } : { b: o.id, kind: "y", extra: 1 };
+    }
+    let kinds = { x: 0, y: 0 };
+    for (let i = 0; i < 2e5; i++) {
+        poly({ id: i, flip: !!(i & 1) }).then((r) => { kinds[r.kind]++; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(kinds.x, 1e5, "phase8 x count");
+    shouldBe(kinds.y, 1e5, "phase8 y count");
+    log.push("phase8 ok");
+}
+
+// Phase 9: adding "then" to Object.prototype AFTER tier-up must invalidate the
+// proof and route resolution through the thenable path.
+{
+    async function makePlain(i) {
+        return { id: i };
+    }
+    let sum = 0;
+    for (let i = 0; i < 2e5; i++) {
+        makePlain(i).then((o) => { sum += (typeof o === "object") ? 1 : 0; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(sum, 2e5, "phase9 warmup");
+
+    Object.prototype.then = function (resolve, reject) { resolve("hijacked:" + this.id); };
+    let got = null;
+    makePlain(7).then((v) => { got = v; });
+    drainMicrotasks();
+    shouldBe(got, "hijacked:7", "phase9 hijacked resolution");
+
+    delete Object.prototype.then;
+    let got2 = null;
+    makePlain(8).then((v) => { got2 = v.id; });
+    drainMicrotasks();
+    shouldBe(got2, 8, "phase9 restored resolution");
+    log.push("phase9 ok");
+}
+
+// Phase 10: adding "then" to a custom prototype AFTER tier-up.
+{
+    class DTO {
+        constructor(id) { this.id = id; }
+    }
+    async function makeDTO(i) {
+        return new DTO(i);
+    }
+    let count = 0;
+    for (let i = 0; i < 2e5; i++) {
+        makeDTO(i).then(() => { count++; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(count, 2e5, "phase10 warmup");
+
+    DTO.prototype.then = function (resolve) { resolve("proto-then:" + this.id); };
+    let got = null;
+    makeDTO(9).then((v) => { got = v; });
+    drainMicrotasks();
+    shouldBe(got, "proto-then:9", "phase10 proto then");
+    log.push("phase10 ok");
+}
+
+// Phase 11: async arrow and async method forms.
+{
+    const toDTOArrow = async (row) => ({ id: row.id, double: row.id * 2 });
+    const service = {
+        async toDTO(row) { return { id: row.id, triple: row.id * 3 }; }
+    };
+    let a = -1, m = -1;
+    for (let i = 0; i < 1e5; i++) {
+        toDTOArrow({ id: i }).then((r) => { a = r.double; });
+        service.toDTO({ id: i }).then((r) => { m = r.triple; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(a, (1e5 - 1) * 2, "phase11 arrow");
+    shouldBe(m, (1e5 - 1) * 3, "phase11 method");
+    log.push("phase11 ok");
+}
+
+print(log.join("\n"));

--- a/JSTests/stress/async-function-return-thenable.js
+++ b/JSTests/stress/async-function-return-thenable.js
@@ -1,0 +1,194 @@
+// Verifies that async functions without await still take the thenable path when
+// the returned object has a "then": as an own property, only on the prototype,
+// deeper in the prototype chain, added after tier-up, or non-callable. The
+// non-thenable constant folding proof must never fire for these shapes.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "bad value: " + actual + ", expected: " + expected);
+}
+
+const ITERS = 2e5;
+
+// Own "then" data property in the object literal: adopted, called once per resolve.
+{
+    let thenCalls = 0;
+    async function makeOwnThenable(i) {
+        return {
+            id: i,
+            then(resolve, reject) {
+                thenCalls++;
+                shouldBe(this.id >= 0, true, "own receiver");
+                resolve(this.id * 2);
+            }
+        };
+    }
+    let got = -1;
+    for (let i = 0; i < ITERS; i++) {
+        makeOwnThenable(i).then((v) => { got = v; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(thenCalls, ITERS, "own then call count");
+    shouldBe(got, (ITERS - 1) * 2, "own then adopted value");
+}
+
+// "then" only on the prototype (class method), not an own property: adopted,
+// looked up through the prototype with the object as receiver.
+{
+    let thenCalls = 0;
+    class ProtoThenable {
+        constructor(id) { this.id = id; }
+        then(resolve, reject) {
+            thenCalls++;
+            resolve("proto:" + this.id);
+        }
+    }
+    async function makeProtoThenable(i) {
+        return new ProtoThenable(i);
+    }
+    shouldBe(Object.getOwnPropertyNames(new ProtoThenable(0)).includes("then"), false, "then is not own");
+    let got = null;
+    for (let i = 0; i < ITERS; i++) {
+        makeProtoThenable(i).then((v) => { got = v; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(thenCalls, ITERS, "proto then call count");
+    shouldBe(got, "proto:" + (ITERS - 1), "proto then adopted value");
+}
+
+// "then" two levels up the prototype chain.
+{
+    let thenCalls = 0;
+    const grandproto = {
+        then(resolve, reject) {
+            thenCalls++;
+            resolve("grand:" + this.id);
+        }
+    };
+    const proto = Object.create(grandproto);
+    async function makeDeepThenable(i) {
+        const o = Object.create(proto);
+        o.id = i;
+        return o;
+    }
+    let got = null;
+    for (let i = 0; i < ITERS; i++) {
+        makeDeepThenable(i).then((v) => { got = v; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(thenCalls, ITERS, "grandproto then call count");
+    shouldBe(got, "grand:" + (ITERS - 1), "grandproto then adopted value");
+}
+
+// "then" getter on the prototype returning a callable: the getter must run once
+// per resolution and the returned function must be invoked.
+{
+    let getterCalls = 0;
+    let thenCalls = 0;
+    class GetterThenable {
+        constructor(id) { this.id = id; }
+        get then() {
+            getterCalls++;
+            const self = this;
+            return function (resolve, reject) {
+                thenCalls++;
+                resolve("getter:" + self.id);
+            };
+        }
+    }
+    async function makeGetterThenable(i) {
+        return new GetterThenable(i);
+    }
+    let got = null;
+    for (let i = 0; i < ITERS; i++) {
+        makeGetterThenable(i).then((v) => { got = v; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(getterCalls, ITERS, "getter call count");
+    shouldBe(thenCalls, ITERS, "returned then call count");
+    shouldBe(got, "getter:" + (ITERS - 1), "getter then adopted value");
+}
+
+// Own "then" added conditionally after object creation. The branch is never
+// taken during warmup, then flipped after tier-up: the structure transition
+// must defeat any non-thenable proof.
+{
+    let thenCalls = 0;
+    async function maybeThenable(i, flag) {
+        const o = { id: i };
+        if (flag)
+            o.then = function (resolve, reject) { thenCalls++; resolve("late-own:" + this.id); };
+        return o;
+    }
+    let plain = 0;
+    for (let i = 0; i < ITERS; i++) {
+        maybeThenable(i, false).then((o) => { plain += (o.id === i | 0); });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(plain, ITERS, "warmup without then");
+    shouldBe(thenCalls, 0, "no then calls during warmup");
+
+    let got = null;
+    maybeThenable(123, true).then((v) => { got = v; });
+    drainMicrotasks();
+    shouldBe(thenCalls, 1, "late own then called");
+    shouldBe(got, "late-own:123", "late own then adopted value");
+}
+
+// "then" added to the prototype AFTER tier-up: the absence watchpoint must fire
+// and subsequent resolutions must adopt.
+{
+    let thenCalls = 0;
+    class LateProto {
+        constructor(id) { this.id = id; }
+    }
+    async function makeLateProto(i) {
+        return new LateProto(i);
+    }
+    let count = 0;
+    for (let i = 0; i < ITERS; i++) {
+        makeLateProto(i).then(() => { count++; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(count, ITERS, "warmup before proto then");
+
+    LateProto.prototype.then = function (resolve, reject) { thenCalls++; resolve("late-proto:" + this.id); };
+    let got = null;
+    for (let i = 0; i < 100; i++)
+        makeLateProto(i).then((v) => { got = v; });
+    drainMicrotasks();
+    shouldBe(thenCalls, 100, "late proto then call count");
+    shouldBe(got, "late-proto:99", "late proto then adopted value");
+}
+
+// Non-callable "then" on the prototype: NOT a thenable, the promise must
+// fulfill with the object itself.
+{
+    class NonCallableThen {
+        constructor(id) { this.id = id; }
+    }
+    NonCallableThen.prototype.then = 42;
+    async function makeNonCallable(i) {
+        return new NonCallableThen(i);
+    }
+    let gotId = -1;
+    for (let i = 0; i < ITERS; i++) {
+        makeNonCallable(i).then((o) => { gotId = o.id; });
+        if ((i & 0xfff) === 0)
+            drainMicrotasks();
+    }
+    drainMicrotasks();
+    shouldBe(gotId, ITERS - 1, "non-callable then fulfills with object");
+}

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -2012,6 +2012,33 @@ private:
                 break;
             }
 
+            case NewResolvedPromise: {
+                if (node->isResolvedValueKnownNonThenable())
+                    break;
+
+                AbstractValue& argument = m_state.forNode(node->child1());
+                if (argument.isType(~SpecObject)) {
+                    node->setResolvedValueKnownNonThenable();
+                    changed = true;
+                    break;
+                }
+
+                auto& structureSet = argument.m_structure;
+                if (structureSet.isFinite() && structureSet.size() == 1) {
+                    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                    auto conditionSet = m_graph.tryEnsureAbsence(globalObject, structureSet.toStructureSet(), CacheableIdentifier::createFromImmortalIdentifier(m_graph.m_vm.propertyNames->then.impl()));
+                    if (conditionSet.isValid()) {
+                        if (m_graph.watchConditions(conditionSet)) {
+                            node->setResolvedValueKnownNonThenable();
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+
+                break;
+            }
+
             case PromiseResolve: {
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                 if (JSValue constructor = m_state.forNode(node->child1()).m_value) {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -947,6 +947,12 @@ public:
         return m_opInfo.as<bool>();
     }
 
+    void setResolvedValueKnownNonThenable()
+    {
+        ASSERT(op() == NewResolvedPromise);
+        m_opInfo = static_cast<uint32_t>(true);
+    }
+
     void NODELETE convertToNewArrayBuffer(FrozenValue* immutableButterfly);
     void NODELETE convertToNewArrayWithSize();
     void NODELETE convertToNewArrayWithButterfly(Graph&, Node* butterfly);


### PR DESCRIPTION
#### 7f538702bc4e7b6abe58e723004d216beac074c3
<pre>
[JSC] Prove resolved values non-thenable for `NewResolvedPromise` in DFG constant folding
<a href="https://bugs.webkit.org/show_bug.cgi?id=318515">https://bugs.webkit.org/show_bug.cgi?id=318515</a>

Reviewed by Yusuke Suzuki.

Returning a value from an async function that has no await compiles to a
NewResolvedPromise node in the DFG and FTL.

NewResolvedPromise already has a fast path that allocates and fulfills the
promise inline, skipping the observable &quot;then&quot; property lookup, gated on its
isResolvedValueKnownNonThenable flag.

However, the flag is only set when constant folding converts
Promise.resolve(object) into NewResolvedPromise; nodes created for async
function returns never get it, so they call into C++ and clobber the world
on every resolution.

This patch adds a NewResolvedPromise case to constant folding that upgrades
the flag in place. If the resolved value is proven non-object, it cannot be
a thenable, so the flag is set immediately. Otherwise, if it has a single
structure, we prove &quot;then&quot; is absent from the structure and its prototype
chain via tryEnsureAbsence and watch those conditions; adding &quot;then&quot; later
fires the watchpoints and jettisons the code. Returning a promise keeps the
slow path, since the absence proof fails on Promise.prototype.then.

                                                baseline                  patched

async-function-return-object-no-await       58.9822+-13.0567    ^     30.9665+-1.6062        ^ definitely 1.9047x faster
async-function-return-number-no-await       41.0872+-2.4379           38.7943+-3.4576          might be 1.0591x faster

Tests: JSTests/microbenchmarks/async-function-return-number-no-await.js
       JSTests/microbenchmarks/async-function-return-object-no-await.js
       JSTests/stress/async-function-return-non-thenable-folding.js
       JSTests/stress/async-function-return-thenable.js

* JSTests/microbenchmarks/async-function-return-number-no-await.js: Added.
(async compute):
(kernel):
(last.then):
* JSTests/microbenchmarks/async-function-return-object-no-await.js: Added.
(async toDTO):
(kernel):
(last.then):
* JSTests/stress/async-function-return-non-thenable-folding.js: Added.
(shouldBe):
(async toDTO):
* JSTests/stress/async-function-return-thenable.js: Added.
(shouldBe):
(async makeOwnThenable):
(i.makeOwnThenable.i.then):
(ProtoThenable):
(ProtoThenable.prototype.then):
(async makeProtoThenable):
(i.makeProtoThenable.i.then):
(string_appeared_here.async makeDeepThenable):
(string_appeared_here):
(GetterThenable):
(GetterThenable.prototype.get then):
(async makeGetterThenable):
(i.makeGetterThenable.i.then):
(string_appeared_here.o.then):
(string_appeared_here.async maybeThenable):
(shouldBe.LateProto):
(shouldBe.async makeLateProto):
(shouldBe.LateProto.prototype.then):
(shouldBe.NonCallableThen):
(shouldBe.async makeNonCallable):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::setResolvedValueKnownNonThenable):

Canonical link: <a href="https://commits.webkit.org/316466@main">https://commits.webkit.org/316466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d6150f54815cc25ac57e206648df3e20d1520cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37504 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36139 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30451 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3147 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184381 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33655 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37062 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142851 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45984 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38546 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46662 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111390 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37776 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205072 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9064 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54751 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44579 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->