### PR TITLE
[JSC] Create generator frame environment lazily at suspend points

### DIFF
--- a/JSTests/microbenchmarks/async-cache-hit-sync-return-many-locals.js
+++ b/JSTests/microbenchmarks/async-cache-hit-sync-return-many-locals.js
@@ -1,0 +1,55 @@
+// Like async-cache-hit-sync-return.js, but with many locals live across the
+// cold-path await. Stresses the per-local cost paid by async function
+// invocations that complete without suspending.
+
+const cache = new Map();
+const keys = [];
+for (let j = 0; j < 16; j++) {
+    const key = 'k' + j;
+    keys.push(key);
+    cache.set(key, { id: j, value: j * 2 });
+}
+
+async function fetchSlow(key) {
+    return { id: -1, value: 100, key };
+}
+
+let acc = 0;
+async function getRecord(key) {
+    const hit = cache.get(key);
+    if (hit !== undefined) {
+        acc += hit.value;
+        return hit;
+    }
+    const l0 = key.length;
+    const l1 = l0 + 1;
+    const l2 = l1 + 1;
+    const l3 = l2 + 1;
+    const l4 = l3 + 1;
+    const l5 = l4 + 1;
+    const l6 = l5 + 1;
+    const l7 = l6 + 1;
+    const fresh = await fetchSlow(key);
+    cache.set(key, fresh);
+    acc += fresh.value + l0 + l1 + l2 + l3 + l4 + l5 + l6 + l7;
+    return fresh;
+}
+
+// Exercise the suspending miss path too.
+let sink;
+for (let j = 0; j < 8; j++)
+    sink = getRecord('m' + j);
+drainMicrotasks();
+
+(function () {
+    for (let i = 0; i < 2000000; i++)
+        sink = getRecord(keys[i & 15]);
+})();
+drainMicrotasks();
+
+// Miss path: key 'm0'..'m7' has length 2, so l0..l7 = 2..9, sum = 44.
+const expected = 8 * (100 + 44) + (2000000 / 16) * 240;
+if (acc !== expected)
+    throw new Error("bad result: " + acc);
+if (typeof sink !== "object")
+    throw new Error("bad sink");

--- a/JSTests/microbenchmarks/async-cache-hit-sync-return.js
+++ b/JSTests/microbenchmarks/async-cache-hit-sync-return.js
@@ -1,0 +1,47 @@
+// Async function with an await only on the cache-miss path: the hot cache-hit
+// path returns synchronously without ever suspending. Stresses the fixed cost
+// of async function invocations that complete without reaching an await
+// (memoized-async / cache-hit pattern).
+
+const cache = new Map();
+const keys = [];
+for (let j = 0; j < 16; j++) {
+    const key = 'k' + j;
+    keys.push(key);
+    cache.set(key, { id: j, value: j * 2 });
+}
+
+async function fetchSlow(key) {
+    return { id: -1, value: 100, key };
+}
+
+let acc = 0;
+async function getRecord(key) {
+    const hit = cache.get(key);
+    if (hit !== undefined) {
+        acc += hit.value;
+        return hit;
+    }
+    const fresh = await fetchSlow(key);
+    cache.set(key, fresh);
+    acc += fresh.value;
+    return fresh;
+}
+
+// Exercise the suspending miss path too.
+let sink;
+for (let j = 0; j < 8; j++)
+    sink = getRecord('m' + j);
+drainMicrotasks();
+
+(function () {
+    for (let i = 0; i < 3000000; i++)
+        sink = getRecord(keys[i & 15]);
+})();
+drainMicrotasks();
+
+const expected = 8 * 100 + (3000000 / 16) * 240;
+if (acc !== expected)
+    throw new Error("bad result: " + acc);
+if (typeof sink !== "object")
+    throw new Error("bad sink");

--- a/JSTests/stress/lazy-generator-frame-environment-tier-up.js
+++ b/JSTests/stress/lazy-generator-frame-environment-tier-up.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// The generator frame environment is created lazily at the first suspend
+// point. Run hot on the non-suspending path so the code tiers up, then take
+// the suspending path for the first time inside optimized code.
+
+const cache = new Map();
+for (let j = 0; j < 16; j++)
+    cache.set('k' + j, j);
+
+async function fetchSlow(key) {
+    return key.length * 1000;
+}
+
+async function getRecord(key) {
+    const hit = cache.get(key);
+    if (hit !== undefined)
+        return hit;
+    const fresh = await fetchSlow(key);
+    cache.set(key, fresh);
+    return fresh;
+}
+
+let sink;
+for (let i = 0; i < testLoopCount; i++)
+    sink = getRecord('k' + (i & 15));
+drainMicrotasks();
+
+let out1 = null, out2 = null;
+getRecord('newkey').then(v => { out1 = v; });
+drainMicrotasks();
+shouldBe(out1, 6000);
+getRecord('newkey').then(v => { out2 = v; });
+drainMicrotasks();
+shouldBe(out2, 6000);
+
+function* maybeYield(n) {
+    let extra = n * 2;
+    if (n < 0) {
+        yield extra;
+        extra += 1;
+        yield extra;
+    }
+    return extra;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    const it = maybeYield(i & 63);
+    const r = it.next();
+    shouldBe(r.done, true);
+    shouldBe(r.value, (i & 63) * 2);
+}
+{
+    const it = maybeYield(-5);
+    shouldBe(it.next().value, -10);
+    shouldBe(it.next().value, -9);
+    const r = it.next();
+    shouldBe(r.done, true);
+    shouldBe(r.value, -9);
+}

--- a/JSTests/stress/lazy-generator-frame-environment.js
+++ b/JSTests/stress/lazy-generator-frame-environment.js
@@ -1,0 +1,94 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// The generator frame environment is created lazily at the first suspend
+// point. Cover cases where the first suspend differs per invocation, where
+// the frame is reused across many suspends, and where no suspend happens.
+
+// First suspend at a different await depending on the branch taken.
+async function branchy(mode, v) {
+    let a = v * 10;
+    if (mode === 0) {
+        const r = await Promise.resolve(1);
+        return a + r;
+    }
+    const r2 = await Promise.resolve(2);
+    return a * r2 + a;
+}
+
+// Synchronous return: the await is never reached, no frame is created.
+const cache = new Map();
+cache.set('hit', 42);
+async function getRecord(key) {
+    const hit = cache.get(key);
+    if (hit !== undefined)
+        return hit;
+    const fresh = await Promise.resolve(key.length);
+    cache.set(key, fresh);
+    return fresh;
+}
+
+// Frame created at the first yield and reused by later suspends.
+function* pick(mode) {
+    let base = 100;
+    if (mode === 0) {
+        yield base + 1;
+        base += 1;
+    } else {
+        yield base + 2;
+        base += 2;
+    }
+    yield base;
+}
+
+// Sent values live across multiple resumes.
+function* acc3() {
+    const a = yield 1;
+    const b = yield 2;
+    const c = yield 3;
+    return a + b + c;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let out0 = null, out1 = null, hit = null, miss = null;
+    branchy(0, 3).then(v => { out0 = v; });
+    branchy(1, 3).then(v => { out1 = v; });
+    getRecord('hit').then(v => { hit = v; });
+    getRecord('miss' + (i & 7)).then(v => { miss = v; });
+    drainMicrotasks();
+    shouldBe(out0, 31);
+    shouldBe(out1, 90);
+    shouldBe(hit, 42);
+    shouldBe(miss, 5);
+
+    const a = pick(0);
+    shouldBe(a.next().value, 101);
+    shouldBe(a.next().value, 101);
+    shouldBe(a.next().done, true);
+    const b = pick(1);
+    shouldBe(b.next().value, 102);
+    shouldBe(b.next().value, 102);
+    shouldBe(b.next().done, true);
+
+    const it = acc3();
+    it.next();
+    it.next(10);
+    it.next(20);
+    const r = it.next(12);
+    shouldBe(r.done, true);
+    shouldBe(r.value, 42);
+
+    // return()/throw() before the first suspend: no frame ever created.
+    const g = pick(0);
+    shouldBe(g.return(7).value, 7);
+    const g2 = pick(0);
+    let caught = false;
+    try {
+        g2.throw(new Error('boom'));
+    } catch (e) {
+        caught = e.message === 'boom';
+    }
+    shouldBe(caught, true);
+}

--- a/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp
@@ -93,7 +93,7 @@ public:
                 data.m_scope = bytecode.m_scope;
                 data.m_symbolTable = bytecode.m_symbolTable;
                 data.m_initialValue = bytecode.m_initialValue;
-                m_generatorFrameData = WTF::move(data);
+                m_generatorFrameDataList.append(WTF::move(data));
                 break;
             }
 
@@ -128,9 +128,9 @@ public:
         return m_instructions.at(m_enterPoint);
     }
 
-    std::optional<GeneratorFrameData> NODELETE generatorFrameData() const
+    const Vector<GeneratorFrameData>& NODELETE generatorFrameDataList() const
     {
-        return m_generatorFrameData;
+        return m_generatorFrameDataList;
     }
 
     const JSInstructionStream& NODELETE instructions() const
@@ -168,7 +168,7 @@ private:
 
     BytecodeGenerator& m_bytecodeGenerator;
     JSInstructionStream::Offset m_enterPoint;
-    std::optional<GeneratorFrameData> m_generatorFrameData;
+    Vector<GeneratorFrameData> m_generatorFrameDataList;
     UnlinkedCodeBlockGenerator* m_codeBlock;
     JSInstructionStreamWriter& m_instructions;
     BytecodeGraph m_graph;
@@ -274,14 +274,14 @@ void BytecodeGeneratorification::run()
         });
     }
 
-    if (m_generatorFrameData) {
-        auto instruction = m_instructions.at(m_generatorFrameData->m_point);
+    for (const GeneratorFrameData& data : m_generatorFrameDataList) {
+        auto instruction = m_instructions.at(data.m_point);
         rewriter.replaceBytecodeWithFragment(instruction, [&] (BytecodeRewriter::Fragment& fragment) {
             if (!m_generatorFrameSymbolTable->scopeSize()) {
                 // This will cause us to put jsUndefined() into the generator frame's scope value.
-                fragment.appendInstruction<OpMov>(m_generatorFrameData->m_dst, m_generatorFrameData->m_initialValue);
+                fragment.appendInstruction<OpMov>(data.m_dst, data.m_initialValue);
             } else
-                fragment.appendInstruction<OpCreateLexicalEnvironment>(m_generatorFrameData->m_dst, m_generatorFrameData->m_scope, m_generatorFrameData->m_symbolTable, m_generatorFrameData->m_initialValue);
+                fragment.appendInstruction<OpCreateLexicalEnvironment>(data.m_dst, data.m_scope, data.m_symbolTable, data.m_initialValue);
         });
     }
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -958,17 +958,11 @@ IGNORE_GCC_WARNINGS_END
     if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode)) {
         m_generatorFrameSymbolTable.set(m_vm, functionSymbolTable);
         m_generatorFrameSymbolTableIndex = symbolTableConstantIndex;
-        if (m_lexicalEnvironmentRegister)
-            move(generatorFrameRegister(), m_lexicalEnvironmentRegister);
-        else {
-            // It would be possible that generator does not need to suspend and resume any registers.
-            // In this case, we would like to avoid creating a lexical environment as much as possible.
-            // op_create_generator_frame_environment is a marker, which is similar to op_yield.
-            // Generatorification inserts lexical environment creation if necessary. Otherwise, we convert it to op_mov frame, `undefined`.
-            OpCreateGeneratorFrameEnvironment::emit(this, generatorFrameRegister(), scopeRegister(), VirtualRegister { symbolTableConstantIndex }, addConstantValue(jsUndefined()));
-        }
         static_assert(static_cast<unsigned>(JSGenerator::Field::Frame) == static_cast<unsigned>(JSAsyncGenerator::Field::Frame));
-        emitPutInternalField(generatorRegister(), static_cast<unsigned>(JSGenerator::Field::Frame), generatorFrameRegister());
+        if (m_lexicalEnvironmentRegister) {
+            move(generatorFrameRegister(), m_lexicalEnvironmentRegister);
+            emitPutInternalField(generatorRegister(), static_cast<unsigned>(JSGenerator::Field::Frame), generatorFrameRegister());
+        }
     }
 
     bool shouldInitializeBlockScopedFunctions = false; // We generate top-level function declarations in ::generate().
@@ -5278,6 +5272,15 @@ void BytecodeGenerator::emitRequireObjectCoercibleForDestructuring(RegisterID* v
 
 void BytecodeGenerator::emitYieldPoint(RegisterID* argument, JSAsyncGenerator::AsyncGeneratorSuspendReason result)
 {
+    if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode()) && !m_lexicalEnvironmentRegister) {
+        // Lazily create the generator frame environment when we actually yield.
+        Ref<Label> frameReady = newLabel();
+        OpJnundefinedOrNull::emit(this, generatorFrameRegister(), frameReady->bind(this));
+        OpCreateGeneratorFrameEnvironment::emit(this, generatorFrameRegister(), scopeRegister(), VirtualRegister { m_generatorFrameSymbolTableIndex }, addConstantValue(jsUndefined()));
+        emitPutInternalField(generatorRegister(), static_cast<unsigned>(JSGenerator::Field::Frame), generatorFrameRegister());
+        emitLabel(frameReady.get());
+    }
+
     Ref<Label> mergePoint = newLabel();
     unsigned yieldPointIndex = m_yieldPoints++;
     auto state = Checked<int32_t>(yieldPointIndex) + 1;


### PR DESCRIPTION
#### a1e43f039c447ae35a9fc9ff23e691601acc4aa6
<pre>
[JSC] Create generator frame environment lazily at suspend points
<a href="https://bugs.webkit.org/show_bug.cgi?id=318526">https://bugs.webkit.org/show_bug.cgi?id=318526</a>

Reviewed by NOBODY (OOPS!).

JSC allocates the generator frame environment at function entry even when
an async function contains an await that is never reached and it returns
synchronously (e.g. the memoized / cache-hit pattern). This patch defers
the allocation until the function actually suspends.

To do this, we emit the op_create_generator_frame_environment marker before
each op_yield, guarded by op_jnundefined_or_null on the frame register, so
the environment is created at the first suspend and reused by later suspends
via the generator&apos;s Frame internal field.

    async-cache-hit-sync-return                   41.3407+-3.6547     ^     33.6422+-2.9263        ^ definitely 1.2288x faster
    async-cache-hit-sync-return-many-locals       37.8114+-0.1490     ^     32.7417+-0.2481        ^ definitely 1.1548x faster

Tests: JSTests/microbenchmarks/async-cache-hit-sync-return-many-locals.js
       JSTests/microbenchmarks/async-cache-hit-sync-return.js
       JSTests/stress/lazy-generator-frame-environment-tier-up.js
       JSTests/stress/lazy-generator-frame-environment.js

* JSTests/microbenchmarks/async-cache-hit-sync-return-many-locals.js: Added.
(async fetchSlow):
(async getRecord):
* JSTests/microbenchmarks/async-cache-hit-sync-return.js: Added.
(async fetchSlow):
(async getRecord):
* JSTests/stress/lazy-generator-frame-environment-tier-up.js: Added.
(shouldBe):
(async fetchSlow):
(async getRecord):
(maybeYield):
* JSTests/stress/lazy-generator-frame-environment.js: Added.
(shouldBe):
(async branchy):
(async getRecord):
(pick):
(acc3):
(i.catch):
* Source/JavaScriptCore/bytecode/BytecodeGeneratorification.cpp:
(JSC::BytecodeGeneratorification::BytecodeGeneratorification):
(JSC::BytecodeGeneratorification::generatorFrameDataList const):
(JSC::BytecodeGeneratorification::run):
(JSC::BytecodeGeneratorification::generatorFrameData const): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
(JSC::BytecodeGenerator::emitYieldPoint):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1e43f039c447ae35a9fc9ff23e691601acc4aa6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134088 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36149 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34448 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30463 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3160 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184393 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33667 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142861 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45996 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142742 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46674 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30975 "Too many flaky failures: http/tests/contentextensions/text-track-blocked.html, http/tests/cookies/same-site/post-from-cross-site-popup.html, http/tests/media/media-element-frame-destroyed-crash.html, http/tests/navigation/redirect-preserves-referrer.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/cannot-read-cssrules.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/policy-does-not-affect-child.html, http/tests/security/mixedContent/mainframe-onload-after-iframe-block.https.html, http/tests/site-isolation/iframe-process-termination-after-navigation-completed.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111409 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37789 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118425 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205084 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45191 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9077 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54754 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->