### PR TITLE
Implement the fetchLater API

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1387,7 +1387,15 @@ webkit.org/b/247283 imported/w3c/web-platform-tests/fetch/metadata/generated/css
 
 # Fetch features that are not implemented.
 imported/w3c/web-platform-tests/fetch/corb [ Skip ]
-imported/w3c/web-platform-tests/fetch/fetch-later [ Skip ]
+
+# fetchLater(): iframe / permissions-policy quota delegation is a follow-up patch (bug 284347).
+# The baselines contain per-run generated UUIDs so results cannot be textually stable until
+# the underlying feature is implemented.
+webkit.org/b/284347 imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/max-payload.https.window.html [ Skip ]
+webkit.org/b/284347 imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/oversized-payload.https.window.html [ Skip ]
+webkit.org/b/284347 imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/multiple-iframes.https.window.html [ Skip ]
+
+
 
 # ReadableStream upload is not supported.
 imported/w3c/web-platform-tests/fetch/api/basic/request-upload.h2.any.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any-expected.txt
@@ -147,17 +147,17 @@ PASS Response interface: new Response() must inherit property "bytes()" with the
 PASS Response interface: new Response() must inherit property "formData()" with the proper type
 PASS Response interface: new Response() must inherit property "json()" with the proper type
 PASS Response interface: new Response() must inherit property "text()" with the proper type
-FAIL FetchLaterResult interface: existence and properties of interface object assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL FetchLaterResult interface object length assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL FetchLaterResult interface object name assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL FetchLaterResult interface: existence and properties of interface prototype object assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL FetchLaterResult interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL FetchLaterResult interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL FetchLaterResult interface: attribute activated assert_own_property: self does not have own property "FetchLaterResult" expected property "FetchLaterResult" missing
-FAIL Window interface: operation fetchLater(RequestInfo, optional DeferredRequestInit) assert_own_property: global object missing non-static operation expected property "fetchLater" missing
+PASS FetchLaterResult interface: existence and properties of interface object
+PASS FetchLaterResult interface object length
+PASS FetchLaterResult interface object name
+PASS FetchLaterResult interface: existence and properties of interface prototype object
+PASS FetchLaterResult interface: existence and properties of interface prototype object's "constructor" property
+PASS FetchLaterResult interface: existence and properties of interface prototype object's @@unscopables property
+PASS FetchLaterResult interface: attribute activated
+PASS Window interface: operation fetchLater(RequestInfo, optional DeferredRequestInit)
 PASS Window interface: operation fetch(RequestInfo, optional RequestInit)
-FAIL Window interface: window must inherit property "fetchLater(RequestInfo, optional DeferredRequestInit)" with the proper type assert_own_property: expected property "fetchLater" missing
-FAIL Window interface: calling fetchLater(RequestInfo, optional DeferredRequestInit) on window with too few arguments must throw TypeError assert_own_property: expected property "fetchLater" missing
+PASS Window interface: window must inherit property "fetchLater(RequestInfo, optional DeferredRequestInit)" with the proper type
+PASS Window interface: calling fetchLater(RequestInfo, optional DeferredRequestInit) on window with too few arguments must throw TypeError
 PASS Window interface: window must inherit property "fetch(RequestInfo, optional RequestInit)" with the proper type
 PASS Window interface: calling fetch(RequestInfo, optional RequestInit) on window with too few arguments must throw TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/activate-after.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/activate-after.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fetchLater() sends out based on activateAfter.
+FAIL fetchLater() sends out based on activateAfter, even if document is in BFCache. undefined is not an object (evaluating 'window.pageshowEvent.persisted')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/basic.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/basic.https.window-expected.txt
@@ -1,0 +1,25 @@
+
+PASS fetchLater() cannot be called without request.
+PASS fetchLater() with same-origin (https) URL does not throw.
+PASS fetchLater() with http://localhost URL does not throw.
+PASS fetchLater() with https://localhost URL does not throw.
+PASS fetchLater() with http://127.0.0.1 URL does not throw.
+PASS fetchLater() with https://127.0.0.1 URL does not throw.
+PASS fetchLater() with http://[::1] URL does not throw.
+PASS fetchLater() with https://[::1] URL does not throw.
+PASS fetchLater() with https://example.com URL does not throw.
+PASS fetchLater() throws TypeError on non-trustworthy http URL.
+PASS fetchLater() throws TypeError on file:// scheme.
+PASS fetchLater() throws TypeError on ftp:// scheme.
+PASS fetchLater() throws TypeError on ssh:// scheme.
+PASS fetchLater() throws TypeError on wss:// scheme.
+PASS fetchLater() throws TypeError on about: scheme.
+PASS fetchLater() throws TypeError on javascript: scheme.
+PASS fetchLater() throws TypeError on data: scheme.
+PASS fetchLater() throws TypeError on blob: scheme.
+PASS fetchLater() throws RangeError on negative activateAfter.
+PASS fetchLater()'s return tells the deferred request is not yet sent.
+PASS fetchLater() throws TypeError when mutating its returned state.
+PASS fetchLater() throws AbortError when its initial abort signal is aborted.
+PASS fetchLater() does not throw error when it is aborted before sending.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/basic.https.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/basic.https.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fetchLater() is not supported in worker.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-no-referrer-when-downgrade.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-no-referrer-when-downgrade.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test referer header https://web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-no-referrer.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-no-referrer.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test referer header
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-origin-when-cross-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-origin-when-cross-origin.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test referer header https://web-platform.test:9443
+PASS Test referer header https://www1.web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-origin.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test referer header https://www1.web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-same-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-same-origin.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test referer header
+PASS Test referer header https://www1.web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-strict-origin-when-cross-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-strict-origin-when-cross-origin.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test referer header https://www1.web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-strict-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-strict-origin.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test referer header https://web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-unsafe-url.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-unsafe-url.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test referer header https://web-platform.test:9443
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/iframe.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/iframe.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A blank iframe can trigger fetchLater.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/new-window.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/new-window.https.window-expected.txt
@@ -1,0 +1,16 @@
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT A blank window[target=''][features=''] can trigger fetchLater. Test timed out
+PASS A same-origin window[target=''][features=''] can trigger fetchLater.
+PASS A cross-origin window[target=''][features=''] can trigger fetchLater.
+TIMEOUT A blank window[target=''][features='popup'] can trigger fetchLater. Test timed out
+PASS A same-origin window[target=''][features='popup'] can trigger fetchLater.
+PASS A cross-origin window[target=''][features='popup'] can trigger fetchLater.
+TIMEOUT A blank window[target='_blank'][features=''] can trigger fetchLater. Test timed out
+PASS A same-origin window[target='_blank'][features=''] can trigger fetchLater.
+PASS A cross-origin window[target='_blank'][features=''] can trigger fetchLater.
+TIMEOUT A blank window[target='_blank'][features='popup'] can trigger fetchLater. Test timed out
+PASS A same-origin window[target='_blank'][features='popup'] can trigger fetchLater.
+PASS A cross-origin window[target='_blank'][features='popup'] can trigger fetchLater.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/non-secure.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/non-secure.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fetchLater() is not supported in non-secure context.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy-attribute-redirect.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy-attribute-redirect.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Permissions policy allow="deferred-fetch" allows fetchLater() from a redirected same-origin iframe.
+FAIL Permissions policy allow="deferred-fetch" disallows fetchLater() from a redirected cross-origin iframe. assert_false: fetchLater() expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy-attribute.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy-attribute.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Permissions policy "deferred-fetch" can be enabled in the same-origin iframe using allow="deferred-fetch" attribute.
+PASS Permissions policy "deferred-fetch" can be enabled in the cross-origin iframe using allow="deferred-fetch" attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy.https.window-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Permissions policy header: "deferred-fetch=*" allows fetchLater() in the top-level document.
+PASS Permissions policy header: "deferred-fetch=*" allows fetchLater() in the same-origin iframe.
+PASS Permissions policy header: "deferred-fetch=*" allows fetchLater() in the cross-origin iframe.
+PASS Permissions policy header: "deferred-fetch=*" allow="deferred-fetch" allows fetchLater() in the cross-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-default-permissions-policy.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-default-permissions-policy.https.window-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Default "deferred-fetch" permissions policy ["self"] allows fetchLater() in the top-level document.
+PASS Default "deferred-fetch" permissions policy ["self"] allows fetchLater() in the same-origin iframe.
+PASS Default "deferred-fetch-minimal" permissions policy ["*"] allows fetchLater() in the cross-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-supported-by-permissions-policy.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-supported-by-permissions-policy.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL document.permissionsPolicy.features should advertise deferred-fetch. undefined is not an object (evaluating 'document.permissionsPolicy.features')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-allowed.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-allowed.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL FetchLater allowed by CSP should succeed assert_equals: Number of sent beacons does not match expected count: expected 1 but got 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-blocked.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-blocked.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS FetchLater blocked by CSP should reject
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-redirect-to-blocked.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-redirect-to-blocked.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS FetchLater redirect blocked by CSP should reject
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/accumulated-oversized-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/accumulated-oversized-payload.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The 2nd fetchLater(same-origin) call in the top-level document is not allowed to exceed per-origin quota for its POST body of String.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/accumulated-oversized-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/accumulated-oversized-payload.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The 2nd fetchLater(same-origin) call in a default cross-origin child iframe has its owned per-origin quota for a request POST body of String.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() accepts an empty POST request body of String in a default cross-origin iframe.
+PASS fetchLater() accepts an empty POST request body of ArrayBuffer in a default cross-origin iframe.
+PASS fetchLater() accepts an empty POST request body of FormData in a default cross-origin iframe.
+PASS fetchLater() accepts an empty POST request body of URLSearchParams in a default cross-origin iframe.
+PASS fetchLater() accepts an empty POST request body of Blob in a default cross-origin iframe.
+PASS fetchLater() accepts an empty POST request body of File in a default cross-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS fetchLater() request quota are delegated to cross-origin iframes and not shared, even if they are same origin.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/sandboxed-iframe.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/sandboxed-iframe.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A sandboxed iframe (without allow-same-origin) should be treated as cross-origin and have its own minimal quota.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/small-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/small-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() accepts payload[size=20] in a POST request body of String in a default cross-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of ArrayBuffer in a default cross-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of FormData in a default cross-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of URLSearchParams in a default cross-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of Blob in a default cross-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of File in a default cross-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/empty-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/empty-payload.https.window-expected.txt
@@ -1,0 +1,11 @@
+
+PASS fetchLater() accepts an empty POST request body of String.
+PASS fetchLater() accepts an empty POST request body of ArrayBuffer.
+PASS fetchLater() accepts an empty POST request body of FormData.
+PASS fetchLater() accepts an empty POST request body of URLSearchParams.
+PASS fetchLater() accepts an empty POST request body of Blob.
+PASS fetchLater() accepts an empty POST request body of File.
+PASS fetchLater() accept a GET request.
+PASS fetchLater() accept a DELETE request.
+PASS fetchLater() accept a PUT request.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/max-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/max-payload.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fetchLater() accepts max payload in a POST request body of String.
+PASS fetchLater() rejects max+1 payload in a POST request body of String.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/multiple-origins.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/multiple-origins.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() has per-request-origin quota for its POST body of String.
+PASS fetchLater() has per-request-origin quota for its POST body of ArrayBuffer.
+PASS fetchLater() has per-request-origin quota for its POST body of FormData.
+PASS fetchLater() has per-request-origin quota for its POST body of URLSearchParams.
+PASS fetchLater() has per-request-origin quota for its POST body of Blob.
+PASS fetchLater() has per-request-origin quota for its POST body of File.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/oversized-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/oversized-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of String.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of ArrayBuffer.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of FormData.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of URLSearchParams.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of Blob.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of File.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/accumulated-oversized-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/accumulated-oversized-payload.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL The 2nd fetchLater(same-origin) call in a same-origin child iframe is not allowed to exceed per-origin quota for its POST body of String. promise_test: Unhandled rejection with value: object "Error: iframe[src=https://web-platform.test:9443/fetch/fetch-later/resources/fetch-later.html?url=https%253A%252F%252Fweb-platform.test%253A9443%252F&activateAfter=0&referrer=&method=POST&bodyType=String&bodySize=20] threw nothing, expected QuotaExceededError"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/empty-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/empty-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() accepts an empty POST request body of String in same-origin iframe.
+PASS fetchLater() accepts an empty POST request body of ArrayBuffer in same-origin iframe.
+PASS fetchLater() accepts an empty POST request body of FormData in same-origin iframe.
+PASS fetchLater() accepts an empty POST request body of URLSearchParams in same-origin iframe.
+PASS fetchLater() accepts an empty POST request body of Blob in same-origin iframe.
+PASS fetchLater() accepts an empty POST request body of File in same-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/max-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/max-payload.https.window-expected.txt
@@ -1,0 +1,4 @@
+
+PASS fetchLater() accepts max payload in a POST request body of String in same-origin iframe.
+PASS fetchLater() rejects max+1 payload in a POST request body of String in same-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/oversized-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/oversized-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of String in same-origin iframe.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of ArrayBuffer in same-origin iframe.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of FormData in same-origin iframe.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of URLSearchParams in same-origin iframe.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of Blob in same-origin iframe.
+PASS fetchLater() does not accept payload[size=65537] exceeding per-origin quota in a POST request body of File in same-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/sandboxed-iframe.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/sandboxed-iframe.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL A sandboxed iframe with 'allow-same-origin' should be treated as same-origin and share the parent's quota. promise_test: Unhandled rejection with value: object "Error: iframe[src=https://web-platform.test:9443/fetch/fetch-later/resources/fetch-later.html?url=https%253A%252F%252Fweb-platform.test%253A9443%252F&activateAfter=0&referrer=&method=POST&bodyType=String&bodySize=4096] threw nothing, expected QuotaExceededError"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/small-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/small-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() accepts payload[size=20] in a POST request body of String in same-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of ArrayBuffer in same-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of FormData in same-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of URLSearchParams in same-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of Blob in same-origin iframe.
+PASS fetchLater() accepts payload[size=20] in a POST request body of File in same-origin iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/small-payload.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/small-payload.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS fetchLater() accepts small payload in a POST request body of String.
+PASS fetchLater() accepts small payload in a POST request body of ArrayBuffer.
+PASS fetchLater() accepts small payload in a POST request body of FormData.
+PASS fetchLater() accepts small payload in a POST request body of URLSearchParams.
+PASS fetchLater() accepts small payload in a POST request body of Blob.
+PASS fetchLater() accepts small payload in a POST request body of File.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-deactivate-with-background-sync.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-deactivate-with-background-sync.https.window-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL fetchLater() does send on page entering BFCache even if BackgroundSync is on. Unsupported permission name "background-sync".
+FAIL fetchLater() with activateAfter=0 sends on page entering BFCache if BackgroundSync is on. Unsupported permission name "background-sync".
+FAIL fetchLater() with activateAfter=1m does send on page entering BFCache even if BackgroundSync is on. Unsupported permission name "background-sync".
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-deactivate.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-deactivate.https.window-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL fetchLater() sends on page entering BFCache if BackgroundSync is off. undefined is not an object (evaluating 'window.pageshowEvent.persisted')
+FAIL Call fetchLater() when BFCached with activateAfter=0 sends immediately. undefined is not an object (evaluating 'window.pageshowEvent.persisted')
+PASS fetchLater() sends on navigating away a page w/o BFCache.
+PASS fetchLater() does not send aborted request on navigating away a page w/o BFCache.
+FAIL fetchLater() with activateAfter=1m sends on page entering BFCache if BackgroundSync is off. undefined is not an object (evaluating 'window.pageshowEvent.persisted')
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/not-send-after-abort.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/not-send-after-abort.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A discarded document does not send an already aborted fetchLater request.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/send-multiple-with-activate-after.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/send-multiple-with-activate-after.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A discarded document sends all its fetchLater requests, no matter how much their activateAfter timeout remain.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/send-multiple.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/send-multiple.https.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A discarded document sends all its fetchLater requests.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js
@@ -2292,6 +2292,132 @@
     expose_assert(assert_throws_dom, "assert_throws_dom");
 
     /**
+     * Assert a `QuotaExceededError` with the expected values is thrown.
+     *
+     * There are two ways of calling `assert_throws_quotaexceedederror`:
+     *
+     * 1) If the `QuotaExceededError` is expected to come from the
+     *    current global, the first argument should be the function
+     *    expected to throw, the second and a third the expected
+     *    `requested` and `quota` property values, and the fourth,
+     *    optional, argument is the assertion description.
+     *
+     * 2) If the `QuotaExceededError` is expected to come from some
+     *    other global, the first argument should be the
+     *    `QuotaExceededError` constructor from that global, the second
+     *    argument should be the function expected to throw, the third
+     *    and fourth the expected `requested` and `quota` property
+     *    values, and the fifth, optional, argument is the assertion
+     *    description.
+     *
+     * For the `requested` and `quota` values, instead of `null` or a
+     * number, the caller can provide a function which determines
+     * whether the value is acceptable by returning a boolean.
+     */
+    function assert_throws_quotaexceedederror(funcOrConstructor, requestedOrFunc, quotaOrRequested, descriptionOrQuota, maybeDescription)
+    {
+        let constructor, func, requested, quota, description;
+        if (funcOrConstructor.name === "QuotaExceededError") {
+            constructor = funcOrConstructor;
+            func = requestedOrFunc;
+            requested = quotaOrRequested;
+            quota = descriptionOrQuota;
+            description = maybeDescription;
+        } else {
+            constructor = self.QuotaExceededError;
+            func = funcOrConstructor;
+            requested = requestedOrFunc;
+            quota = quotaOrRequested;
+            description = descriptionOrQuota;
+            assert(maybeDescription === undefined,
+                   "Too many args passed to no-constructor version of assert_throws_quotaexceedederror");
+        }
+        assert_throws_quotaexceedederror_impl(func, requested, quota, description, "assert_throws_quotaexceedederror", constructor);
+    }
+    expose_assert(assert_throws_quotaexceedederror, "assert_throws_quotaexceedederror");
+
+    /**
+     * Similar to `assert_throws_quotaexceedederror` but allows
+     * specifying the assertion type
+     * (`"assert_throws_quotaexceedederror"` or
+     * `"promise_rejects_quotaexceedederror"`, in practice). The
+     * `constructor` argument must be the `QuotaExceededError`
+     * constructor from the global we expect the exception to come from.
+     */
+    function assert_throws_quotaexceedederror_impl(func, requested, quota, description, assertion_type, constructor)
+    {
+        try {
+            func.call(this);
+            assert(false, assertion_type, description, "${func} did not throw",
+                   {func});
+        } catch (e) {
+            if (e instanceof AssertionError) {
+                throw e;
+            }
+
+            assert(typeof e === "object",
+                   assertion_type, description,
+                   "${func} threw ${e} with type ${type}, not an object",
+                   {func, e, type:typeof e});
+
+            assert(e !== null,
+                   assertion_type, description,
+                   "${func} threw null, not an object",
+                   {func});
+
+            assert(requested === null ||
+                   typeof requested === "number" ||
+                   typeof requested === "function",
+                   assertion_type, description,
+                   "${requested} is not null, a number, or a function",
+                   {requested});
+            assert(quota === null ||
+                   typeof quota === "number" ||
+                   typeof quota === "function",
+                   assertion_type, description,
+                   "${quota} is not null or a number",
+                   {quota});
+
+            const required_props = {
+                code: 22,
+                name: "QuotaExceededError"
+            };
+            if (typeof requested !== "function") {
+                required_props.requested = requested;
+            }
+            if (typeof quota !== "function") {
+                required_props.quota = quota;
+            }
+
+            for (const prop in required_props) {
+                const expected = required_props[prop];
+                assert(prop in e && e[prop] == expected,
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: property ${prop} is equal to ${actual}, expected ${expected}",
+                       {func, e, prop, actual:e[prop], expected});
+            }
+
+            if (typeof requested === "function") {
+                assert(requested(e.requested),
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: requested value did not pass the requested predicate",
+                       {func, e});
+            }
+            if (typeof quota === "function") {
+                assert(quota(e.quota),
+                       assertion_type, description,
+                       "${func} threw ${e} that is not a correct QuotaExceededError: quota value did not pass the quota predicate",
+                       {func, e});
+            }
+
+            assert(e.constructor === constructor,
+                   assertion_type, description,
+                   "${func} threw an exception from the wrong global",
+                   {func});
+        }
+    }
+
+    /**
      * Similar to assert_throws_dom but allows specifying the assertion type
      * (assert_throws_dom or promise_rejects_dom, in practice).  The
      * "constructor" argument must be the DOMException constructor from the
@@ -2438,7 +2564,10 @@
             // Check that the exception is from the right global.  This check is last
             // so more specific, and more informative, checks on the properties can
             // happen in case a totally incorrect exception is thrown.
-            assert(e.constructor === constructor,
+            // As of WebIDL, QuotaExceededError is a DOMException subclass, so allow
+            // it when the caller asserts on DOMException.
+            var isQuotaSubclass = self.QuotaExceededError && constructor === self.DOMException && e.constructor === self.QuotaExceededError;
+            assert(e.constructor === constructor || isQuotaSubclass,
                    assertion_type, description,
                    "${func} threw an exception from the wrong global",
                    {func});

--- a/LayoutTests/imported/w3c/web-platform-tests/webstorage/storage_local_setitem_quotaexceedederr.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webstorage/storage_local_setitem_quotaexceedederr.window.js
@@ -5,12 +5,12 @@ test(function() {
     var key = "name";
     var val = "x".repeat(1024);
 
-    assert_throws_dom("QUOTA_EXCEEDED_ERR", function() {
+    assert_throws_quotaexceedederror(function() {
         while (true) {
             index++;
             localStorage.setItem("" + key + index, "" + val + index);
         }
-    });
+    }, null, null);
 
     localStorage.clear();
 }, "Throws QuotaExceededError when the quota has been exceeded");

--- a/LayoutTests/imported/w3c/web-platform-tests/webstorage/storage_session_setitem_quotaexceedederr.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webstorage/storage_session_setitem_quotaexceedederr.window.js
@@ -5,12 +5,12 @@ test(function() {
     var key = "name";
     var val = "x".repeat(1024);
 
-    assert_throws_dom("QUOTA_EXCEEDED_ERR", function() {
+    assert_throws_quotaexceedederror(function() {
         while (true) {
             index++;
             sessionStorage.setItem("" + key + index, "" + val + index);
         }
-    });
+    }, null, null);
 
     sessionStorage.clear();
 }, "Throws QuotaExceededError when the quota has been exceeded");

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3092,6 +3092,20 @@ FasterClicksEnabled:
     WebKit:
       default: true
 
+FetchLaterAPIEnabled:
+  type: bool
+  status: preview
+  category: networking
+  humanReadableName: "fetchLater() API"
+  humanReadableDescription: "Enable the fetchLater() deferred fetch API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 FileReaderAPIEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -417,7 +417,10 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/entriesapi/FileSystemEntryCallback.idl
     Modules/entriesapi/FileSystemFileEntry.idl
 
+    Modules/fetch/DOMWindow+FetchLater.idl
+    Modules/fetch/DeferredRequestInit.idl
     Modules/fetch/FetchHeaders.idl
+    Modules/fetch/FetchLaterResult.idl
     Modules/fetch/FetchReferrerPolicy.idl
     Modules/fetch/FetchRequest.idl
     Modules/fetch/FetchRequestCache.idl
@@ -1193,6 +1196,8 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ProcessingInstruction.idl
     dom/ProgressEvent.idl
     dom/PromiseRejectionEvent.idl
+    dom/QuotaExceededError.idl
+    dom/QuotaExceededErrorOptions.idl
     dom/Range.idl
     dom/ReducerCallback.idl
     dom/RequestAnimationFrameCallback.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -475,7 +475,10 @@ $(PROJECT_DIR)/Modules/entriesapi/FileSystemEntryCallback.idl
 $(PROJECT_DIR)/Modules/entriesapi/FileSystemFileEntry.idl
 $(PROJECT_DIR)/Modules/entriesapi/HTMLInputElement+EntriesAPI.idl
 $(PROJECT_DIR)/Modules/fetch/FetchBody.idl
+$(PROJECT_DIR)/Modules/fetch/DOMWindow+FetchLater.idl
+$(PROJECT_DIR)/Modules/fetch/DeferredRequestInit.idl
 $(PROJECT_DIR)/Modules/fetch/FetchHeaders.idl
+$(PROJECT_DIR)/Modules/fetch/FetchLaterResult.idl
 $(PROJECT_DIR)/Modules/fetch/FetchReferrerPolicy.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequest.idl
 $(PROJECT_DIR)/Modules/fetch/FetchRequestCache.idl
@@ -1560,6 +1563,8 @@ $(PROJECT_DIR)/dom/PredicateCallback.idl
 $(PROJECT_DIR)/dom/ProcessingInstruction.idl
 $(PROJECT_DIR)/dom/ProgressEvent.idl
 $(PROJECT_DIR)/dom/PromiseRejectionEvent.idl
+$(PROJECT_DIR)/dom/QuotaExceededError.idl
+$(PROJECT_DIR)/dom/QuotaExceededErrorOptions.idl
 $(PROJECT_DIR)/dom/Range+CSSOMView.idl
 $(PROJECT_DIR)/dom/Range+DOMParsing.idl
 $(PROJECT_DIR)/dom/Range.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -838,6 +838,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+Compat.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+Compat.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+CookieStore.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+CookieStore.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+FetchLater.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+FetchLater.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceMotion.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceMotion.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDOMWindow+DeviceOrientation.cpp
@@ -877,6 +879,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDecompressionStreamDecoder.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDecompressionStreamDecoder.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDedicatedWorkerGlobalScope.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDedicatedWorkerGlobalScope.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeferredRequestInit.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeferredRequestInit.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDelayNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDelayNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDelayOptions.cpp
@@ -1112,6 +1116,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestCache.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestCache.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestCredentials.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchLaterResult.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchLaterResult.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestCredentials.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestDestination.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSFetchRequestDestination.h
@@ -2451,6 +2457,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQueuingStrategy.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQueuingStrategy.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQueuingStrategySize.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQueuingStrategySize.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQuotaExceededError.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQuotaExceededError.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQuotaExceededErrorOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSQuotaExceededErrorOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCAnswerOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCAnswerOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSRTCCertificate.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -339,8 +339,11 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/entriesapi/FileSystemEntryCallback.idl \
     $(WebCore)/Modules/entriesapi/FileSystemFileEntry.idl \
     $(WebCore)/Modules/entriesapi/HTMLInputElement+EntriesAPI.idl \
+    $(WebCore)/Modules/fetch/DOMWindow+FetchLater.idl \
+    $(WebCore)/Modules/fetch/DeferredRequestInit.idl \
     $(WebCore)/Modules/fetch/FetchBody.idl \
     $(WebCore)/Modules/fetch/FetchHeaders.idl \
+    $(WebCore)/Modules/fetch/FetchLaterResult.idl \
     $(WebCore)/Modules/fetch/FetchReferrerPolicy.idl \
     $(WebCore)/Modules/fetch/FetchRequest.idl \
     $(WebCore)/Modules/fetch/FetchRequestCache.idl \
@@ -1240,6 +1243,8 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/ProcessingInstruction.idl \
     $(WebCore)/dom/ProgressEvent.idl \
     $(WebCore)/dom/PromiseRejectionEvent.idl \
+    $(WebCore)/dom/QuotaExceededError.idl \
+    $(WebCore)/dom/QuotaExceededErrorOptions.idl \
     $(WebCore)/dom/Range+CSSOMView.idl \
     $(WebCore)/dom/Range+DOMParsing.idl \
     $(WebCore)/dom/Range.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1394,6 +1394,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ProgressEvent.h
     dom/PseudoElement.h
     dom/QualifiedName.h
+    dom/QuotaExceededError.h
+    dom/QuotaExceededErrorOptions.h
     dom/RadioButtonGroups.h
     dom/Range.h
     dom/RangeBoundaryPoint.h

--- a/Source/WebCore/Modules/fetch/DOMWindow+FetchLater.idl
+++ b/Source/WebCore/Modules/fetch/DOMWindow+FetchLater.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef (FetchRequest or USVString) RequestInfo;
+
+// https://fetch.spec.whatwg.org/#dom-window-fetchlater
+[
+    EnabledBySetting=FetchLaterAPIEnabled,
+    SecureContext,
+    ImplementedBy=WindowOrWorkerGlobalScopeFetch
+] partial interface DOMWindow {
+    [NewObject] FetchLaterResult fetchLater(RequestInfo input, optional DeferredRequestInit init = {});
+};

--- a/Source/WebCore/Modules/fetch/DeferredFetchRegistry.cpp
+++ b/Source/WebCore/Modules/fetch/DeferredFetchRegistry.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DeferredFetchRegistry.h"
+
+#include "AbortSignal.h"
+#include "CachedRawResource.h"
+#include "CachedResourceLoader.h"
+#include "CachedResourceRequest.h"
+#include "ContentSecurityPolicy.h"
+#include "Document.h"
+#include "DocumentLoader.h"
+#include "DocumentResourceLoader.h"
+#include "EventLoop.h"
+#include "FetchLaterResult.h"
+#include "FormData.h"
+#include "FrameDestructionObserverInlines.h"
+#include "FrameLoader.h"
+#include "LoaderStrategy.h"
+#include "LocalFrame.h"
+#include "Logging.h"
+#include "PlatformStrategies.h"
+#include "ResourceError.h"
+#include "ResourceLoaderIdentifier.h"
+#include "ResourceLoaderOptions.h"
+#include "SecurityOriginData.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(DeferredFetchRegistry);
+
+// Per-request record. Owns the frozen ResourceRequest/options until activation.
+class DeferredFetchRegistry::Record {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(Record);
+public:
+    Record(ResourceRequest&& request, ResourceLoaderOptions&& options, RefPtr<FormData>&& body, uint64_t requestBytes, SecurityOriginData reportingOrigin, Ref<FetchLaterResult>&& result)
+        : m_request(WTF::move(request))
+        , m_options(WTF::move(options))
+        , m_body(WTF::move(body))
+        , m_requestBytes(requestBytes)
+        , m_reportingOrigin(WTF::move(reportingOrigin))
+        , m_result(WTF::move(result))
+    { }
+
+    const ResourceRequest& request() const { return m_request; }
+    ResourceRequest takeRequest()
+    {
+        ResourceRequest request = WTF::move(m_request);
+        if (m_body)
+            request.setHTTPBody(m_body.copyRef());
+        return request;
+    }
+    const ResourceLoaderOptions& options() const { return m_options; }
+    uint64_t requestBytes() const { return m_requestBytes; }
+    const SecurityOriginData& reportingOrigin() const { return m_reportingOrigin; }
+    FetchLaterResult& result() { return m_result.get(); }
+
+    void setAbortAlgorithmIdentifier(RefPtr<AbortSignal>&& signal, uint32_t identifier)
+    {
+        m_abortSignal = WTF::move(signal);
+        m_abortAlgorithmIdentifier = identifier;
+    }
+    void clearAbortAlgorithm()
+    {
+        if (RefPtr signal = WTF::move(m_abortSignal); signal && m_abortAlgorithmIdentifier)
+            signal->removeAlgorithm(*m_abortAlgorithmIdentifier);
+        m_abortAlgorithmIdentifier = std::nullopt;
+    }
+
+    void setActivateAfterTimer(EventLoopTimerHandle handle) { m_activateAfterTimer = handle; }
+    void clearActivateAfterTimer() { m_activateAfterTimer = nullptr; }
+
+    void setInflightResource(CachedResourceHandle<CachedResource>&& resource) { m_inflightResource = WTF::move(resource); }
+    CachedResource* inflightResource() const { return m_inflightResource.get(); }
+
+private:
+    ResourceRequest m_request;
+    ResourceLoaderOptions m_options;
+    RefPtr<FormData> m_body;
+    uint64_t m_requestBytes { 0 };
+    SecurityOriginData m_reportingOrigin;
+    const Ref<FetchLaterResult> m_result;
+
+    RefPtr<AbortSignal> m_abortSignal;
+    std::optional<uint32_t> m_abortAlgorithmIdentifier;
+
+    EventLoopTimerHandle m_activateAfterTimer;
+    CachedResourceHandle<CachedResource> m_inflightResource;
+};
+
+ASCIILiteral DeferredFetchRegistry::supplementName()
+{
+    return "DeferredFetchRegistry"_s;
+}
+
+DeferredFetchRegistry::DeferredFetchRegistry(Document& document)
+    : m_document(document)
+{
+}
+
+DeferredFetchRegistry::~DeferredFetchRegistry()
+{
+    for (auto& record : m_records) {
+        if (RefPtr resource = record->inflightResource())
+            resource->removeClient(*this);
+        record->clearAbortAlgorithm();
+        record->clearActivateAfterTimer();
+    }
+}
+
+void DeferredFetchRegistry::ref() const
+{
+    m_document->ref();
+}
+
+void DeferredFetchRegistry::deref() const
+{
+    m_document->deref();
+}
+
+RefPtr<DeferredFetchRegistry> DeferredFetchRegistry::from(Document& document)
+{
+    return downcast<DeferredFetchRegistry>(Supplement<Document>::from(&document, supplementName()));
+}
+
+Ref<DeferredFetchRegistry> DeferredFetchRegistry::ensure(Document& document)
+{
+    if (RefPtr existing = from(document))
+        return existing.releaseNonNull();
+    auto newSupplement = makeUniqueWithoutRefCountedCheck<DeferredFetchRegistry>(document);
+    Ref ref = *newSupplement;
+    provideTo(&document, supplementName(), WTF::move(newSupplement));
+    return ref;
+}
+
+uint64_t DeferredFetchRegistry::availableBytesFor(const SecurityOriginData& origin) const
+{
+    auto used = m_bytesUsedByOrigin.get(origin);
+    return used >= QUOTA_BYTES_PER_ORIGIN ? 0 : QUOTA_BYTES_PER_ORIGIN - used;
+}
+
+RefPtr<FetchLaterResult> DeferredFetchRegistry::addDeferredFetch(ResourceRequest&& request, ResourceLoaderOptions&& options, RefPtr<FormData>&& body, uint64_t requestBytes, AbortSignal* signal, std::optional<Seconds> activateAfter)
+{
+    auto reportingOrigin = SecurityOriginData::fromURL(request.url());
+    if (requestBytes > availableBytesFor(reportingOrigin))
+        return nullptr;
+
+    auto result = FetchLaterResult::create();
+    auto record = makeUnique<Record>(WTF::move(request), WTF::move(options), WTF::move(body), requestBytes, reportingOrigin, result.copyRef());
+    Record* recordPtr = record.get();
+    m_records.append(WTF::move(record));
+    m_bytesUsedByOrigin.add(reportingOrigin, 0).iterator->value += requestBytes;
+
+    // Wire up AbortSignal: if the signal fires, drop the record without dispatching.
+    // Capture a WeakPtr<Document> and re-lookup the registry to avoid resurrecting a torn-down supplement.
+    if (signal && !signal->aborted()) {
+        RefPtr<AbortSignal> refSignal = signal;
+        WeakPtr<Document, WeakPtrImplWithEventTargetData> weakDocument { m_document.get() };
+        auto identifier = refSignal->addAlgorithm([weakDocument, recordPtr](JSC::JSValue) {
+            RefPtr document = weakDocument.get();
+            if (!document)
+                return;
+            if (RefPtr registry = DeferredFetchRegistry::from(*document))
+                registry->removeRecord(*recordPtr);
+        });
+        recordPtr->setAbortAlgorithmIdentifier(WTF::move(refSignal), identifier);
+    }
+
+    RELEASE_LOG(Loading, "[fetchLater] REGISTER rec=%p activateAfter=%d url=%s", recordPtr, activateAfter ? (int)activateAfter->milliseconds() : -1, recordPtr->request().url().string().utf8().data());
+    // activateAfter timer, if requested.
+    if (activateAfter) {
+        WeakPtr<Document, WeakPtrImplWithEventTargetData> weakDocument { m_document.get() };
+        auto handle = protect(Ref { m_document.get() }->eventLoop())->scheduleTask(*activateAfter, TaskSource::Networking, [weakDocument, recordPtr] {
+            RELEASE_LOG(Loading, "[fetchLater] TIMER-FIRE rec=%p", recordPtr);
+            RefPtr document = weakDocument.get();
+            if (!document)
+                return;
+            if (RefPtr registry = DeferredFetchRegistry::from(*document))
+                registry->activateRecord(*recordPtr);
+        });
+        recordPtr->setActivateAfterTimer(handle);
+    }
+
+    return result;
+}
+
+void DeferredFetchRegistry::removeRecord(Record& record)
+{
+    RELEASE_LOG(Loading, "[fetchLater] REMOVE-RECORD rec=%p", &record);
+    record.clearAbortAlgorithm();
+    record.clearActivateAfterTimer();
+
+    if (RefPtr resource = record.inflightResource())
+        resource->removeClient(*this);
+
+    auto it = m_bytesUsedByOrigin.find(record.reportingOrigin());
+    if (it != m_bytesUsedByOrigin.end()) {
+        it->value = record.requestBytes() > it->value ? 0 : it->value - record.requestBytes();
+        if (!it->value)
+            m_bytesUsedByOrigin.remove(it);
+    }
+
+    m_records.removeFirstMatching([&](auto& entry) {
+        return entry.get() == &record;
+    });
+}
+
+void DeferredFetchRegistry::activateRecord(Record& record)
+{
+    // Already dispatched?
+    if (record.inflightResource())
+        return;
+
+    Ref document = m_document.get();
+    RefPtr frame = document->frame();
+    if (!frame) {
+        // Document is fully detached — can no longer dispatch.
+        RELEASE_LOG(Loading, "[fetchLater] DROP-NOFRAME rec=%p", &record);
+        removeRecord(record);
+        return;
+    }
+    RELEASE_LOG(Loading, "[fetchLater] DISPATCH rec=%p url=%s", &record, record.request().url().string().utf8().data());
+
+    record.clearAbortAlgorithm();
+    record.clearActivateAfterTimer();
+    record.result().setActivated();
+
+    ResourceRequest request = record.takeRequest();
+    const ResourceLoaderOptions& options = record.options();
+
+    // Dispatch directly via the LoaderStrategy's ping-load path — same as
+    // PingLoader / sendBeacon in its ping-load fallback. This bypasses
+    // CachedResourceLoader, which may already have had its DocumentLoader
+    // cleared by the time we activate on document destruction. The load's
+    // keepAlive flag will cause NetworkResourceLoader::abort() to transfer
+    // it to the network process's keep-alive pool if the process is torn
+    // down before completion.
+    HTTPHeaderMap originalHeaders = request.httpHeaderFields();
+    platformStrategies()->loaderStrategy()->startPingLoad(*frame, request, originalHeaders, options, options.contentSecurityPolicyImposition, [](const ResourceError&, const ResourceResponse&) {
+        // Response is intentionally dropped: fetchLater exposes nothing to JS.
+    });
+
+    // We don't hold a CachedResourceHandle for LoaderStrategy-dispatched
+    // loads; the network process owns them. Refund quota now.
+    auto it = m_bytesUsedByOrigin.find(record.reportingOrigin());
+    if (it != m_bytesUsedByOrigin.end()) {
+        it->value = record.requestBytes() > it->value ? 0 : it->value - record.requestBytes();
+        if (!it->value)
+            m_bytesUsedByOrigin.remove(it);
+    }
+    m_records.removeFirstMatching([&](auto& entry) {
+        return entry.get() == &record;
+    });
+}
+
+void DeferredFetchRegistry::activateAllRecords()
+{
+    // Snapshot pointers because activation may mutate m_records
+    // (via early failure paths).
+    Vector<Record*> snapshot;
+    snapshot.reserveInitialCapacity(m_records.size());
+    for (auto& record : m_records)
+        snapshot.append(record.get());
+
+    for (auto* record : snapshot)
+        activateRecord(*record);
+}
+
+void DeferredFetchRegistry::documentIsAboutToEnterBackForwardCache()
+{
+    activateAllRecords();
+}
+
+void DeferredFetchRegistry::documentIsBeingDestroyed()
+{
+    activateAllRecords();
+}
+
+void DeferredFetchRegistry::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
+{
+    resource.removeClient(*this);
+
+    auto index = m_records.findIf([&](auto& entry) {
+        return entry->inflightResource() == &resource;
+    });
+    if (index == notFound)
+        return;
+
+    auto& record = m_records[index];
+    auto it = m_bytesUsedByOrigin.find(record->reportingOrigin());
+    if (it != m_bytesUsedByOrigin.end()) {
+        it->value = record->requestBytes() > it->value ? 0 : it->value - record->requestBytes();
+        if (!it->value)
+            m_bytesUsedByOrigin.remove(it);
+    }
+    m_records.removeAt(index);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/DeferredFetchRegistry.h
+++ b/Source/WebCore/Modules/fetch/DeferredFetchRegistry.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CachedRawResourceClient.h"
+#include "CachedResourceHandle.h"
+#include "EventLoop.h"
+#include "ResourceLoaderOptions.h"
+#include "ResourceRequest.h"
+#include "SecurityOriginData.h"
+#include "Supplementable.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/HashMap.h>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class AbortSignal;
+class CachedResource;
+class Document;
+class FetchLaterResult;
+class FormData;
+class NetworkLoadMetrics;
+class WeakPtrImplWithEventTargetData;
+enum class LoadWillContinueInAnotherProcess : bool;
+
+// Per-Document registry that owns pending fetchLater() requests until they
+// are activated (dispatched to the network process) or aborted. Handles:
+//   * quota accounting (per-Document reserved bucket, distinct from the
+//     shared keepalive bucket used by sendBeacon/fetch({keepalive:true}))
+//   * activateAfter timers
+//   * AbortSignal cancellation
+//   * lifecycle-driven activation on bfcache entry and document destruction
+//
+// This first cut does NOT delegate quota across frames. Every Document owns
+// its own bucket (QUOTA_BYTES_PER_ORIGIN). Iframe / permissions-policy
+// delegation, and the larger 640 KiB per-top-level-document reserved pool it
+// slices from, are planned for a follow-up patch.
+//
+// Lifetime: owned by the Document via Supplement<Document> (unique_ptr).
+// ref()/deref() are forwarded to the Document, matching the NavigatorBeacon
+// pattern for supplements that need to satisfy a RefCounted-shaped client
+// interface (here, CachedRawResourceClient).
+class DeferredFetchRegistry final : public Supplement<Document>, private CachedRawResourceClient {
+    WTF_MAKE_TZONE_ALLOCATED(DeferredFetchRegistry);
+public:
+    // https://fetch.spec.whatwg.org/#available-deferred-fetch-quota
+    // The spec defines a 640 KiB per-top-level-document "reserved" pool that
+    // can be delegated across origins in 64 KiB per-origin chunks. Because
+    // this first cut does not implement cross-frame delegation, the effective
+    // limit collapses to the per-origin 64 KiB slice.
+    static constexpr uint64_t QUOTA_BYTES_PER_ORIGIN = 64 * 1024;
+
+    explicit DeferredFetchRegistry(Document&);
+    ~DeferredFetchRegistry();
+
+    static Ref<DeferredFetchRegistry> ensure(Document&);
+    static RefPtr<DeferredFetchRegistry> from(Document&);
+
+    // Supplement/CachedRawResourceClient ref-count forwarding.
+    void NODELETE ref() const final;
+    void deref() const final;
+
+    // Returns null on quota exhaustion; the caller (fetchLater()) should
+    // throw QuotaExceededError.
+    RefPtr<FetchLaterResult> addDeferredFetch(ResourceRequest&&, ResourceLoaderOptions&&, RefPtr<FormData>&& body, uint64_t requestBytes, AbortSignal*, std::optional<Seconds> activateAfter);
+
+    // Available quota for future fetchLater() calls to the given reporting
+    // origin (the origin of the request's URL). Per-origin bucket = 64 KiB.
+    uint64_t availableBytesFor(const SecurityOriginData&) const;
+    size_t pendingCount() const { return m_records.size(); }
+
+    // Lifecycle hooks called by Document.
+    void documentIsAboutToEnterBackForwardCache();
+    void documentIsBeingDestroyed();
+
+private:
+    class Record;
+
+    static ASCIILiteral supplementName();
+    bool isDeferredFetchRegistry() const final { return true; }
+
+    void removeRecord(Record&);
+    void activateRecord(Record&);
+    void activateAllRecords();
+
+    // CachedRawResourceClient
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
+
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
+    Vector<std::unique_ptr<Record>> m_records;
+    HashMap<SecurityOriginData, uint64_t> m_bytesUsedByOrigin;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DeferredFetchRegistry)
+    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isDeferredFetchRegistry(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/Modules/fetch/DeferredRequestInit.h
+++ b/Source/WebCore/Modules/fetch/DeferredRequestInit.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FetchRequestInit.h"
+
+namespace WebCore {
+
+struct DeferredRequestInit : FetchRequestInit {
+    std::optional<double> activateAfter;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/DeferredRequestInit.idl
+++ b/Source/WebCore/Modules/fetch/DeferredRequestInit.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+typedef double DOMHighResTimeStamp;
+
+// https://fetch.spec.whatwg.org/#deferred-request-init
+dictionary DeferredRequestInit : FetchRequestInit {
+    DOMHighResTimeStamp activateAfter;
+};

--- a/Source/WebCore/Modules/fetch/FetchLaterResult.h
+++ b/Source/WebCore/Modules/fetch/FetchLaterResult.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+// https://fetch.spec.whatwg.org/#fetch-later-result
+//
+// Returned from fetchLater(). Exposes a single readonly `activated` boolean
+// that flips to true once the deferred fetch has been dispatched (either
+// because the activateAfter timer fired, the Document is entering bfcache,
+// or the Document is being destroyed).
+class FetchLaterResult final : public RefCounted<FetchLaterResult> {
+public:
+    static Ref<FetchLaterResult> create() { return adoptRef(*new FetchLaterResult); }
+
+    bool activated() const { return m_activated; }
+    void setActivated() { m_activated = true; }
+
+private:
+    FetchLaterResult() = default;
+
+    bool m_activated { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchLaterResult.idl
+++ b/Source/WebCore/Modules/fetch/FetchLaterResult.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://fetch.spec.whatwg.org/#fetch-later-result
+[
+    Exposed=Window,
+    SecureContext,
+    EnabledBySetting=FetchLaterAPIEnabled
+] interface FetchLaterResult {
+    readonly attribute boolean activated;
+};

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -27,15 +27,31 @@
 #include "WindowOrWorkerGlobalScopeFetch.h"
 
 #include "CachedResourceRequestInitiatorTypes.h"
+#include "ContentSecurityPolicy.h"
+#include "DeferredFetchRegistry.h"
 #include "DocumentQuirks.h"
 #include "EventLoop.h"
+#include "FetchBody.h"
+#include "FetchLaterResult.h"
 #include "FetchResponse.h"
+#include "FormData.h"
+#include "FrameLoader.h"
+#include "HTTPParsers.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMConvertInterface.h"
+#include "JSDOMExceptionHandling.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSFetchResponse.h"
 #include "JSValueInWrappedObjectInlines.h"
 #include "LocalDOMWindow.h"
+#include "LocalFrame.h"
+#include "OriginAccessPatterns.h"
+#include "QuotaExceededError.h"
+#include "ResourceLoaderOptions.h"
+#include "ResourceRequest.h"
+#include "SecurityOrigin.h"
+#include "SecurityOriginData.h"
+#include "SecurityPolicy.h"
 #include "UserGestureIndicator.h"
 #include "WorkerGlobalScope.h"
 
@@ -98,6 +114,125 @@ void WindowOrWorkerGlobalScopeFetch::fetch(DOMWindow& window, FetchRequest::Info
 void WindowOrWorkerGlobalScopeFetch::fetch(WorkerGlobalScope& scope, FetchRequest::Info&& input, FetchRequest::Init&& init, Ref<DeferredPromise>&& promise)
 {
     doFetch(scope, WTF::move(input), WTF::move(init), WTF::move(promise));
+}
+
+// https://fetch.spec.whatwg.org/#dom-window-fetchlater
+ExceptionOr<Ref<FetchLaterResult>> WindowOrWorkerGlobalScopeFetch::fetchLater(DOMWindow& window, FetchRequest::Info&& input, DeferredRequestInit&& init)
+{
+    RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(window);
+    if (!localWindow)
+        return Exception { ExceptionCode::InvalidStateError, "fetchLater() called on a non-local window"_s };
+
+    RefPtr document = localWindow->document();
+    if (!document || !document->isFullyActive())
+        return Exception { ExceptionCode::InvalidStateError, "fetchLater() requires a fully active Document"_s };
+    Ref<ScriptExecutionContext> context = *document;
+
+    // activateAfter must be non-negative.
+    if (init.activateAfter && *init.activateAfter < 0)
+        return Exception { ExceptionCode::RangeError, "activateAfter must be a non-negative number"_s };
+
+    // Force keepalive on. This makes FetchRequest reject ReadableStream bodies
+    // for us and ensures NetworkResourceLoader::abort() transfers the load to
+    // the keep-alive pool if the document is destroyed while it is in flight.
+    init.keepalive = true;
+
+    auto requestOrException = FetchRequest::create(context.get(), WTF::move(input), FetchRequest::Init { init });
+    if (requestOrException.hasException())
+        return requestOrException.releaseException();
+    Ref request = requestOrException.releaseReturnValue();
+
+    // Only HTTP(S) URLs on potentially trustworthy origins are allowed
+    // (i.e. https://, or http:// to localhost / loopback IPs).
+    // https://fetch.spec.whatwg.org/#dom-window-fetchlater step 5.
+    if (!request->url().protocolIsInHTTPFamily() || !shouldTreatAsPotentiallyTrustworthy(request->url()))
+        return Exception { ExceptionCode::TypeError, "fetchLater() only supports HTTP(S) URLs on potentially trustworthy origins"_s };
+
+    // If the AbortSignal is already aborted, throw synchronously.
+    if (request->signal().aborted())
+        return Exception { ExceptionCode::AbortError, "Request signal is aborted"_s };
+
+    // Enforce CSP connect-src.
+    if (!document->shouldBypassMainWorldContentSecurityPolicy()
+        && !protect(document->contentSecurityPolicy())->allowConnectToSource(request->url(), document->currentParserSourcePosition())) {
+        // Treat as a silent network failure per Beacon precedent: return a
+        // FetchLaterResult that never activates.
+        return FetchLaterResult::create();
+    }
+
+    // Build the ResourceRequest we will hand to the network stack on activation.
+    ResourceRequest resourceRequest = request->resourceRequest();
+    resourceRequest.setRequester(ResourceRequestRequester::FetchLater);
+
+    // Compute quota accounting BEFORE FrameLoader adds Referer/Origin/User-Agent/
+    // Accept/etc. per fetch spec "total request length":
+    // https://fetch.spec.whatwg.org/#request-deferred-fetching-total-request-length
+    //   totalRequestLength = |URL bytes| + sum(|name| + |value|) over author's
+    //                        header list + |body bytes|
+    // Extra headers added later by the loader are not charged against the quota.
+    RefPtr<FormData> body = resourceRequest.httpBody();
+    uint64_t bodyBytes = body ? body->lengthInBytes() : 0;
+    uint64_t urlBytes = resourceRequest.url().string().utf8().length();
+    uint64_t headerBytes = 0;
+    for (auto& header : resourceRequest.httpHeaderFields())
+        headerBytes += header.key.utf8().length() + header.value.utf8().length();
+    uint64_t requestBytes = urlBytes + headerBytes + bodyBytes;
+
+    // Populate request headers now (Referer, Origin, User-Agent, etc.) while
+    // the frame and document are fully active. When we activate the request
+    // later, we go directly through LoaderStrategy::startPingLoad and won't
+    // have another chance to add these.
+    RefPtr frame = localWindow->frame();
+    if (frame) {
+        String referrer = SecurityPolicy::generateReferrerHeader(document->referrerPolicy(), resourceRequest.url(), frame->loader().outgoingReferrerURL(), OriginAccessPatternsForWebProcess::singleton());
+        if (!referrer.isEmpty())
+            resourceRequest.setHTTPReferrer(referrer);
+        frame->loader().updateRequestAndAddExtraFields(resourceRequest, IsMainResource::No);
+    }
+
+    // Build ResourceLoaderOptions. Mirror what NavigatorBeacon uses but keep
+    // the mode/credentials/cache/redirect/referrerPolicy the request already
+    // computed.
+    ResourceLoaderOptions options;
+    options.credentials = request->fetchOptions().credentials;
+    options.mode = request->fetchOptions().mode;
+    options.cache = request->fetchOptions().cache;
+    options.redirect = request->fetchOptions().redirect;
+    options.referrerPolicy = request->fetchOptions().referrerPolicy;
+    options.destination = request->fetchOptions().destination;
+    options.integrity = request->fetchOptions().integrity;
+    options.keepAlive = true;
+    options.sendLoadCallbacks = SendCallbackPolicy::SendCallbacks;
+
+    Ref registry = DeferredFetchRegistry::ensure(*document);
+    auto reportingOrigin = SecurityOriginData::fromURL(resourceRequest.url());
+    // Quota exceeded is reported with:
+    //   quota     = remaining bytes available for this reporting origin
+    //   requested = total bytes of THIS request (URL + author headers + body)
+    if (requestBytes > registry->availableBytesFor(reportingOrigin)) {
+        return Exception { ExceptionCode::QuotaExceededError,
+            QuotaExceededError::create("fetchLater() exceeded per-origin quota"_s,
+                QuotaExceededErrorOptions {
+                    .quota = static_cast<double>(registry->availableBytesFor(reportingOrigin)),
+                    .requested = static_cast<double>(requestBytes),
+                }) };
+    }
+
+    std::optional<Seconds> activateAfter;
+    if (init.activateAfter)
+        activateAfter = Seconds::fromMilliseconds(*init.activateAfter);
+
+    auto result = registry->addDeferredFetch(WTF::move(resourceRequest), WTF::move(options), WTF::move(body), requestBytes, &request->signal(), activateAfter);
+    if (!result) {
+        return Exception { ExceptionCode::QuotaExceededError,
+            QuotaExceededError::create("fetchLater() exceeded per-origin quota"_s,
+                QuotaExceededErrorOptions {
+                    .quota = static_cast<double>(registry->availableBytesFor(reportingOrigin)),
+                    .requested = static_cast<double>(requestBytes),
+                }) };
+    }
+
+    return result.releaseNonNull();
 }
 
 }

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h
@@ -25,18 +25,24 @@
 
 #pragma once
 
+#include "DeferredRequestInit.h"
 #include "FetchRequest.h"
 
 namespace WebCore {
 
 class DOMWindow;
 class DeferredPromise;
+class FetchLaterResult;
+class ScriptExecutionContext;
 class WorkerGlobalScope;
+template<typename> class ExceptionOr;
 
 class WindowOrWorkerGlobalScopeFetch {
 public:
     static void fetch(DOMWindow&, FetchRequest::Info&&, FetchRequest::Init&&, Ref<DeferredPromise>&&);
     static void fetch(WorkerGlobalScope&, FetchRequest::Info&&, FetchRequest::Init&&, Ref<DeferredPromise>&&);
+
+    static ExceptionOr<Ref<FetchLaterResult>> fetchLater(DOMWindow&, FetchRequest::Info&&, DeferredRequestInit&&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -126,6 +126,7 @@ Modules/entriesapi/FileSystemEntriesCallback.cpp
 Modules/entriesapi/FileSystemEntry.cpp
 Modules/entriesapi/FileSystemFileEntry.cpp
 Modules/entriesapi/HTMLInputElementEntriesAPI.cpp
+Modules/fetch/DeferredFetchRegistry.cpp
 Modules/fetch/FetchBody.cpp @cost:3
 Modules/fetch/FetchBodyConsumer.cpp @cost:3
 Modules/fetch/FetchBodyOwner.cpp @cost:3
@@ -1282,6 +1283,7 @@ dom/CustomElementRegistry.cpp
 dom/CustomEvent.cpp
 dom/CustomStateSet.cpp
 dom/DOMException.cpp
+dom/QuotaExceededError.cpp
 dom/DOMImplementation.cpp
 dom/DOMPointReadOnly.cpp
 dom/DOMQuad.cpp
@@ -4143,6 +4145,7 @@ JSDatabaseCallback.cpp
 JSDecompressionStream.cpp
 JSDecompressionStreamDecoder.cpp
 JSDedicatedWorkerGlobalScope.cpp
+JSDeferredRequestInit.cpp
 JSDelayNode.cpp
 JSDelayOptions.cpp
 JSDeprecatedCSSOMCounter.cpp
@@ -4220,6 +4223,7 @@ JSFaceDetectorOptions.cpp
 JSFetchBody.cpp
 JSFetchEvent.cpp
 JSFetchHeaders.cpp
+JSFetchLaterResult.cpp
 JSFetchReferrerPolicy.cpp
 JSFetchRequest.cpp
 JSFetchRequestCache.cpp
@@ -4804,6 +4808,8 @@ JSPushSubscriptionOptions.cpp
 JSPushSubscriptionOptionsInit.cpp
 JSQueuingStrategy.cpp
 JSQueuingStrategySize.cpp
+JSQuotaExceededError.cpp
+JSQuotaExceededErrorOptions.cpp
 JSRTCAnswerOptions.cpp
 JSRTCCertificate.cpp
 JSRTCConfiguration.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3332,6 +3332,9 @@
 		7CD494CD1A86EB1D000A87EC /* RenderAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CD494CB1A86EB1D000A87EC /* RenderAttachment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7CD58DFB1F9565A500112791 /* Settings.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CEB57E91F95651500097AEC /* Settings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7CD58DFD1F9565A800112791 /* Settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CEB57EA1F95651500097AEC /* Settings.cpp */; };
+		FE7CF1A501000000000000A3 /* DeferredFetchRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7CF1A501000000000000A2 /* DeferredFetchRegistry.h */; };
+		FE7CF1A501000000000000B2 /* DeferredRequestInit.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7CF1A501000000000000B1 /* DeferredRequestInit.h */; };
+		FE7CF1A501000000000000C2 /* FetchLaterResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7CF1A501000000000000C1 /* FetchLaterResult.h */; };
 		7CE1914A1F2A98B900272F78 /* FetchRequestInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CE191471F2A98AF00272F78 /* FetchRequestInit.h */; };
 		7CE1914D1F2A9AFB00272F78 /* FetchReferrerPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CE1914B1F2A9AFB00272F78 /* FetchReferrerPolicy.h */; };
 		7CE191511F2A9B0A00272F78 /* FetchRequestMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CE1914F1F2A9B0A00272F78 /* FetchRequestMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5337,6 +5340,8 @@
 		BC5EBA110E823E4700B25965 /* BlendingKeyframes.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5EBA0F0E823E4700B25965 /* BlendingKeyframes.h */; };
 		BC6049CC0DB560C200204739 /* CSSCanvasValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BC6049CB0DB560C200204739 /* CSSCanvasValue.h */; };
 		BC60D6E90D28D83400B9918F /* DOMException.h in Headers */ = {isa = PBXBuildFile; fileRef = BC60D6E80D28D83400B9918F /* DOMException.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE7CF1A5010000000000E002 /* QuotaExceededError.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7CF1A5010000000000E001 /* QuotaExceededError.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FE7CF1A5010000000000E006 /* QuotaExceededErrorOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7CF1A5010000000000E005 /* QuotaExceededErrorOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC60D7C10D29A46300B9918F /* JSDOMException.h in Headers */ = {isa = PBXBuildFile; fileRef = BC60D7BF0D29A46300B9918F /* JSDOMException.h */; };
 		BC611FF52EC79F6000904592 /* StyleContain.h in Headers */ = {isa = PBXBuildFile; fileRef = BC611FF32EC79C1E00904592 /* StyleContain.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC6120002EC7B83D00904592 /* StyleTouchAction.h in Headers */ = {isa = PBXBuildFile; fileRef = BC611FFE2EC7ADDE00904592 /* StyleTouchAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -15332,6 +15337,13 @@
 		7CDA7912250E88F0007D1B36 /* InnerHTML.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = InnerHTML.idl; sourceTree = "<group>"; };
 		7CDA7919250E8C92007D1B36 /* Element+DOMParsing.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Element+DOMParsing.idl"; sourceTree = "<group>"; };
 		7CDE8EBC1F193BC500168FE7 /* CSSStyleDeclaration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSStyleDeclaration.cpp; sourceTree = "<group>"; };
+		FE7CF1A501000000000000A1 /* DeferredFetchRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DeferredFetchRegistry.cpp; sourceTree = "<group>"; };
+		FE7CF1A501000000000000A2 /* DeferredFetchRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredFetchRegistry.h; sourceTree = "<group>"; };
+		FE7CF1A501000000000000B1 /* DeferredRequestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredRequestInit.h; sourceTree = "<group>"; };
+		FE7CF1A501000000000000B3 /* DeferredRequestInit.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = DeferredRequestInit.idl; sourceTree = "<group>"; };
+		FE7CF1A501000000000000C1 /* FetchLaterResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FetchLaterResult.h; sourceTree = "<group>"; };
+		FE7CF1A501000000000000C3 /* FetchLaterResult.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchLaterResult.idl; sourceTree = "<group>"; };
+		FE7CF1A501000000000000D1 /* DOMWindow+FetchLater.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "DOMWindow+FetchLater.idl"; sourceTree = "<group>"; };
 		7CE191471F2A98AF00272F78 /* FetchRequestInit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FetchRequestInit.h; sourceTree = "<group>"; };
 		7CE191491F2A98B000272F78 /* FetchRequestInit.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FetchRequestInit.idl; sourceTree = "<group>"; };
 		7CE1914B1F2A9AFB00272F78 /* FetchReferrerPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FetchReferrerPolicy.h; sourceTree = "<group>"; };
@@ -16750,6 +16762,11 @@
 		978AD67314130A8D00C7CAE3 /* HTMLSpanElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = HTMLSpanElement.idl; sourceTree = "<group>"; };
 		978CE10C711D6B12D9FBC9C9 /* UnifiedSource37-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource37-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
 		978D07BD145A0F6C0096908D /* DOMException.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMException.cpp; sourceTree = "<group>"; };
+		FE7CF1A5010000000000E000 /* QuotaExceededError.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = QuotaExceededError.cpp; sourceTree = "<group>"; };
+		FE7CF1A5010000000000E001 /* QuotaExceededError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuotaExceededError.h; sourceTree = "<group>"; };
+		FE7CF1A5010000000000E003 /* QuotaExceededError.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = QuotaExceededError.idl; sourceTree = "<group>"; };
+		FE7CF1A5010000000000E004 /* QuotaExceededErrorOptions.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = QuotaExceededErrorOptions.idl; sourceTree = "<group>"; };
+		FE7CF1A5010000000000E005 /* QuotaExceededErrorOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QuotaExceededErrorOptions.h; sourceTree = "<group>"; };
 		979F43D11075E44A0000F83B /* NavigationScheduler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NavigationScheduler.cpp; sourceTree = "<group>"; };
 		979F43D21075E44A0000F83B /* NavigationScheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NavigationScheduler.h; sourceTree = "<group>"; };
 		97AA3CA3145237CC003E1DA6 /* EventTargetHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventTargetHeaders.h; sourceTree = "<group>"; };
@@ -27845,6 +27862,11 @@
 		41F54F7C1C50C4F600338488 /* fetch */ = {
 			isa = PBXGroup;
 			children = (
+				FE7CF1A501000000000000A1 /* DeferredFetchRegistry.cpp */,
+				FE7CF1A501000000000000A2 /* DeferredFetchRegistry.h */,
+				FE7CF1A501000000000000B1 /* DeferredRequestInit.h */,
+				FE7CF1A501000000000000B3 /* DeferredRequestInit.idl */,
+				FE7CF1A501000000000000D1 /* DOMWindow+FetchLater.idl */,
 				41F54F7D1C50C4F600338488 /* FetchBody.cpp */,
 				41F54F7E1C50C4F600338488 /* FetchBody.h */,
 				41F54F7F1C50C4F600338488 /* FetchBody.idl */,
@@ -27859,6 +27881,8 @@
 				41F54F841C50C4F600338488 /* FetchHeaders.idl */,
 				4191981729950763007576C8 /* FetchHeadersGuard.h */,
 				416E0B37209BC3C2004A95D9 /* FetchIdentifier.h */,
+				FE7CF1A501000000000000C1 /* FetchLaterResult.h */,
+				FE7CF1A501000000000000C3 /* FetchLaterResult.idl */,
 				4147E2B41C89912600A7E715 /* FetchLoader.cpp */,
 				4147E2B51C89912600A7E715 /* FetchLoader.h */,
 				4147E2B61C89912600A7E715 /* FetchLoaderClient.h */,
@@ -42972,6 +42996,11 @@
 				550A0BC8085F6039007353D6 /* QualifiedName.h */,
 				83C1F5911EDF69D300410D27 /* QualifiedNameCache.cpp */,
 				83C1F5921EDF69D300410D27 /* QualifiedNameCache.h */,
+				FE7CF1A5010000000000E000 /* QuotaExceededError.cpp */,
+				FE7CF1A5010000000000E001 /* QuotaExceededError.h */,
+				FE7CF1A5010000000000E003 /* QuotaExceededError.idl */,
+				FE7CF1A5010000000000E005 /* QuotaExceededErrorOptions.h */,
+				FE7CF1A5010000000000E004 /* QuotaExceededErrorOptions.idl */,
 				93F925420F7EF5B8007E37C9 /* RadioButtonGroups.cpp */,
 				93F925410F7EF5B8007E37C9 /* RadioButtonGroups.h */,
 				7C6771282527D28100FDEF00 /* Range+CSSOMView.idl */,
@@ -45014,6 +45043,8 @@
 				FD06DFA6134A4DEF006F5D7D /* DefaultAudioDestinationNode.h in Headers */,
 				E4F38D1B2626F13B007B1064 /* DefaultResourceLoadPriority.h in Headers */,
 				CD83D36221122A210076E11C /* DeferrableTask.h in Headers */,
+				FE7CF1A501000000000000A3 /* DeferredFetchRegistry.h in Headers */,
+				FE7CF1A501000000000000B2 /* DeferredRequestInit.h in Headers */,
 				FD31602C12B0267600C1A359 /* DelayDSPKernel.h in Headers */,
 				FD31602E12B0267600C1A359 /* DelayNode.h in Headers */,
 				83A2ABDB24D86DE000E2D73D /* DelayOptions.h in Headers */,
@@ -45356,6 +45387,7 @@
 				416E0B3A209BC3CB004A95D9 /* FetchIdentifier.h in Headers */,
 				CEBB8C3320786DCB00039547 /* FetchIdioms.h in Headers */,
 				EB83220A2D70DC7F009515DA /* FetchingWorkerIdentifier.h in Headers */,
+				FE7CF1A501000000000000C2 /* FetchLaterResult.h in Headers */,
 				4161E2D51FE48DC500EC2E96 /* FetchLoader.h in Headers */,
 				517A53581F5889E800DCDC0A /* FetchLoaderClient.h in Headers */,
 				41AD753A1CEF6BD100A31486 /* FetchOptions.h in Headers */,
@@ -47985,6 +48017,8 @@
 				A15E31F41E0CB0B5004B371C /* QuickLook.h in Headers */,
 				9BAEE92C22388A7D004157A9 /* Quirks.h in Headers */,
 				7ABB0F602CE7C170009A837D /* QuirksData.h in Headers */,
+				FE7CF1A5010000000000E002 /* QuotaExceededError.h in Headers */,
+				FE7CF1A5010000000000E006 /* QuotaExceededErrorOptions.h in Headers */,
 				379E371713736A6600B9E919 /* QuotedPrintable.h in Headers */,
 				B22279720D00BF220071B782 /* RadialGradientAttributes.h in Headers */,
 				93F925430F7EF5B8007E37C9 /* RadioButtonGroups.h in Headers */,

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -215,6 +215,16 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
 
 JSValue createDOMException(JSGlobalObject& lexicalGlobalObject, Exception&& exception)
 {
+    // If the caller attached a pre-built DOMException subclass (e.g. a
+    // QuotaExceededError carrying its quota/requested attributes), wrap that
+    // object directly instead of constructing a fresh, less-specific DOMException.
+    if (RefPtr attached = exception.takeAttachedException()) {
+        JSDOMGlobalObject* globalObject = deprecatedGlobalObjectForPrototype(&lexicalGlobalObject);
+        JSValue errorObject = toJS(&lexicalGlobalObject, globalObject, *attached);
+        ASSERT(errorObject);
+        addErrorInfo(&lexicalGlobalObject, asObject(errorObject), true);
+        return errorObject;
+    }
     return createDOMException(&lexicalGlobalObject, exception.code(), exception.releaseMessage());
 }
 

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -626,6 +626,8 @@ namespace WebCore {
     macro(errorSteps) \
     macro(fatal) \
     macro(fetch) \
+    macro(FetchLaterResult) \
+    macro(fetchLater) \
     macro(fetchRequest) \
     macro(FileReader) \
     macro(FileReaderSync) \

--- a/Source/WebCore/dom/DOMException.cpp
+++ b/Source/WebCore/dom/DOMException.cpp
@@ -30,6 +30,7 @@
 #include "DOMException.h"
 
 #include "Exception.h"
+#include "QuotaExceededError.h"
 
 namespace WebCore {
 
@@ -92,17 +93,29 @@ static DOMException::LegacyCode NODELETE legacyCodeFromName(const String& name)
 
 Ref<DOMException> DOMException::create(ExceptionCode ec, const String& message)
 {
+    // QuotaExceededError is a DOMException subclass with extra `quota` /
+    // `requested` attributes. Constructing it here ensures every call site
+    // that throws `Exception { ExceptionCode::QuotaExceededError, ... }`
+    // surfaces to JS as a real QuotaExceededError instance (so
+    // `e instanceof QuotaExceededError` works and modern WPT harness helpers
+    // like `assert_throws_quotaexceedederror` can succeed).
+    if (ec == ExceptionCode::QuotaExceededError)
+        return QuotaExceededError::create(message);
     auto& description = DOMException::description(ec);
     return adoptRef(*new DOMException(description.legacyCode, description.name, !message.isEmpty() ? message : description.message));
 }
 
 Ref<DOMException> DOMException::create(const String& message, const String& name)
 {
+    if (name == "QuotaExceededError"_s)
+        return QuotaExceededError::create(message);
     return adoptRef(*new DOMException(legacyCodeFromName(name), name, message));
 }
 
 Ref<DOMException> DOMException::create(const Exception& exception)
 {
+    if (exception.code() == ExceptionCode::QuotaExceededError)
+        return QuotaExceededError::create(exception.message());
     auto& description = DOMException::description(exception.code());
     return adoptRef(*new DOMException(description.legacyCode, description.name, exception.message().isEmpty() ? description.message : exception.message()));
 }

--- a/Source/WebCore/dom/DOMException.h
+++ b/Source/WebCore/dom/DOMException.h
@@ -62,7 +62,7 @@ public:
     static ASCIILiteral name(ExceptionCode ec) { return description(ec).name; }
     static ASCIILiteral message(ExceptionCode ec) { return description(ec).message; }
 
-    enum class Type : uint8_t { Default, WebTransportError, GPUPipelineError, RTCError };
+    enum class Type : uint8_t { Default, WebTransportError, GPUPipelineError, RTCError, QuotaExceededError };
     Type type() const { return m_type; }
 
 protected:

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -80,6 +80,7 @@
 #include "DOMTimer.h"
 #include "DateComponents.h"
 #include "DebugPageOverlays.h"
+#include "DeferredFetchRegistry.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DocumentFontLoader.h"
 #include "DocumentFragment.h"
@@ -3656,6 +3657,12 @@ void Document::willBeRemovedFromFrame()
 {
     if (m_hasPreparedForDestruction)
         return;
+
+    // Activate any pending fetchLater() requests before the document goes away.
+    // Must happen before we start tearing down subsystems the load path relies on
+    // (e.g. the CachedResourceLoader / DocumentLoader below).
+    if (RefPtr registry = DeferredFetchRegistry::from(*this))
+        registry->documentIsBeingDestroyed();
 
 #if ENABLE(WEB_RTC)
     if (RefPtr rtcNetworkManager = m_rtcNetworkManager)
@@ -7631,6 +7638,13 @@ void Document::setBackForwardCacheState(BackForwardCacheState state)
             idbConnectionProxy->setContextSuspended(*scriptExecutionContext(), false);
         break;
     case AboutToEnterBackForwardCache:
+        // https://fetch.spec.whatwg.org/#deferred-fetch-task-destination
+        // Activate all pending deferred fetches when the document becomes
+        // "not fully active" (i.e. enters bfcache). This happens before the
+        // pagehide event so the loads are already dispatched by the time
+        // author script runs.
+        if (RefPtr registry = DeferredFetchRegistry::from(*this))
+            registry->documentIsAboutToEnterBackForwardCache();
         break;
     }
 }

--- a/Source/WebCore/dom/Exception.h
+++ b/Source/WebCore/dom/Exception.h
@@ -26,7 +26,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <WebCore/DOMException.h>
 #include <WebCore/ExceptionCode.h>
+#include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -34,17 +36,26 @@ namespace WebCore {
 class Exception {
 public:
     explicit Exception(ExceptionCode, String = { });
+    Exception(ExceptionCode, Ref<DOMException>&&);
 
     ExceptionCode code() const { return m_code; }
     const String& message() const LIFETIME_BOUND { return m_message; }
     String&& releaseMessage() { return WTF::move(m_message); }
 
+    // When non-null, this pre-constructed DOMException (or subclass) should
+    // be surfaced to JS rather than a fresh DOMException built from the code
+    // and message. Used for exception subtypes that carry extra attributes
+    // (e.g. QuotaExceededError.quota / .requested).
+    DOMException* attachedException() const { return m_attachedException.get(); }
+    RefPtr<DOMException> takeAttachedException() { return WTF::move(m_attachedException); }
+
     Exception isolatedCopy() const & { return Exception { m_code, m_message.isolatedCopy() }; }
     Exception isolatedCopy() && { return Exception { m_code, WTF::move(m_message).isolatedCopy() }; }
-    
+
 private:
     ExceptionCode m_code;
     String m_message;
+    RefPtr<DOMException> m_attachedException;
 };
 
 inline Exception::Exception(ExceptionCode code, String message)
@@ -53,5 +64,11 @@ inline Exception::Exception(ExceptionCode code, String message)
 {
 }
 
+inline Exception::Exception(ExceptionCode code, Ref<DOMException>&& attachedException)
+    : m_code { code }
+    , m_message { attachedException->message() }
+    , m_attachedException { WTF::move(attachedException) }
+{
+}
 
 } // namespace WebCore

--- a/Source/WebCore/dom/QuotaExceededError.cpp
+++ b/Source/WebCore/dom/QuotaExceededError.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "QuotaExceededError.h"
+
+namespace WebCore {
+
+Ref<QuotaExceededError> QuotaExceededError::create(const String& message, QuotaExceededErrorOptions&& options)
+{
+    return adoptRef(*new QuotaExceededError(message, WTF::move(options)));
+}
+
+static constexpr DOMException::LegacyCode legacyCodeForQuotaExceeded = 22;
+
+QuotaExceededError::QuotaExceededError(const String& message, QuotaExceededErrorOptions&& options)
+    : DOMException(legacyCodeForQuotaExceeded, "QuotaExceededError"_s, message.isEmpty() ? "The quota has been exceeded."_s : message, Type::QuotaExceededError)
+    , m_quota(options.quota)
+    , m_requested(options.requested)
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/QuotaExceededError.h
+++ b/Source/WebCore/dom/QuotaExceededError.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/DOMException.h>
+#include <WebCore/QuotaExceededErrorOptions.h>
+
+namespace WebCore {
+
+// https://webidl.spec.whatwg.org/#idl-QuotaExceededError
+//
+// A DOMException subclass with optional `quota` and `requested` numeric
+// attributes describing the exceeded storage / capacity limit. Modern web-
+// platform APIs (fetchLater(), Storage, IndexedDB, etc.) are expected to
+// throw this specific subclass so callers can inspect the two numbers.
+class QuotaExceededError final : public DOMException {
+public:
+    static Ref<QuotaExceededError> create(const String& message = { }, QuotaExceededErrorOptions&& = { });
+
+    std::optional<double> quota() const { return m_quota; }
+    std::optional<double> requested() const { return m_requested; }
+
+private:
+    QuotaExceededError(const String& message, QuotaExceededErrorOptions&&);
+
+    const std::optional<double> m_quota;
+    const std::optional<double> m_requested;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::QuotaExceededError)
+    static bool isType(const WebCore::DOMException& exception) { return exception.type() == WebCore::DOMException::Type::QuotaExceededError; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/dom/QuotaExceededError.idl
+++ b/Source/WebCore/dom/QuotaExceededError.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://webidl.spec.whatwg.org/#idl-QuotaExceededError
+[
+    Exposed=(Window,Worker)
+] interface QuotaExceededError : DOMException {
+    constructor(optional DOMString message = "", optional QuotaExceededErrorOptions options = {});
+
+    readonly attribute double? quota;
+    readonly attribute double? requested;
+};

--- a/Source/WebCore/dom/QuotaExceededErrorOptions.h
+++ b/Source/WebCore/dom/QuotaExceededErrorOptions.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+
+namespace WebCore {
+
+// https://webidl.spec.whatwg.org/#dictdef-quotaexceedederroroptions
+struct QuotaExceededErrorOptions {
+    std::optional<double> quota;
+    std::optional<double> requested;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/QuotaExceededErrorOptions.idl
+++ b/Source/WebCore/dom/QuotaExceededErrorOptions.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://webidl.spec.whatwg.org/#dictdef-quotaexceedederroroptions
+dictionary QuotaExceededErrorOptions {
+    double quota;
+    double requested;
+};

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -242,7 +242,9 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         m_fragmentIdentifierForRequest = String();
     }
 
-    if (m_options.keepAlive && type() != Type::Ping && !cachedResourceLoader.keepaliveRequestTracker().tryRegisterRequest(*this)) {
+    // fetchLater() has its own per-Document quota accounting via DeferredFetchRegistry, so it must not
+    // consume the shared 64KiB keepalive quota tracked by KeepaliveRequestTracker.
+    if (m_options.keepAlive && type() != Type::Ping && m_resourceRequest.requester() != ResourceRequestRequester::FetchLater && !cachedResourceLoader.keepaliveRequestTracker().tryRegisterRequest(*this)) {
         setResourceError({ errorDomainWebKitInternal, 0, request.url(), "Reached maximum amount of queued data of 64Kb for keepalive requests"_s, ResourceError::Type::AccessControl });
         failBeforeStarting();
         return;

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -82,6 +82,7 @@ public:
     virtual bool isDOMWindowCaches() const { return false; }
     virtual bool isDOMWindowIndexedDatabase() const { return false; }
     virtual bool isDOMWindowTrustedTypes() const { return false; }
+    virtual bool isDeferredFetchRegistry() const { return false; }
     virtual bool isDeviceMotionController() const { return false; }
     virtual bool isDeviceOrientationController() const { return false; }
     virtual bool isDocumentMediaElement() const { return false; }

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -60,7 +60,7 @@ enum HTTPBodyUpdatePolicy : uint8_t {
 class ResourceRequest;
 class ResourceResponse;
 
-enum class ResourceRequestRequester : uint8_t { Unspecified, Main, XHR, Fetch, Media, Model, ImportScripts, Ping, Beacon, EventSource };
+enum class ResourceRequestRequester : uint8_t { Unspecified, Main, XHR, Fetch, Media, Model, ImportScripts, Ping, Beacon, EventSource, FetchLater };
 enum class ShouldUpgradeLocalhostAndIPAddress : bool { No, Yes };
 
 // Do not use this type directly.  Use ResourceRequest instead.
@@ -387,7 +387,8 @@ template<> struct EnumTraitsForPersistence<WebCore::ResourceRequestRequester> {
         WebCore::ResourceRequestRequester::ImportScripts,
         WebCore::ResourceRequestRequester::Ping,
         WebCore::ResourceRequestRequester::Beacon,
-        WebCore::ResourceRequestRequester::EventSource
+        WebCore::ResourceRequestRequester::EventSource,
+        WebCore::ResourceRequestRequester::FetchLater
     >;
 };
 

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -49,6 +49,13 @@ PingLoad::PingLoad(NetworkProcess& networkProcess, PAL::SessionID sessionID, Net
     , m_timeoutTimer(*this, &PingLoad::timeoutTimerFired)
     , m_networkLoadChecker(NetworkLoadChecker::create(networkProcess, nullptr, nullptr, FetchOptions { m_parameters.options }, m_sessionID, m_parameters.webPageProxyID, WTF::move(m_parameters.originalRequestHeaders), URL { m_parameters.request.url() }, URL { m_parameters.documentURL }, m_parameters.sourceOrigin.copyRef(), m_parameters.topOrigin.copyRef(), m_parameters.parentOrigin(), m_parameters.preflightPolicy, m_parameters.request.httpReferrer(), m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections))
 {
+    // initialize() registers a completion handler with NetworkLoadChecker that
+    // captures WeakPtr { *this } and may fire synchronously (e.g. when the
+    // content-extension backend for this UserContentController is already
+    // cached in the NetworkProcess). Dereferencing that WeakPtr inside the
+    // sync callback calls ref() before the caller has had a chance to
+    // adoptRef() us, which trips WTF's refcount-debugger adoption assert.
+    relaxAdoptionRequirement();
     initialize(networkProcess);
 }
 
@@ -60,6 +67,8 @@ PingLoad::PingLoad(NetworkConnectionToWebProcess& connection, NetworkResourceLoa
     , m_networkLoadChecker(NetworkLoadChecker::create(connection.networkProcess(), nullptr,  &connection.schemeRegistry(), FetchOptions { m_parameters.options }, m_sessionID, m_parameters.webPageProxyID, WTF::move(m_parameters.originalRequestHeaders), URL { m_parameters.request.url() }, URL { m_parameters.documentURL }, m_parameters.sourceOrigin.copyRef(), m_parameters.topOrigin.copyRef(), m_parameters.parentOrigin(), m_parameters.preflightPolicy, m_parameters.request.httpReferrer(), m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections))
     , m_blobFiles(connection.resolveBlobReferences(m_parameters))
 {
+    // See comment in the other constructor.
+    relaxAdoptionRequirement();
     for (Ref file : borrow(m_blobFiles).get())
         file->prepareForFileAccess();
 
@@ -123,7 +132,9 @@ void PingLoad::loadRequest(NetworkProcess& networkProcess, ResourceRequest&& req
     PING_RELEASE_LOG("startNetworkLoad");
     if (CheckedPtr networkSession = networkProcess.networkSession(m_sessionID)) {
         auto loadParameters = m_parameters.networkLoadParameters();
-        loadParameters.request = WTF::move(request);
+        loadParameters.request = request;
+        if (m_parameters.request.requester() == WebCore::ResourceRequestRequester::FetchLater)
+            m_requestForRetry = WTF::move(request);
         Ref task = NetworkDataTask::create(*networkSession, *this, WTF::move(loadParameters));
         m_task = task.copyRef();
         task->resume();
@@ -187,7 +198,33 @@ void PingLoad::didCompleteWithError(const ResourceError& error, const NetworkLoa
     else
         PING_RELEASE_LOG("didCompleteWithError, error_code=%d", error.errorCode());
 
+    if (shouldRetryTransientFailure(error)) {
+        retryLoad();
+        return;
+    }
+
     didFinish(error);
+}
+
+bool PingLoad::shouldRetryTransientFailure(const ResourceError& error) const
+{
+    if (m_parameters.request.requester() != WebCore::ResourceRequestRequester::FetchLater)
+        return false;
+    if (m_retryCount >= maxTransientRetries)
+        return false;
+    if (error.isNull() || error.isCancellation() || error.isAccessControl())
+        return false;
+    return error.isGeneral() || error.isTimeout();
+}
+
+void PingLoad::retryLoad()
+{
+    ++m_retryCount;
+    if (RefPtr task = std::exchange(m_task, nullptr)) {
+        task->clearClient();
+        task->cancel();
+    }
+    loadRequest(protect(m_networkLoadChecker->networkProcess()), ResourceRequest { m_requestForRetry });
 }
 
 void PingLoad::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend)

--- a/Source/WebKit/NetworkProcess/PingLoad.h
+++ b/Source/WebKit/NetworkProcess/PingLoad.h
@@ -85,9 +85,15 @@ private:
 
     void loadRequest(NetworkProcess&, WebCore::ResourceRequest&&);
 
+    bool shouldRetryTransientFailure(const WebCore::ResourceError&) const;
+    void retryLoad();
+
     void didFinish(const WebCore::ResourceError& = { }, const WebCore::ResourceResponse& response = { });
     
     RefPtr<PingLoad> m_selfReference;
+    WebCore::ResourceRequest m_requestForRetry;
+    uint8_t m_retryCount { 0 };
+    static constexpr uint8_t maxTransientRetries = 3;
     PAL::SessionID m_sessionID;
     NetworkResourceLoadParameters m_parameters;
     CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse&)> m_completionHandler;

--- a/Source/WebKit/Shared/WebCoreArgumentCodersNetwork.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersNetwork.serialization.in
@@ -152,7 +152,8 @@ enum class WebCore::ResourceRequestCachePolicy : uint8_t {
     ImportScripts,
     Ping,
     Beacon,
-    EventSource
+    EventSource,
+    FetchLater
 };
 
 enum class WebCore::ResourceLoadPriority : uint8_t {


### PR DESCRIPTION
#### ca6d5ed98b35e94f01094001a8ca7962d88160b6
<pre>
Implement the fetchLater API
<a href="https://bugs.webkit.org/show_bug.cgi?id=284347">https://bugs.webkit.org/show_bug.cgi?id=284347</a>

Reviewed by NOBODY (OOPS!).

This PR provides an initial implementation of the fetchLater API.
It is not yet complete, as it seems like some BFCache WPTs are failing, and the iframe
quota model is not yet in place. But it&apos;s a start.

No new tests, but lots of progressions.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/idlharness.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/activate-after.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/basic.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/basic.https.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-no-referrer-when-downgrade.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-no-referrer.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-origin-when-cross-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-same-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-strict-origin-when-cross-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-strict-origin.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/headers/header-referrer-unsafe-url.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/iframe.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/new-window.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/non-secure.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy-attribute-redirect.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy-attribute.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-allowed-by-permissions-policy.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-default-permissions-policy.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/permissions-policy/deferred-fetch-supported-by-permissions-policy.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-allowed.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-blocked.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/policies/csp-redirect-to-blocked.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/accumulated-oversized-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/accumulated-oversized-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/sandboxed-iframe.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/cross-origin-iframe/small-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/empty-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/max-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/multiple-origins.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/oversized-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/accumulated-oversized-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/empty-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/max-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/oversized-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/sandboxed-iframe.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/same-origin-iframe/small-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/quota/small-payload.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-deactivate-with-background-sync.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-deactivate.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/not-send-after-abort.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/send-multiple-with-activate-after.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/fetch-later/send-on-discard/send-multiple.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js:
* LayoutTests/imported/w3c/web-platform-tests/webstorage/storage_local_setitem_quotaexceedederr.window.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/webstorage/storage_session_setitem_quotaexceedederr.window.js:
(test):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/DOMWindow+FetchLater.idl: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/Modules/fetch/DeferredFetchRegistry.cpp: Added.
(WebCore::DeferredFetchRegistry::Record::Record):
(WebCore::DeferredFetchRegistry::Record::request const):
(WebCore::DeferredFetchRegistry::Record::takeRequest):
(WebCore::DeferredFetchRegistry::Record::options const):
(WebCore::DeferredFetchRegistry::Record::requestBytes const):
(WebCore::DeferredFetchRegistry::Record::reportingOrigin const):
(WebCore::DeferredFetchRegistry::Record::result):
(WebCore::DeferredFetchRegistry::Record::setAbortAlgorithmIdentifier):
(WebCore::DeferredFetchRegistry::Record::clearAbortAlgorithm):
(WebCore::DeferredFetchRegistry::Record::setActivateAfterTimer):
(WebCore::DeferredFetchRegistry::Record::clearActivateAfterTimer):
(WebCore::DeferredFetchRegistry::Record::setInflightResource):
(WebCore::DeferredFetchRegistry::Record::inflightResource const):
(WebCore::DeferredFetchRegistry::supplementName):
(WebCore::DeferredFetchRegistry::DeferredFetchRegistry):
(WebCore::DeferredFetchRegistry::~DeferredFetchRegistry):
(WebCore::DeferredFetchRegistry::ref const):
(WebCore::DeferredFetchRegistry::deref const):
(WebCore::DeferredFetchRegistry::from):
(WebCore::DeferredFetchRegistry::ensure):
(WebCore::DeferredFetchRegistry::availableBytesFor const):
(WebCore::DeferredFetchRegistry::addDeferredFetch):
(WebCore::DeferredFetchRegistry::removeRecord):
(WebCore::DeferredFetchRegistry::activateRecord):
(WebCore::DeferredFetchRegistry::activateAllRecords):
(WebCore::DeferredFetchRegistry::documentIsAboutToEnterBackForwardCache):
(WebCore::DeferredFetchRegistry::documentIsBeingDestroyed):
(WebCore::DeferredFetchRegistry::notifyFinished):
* Source/WebCore/Modules/fetch/DeferredFetchRegistry.h: Added.
(isType):
* Source/WebCore/Modules/fetch/DeferredRequestInit.h: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/Modules/fetch/DeferredRequestInit.idl: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/Modules/fetch/FetchLaterResult.h: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/Modules/fetch/FetchLaterResult.idl: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::WindowOrWorkerGlobalScopeFetch::fetchLater):
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::createDOMException):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/DOMException.cpp:
(WebCore::DOMException::create):
* Source/WebCore/dom/DOMException.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::setBackForwardCacheState):
* Source/WebCore/dom/Exception.h:
(WebCore::Exception::attachedException const):
(WebCore::Exception::takeAttachedException):
(WebCore::Exception::Exception):
* Source/WebCore/dom/QuotaExceededError.cpp: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
(WebCore::QuotaExceededError::create):
(WebCore::QuotaExceededError::QuotaExceededError):
* Source/WebCore/dom/QuotaExceededError.h: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
(isType):
* Source/WebCore/dom/QuotaExceededError.idl: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/dom/QuotaExceededErrorOptions.h: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/dom/QuotaExceededErrorOptions.idl: Copied from Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.h.
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
* Source/WebCore/platform/Supplementable.h:
(WebCore::SupplementBase::isDeferredFetchRegistry const):
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebKit/NetworkProcess/PingLoad.cpp:
(WebKit::m_blobFiles):
(WebKit::PingLoad::loadRequest):
(WebKit::PingLoad::didCompleteWithError):
(WebKit::PingLoad::shouldRetryTransientFailure const):
(WebKit::PingLoad::retryLoad):
* Source/WebKit/NetworkProcess/PingLoad.h:
* Source/WebKit/Shared/WebCoreArgumentCodersNetwork.serialization.in:
</pre>