### PR TITLE
[JSC] Convert `HasOwnProperty` on the current for-in property name to `EnumeratorHasOwnProperty`

### DIFF
--- a/JSTests/microbenchmarks/has-own-property-call-for-in-loop.js
+++ b/JSTests/microbenchmarks/has-own-property-call-for-in-loop.js
@@ -1,0 +1,33 @@
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+function test1() {
+    function count(o) {
+        let c = 0;
+        for (let p in o) {
+            if (Object.prototype.hasOwnProperty.call(o, p))
+                c += p.length;
+        }
+        return c;
+    }
+    noInline(count);
+
+    const keys = ['method', 'url', 'status', 'headers', 'body', 'retries', 'timeout', 'ok'];
+    let srcs = [];
+    for (let j = 0; j < 16; j++) {
+        let o = {};
+        for (let k of keys)
+            o[k] = k + j;
+        srcs.push(o);
+    }
+
+    let expected = 0;
+    for (let k of keys)
+        expected += k.length;
+
+    for (let i = 0; i < 1000000; ++i)
+        assert(count(srcs[i & 15]) === expected);
+}
+test1();

--- a/JSTests/stress/for-in-has-own-property-call-edge-cases.js
+++ b/JSTests/stress/for-in-has-own-property-call-edge-cases.js
@@ -1,0 +1,236 @@
+function assert(b, m) {
+    if (!b)
+        throw new Error(m);
+}
+
+const hop = Object.prototype.hasOwnProperty;
+
+function oracle(o, p) {
+    return Reflect.getOwnPropertyDescriptor(Object(o), p) !== undefined;
+}
+noInline(oracle);
+
+// The guard must observe a delete of the current key.
+function deleteCurrent(o) {
+    const seen = [];
+    for (const p in o) {
+        delete o[p];
+        seen.push(p + ':' + Object.prototype.hasOwnProperty.call(o, p));
+    }
+    return seen.join(',');
+}
+noInline(deleteCurrent);
+
+function deleteCurrentHasOwn(o) {
+    const seen = [];
+    for (const p in o) {
+        delete o[p];
+        seen.push(p + ':' + Object.hasOwn(o, p));
+    }
+    return seen.join(',');
+}
+noInline(deleteCurrentHasOwn);
+
+// A call that clobbers the world between the property name production and the guard.
+let clobberTarget = null;
+let clobberKey = '';
+function clobber() {
+    if (clobberTarget)
+        delete clobberTarget[clobberKey];
+}
+noInline(clobber);
+
+function guardAfterClobber(o, victim) {
+    const seen = [];
+    for (const p in o) {
+        clobberTarget = p === victim ? o : null;
+        clobberKey = p;
+        clobber();
+        seen.push(p + ':' + hop.call(o, p));
+    }
+    clobberTarget = null;
+    return seen.join(',');
+}
+noInline(guardAfterClobber);
+
+// The guard must always agree with Reflect.getOwnPropertyDescriptor, even while
+// the mutator churns structures, prototypes, and upcoming keys.
+function differential(o, mutate) {
+    let ones = 0;
+    for (const p in o) {
+        if (mutate)
+            mutate(o, p);
+        const got = Object.prototype.hasOwnProperty.call(o, p);
+        assert(got === oracle(o, p), "differential mismatch for " + p);
+        if (got)
+            ones++;
+    }
+    return ones;
+}
+noInline(differential);
+
+// Loop variable reassignment: q keeps the enumerated name, p does not.
+function reassign(o) {
+    let n = 0;
+    for (let p in o) {
+        const q = p;
+        p = 'not a property';
+        assert(!hop.call(o, p), "reassigned key must miss");
+        if (hop.call(o, q))
+            n++;
+    }
+    return n;
+}
+noInline(reassign);
+
+// Nested enumerations over the same object, guarding both loop variables.
+function nested(o) {
+    let n = 0;
+    for (const p in o) {
+        for (const q in o) {
+            if (hop.call(o, p))
+                n++;
+            if (Object.hasOwn(o, q))
+                n += 10;
+        }
+    }
+    return n;
+}
+noInline(nested);
+
+// The guard on a proxy must consult the getOwnPropertyDescriptor trap every time.
+function proxyGuard(o, counter) {
+    let n = 0;
+    for (const p in o) {
+        const before = counter.count;
+        if (hop.call(o, p))
+            n++;
+        assert(counter.count > before, "guard must hit the proxy trap");
+    }
+    return n;
+}
+noInline(proxyGuard);
+
+// A trap that starts throwing mid-enumeration must surface the exception.
+function proxyThrow(o, state) {
+    const seen = [];
+    for (const p in o) {
+        seen.push(p + ':' + hop.call(o, p));
+        state.throwing = true;
+    }
+    return seen.join(',');
+}
+noInline(proxyThrow);
+
+// Polymorphic bases: plain, null-proto, frozen, large, array, string primitive.
+function polyBase(o) {
+    let n = 0;
+    for (const p in o) {
+        if (Object.prototype.hasOwnProperty.call(o, p))
+            n++;
+    }
+    return n;
+}
+noInline(polyBase);
+
+const protoBase = { pa: 1, pb: 2 };
+
+function makeLarge() {
+    const o = {};
+    for (let i = 0; i < 40; ++i)
+        o['k' + i] = i;
+    return o;
+}
+
+const largeTemplate = makeLarge();
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assert(deleteCurrent({ a: 1, b: 2, c: 3 }) === 'a:false,b:false,c:false', "deleteCurrent");
+    assert(deleteCurrentHasOwn({ a: 1, b: 2, c: 3 }) === 'a:false,b:false,c:false', "deleteCurrentHasOwn");
+
+    assert(guardAfterClobber({ a: 1, b: 2, c: 3 }, 'b') === 'a:true,b:false,c:true', "guardAfterClobber");
+
+    {
+        const o = Object.create(protoBase);
+        o.a = 1;
+        o.b = 2;
+        assert(differential(o, null) === 2, "differential proto");
+    }
+    {
+        const o = { a: 1, b: 2, c: 3 };
+        assert(differential(o, (t, p) => { if (p === 'a') delete t.c; }) === 2, "differential delete upcoming");
+    }
+    {
+        const o = { a: 1, b: 2 };
+        differential(o, (t, p) => { t['n' + p] = 1; });
+    }
+    {
+        const o = Object.create(protoBase);
+        o.a = 1;
+        differential(o, (t, p) => { if (p === 'a') Object.setPrototypeOf(t, { zz: 1 }); });
+    }
+    {
+        const o = { a: 1, b: 2, c: 3, d: 4 };
+        delete o.b;
+        o['k' + (i & 7)] = 1;
+        assert(differential(o, null) === 4, "differential dictionary");
+    }
+
+    assert(reassign({ a: 1, b: 2, c: 3 }) === 3, "reassign");
+    assert(nested({ a: 1, b: 2, c: 3 }) === 99, "nested");
+
+    {
+        const counter = { count: 0 };
+        const proxy = new Proxy({ a: 1, b: 2 }, {
+            getOwnPropertyDescriptor(t, k) {
+                counter.count++;
+                return Reflect.getOwnPropertyDescriptor(t, k);
+            }
+        });
+        assert(proxyGuard(proxy, counter) === 2, "proxyGuard");
+    }
+    {
+        const state = { throwing: false };
+        const proxy = new Proxy({ a: 1, b: 2 }, {
+            getOwnPropertyDescriptor(t, k) {
+                if (state.throwing)
+                    throw new Error('trap');
+                return Reflect.getOwnPropertyDescriptor(t, k);
+            }
+        });
+        let threw = false;
+        let result = null;
+        try {
+            result = proxyThrow(proxy, state);
+        } catch (e) {
+            threw = true;
+            assert(e.message === 'trap', "proxyThrow message");
+        }
+        assert(threw || result === 'a:true,b:true', "proxyThrow " + result);
+    }
+
+    assert(polyBase({ a: 1, b: 2, c: 3 }) === 3, "polyBase object");
+    assert(polyBase("abcd") === 4, "polyBase string");
+    {
+        const arr = [10, 20, 30];
+        arr.named = 1;
+        delete arr[1];
+        assert(polyBase(arr) === 3, "polyBase array");
+    }
+    {
+        const o = Object.create(null);
+        o.x = 1;
+        o.y = 2;
+        assert(polyBase(o) === 2, "polyBase null proto");
+    }
+    assert(polyBase(Object.freeze({ f1: 1, f2: 2 })) === 2, "polyBase frozen");
+    {
+        const o = { ...largeTemplate };
+        assert(polyBase(o) === 40, "polyBase large");
+    }
+    {
+        const o = Object.create(protoBase);
+        o.own = 1;
+        assert(polyBase(o) === 1, "polyBase inherited");
+    }
+}

--- a/JSTests/stress/for-in-has-own-property-call.js
+++ b/JSTests/stress/for-in-has-own-property-call.js
@@ -1,0 +1,94 @@
+function assert(b, m) {
+    if (!b)
+        throw new Error(m);
+}
+
+const hop = Object.prototype.hasOwnProperty;
+
+function countOwn(o) {
+    let own = 0;
+    let inherited = 0;
+    for (const p in o) {
+        if (Object.prototype.hasOwnProperty.call(o, p))
+            own++;
+        else
+            inherited++;
+    }
+    return [own, inherited];
+}
+noInline(countOwn);
+
+function countHasOwn(o) {
+    let own = 0;
+    for (const p in o) {
+        if (Object.hasOwn(o, p))
+            own++;
+    }
+    return own;
+}
+noInline(countHasOwn);
+
+function crossCheck(o, other) {
+    let n = 0;
+    for (const p in o) {
+        if (hop.call(other, p))
+            n++;
+    }
+    return n;
+}
+noInline(crossCheck);
+
+function deleteDuring(o, victim) {
+    const seen = [];
+    for (const p in o) {
+        if (p === 'a')
+            delete o[victim];
+        seen.push(p + ':' + hop.call(o, p));
+    }
+    return seen.join(',');
+}
+noInline(deleteDuring);
+
+function countIndexed(o) {
+    let own = 0;
+    for (const p in o) {
+        if (hop.call(o, p))
+            own++;
+    }
+    return own;
+}
+noInline(countIndexed);
+
+const proto = { pa: 1, pb: 2 };
+
+for (let i = 0; i < testLoopCount; ++i) {
+    const o = Object.create(proto);
+    o.a = 1;
+    o.b = 2;
+    o.c = 3;
+    const [own, inherited] = countOwn(o);
+    assert(own === 3, "own " + own);
+    assert(inherited === 2, "inherited " + inherited);
+
+    const shadow = Object.create(proto);
+    shadow.pa = 9;
+    shadow.x = 1;
+    const [sOwn, sInherited] = countOwn(shadow);
+    assert(sOwn === 2, "shadow own " + sOwn);
+    assert(sInherited === 1, "shadow inherited " + sInherited);
+
+    const h = Object.create(proto);
+    h.a = 1;
+    h.b = 2;
+    assert(countHasOwn(h) === 2, "hasOwn");
+
+    assert(crossCheck({ a: 1, b: 2, c: 3 }, { a: 1, c: 3 }) === 2, "cross");
+
+    const d = { a: 1, b: 2, c: 3 };
+    const r = deleteDuring(d, 'c');
+    assert(r === 'a:true,b:true' || r === 'a:true,b:true,c:false', "delete " + r);
+
+    const arr = [10, 20, 30];
+    arr.named = 1;
+    assert(countIndexed(arr) === 4, "indexed");
+}

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -422,6 +422,22 @@ void Node::convertToDefineAccessorProperty(Graph& graph, Edge base, Edge propert
     children = AdjacencyList(AdjacencyList::Variable, firstChild, 5);
 }
 
+void Node::convertToEnumeratorHasOwnProperty(Graph& graph, Edge base, Edge propertyName, Edge index, Edge mode, Edge enumerator, ArrayMode arrayMode, unsigned enumeratorMetadata)
+{
+    ASSERT(op() == HasOwnProperty);
+    setOpAndDefaultFlags(EnumeratorHasOwnProperty);
+    m_opInfo = arrayMode.asWord();
+    m_opInfo2 = enumeratorMetadata;
+
+    unsigned firstChild = graph.m_varArgChildren.size();
+    graph.m_varArgChildren.append(base);
+    graph.m_varArgChildren.append(propertyName);
+    graph.m_varArgChildren.append(index);
+    graph.m_varArgChildren.append(mode);
+    graph.m_varArgChildren.append(enumerator);
+    children = AdjacencyList(AdjacencyList::Variable, firstChild, 5);
+}
+
 void Node::convertToObjectDefinePropertyFromFields(Graph& graph, Edge target, Edge key, Edge enumerable, Edge configurable, Edge value, Edge writable, Edge getter, Edge setter)
 {
     ASSERT(op() == ObjectDefineProperty);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -986,6 +986,7 @@ public:
     void convertToDefineAccessorProperty(Graph&, Edge base, Edge property, Edge getter, Edge setter, Edge attributes);
     void convertToObjectDefinePropertyFromFields(Graph&, Edge target, Edge key, Edge enumerable, Edge configurable, Edge value, Edge writable, Edge getter, Edge setter);
     void convertToPutByIdDirect(Graph&, Edge base, Edge value, CacheableIdentifier, ECMAMode);
+    void convertToEnumeratorHasOwnProperty(Graph&, Edge base, Edge propertyName, Edge index, Edge mode, Edge enumerator, ArrayMode, unsigned enumeratorMetadata);
 
     void convertToSetRegExpObjectLastIndex()
     {

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1710,6 +1710,19 @@ private:
                 keyEdge->setOp(MakeAtomString);
                 m_changed = true;
             }
+
+            Node* object = m_graph.child(m_node, 0).node();
+            Node* key = keyEdge.node();
+            if (key->op() == EnumeratorNextUpdatePropertyName && key->child3()->op() == GetPropertyEnumerator && key->child3()->child1().node() == object) {
+                Node* indexNode = key->child1().node();
+                if (indexNode->op() == ExtractFromTuple && indexNode->child1()->op() == EnumeratorNextUpdateIndexAndMode) {
+                    m_node->convertToEnumeratorHasOwnProperty(
+                        m_graph, Edge(object, CellUse), Edge(key, UntypedUse),
+                        key->child1(), key->child2(), key->child3(),
+                        indexNode->child1()->arrayMode(), key->enumeratorMetadata().toRaw());
+                    m_changed = true;
+                }
+            }
             break;
         }
 


### PR DESCRIPTION
#### 752e7e8b0d05a5b13ce3d573bb75e7e8c86ad019
<pre>
[JSC] Convert `HasOwnProperty` on the current for-in property name to `EnumeratorHasOwnProperty`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318528">https://bugs.webkit.org/show_bug.cgi?id=318528</a>

Reviewed by Yusuke Suzuki.

Object.prototype.hasOwnProperty.call(o, p) is a common guard inside `for (p in o)`
(eslint&apos;s no-prototype-builtins rewrites o.hasOwnProperty(p) into this form).
However, op_enumerator_has_own_property is not emitted for it: the recognition
happens only in the parser, which matches the exact syntactic form
`o.hasOwnProperty(p)`, so the .call spelling (and Object.hasOwn) falls back to
the generic HasOwnProperty node that hashes the key on every iteration.

This patch additionally converts HasOwnProperty to EnumeratorHasOwnProperty in
DFG strength reduction, when the key is the EnumeratorNextUpdatePropertyName of
an enumeration whose GetPropertyEnumerator base is the same node as the object.
This makes the guard a structure ID comparison regardless of spelling.

                                                   Baseline                  Patched

object-has-own-for-in-loop                      4.7828+-0.0548     ^      4.0638+-0.0909        ^ definitely 1.1769x faster
has-own-property-call-for-in-loop              12.0470+-0.2778     ^      9.5166+-0.2442        ^ definitely 1.2659x faster

Tests: JSTests/microbenchmarks/has-own-property-call-for-in-loop.js
       JSTests/stress/for-in-has-own-property-call-edge-cases.js
       JSTests/stress/for-in-has-own-property-call.js

* JSTests/microbenchmarks/has-own-property-call-for-in-loop.js: Added.
(assert):
(test1.count):
(test1):
* JSTests/stress/for-in-has-own-property-call-edge-cases.js: Added.
(assert):
(oracle):
(deleteCurrent):
(deleteCurrentHasOwn):
(clobber):
(guardAfterClobber):
(differential):
(reassign):
(nested):
(proxyGuard):
(proxyThrow):
(polyBase):
(makeLarge):
(i.assert.guardAfterClobber):
(i.assert):
(i.p.string_appeared_here.Object.setPrototypeOf):
(i.assert.nested):
(i.assert.polyBase):
(i.assert.polyBase.Object.freeze):
* JSTests/stress/for-in-has-own-property-call.js: Added.
(assert):
(countOwn):
(countHasOwn):
(crossCheck):
(deleteDuring):
(countIndexed):
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToEnumeratorHasOwnProperty):
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/316538@main">https://commits.webkit.org/316538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e203f4fc93dc44ee47ff9678532e6881b7c81fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129965 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94604 "22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34450 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30466 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3158 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184396 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33670 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142862 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45999 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142743 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38606 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46677 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30973 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111412 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37791 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118428 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205087 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45194 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9075 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54756 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->