### PR TITLE
AX: A text-stitch-group representative's text marker range is truncated to its first run

### DIFF
--- a/LayoutTests/accessibility/mac/stitched-text-marker-range-for-ui-element-expected.txt
+++ b/LayoutTests/accessibility/mac/stitched-text-marker-range-for-ui-element-expected.txt
@@ -1,0 +1,9 @@
+This test ensures AXTextMarkerRangeForUIElement spans the full text of a stitch-group representative, rather than collapsing to its first run.
+
+PASS: rangeString === 'By John Gruber'
+PASS: webArea.textMarkerRangeLength(range) === 14
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+By John Gruber

--- a/LayoutTests/accessibility/mac/stitched-text-marker-range-for-ui-element.html
+++ b/LayoutTests/accessibility/mac/stitched-text-marker-range-for-ui-element.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ AccessibilityTextStitchingEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="byline">By <strong>John Gruber</strong></p>
+
+<script>
+var output = "This test ensures AXTextMarkerRangeForUIElement spans the full text of a stitch-group representative, rather than collapsing to its first run.\n\n";
+
+if (window.accessibilityController) {
+    // "By " and the bold "John Gruber" are stitched into a single StaticText. Its
+    // text marker range must cover the whole stitched string, not just the first
+    // run "By " (rdar://problem regression: textMarkerRange() derived its endpoint
+    // from a topology-dependent tree traversal instead of the stitch member list).
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    var stitchedText = accessibilityController.accessibleElementById("byline").childAtIndex(0);
+    var range = webArea.textMarkerRangeForElement(stitchedText);
+    var rangeString = webArea.stringForTextMarkerRange(range);
+
+    output += expect("rangeString", "'By John Gruber'");
+    output += expect("webArea.textMarkerRangeLength(range)", "14");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -283,6 +283,32 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
         return { };
     }
 
+    if (std::optional stitchGroup = stitchGroupIfRepresentative()) {
+        // A stitch representative's text is the concatenation of its members, so its
+        // range must span the first through last member with text runs, like the
+        // main-thread AccessibilityObject::simpleRange().
+        RefPtr<AXIsolatedObject> firstMember;
+        RefPtr<AXIsolatedObject> lastMember;
+        unsigned lastMemberLength = 0;
+        for (AXID memberID : stitchGroup->members()) {
+            RefPtr member = tree().objectForID(memberID);
+            if (!member || member->isAXHidden())
+                continue;
+            const auto* runs = member->textRuns();
+            if (!runs)
+                continue;
+            unsigned length = runs->totalLength();
+            if (!length)
+                continue;
+            if (!firstMember)
+                firstMember = member;
+            lastMember = member;
+            lastMemberLength = length;
+        }
+        if (firstMember && lastMember)
+            return { AXTextMarker { *firstMember, 0 }, AXTextMarker { *lastMember, lastMemberLength } };
+    }
+
     // This object doesn't have text content of its own. Create a range pointing to the first and last
     // text positions of our descendants. We can do this by stopping text marker traversal when we try
     // to move to our sibling. For example, getting textMarkerRange() for {ID 1, Role Group}:
@@ -295,15 +321,6 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
     //
     // We would expect the returned range to be: {ID 2, offset 0} to {ID 4, offset 3}
     Ref stopAfterObject = *this;
-
-    if (std::optional stitchGroup = stitchGroupIfRepresentative()) {
-        for (auto axID = stitchGroup->members().rbegin(); axID != stitchGroup->members().rend(); ++axID) {
-            if (RefPtr lastGroupMember = tree().objectForID(*axID); lastGroupMember && !lastGroupMember->isAXHidden()) {
-                stopAfterObject = lastGroupMember.releaseNonNull();
-                break;
-            }
-        }
-    }
     std::optional<AXID> stopAtID = stopAfterObject->idOfNextSiblingIncludingIgnoredOrParent();
 
     auto thisMarker = AXTextMarker { *this, 0 };
@@ -314,6 +331,7 @@ AXTextMarkerRange AXIsolatedObject::textMarkerRange() const
         // One or more of our descendants have text, so let's form a range from the first and last text positions.
         range = { WTF::move(startMarker), WTF::move(endMarker) };
     }
+
     return range;
 }
 


### PR DESCRIPTION
#### 5fd9a4304b881e29883ec2d31858386440f7e39a
<pre>
AX: A text-stitch-group representative&apos;s text marker range is truncated to its first run
<a href="https://bugs.webkit.org/show_bug.cgi?id=318529">https://bugs.webkit.org/show_bug.cgi?id=318529</a>
&lt;<a href="https://rdar.apple.com/problem/181299126">rdar://problem/181299126</a>&gt;

Reviewed by Dominic Mazzoni.

When accessibility text stitching merges adjacent text runs into a single static-text
representative, the representative&apos;s value spans all of its members, but its text marker
range did not. On the isolated tree, AXIsolatedObject::textMarkerRange() used the stitch
group only to pick a stop boundary and then derived the range endpoints by walking the
accessibility tree, a walk that stops at the representative&apos;s own run. As a result
AXTextMarkerRangeForUIElement, and the string, attributed-string, and length APIs derived
from that range, returned only the first run (e.g. &quot;By&quot; of a stitched &quot;By JOHN GRUBER&quot;)
rather than the full stitched text, so a client that reads an element&apos;s text through its
marker range got truncated content that disagreed with the element&apos;s value.

Build the representative&apos;s range directly from its stitch-group members, from the first
through the last member that has text runs, mirroring the main-thread
AccessibilityObject::simpleRange(). This spans the full stitched text and is consistent
with stringValue() and relativeFrame(), which already iterate the members.

Test: accessibility/mac/stitched-text-marker-range-for-ui-element.html

* LayoutTests/accessibility/mac/stitched-text-marker-range-for-ui-element-expected.txt: Added.
* LayoutTests/accessibility/mac/stitched-text-marker-range-for-ui-element.html: Added.
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::textMarkerRange const): Build a stitch-group representative&apos;s
range from its members instead of a tree walk that stops at the first run.

Canonical link: <a href="https://commits.webkit.org/316576@main">https://commits.webkit.org/316576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee2bb1dc99b407852b454619a0c98da83885e93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129968 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4666bce4-3bec-4f8a-9691-838c8813df47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134094 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94606 "20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c274533-d38f-46e3-a9b1-346b4e09b88e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a64bd5e3-6d9f-4c19-b2db-c523e4211f88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34452 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30469 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184400 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142866 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142747 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38630 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46680 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111417 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37792 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118431 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45197 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9080 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->