### PR TITLE
Optimize SVGURIReference::fragmentIdentifierFromIRIString to avoid redundant URL parsing and string allocations

### DIFF
--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -79,13 +79,10 @@ AtomString SVGURIReference::fragmentIdentifierFromIRIString(const String& url, c
     if (!start)
         return AtomString(PAL::decodeURLEscapeSequences(StringView(url).substring(1)));
 
-    URL base = URL(document.baseURL(), url.left(start));
-    String fragmentIdentifier = url.substring(start);
-    URL urlWithFragment(base, fragmentIdentifier);
+    URL urlWithFragment = document.encodingParseURL(url);
     if (equalIgnoringFragmentIdentifier(urlWithFragment, document.url()))
-        return AtomString(PAL::decodeURLEscapeSequences(StringView(fragmentIdentifier).substring(1)));
+        return AtomString(PAL::decodeURLEscapeSequences(urlWithFragment.fragmentIdentifier()));
 
-    // The url doesn't have any fragment identifier.
     return emptyAtom();
 }
 


### PR DESCRIPTION
#### 52256fbd159a84cdf834a19b4f4c7f8a6946c777
<pre>
Optimize SVGURIReference::fragmentIdentifierFromIRIString to avoid redundant URL parsing and string allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=318531">https://bugs.webkit.org/show_bug.cgi?id=318531</a>

Reviewed by Nikolas Zimmermann.

Improve performance in SVGURIReference::fragmentIdentifierFromIRIString by using
Document::encodingParseURL to resolve the URL in a single pass. This avoids manual
slicing of URLs and multiple URL object constructions, reducing heap allocations
and duplicate parsing.

* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::fragmentIdentifierFromIRIString):

Canonical link: <a href="https://commits.webkit.org/316480@main">https://commits.webkit.org/316480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9453183b4c66e11087c0aba337222e3cdef1a73f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129973 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bd0ecee-dd35-4090-baf3-f2365b81e992) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134096 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f8f09cf-0669-4430-883c-4c69123d5932) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114567 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f8d102e-3956-4d47-aeca-544bc77a488a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36154 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30474 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184405 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142878 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46007 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38562 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46685 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111427 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37794 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118436 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45202 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9085 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44661 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->