### PR TITLE
Cherry-pick 249edf86a9f5. https://bugs.webkit.org/show_bug.cgi?id=313866

### DIFF
--- a/JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js
+++ b/JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js
@@ -1,0 +1,32 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.1", "--useConcurrentGC=false", "--verifyGC=true", "--gcMaxHeapSize=500000")
+
+var g_value = {};
+
+function makeObj() { return {}; }
+
+function foo(cond) {
+    let a = makeObj();
+    a.p1 = 1;
+    a.p2 = 1;
+    a.p3 = 1;
+    a.p4 = 1;
+    a.p5 = 1;
+    if (cond)
+        a.y = 1;
+    else
+        a.z = 1;
+    a.x = g_value;
+    return a;
+}
+noInline(foo);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    g_value = {};
+    foo(i & 1);
+}
+
+var holder = new Array(100000).fill(null);
+fullGC();
+
+for (let i = 0; i < testLoopCount * 10; ++i)
+    holder[i % 100000] = foo(i & 1);

--- a/JSTests/stress/yarr-negative-offset.js
+++ b/JSTests/stress/yarr-negative-offset.js
@@ -1,0 +1,33 @@
+//@ skip if $memoryLimited
+
+// YarrJIT OOB crash — page-aligned variant
+//
+// sizeof(StringImpl) = 0x14, page_size = 0x4000 (Apple Silicon 16K pages)
+// Solve: 0x14 + (K + 0x40000000)*2 ≡ 0 (mod 0x4000)  →  K = 0x1FF6
+//
+// Pattern: \u0100{K} [\u0100] \u0100{0x3FFFFFFF}    flags: y
+// Subject: "\u0100".repeat(K + 0x40000000)
+//
+// The OOB ldrh lands at alloc_base + page_size*N exactly → unmapped → SIGSEGV
+
+"use strict";
+
+const K     = 0x1FF6;
+const LEN   = K + 0x40000000;   // 0x40001FF6
+const QUANT = 0x3FFFFFFF;
+
+// allocate
+let s;
+try {
+    s = "\u0100".repeat(LEN);
+} catch (e) {
+    print("[!] OOM: " + e);
+    quit();
+}
+if(s.length !== 0x40001ff6) throw new Error("unexpected s.length "+s.length);
+
+let pattern = "\\u0100{" + K + "}[\\u0100]\\u0100{" + QUANT + "}";
+let re = new RegExp(pattern, "y");
+re.lastIndex = 0;
+
+re.test(s); // should SIGSEGV if the bug is present

--- a/LayoutTests/fast/canvas/webgl/context-restore-concurrent-gc-no-crash-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/context-restore-concurrent-gc-no-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/canvas/webgl/context-restore-concurrent-gc-no-crash.html
+++ b/LayoutTests/fast/canvas/webgl/context-restore-concurrent-gc-no-crash.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<body>
+<!-- Exercises a race between WebGL2 context restoration (which reinitializes
+     bound-object state via initializeNewContext) and concurrent GC marking (which
+     traverses that state via addMembersToOpaqueRoots). Without objectGraphLock()
+     held during restoration, the restore path can free objects the GC marker is
+     still reading, causing a use-after-free. -->
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+if (window.internals)
+    internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
+const tick = () => new Promise(r => setTimeout(r, 0));
+
+// Ensure the GC marker doesn't reach the WebGL wrapper until the concurrent phase.
+const heapPaddingSize = 300000;
+const heapPadding = new Array(heapPaddingSize);
+for (let i = 0; i < heapPaddingSize; i++)
+    heapPadding[i] = { a: i, b: { c: i } };
+
+async function loseAndRestoreContext() {
+    const canvas = document.body.appendChild(document.createElement('canvas'));
+    canvas.width = 1;
+    canvas.height = 1;
+    const gl = canvas.getContext('webgl2');
+    const ext = gl.getExtension('WEBGL_lose_context');
+    for (let i = 0; i < heapPaddingSize; i += 4096)
+        heapPadding[i].g = gl;
+
+    const contextLost = new Promise(r => {
+        canvas.addEventListener('webglcontextlost', e => { e.preventDefault(); r(); });
+    });
+    const contextRestored = new Promise(r => {
+        canvas.addEventListener('webglcontextrestored', () => r());
+    });
+
+    ext.loseContext();
+    await contextLost;
+    await tick();
+
+    // Trigger GC so its concurrent marking phase overlaps the restore timer.
+    new WebAssembly.Memory({ initial: 1024 });
+    new WebAssembly.Memory({ initial: 1024 });
+    ext.restoreContext();
+    await tick();
+    await tick();
+    await contextRestored;
+
+    canvas.remove();
+}
+
+async function runTest() {
+    for (let i = 0; i < 50; i++)
+        await loseAndRestoreContext();
+    document.body.textContent = 'PASS if no crash.';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet-expected.txt
+++ b/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet-expected.txt
@@ -1,0 +1,12 @@
+Test that a parent stylesheet wrapper is not collected when only the @import child stylesheet is alive.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS parentSheet instanceof CSSStyleSheet is true
+PASS parentSheet.cssRules[0].type is CSSRule.IMPORT_RULE
+PASS childSheet.parentStyleSheet.foo is "bar"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet.html
+++ b/LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+window.jsTestIsAsync = true;
+description("Test that a parent stylesheet wrapper is not collected when only the @import child stylesheet is alive.");
+
+var style = document.createElement("style");
+style.textContent = '@import url("resources/detached-style.css");';
+document.head.appendChild(style);
+
+var parentSheet = style.sheet;
+shouldBeTrue("parentSheet instanceof CSSStyleSheet");
+shouldBe("parentSheet.cssRules[0].type", "CSSRule.IMPORT_RULE");
+
+// Set a custom property on the parent stylesheet wrapper.
+parentSheet.foo = "bar";
+
+// Hold onto the imported (child) stylesheet only.
+window.onload = () => {
+    window.childSheet = parentSheet.cssRules[0].styleSheet;
+
+    // Release all direct references to the parent.
+    parentSheet = null;
+    style.remove();
+    style = null;
+
+    gc();
+    setTimeout(function() {
+        gc();
+        // The parent wrapper should survive because the child's opaque root
+        // should group it with the parent. If it doesn't, the parent wrapper
+        // is collected and a new one is created without the custom property.
+        shouldBeEqualToString('childSheet.parentStyleSheet.foo', 'bar');
+        finishJSTest();
+    }, 0);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash-expected.txt
+++ b/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html
+++ b/LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CloseWatcherEnabled=true ] -->
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+let first = new CloseWatcher();
+let second;
+internals.withUserGesture(() => { second = new CloseWatcher(); });
+first.destroy();
+second.destroy();
+
+document.write("PASS if no crash.");
+</script>

--- a/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html
+++ b/LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<body>
+<div id="target">PASS if this does not crash.</div>
+<script>
+
+window.testRunner?.dumpAsText();
+
+document.getElementById("target").animate({ offset: "cover 0%", transform: "scale(2)" }, 1000);
+
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -68,6 +68,8 @@ enum class PhaseMode {
     Global
 };
 
+// FIXME(rdar://177100632): Document barrier placement invariants expected of nodes for this phase
+// and improve barrier-related phases overall.
 template<PhaseMode mode>
 class StoreBarrierInsertionPhase : public Phase {
 public:
@@ -349,9 +351,20 @@ private:
                 break;
             }
                 
-            case MultiPutByOffset:
+            case MultiPutByOffset: {
+                // This node may cause a transition before performing a store if it reallocates
+                // storage. This is different from the usual assumption in this phase a node's fast
+                // path either does GC or performs a store, but not both within the same node (a
+                // slow path call to an operation always performs its own barrier). In this special
+                // case, bump the epoch before considering the barrier.
+                if (m_node->multiPutByOffsetData().reallocatesStorage())
+                    m_currentEpoch.bump();
+                considerBarrier(m_node->child1());
+                break;
+            }
+
             case MultiDeleteByOffset: {
-                // These nodes may cause transition too.
+                // This node may cause a transition but does not GC.
                 considerBarrier(m_node->child1());
                 break;
             }

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1120,9 +1120,9 @@ class YarrGenerator final : public YarrJITInfo {
         Checked<int32_t> characterOffset(-static_cast<int32_t>(negativeCharacterOffset));
 
         if (m_charSize == CharSize::Char8)
-            return MacroAssembler::BaseIndex(m_regs.input, indexReg, MacroAssembler::TimesOne, characterOffset * static_cast<int32_t>(sizeof(char)));
+            return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesOne, characterOffset * static_cast<int32_t>(sizeof(char)));
 
-        return MacroAssembler::BaseIndex(m_regs.input, indexReg, MacroAssembler::TimesTwo, characterOffset * static_cast<int32_t>(sizeof(char16_t)));
+        return MacroAssembler::BaseIndex(base, indexReg, MacroAssembler::TimesTwo, characterOffset * static_cast<int32_t>(sizeof(char16_t)));
     }
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2567,6 +2567,9 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
             continue;
 
         auto offset = keyframe.offset();
+        if (std::isnan(offset))
+            return false;
+
         if (!offset)
             computedBoundsForFromKeyframe = true;
         if (offset == 1.0)

--- a/Source/WebCore/bindings/js/JSStyleSheetCustom.h
+++ b/Source/WebCore/bindings/js/JSStyleSheetCustom.h
@@ -35,11 +35,7 @@ namespace WebCore {
 
 inline WebCoreOpaqueRoot root(StyleSheet* styleSheet)
 {
-    if (SUPPRESS_UNCOUNTED_LOCAL CSSImportRule* ownerRule = styleSheet->ownerRule())
-        return root(ownerRule);
-    if (SUPPRESS_UNCOUNTED_LOCAL Node* ownerNode = styleSheet->ownerNode())
-        return root(ownerNode);
-    return WebCoreOpaqueRoot { styleSheet };
+    return styleSheet->opaqueRootForGCThread();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSImportRule);
+
 CSSImportRule::CSSImportRule(StyleRuleImport& importRule, CSSStyleSheet* parent)
     : CSSRule(parent)
     , m_importRule(importRule)

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <WebCore/CSSRule.h>
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -33,7 +34,9 @@ struct MediaQuery;
 using MediaQueryList = Vector<MediaQuery>;
 }
 
-class CSSImportRule final : public CSSRule {
+class CSSImportRule final : public CSSRule, public CanMakeCheckedPtr<CSSImportRule> {
+    WTF_MAKE_TZONE_ALLOCATED(CSSImportRule);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CSSImportRule);
 public:
     static Ref<CSSImportRule> create(StyleRuleImport& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSImportRule(rule, sheet)); }
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -30,6 +30,7 @@
 #include "HTMLStyleElement.h"
 #include "JSCSSStyleSheet.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSNodeCustomInlines.h"
 #include "Logging.h"
 #include "MediaList.h"
 #include "MediaQueryParser.h"
@@ -276,12 +277,31 @@ void CSSStyleSheet::forEachStyleScope(NOESCAPE const Function<void(Style::Scope&
 
 void CSSStyleSheet::clearOwnerNode()
 {
+    Locker locker { m_opaqueRootLockForGC };
     m_ownerNode = nullptr;
+}
+
+WebCoreOpaqueRoot CSSStyleSheet::opaqueRootForGCThread()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    if (m_ownerNode)
+        return root(m_ownerNode.get());
+    if (auto* ownerRule = m_ownerRule.get()) {
+        if (auto* parentSheet = ownerRule->parentStyleSheet())
+            return parentSheet->opaqueRootForGCThread();
+    }
+    return WebCoreOpaqueRoot { this };
 }
 
 CSSImportRule* CSSStyleSheet::ownerRule() const
 {
     return m_ownerRule.get();
+}
+
+void CSSStyleSheet::clearOwnerRule()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    m_ownerRule = nullptr;
 }
 
 void CSSStyleSheet::reattachChildRuleCSSOMWrappers()

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -26,8 +26,10 @@
 #include <WebCore/MediaList.h>
 #include <WebCore/MediaQuery.h>
 #include <WebCore/StyleSheet.h>
+#include <WebCore/WebCoreOpaqueRoot.h>
 #include <memory>
 #include <wtf/CheckedPtr.h>
+#include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
@@ -105,7 +107,7 @@ public:
     URL baseURL() const final;
     bool isLoading() const final;
 
-    void clearOwnerRule() { m_ownerRule = nullptr; }
+    void clearOwnerRule();
 
     void removeAdoptingTreeScope(ContainerNode&);
     void addAdoptingTreeScope(ContainerNode&);
@@ -162,6 +164,8 @@ public:
     String cssText(const CSS::SerializationContext&);
     void getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>&);
 
+    WebCoreOpaqueRoot opaqueRootForGCThread() override;
+
     bool isDetached() const;
 
 private:
@@ -188,8 +192,9 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_constructorDocument;
     WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
-    WeakPtr<CSSImportRule> m_ownerRule;
+    mutable Lock m_opaqueRootLockForGC;
+    CheckedPtr<Node> m_ownerNode;
+    CheckedPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;
 

--- a/Source/WebCore/css/StyleSheet.h
+++ b/Source/WebCore/css/StyleSheet.h
@@ -34,6 +34,7 @@ class CSSImportRule;
 class MediaList;
 class Node;
 class StyleSheet;
+class WebCoreOpaqueRoot;
 
 class StyleSheet : public RefCounted<StyleSheet> {
 public:
@@ -50,6 +51,7 @@ public:
 
     virtual CSSImportRule* ownerRule() const { return nullptr; }
     virtual void clearOwnerNode() = 0;
+    virtual WebCoreOpaqueRoot opaqueRootForGCThread() = 0;
     virtual URL baseURL() const = 0;
     virtual bool isLoading() const = 0;
     virtual bool isCSSStyleSheet() const { return false; }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -261,7 +261,7 @@ public:
 
 private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;
-    void initializeContextState() final;
+    void initializeContextState() WTF_REQUIRES_LOCK(objectGraphLock()) final;
 
     RefPtr<ArrayBufferView> arrayBufferViewSliceFactory(ASCIILiteral functionName, const ArrayBufferView& data, unsigned startByte, unsigned bytelength);
     RefPtr<ArrayBufferView> sliceArrayBufferView(ASCIILiteral functionName, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length);
@@ -269,7 +269,7 @@ private:
     long long getInt64Parameter(GCGLenum) final;
     Vector<bool> getIndexedBooleanArrayParameter(GCGLenum pname, GCGLuint index);
 
-    void initializeDefaultObjects() final;
+    void initializeDefaultObjects() WTF_REQUIRES_LOCK(objectGraphLock()) final;
     bool validateBufferTarget(ASCIILiteral functionName, GCGLenum target) final;
     bool validateBufferTargetCompatibility(ASCIILiteral, GCGLenum, WebGLBuffer*);
     RefPtr<WebGLBuffer> validateBufferDataParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum usage) final;

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -50,7 +50,7 @@ public:
 
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;
-    void initializeDefaultObjects() final;
+    void initializeDefaultObjects() WTF_REQUIRES_LOCK(objectGraphLock()) final;
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) final;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -525,8 +525,11 @@ void WebGLRenderingContextBase::initializeNewContext(Ref<GraphicsContextGL> cont
     updateActiveOrdinal();
     if (!wasActive)
         addActiveContext(*this);
-    initializeContextState();
-    initializeDefaultObjects();
+    {
+        Locker locker { objectGraphLock() };
+        initializeContextState();
+        initializeDefaultObjects();
+    }
     // Next calls will receive the context lost callback.
     m_context->setClient(this);
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -529,8 +529,8 @@ protected:
     friend class ScopedWebGLRestoreTexture;
 
     void initializeNewContext(Ref<GraphicsContextGL>);
-    virtual void initializeContextState();
-    virtual void initializeDefaultObjects();
+    virtual void initializeContextState() WTF_REQUIRES_LOCK(objectGraphLock());
+    virtual void initializeDefaultObjects() WTF_REQUIRES_LOCK(objectGraphLock());
 
     // ActiveDOMObject
     void stop() override;

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
@@ -52,13 +52,12 @@ void CloseWatcherManager::add(Ref<CloseWatcher> watcher)
 
 void CloseWatcherManager::remove(CloseWatcher& watcher)
 {
-    for (auto& group : m_groups) {
-        group.removeFirstMatching([&watcher] (const Ref<CloseWatcher>& current) {
+    m_groups.removeAllMatching([&watcher](auto& group) {
+        group.removeFirstMatching([&watcher](const Ref<CloseWatcher>& current) {
             return current.ptr() == &watcher;
         });
-        if (group.isEmpty())
-            m_groups.removeFirst(group);
-    }
+        return group.isEmpty();
+    });
 }
 
 void CloseWatcherManager::notifyAboutUserActivation()

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -1611,7 +1611,19 @@ void GraphicsContextGLANGLE::pixelStorei(GCGLenum pname, GCGLint param)
 {
     if (!makeContextCurrent())
         return;
-
+    switch (pname) {
+    case UNPACK_ALIGNMENT:
+    case UNPACK_ROW_LENGTH:
+    case UNPACK_IMAGE_HEIGHT:
+    case UNPACK_SKIP_PIXELS:
+    case UNPACK_SKIP_ROWS:
+    case UNPACK_SKIP_IMAGES:
+        break;
+    default:
+        // Should be never set, rather passed to the commands that need these.
+        addError(GCGLErrorCode::InvalidOperation);
+        return;
+    }
     GL_PixelStorei(pname, param);
 }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -345,6 +345,11 @@ inline void FEGaussianBlurSoftwareApplier::boxBlurGeneric(PixelBuffer& ioBuffer,
     }
 #endif
 
+    // boxBlurAlphaOnly() fills the alpha channel only. Make
+    // sure the other channels are initialized in this case.
+    if (isAlphaImage)
+        tempBuffer.zeroFill();
+
     boxBlurUnaccelerated(ioBuffer, tempBuffer, kernelSizeX, kernelSizeY, stride, paintSize, isAlphaImage, edgeMode);
 }
 

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -28,6 +28,8 @@
 #include "StyleSheet.h"
 #include <libxml/parser.h>
 #include <libxslt/transform.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/Lock.h>
 #include <wtf/Ref.h>
 #include <wtf/TypeCasts.h>
 
@@ -93,7 +95,8 @@ public:
     String href() const override { return m_originalURL; }
     String title() const override { return { }; }
 
-    void clearOwnerNode() override { m_ownerNode = nullptr; }
+    void clearOwnerNode() override;
+    WebCoreOpaqueRoot opaqueRootForGCThread() override;
     URL baseURL() const override { return m_finalURL; }
     bool isLoading() const override;
 
@@ -106,7 +109,8 @@ private:
 
     void clearXSLStylesheetDocument();
 
-    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_ownerNode;
+    mutable Lock m_opaqueRootLockForGC;
+    CheckedPtr<Node> m_ownerNode;
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -26,6 +26,7 @@
 #include "DocumentResourceLoader.h"
 #include "FrameConsoleClient.h"
 #include "FrameDestructionObserverInlines.h"
+#include "JSNodeCustomInlines.h"
 #include "LocalFrame.h"
 #include "NodeDocument.h"
 #include "Page.h"
@@ -45,8 +46,7 @@
 namespace WebCore {
 
 XSLStyleSheet::XSLStyleSheet(XSLStyleSheet* parentSheet, const String& originalURL, const URL& finalURL)
-    : m_ownerNode(nullptr)
-    , m_originalURL(originalURL)
+    : m_originalURL(originalURL)
     , m_finalURL(finalURL)
     , m_embedded(false)
     , m_processed(false) // Child sheets get marked as processed when the libxslt engine has finally seen them.
@@ -71,6 +71,20 @@ XSLStyleSheet::~XSLStyleSheet()
         ASSERT(import->parentStyleSheet() == this);
         import->setParentStyleSheet(nullptr);
     }
+}
+
+void XSLStyleSheet::clearOwnerNode()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    m_ownerNode = nullptr;
+}
+
+WebCoreOpaqueRoot XSLStyleSheet::opaqueRootForGCThread()
+{
+    Locker locker { m_opaqueRootLockForGC };
+    if (m_ownerNode)
+        return root(m_ownerNode.get());
+    return WebCoreOpaqueRoot { this };
 }
 
 bool XSLStyleSheet::isLoading() const

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1405,10 +1405,19 @@ void NetworkResourceLoader::continueWillSendRedirectedRequest(ResourceRequest&& 
 
     // We send the request body separately because the ResourceRequest body normally does not get encoded when sent over IPC, as an optimization.
     // However, we really need the body here because a redirect cross-site may cause a process-swap and the request to start again in a new WebContent process.
-    sendWithAsyncReply(Messages::WebResourceLoader::WillSendRequest(redirectRequest, IPC::FormDataReference { redirectRequest.httpBody() }, sanitizeResponseIfPossible(WTF::move(redirectResponse), ResourceResponse::SanitizationType::Redirection)), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)] (ResourceRequest&& newRequest, bool isAllowedToAskUserForCredentials) mutable {
+    sendWithAsyncReply(Messages::WebResourceLoader::WillSendRequest(redirectRequest, IPC::FormDataReference { redirectRequest.httpBody() }, sanitizeResponseIfPossible(WTF::move(redirectResponse), ResourceResponse::SanitizationType::Redirection)), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), firstPartyForCookiesFromRedirectRequest = redirectRequest.firstPartyForCookies()] (ResourceRequest&& newRequest, bool isAllowedToAskUserForCredentials) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
+
+        if (newRequest.firstPartyForCookies() != firstPartyForCookiesFromRedirectRequest) {
+            Ref connection = protectedThis->m_connection;
+            auto allowCookieAccess = connection->networkProcess().allowsFirstPartyForCookies(
+                connection->webProcessIdentifier(), newRequest.firstPartyForCookies());
+            MESSAGE_CHECK_COMPLETION_BASE(allowCookieAccess == NetworkProcess::AllowCookieAccess::Allow,
+                connection->connection(), completionHandler({ }));
+        }
+
         protectedThis->continueWillSendRequest(WTF::move(newRequest), isAllowedToAskUserForCredentials, WTF::move(completionHandler));
     });
 }

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -634,6 +634,7 @@ Ref<FrameState> WebBackForwardList::completeFrameStateForNavigation(Ref<FrameSta
 
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_COMPLETION(process, assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, process->connection(), completion)
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(process, assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, process->connection(), returnValue)
 
 void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<FrameState>&& navigatedFrameState)
 {
@@ -641,7 +642,7 @@ void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<Fra
         backForwardAddItemShared(connection, WTF::move(navigatedFrameState), webPageProxy->didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-static void messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
+static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
 {
     URL itemURL { frameState->urlString };
     URL itemOriginalURL { frameState->originalURLString };
@@ -652,17 +653,19 @@ static void messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProx
 #endif // PLATFORM(MAC)
     ) {
 #endif // PLATFORM(COCOA)
-        MESSAGE_CHECK(process, !itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
-        MESSAGE_CHECK(process, !itemOriginalURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemOriginalURL));
+        MESSAGE_CHECK_WITH_RETURN_VALUE(process, !itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL), false);
+        MESSAGE_CHECK_WITH_RETURN_VALUE(process, !itemOriginalURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemOriginalURL), false);
 #if PLATFORM(COCOA)
     }
 #endif
+    return true;
 }
 
 void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, Ref<FrameState>&& navigatedFrameState, LoadedWebArchive loadedWebArchive)
 {
     Ref process = WebProcessProxy::fromConnection(connection);
-    messageCheckItemURLs(navigatedFrameState, process);
+    if (!messageCheckItemURLs(navigatedFrameState, process))
+        return;
 
     if (RefPtr targetFrame = WebFrameProxy::webFrame(navigatedFrameState->frameID)) {
         if (targetFrame->isPendingInitialHistoryItem()) {
@@ -693,7 +696,8 @@ void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, R
 void WebBackForwardList::backForwardSetChildItem(IPC::Connection& connection, BackForwardFrameItemIdentifier frameItemID, Ref<FrameState>&& frameState)
 {
     Ref process = WebProcessProxy::fromConnection(connection);
-    messageCheckItemURLs(frameState, process);
+    if (!messageCheckItemURLs(frameState, process))
+        return;
 
     RefPtr item = currentItem();
     if (!item)
@@ -716,8 +720,8 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
     // In the case of a process swap, the `backForwardUpdateItem` message can be received from the old process,
     // and therefore present an unexpected file: URL.
     // We can safely skip the message check in these cases.
-    if (!m_handlingProvisionalMessage)
-        messageCheckItemURLs(frameState, process);
+    if (!m_handlingProvisionalMessage && !messageCheckItemURLs(frameState, process))
+        return;
 
     RefPtr frameItem = frameState->itemID && frameState->frameItemID ? WebBackForwardListFrameItem::itemForID(*frameState->itemID, *frameState->frameItemID) : nullptr;
     if (!frameItem)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1118,9 +1118,12 @@ bool WebProcessProxy::checkURLReceivedFromWebProcess(const URL& url, CheckBackFo
 
     // Items in back/forward list have been already checked.
     // One case where we don't have sandbox extensions for file URLs in b/f list is if the list has been reinstated after a crash or a browser restart.
+    // Only consider items belonging to a page hosted by this WebProcessProxy.
     if (checkBackForwardList == CheckBackForwardList::Yes) {
         String path = url.fileSystemPath();
         for (auto& item : WebBackForwardListItem::allItems().values()) {
+            if (!m_pageMap.contains(item->pageID()))
+                continue;
             URL itemURL { item->url() };
             if (itemURL.protocolIsFile() && itemURL.fileSystemPath() == path)
                 return true;

--- a/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_race_test_hooks.h
@@ -33,7 +33,8 @@ PAS_BEGIN_EXTERN_C;
 enum pas_race_test_hook_kind {
     pas_race_test_hook_local_allocator_stop_before_did_stop_allocating,
     pas_race_test_hook_local_allocator_stop_before_unlock,
-    pas_race_test_hook_bitfit_directory_take_last_empty_after_loop
+    pas_race_test_hook_bitfit_directory_take_last_empty_after_loop,
+    pas_race_test_hook_medium_directory_after_directory_store
 };
 
 typedef enum pas_race_test_hook_kind pas_race_test_hook_kind;
@@ -47,6 +48,8 @@ static inline const char* pas_race_test_hook_kind_get_string(pas_race_test_hook_
         return "local_allocator_stop_before_unlock";
     case pas_race_test_hook_bitfit_directory_take_last_empty_after_loop:
         return "bitfit_directory_take_last_empty_after_loop";
+    case pas_race_test_hook_medium_directory_after_directory_store:
+        return "medium_directory_after_directory_store";
     }
     PAS_ASSERT_NOT_REACHED();
     return NULL;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c
@@ -38,6 +38,7 @@
 #include "pas_large_expendable_memory.h"
 #include "pas_large_utility_free_heap.h"
 #include "pas_min_heap.h"
+#include "pas_race_test_hooks.h"
 #include "pas_segregated_heap_inlines.h"
 #include "pas_segregated_size_directory.h"
 #include "pas_segregated_page.h"
@@ -324,7 +325,8 @@ pas_segregated_size_directory* pas_segregated_heap_size_directory_for_index_slow
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    const pas_heap_config* config)
+    const pas_heap_config* config,
+    pas_lock_hold_mode heap_lock_hold_mode)
 {
     if (pas_segregated_heap_index_is_cached_index_and_cached_index_is_set(heap, cached_index, index, config)) {
         pas_segregated_size_directory* result;
@@ -340,7 +342,7 @@ pas_segregated_size_directory* pas_segregated_heap_size_directory_for_index_slow
     return pas_segregated_heap_medium_size_directory_for_index(
         heap, index,
         pas_segregated_heap_medium_size_directory_search_within_size_class_progression,
-        pas_lock_is_held);
+        heap_lock_hold_mode);
 }
 
 typedef struct {
@@ -1508,7 +1510,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
 
     ensure_size_lookup_if_necessary(heap, size_lookup_mode, config, cached_index, index);
 
-    result = pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config);
+    result = pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config, pas_lock_is_held);
 
     if (verbose && result) {
         pas_log("Found result = %p, object_size = %u, min_index = %u\n",
@@ -2182,6 +2184,8 @@ pas_segregated_heap_ensure_size_directory_for_size(
                     &medium_directory->directory, result);
                 medium_directory->allocator_index = 0;
 
+                pas_race_test_hook(pas_race_test_hook_medium_directory_after_directory_store);
+
                 if (verbose) {
                     pas_log("In rare_data = %p, Installing medium tuple %zu...%zu\n",
                             rare_data, index, medium_install_index);
@@ -2221,7 +2225,7 @@ pas_segregated_heap_ensure_size_directory_for_size(
             }
         }
 
-        PAS_ASSERT(pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config)
+        PAS_ASSERT(pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config, pas_lock_is_held)
                    == result);
     }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_heap_inlines.h
@@ -37,28 +37,30 @@ PAS_API pas_segregated_size_directory* pas_segregated_heap_size_directory_for_in
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    const pas_heap_config* config);
+    const pas_heap_config* config,
+    pas_lock_hold_mode heap_lock_hold_mode);
 
 static PAS_ALWAYS_INLINE pas_segregated_size_directory*
 pas_segregated_heap_size_directory_for_index(
     pas_segregated_heap* heap,
     size_t index,
     unsigned* cached_index,
-    const pas_heap_config* config)
+    const pas_heap_config* config,
+    pas_lock_hold_mode heap_lock_hold_mode)
 {
     pas_compact_atomic_segregated_size_directory_ptr* index_to_size_directory;
     pas_segregated_size_directory* result;
-    
+
     if (index >= (size_t)heap->small_index_upper_bound)
         goto slow;
-    
+
     index_to_size_directory = heap->index_to_small_size_directory;
     if (!index_to_size_directory) {
         /* Code that holds no locks may see this since we have no ordering between when the
            upper_bound is set and when this is set. */
         goto slow;
     }
-    
+
     result = pas_compact_atomic_segregated_size_directory_ptr_load(index_to_size_directory + index);
     if (result)
         return result;
@@ -67,7 +69,7 @@ pas_segregated_heap_size_directory_for_index(
        for the entry corresponding to the basic_size_directory to be unset in the lookup table! */
 
 slow:
-    return pas_segregated_heap_size_directory_for_index_slow(heap, index, cached_index, config);
+    return pas_segregated_heap_size_directory_for_index_slow(heap, index, cached_index, config, heap_lock_hold_mode);
 }
 
 static PAS_ALWAYS_INLINE pas_segregated_size_directory*
@@ -78,10 +80,15 @@ pas_segregated_heap_size_directory_for_size(
     unsigned* cached_index)
 {
     size_t index;
-    
+
     index = pas_segregated_heap_index_for_size(size, config);
-    
-    return pas_segregated_heap_size_directory_for_index(heap, index, cached_index, config.config_ptr);
+
+    /* This entry point is reached on the lock-free allocation slow path
+       (pas_heap_ensure_size_directory_for_size), so the heap lock cannot be
+       held here. The medium-tuple lookup uses the seqlock to validate
+       against concurrent writers. */
+    return pas_segregated_heap_size_directory_for_index(
+        heap, index, cached_index, config.config_ptr, pas_lock_is_not_held);
 }
 
 static PAS_ALWAYS_INLINE bool pas_segregated_heap_touch_lookup_tables(

--- a/Source/bmalloc/libpas/src/test/RaceTests.cpp
+++ b/Source/bmalloc/libpas/src/test/RaceTests.cpp
@@ -28,9 +28,14 @@
 #include <functional>
 #include "iso_heap.h"
 #include "iso_heap_config.h"
+#include "iso_heap_ref.h"
 #include <map>
 #include <mutex>
+#include "pas_heap.h"
+#include "pas_primitive_heap_ref.h"
 #include "pas_race_test_hooks.h"
+#include "pas_segregated_heap_inlines.h"
+#include "pas_segregated_size_directory.h"
 #include "pas_thread_local_cache.h"
 #include <set>
 #include <thread>
@@ -251,6 +256,82 @@ void testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_kind kindToSto
     CHECK(shrinkDidFinish);
 }
 
+void testMediumDirectoryTornInsertRace()
+{
+    pas_scavenger_suspend();
+
+    pas_primitive_heap_ref heap = ISO_PRIMITIVE_HEAP_REF_INITIALIZER;
+    constexpr size_t kBigSize = 8192;
+    constexpr size_t kNewSize = 1024;
+
+    /* This is a bit of a hack: we want to catch a race on the medium-tuple
+       insertion path, but in order to set up the race we need to go through
+       the insertion path once without getting stopped by the hook.
+       So we start with a no-op hook and only afterwards install the effectful one. */
+    hookCallback = [] (pas_race_test_hook_kind) { };
+    void* seedBig = iso_allocate_primitive(&heap, kBigSize, pas_non_compact_allocation_mode);
+    CHECK(seedBig);
+
+    bool didGetToHook = false;
+    bool hookShouldStop = false;
+    bool hookDidStop = false;
+
+    hookCallback =
+        [&] (pas_race_test_hook_kind kind) {
+            if (kind != pas_race_test_hook_medium_directory_after_directory_store)
+                return;
+
+            unique_lock<mutex> locker(globalLock);
+            didGetToHook = true;
+            globalCond.notify_all();
+            while (!hookShouldStop && !isHoldingContendedLocks())
+                globalCond.wait(locker);
+            hookDidStop = true;
+        };
+
+    thread writer = thread(
+        [&] () {
+            /* Inserts a smaller medium tuple at slot 0, shifting the original
+               tuple to slot 1.
+               Once the hook fires, slot[0]'s directory ptr will have been overwritten,
+               but its begin_index/end_index fields won't yet have been.
+               If there is a race here, then the reader will see
+               { new_directory_ptr, old_begin_index, old_end_index } */
+            void* small = iso_allocate_primitive(&heap, kNewSize, pas_non_compact_allocation_mode);
+            CHECK(small);
+        });
+
+    {
+        unique_lock<mutex> locker(globalLock);
+        while (!didGetToHook)
+            globalCond.wait(locker);
+    }
+
+    /* A NULL cached_index forces the lookup to skip the
+       basic-size-directory path, which ensures we take the medium path.
+       Since the slot-write hasn't finished yet, we should expect to see
+       the original directory, with object_size == kBigSize.
+       If we see a directory with kNewSize, then there is a race.
+       If the lock-free medium path doesn't respect the seqlock, it will
+       observe the torn slot we created above. */
+    size_t bigIndex = pas_segregated_heap_index_for_size(kBigSize, iso_heap_config);
+    pas_segregated_size_directory* observed =
+        pas_segregated_heap_size_directory_for_index(
+            &heap.base.heap->segregated_heap, bigIndex, NULL, &iso_heap_config,
+            pas_lock_is_not_held);
+
+    {
+        unique_lock<mutex> locker(globalLock);
+        hookShouldStop = true;
+        globalCond.notify_all();
+    }
+    writer.join();
+
+    CHECK(hookDidStop);
+    CHECK(observed);
+    CHECK_GREATER_EQUAL((size_t)observed->object_size, kBigSize);
+}
+
 } // anonymous namespace
 
 #endif // PAS_ENABLE_TESTING && PAS_ENABLE_ISO
@@ -269,6 +350,8 @@ void addRaceTests()
         ADD_TEST(testLocalAllocatorStopRace(pas_race_test_hook_local_allocator_stop_before_unlock));
         ADD_TEST(testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_local_allocator_stop_before_did_stop_allocating));
         ADD_TEST(testLocalAllocatorStopRaceAgainstScavenge(pas_race_test_hook_local_allocator_stop_before_unlock));
+
+        ADD_TEST(testMediumDirectoryTornInsertRace());
     }
 #endif // PAS_ENABLE_TESTING && PAS_ENABLE_ISO
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -1046,4 +1046,143 @@ TEST(WKBackForwardList, BackForwardUpdateItemRejectsFileURL)
         EXPECT_FALSE([item.URL.absoluteString hasPrefix:@"file://"]);
 }
 
+static constexpr auto forgedFileURLTestMainBytes = R"TESTRESOURCE(
+<!DOCTYPE html>
+<script src="coreipc.js"></script>
+<script>
+(async () => {
+    if (typeof IPC !== 'object') {
+        alert('FAIL: IPC testing API not available');
+        return;
+    }
+
+    // Patch the shared coreipc.js: parseMarkable returns a flat value when present,
+    // but serializeMarkable expects it wrapped in { optionalValue }. Make them agree
+    // for the duration of this test.
+    const origParseMarkable = ArgumentParser.parseMarkable;
+    ArgumentParser.parseMarkable = function (buffer, position, innerType) {
+        const [newPos, result] = origParseMarkable.call(this, buffer, position, innerType);
+        if (result && typeof result === 'object' && Object.keys(result).length > 0 && !Object.hasOwn(result, 'optionalValue'))
+            return [newPos, { optionalValue: result }];
+        return [newPos, result];
+    };
+
+    const CoreIPC = new CoreIPCClass();
+
+    // Fixups for FrameState round-tripping.
+    function fixTypeInfo(ti) {
+        for (const k in ti) {
+            const v = ti[k];
+            if (!Array.isArray(v)) continue;
+            for (const f of v) {
+                if (typeof f.type === 'string') {
+                    if (f.type.startsWith('HashSet<') && f.type.includes(', IntHash')) {
+                        const inner = f.type.slice('HashSet<'.length, -1).split(',')[0].trim();
+                        f.type = 'HashSet<' + inner + '>';
+                    }
+                    f.type = f.type.replace(/std::monostate/g, 'std::nullptr_t');
+                }
+                if (f.variantTypes)
+                    f.variantTypes = f.variantTypes.map(t => t === 'std::monostate' ? 'std::nullptr_t' : t);
+            }
+        }
+    }
+    fixTypeInfo(CoreIPC.typeInfo);
+    try { fixTypeInfo(IPC.serializedTypeInfo); } catch (e) {}
+
+    const origSerializeOptional = ArgumentSerializer.prototype.serializeOptional;
+    ArgumentSerializer.prototype.serializeOptional = function (t, a) { return origSerializeOptional.call(this, t, a ?? {}); };
+    const origSerializeMarkable = ArgumentSerializer.prototype.serializeMarkable;
+    ArgumentSerializer.prototype.serializeMarkable = function (t, a) { return origSerializeMarkable.call(this, t, a ?? {}); };
+
+    function fixNullVariants(o, depth = 0) {
+        if (depth > 100) return o;
+        if (o && typeof o === 'object') {
+            if (o.variantType === 'std::nullptr_t' && o.variant === 'null') o.variant = null;
+            for (const k in o) fixNullVariants(o[k], depth + 1);
+        }
+        return o;
+    }
+
+    // Capture a legitimate BackForwardAddItem IPC template via same-origin pushState.
+    let bfTemplate = null;
+    const BF_NAME = IPC.messages.WebBackForwardList_BackForwardAddItem.name;
+    const tap = new IPCWireTap('UI', 'Outgoing');
+    tap.tapAll((proc, dest, name, typed, parsed) => {
+        if (name === BF_NAME && !bfTemplate)
+            bfTemplate = parsed;
+    });
+    history.pushState({}, '', location.pathname + '?capture=1');
+    for (let i = 0; i < 40 && !bfTemplate; i++)
+        await new Promise(r => setTimeout(r, 25));
+    if (!bfTemplate) {
+        alert('FAIL: could not capture BackForwardAddItem template');
+        return;
+    }
+    fixNullVariants(bfTemplate);
+
+    // Our process identifier, extracted from the captured item's BackForwardItemIdentifier.
+    const myProcId = bfTemplate.navigatedFrameState.itemID.optionalValue.processIdentifier;
+
+    // Forge a BackForwardAddItem for a file:// URL this process has never visited.
+    const forgedItemID = { object: 0x5a5a5a5an, processIdentifier: myProcId };
+    const forgedFrameItemID = { object: 0x5b5b5b5bn, processIdentifier: myProcId };
+    const fs = bfTemplate.navigatedFrameState;
+    fs.urlString = 'file:///etc/forged-never-visited-by-this-process';
+    fs.originalURLString = fs.urlString;
+    fs.referrer = '';
+    fs.target = { string: '' };
+    fs.title = '';
+    fs.frameID = { optionalValue: BigInt(IPC.frameID) };
+    fs.itemID = { optionalValue: forgedItemID };
+    fs.frameItemID = { optionalValue: forgedFrameItemID };
+    fs.children = [];
+    fs.stateObjectData = {};
+    fs.httpBody = {};
+    fs.sessionStateObject = {};
+    fs.documentState = [];
+
+    CoreIPC.UI.WebBackForwardList.BackForwardAddItem(IPC.webPageProxyID, bfTemplate);
+
+    // Yield so the UI process can dispatch the (rejected) message.
+    await new Promise(r => setTimeout(r, 100));
+
+    // Synchronous probe: is the forged item in the back-forward list?
+    let wasAdded = null;
+    CoreIPC.UI.WebBackForwardList.BackForwardListContainsItem(IPC.webPageProxyID,
+        { itemID: forgedItemID },
+        (reply) => { wasAdded = reply.contains; });
+
+    if (wasAdded === false)
+        alert('PASS: forged file:// back-forward item was rejected by MESSAGE_CHECK');
+    else
+        alert('FAIL: forged file:// back-forward item leaked into the list (wasAdded=' + wasAdded + ')');
+})().catch(e => alert('FAIL: ' + e + '\n' + (e && e.stack ? e.stack : '')));
+</script>
+)TESTRESOURCE"_s;
+
+TEST(WKBackForwardList, ForgedFileURLItemIsRejected)
+{
+    RetainPtr coreIPCURL = [NSBundle.test_resourcesBundle URLForResource:@"coreipc" withExtension:@"js"];
+    RetainPtr coreIPCData = [NSData dataWithContentsOfURL:coreIPCURL.get()];
+
++    TestWebKitAPI::HTTPServer server({
++        { "/"_s, { forgedFileURLTestMainBytes } },
++        { "/coreipc.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, coreIPCData.get() } },
++    });
++
++    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
++    for (_WKFeature *feature in [WKPreferences _features]) {
++        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
++            [[configuration preferences] _setEnabled:YES forFeature:feature];
++            break;
++        }
++    }
++
++    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration.get()]);
++    [webView loadRequest:server.request("/"_s)];
++
++    EXPECT_WK_STREQ([webView _test_waitForAlert], "PASS: forged file:// back-forward item was rejected by MESSAGE_CHECK");
++}
+
 #endif // ENABLE(IPC_TESTING_API)


### PR DESCRIPTION
#### c0887a6ed84d0d5160dceb75278f9eb1833f5163
<pre>
Cherry-pick 249edf86a9f5. <a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>

Need a process-specific `WebBackForwardListItem::allItems()` instead of the process-global map for better message checking
<a href="https://rdar.apple.com/174702519">rdar://174702519</a>

Reviewed by Ben Nham.

When considering whether a given web process should have access to a given back/forward entry,
the global map is the wrong tool.

Check on a per-process basis instead.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::messageCheckItemURLs):
(WebKit::WebBackForwardList::backForwardAddItemShared):
(WebKit::WebBackForwardList::backForwardSetChildItem):
(WebKit::WebBackForwardList::backForwardUpdateItem):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::checkURLReceivedFromWebProcess):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(&lt;script&gt;):
(ForgedFileURLItemIsRejected)):

Identifier: 305413.831@safari-7624-branch

Identifier: 305413.823@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.907@webkitglib/2.52">https://commits.webkit.org/305877.907@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 902c41b6c73302a9b92aad90df4ace31a7f2c2ff
<pre>
Cherry-pick 9fd9439df22f. <a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>

WebResourceLoader::WillSendRequest reply may lead to cross-origin cookie access
<a href="https://bugs.webkit.org/show_bug.cgi?id=313866">https://bugs.webkit.org/show_bug.cgi?id=313866</a>
<a href="https://rdar.apple.com/174663032">rdar://174663032</a>

Reviewed by Per Arne Vollan.

Consider this sequence of events:
1. A compromised web process schedules a load with its own origin used for
   firstPartyForCookies.
2. NetworkConnectionToWebProcess::scheduleResourceLoad() is called and the
   message check passes.
3. The request goes through and the server responds with 302 (redirect).
4. NetworkResourceLoader::continueWillSendRedirectedRequest() calls
   WebResourceLoader::WillSendRequest() which gives the web process the chance
   to alter the request that will be sent to perform the redirect.
5. The compromised web process alters the request so that firstPartyForCookies
   is now a different origin.
6. NetworkResourceLoader::continueWillSendRequest() receives this altered
   request and passes it off to CFNetwork.
7. The result of this request is that the compromised web process receives
   the cookies of this different origin.

There are multiple callsites of continueWillSendRequest(), but only one place
which allows the web process to alter the request before it&apos;s given to
continueWillSendRequest(). So we fix this by adding a message check right
before that callsite that will double check that the origin contained in this
potentially modified request from the web process is in this web process&apos;s
allowed list. If not, the web process will be killed so that it doesn&apos;t recieve
the cross-origin cookies.

We also only do this message check if the web process actually changes the
origin. This is because there are cases where the origin is not yet in the
allowlist but not because the web process modified it (like in:
imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect
where there is a cross-site redirect as part of a prefetch, so the cross-site
origin is supplied by the server but hasn&apos;t made it into the allow list since
the navigation to it is not complete).

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::continueWillSendRedirectedRequest):

Identifier: 305413.834@safari-7624-branch

Identifier: 305413.821@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.906@webkitglib/2.52">https://commits.webkit.org/305877.906@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ef88aa955291fa2a12defd63586a4d4ba2f5a5e0
<pre>
Cherry-pick dd484347691b. <a href="https://bugs.webkit.org/show_bug.cgi?id=312566">https://bugs.webkit.org/show_bug.cgi?id=312566</a>

WebGL: GraphicsContextGLANGLE PACK_* state is modifiable through pixelStorei
<a href="https://bugs.webkit.org/show_bug.cgi?id=312566">https://bugs.webkit.org/show_bug.cgi?id=312566</a>
<a href="https://rdar.apple.com/174740214">rdar://174740214</a>

Reviewed by Dan Glastonbury.

Filter out pixelStorei parameters.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::pixelStorei):

Identifier: 305413.710@safari-7624-branch

Identifier: 305413.820@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.905@webkitglib/2.52">https://commits.webkit.org/305877.905@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a606bccf2adbf0d4bdc3289a1b47bd884111b62f
<pre>
Cherry-pick 6d64b1760e9a. <a href="https://bugs.webkit.org/show_bug.cgi?id=315161">https://bugs.webkit.org/show_bug.cgi?id=315161</a>

[WebGL] Missing objectGraphLock on WebGL context restore races with GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=315161">https://bugs.webkit.org/show_bug.cgi?id=315161</a>
<a href="https://rdar.apple.com/177359720">rdar://177359720</a>

Reviewed by Kimmo Kinnunen.

All mutators of the WebGL bound-object graph hold objectGraphLock to synchronize with
addMembersToOpaqueRoots on the GC helper thread, except for initializeContextState and
initializeDefaultObjects on the WEBGL_lose_context restore path. That path reassigns
binding points for the default WebGLTransformFeedback and WebGLVertexArrayObject, freeing
them while the GC marker may still be traversing them.

Fix by holding objectGraphLock in initializeNewContext around both calls and add
WTF_REQUIRES_LOCK annotations to catch this at compile time.

Test: fast/canvas/webgl/context-restore-concurrent-gc-no-crash.html

* LayoutTests/fast/canvas/webgl/context-restore-concurrent-gc-no-crash-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/context-restore-concurrent-gc-no-crash.html: Added.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeNewContext):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Identifier: 305413.940@safari-7624-branch

Identifier: 305413.817@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.904@webkitglib/2.52">https://commits.webkit.org/305877.904@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b7889ad3cc4f12efe5329f6a3266c07c68185b20
<pre>
Cherry-pick 30c8460241f3. <a href="https://bugs.webkit.org/show_bug.cgi?id=312415">https://bugs.webkit.org/show_bug.cgi?id=312415</a>

YarrJIT negativeOffsetIndexedAddress discards adjusted base register
<a href="https://bugs.webkit.org/show_bug.cgi?id=312415">https://bugs.webkit.org/show_bug.cgi?id=312415</a>
<a href="https://rdar.apple.com/174714198">rdar://174714198</a>

Reviewed by Yijia Huang.

In YarrJIT negativeOffsetIndexedAddress computes a negative offset from
a base address but the function mistakenly uses the original value
instead of the adjusted value. This patch fixes it to use the adjusted
value.

Test: JSTests/stress/yarr-negative-offset.js

* JSTests/stress/yarr-negative-offset.js: Added.
(catch):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Identifier: 305413.685@safari-7624-branch

Identifier: 305413.816@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.903@webkitglib/2.52">https://commits.webkit.org/305877.903@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3940a0303e2877e0580a496448e56e0ce3d34054
<pre>
Cherry-pick 96b0a368415e. <a href="https://bugs.webkit.org/show_bug.cgi?id=314345">https://bugs.webkit.org/show_bug.cgi?id=314345</a>

Uninitialized result of FEGaussianBlur if the input isAlphaImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=314345">https://bugs.webkit.org/show_bug.cgi?id=314345</a>
<a href="https://rdar.apple.com/175674593">rdar://175674593</a>

Reviewed by Simon Fraser.

`FEGaussianBlurSoftwareApplier::apply()` creates uninitialized `tempBuffer`
through `createScratchPixelBuffer()`.

-- If the stdDeviation of feGaussianBlur is asymmetric, e.g. &quot;5 0&quot;, then applying
   this filter falls back to `boxBlurUnaccelerated()`.
-- If the input of feGaussianBlur isAlphaImage, e.g. feColorMatrix(luminanceToAlpha),
   then `boxBlur()` short-circuits to `boxBlurAlphaOnly()`, which writes only
   the alpha channel of each pixel.
-- If one of the stdDeviation is zero, e.g. &quot;5 0&quot;, `boxBlurUnaccelerated()` will
   copy the `tempBuffer` to the `destinationPixelBuffer` with three uninitialized
   channels before it returns.

If isAlphaImage is true Make sure `tempBuffer` is zero-filled.

* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurGeneric):

Identifier: 305413.858@safari-7624-branch

Identifier: 305413.815@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.902@webkitglib/2.52">https://commits.webkit.org/305877.902@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3c7ca7019d0334140a800622c140cc620cbf7937
<pre>
Cherry-pick 58ebed1e9cec. <a href="https://bugs.webkit.org/show_bug.cgi?id=314829">https://bugs.webkit.org/show_bug.cgi?id=314829</a>

[libpas] Fix race in pas_segregated_heap_medium_size_directory_for_index
<a href="https://bugs.webkit.org/show_bug.cgi?id=314829">https://bugs.webkit.org/show_bug.cgi?id=314829</a>
<a href="https://rdar.apple.com/175683224">rdar://175683224</a>

Reviewed by Dan Hecht and Yijia Huang.

The medium-size directory is protected by both the heap-lock and a
seqlock (i.e. pas_mutation_count on rare_data-&gt;mutation_count).
The seqlock allows for readers to access the rare_data without
acquiring a lock; if the mutation-count shows that the object is being
mutated, then the reader is supposed to fall-back to acquiring the
heap-lock. However, as an optimization, if the heap-lock is already
held, the reader skips the seqlock step.
Previously, pas_segregated_heap_size_directory_for_index_slow would
always call pas_segregated_heap_medium_size_directory_for_index with
pas_lock_is_held. This meant that in certain cases, slow-path calls
will hit a race that results in a malloc call being given a slot within
segregated-heap slot that is actually too small for the requested size.

Operationally, what would happen is more or less
  1. ThreadA tries allocating an object X and searches for a
     matching medium-size-directory, but fails to find one.
  2. This means it needs to create a new medium-size-directory.
     This requires inserting a new entry into the medium-tuple array.
     ThreadA determines that the new tuple should live at index M.
  3. The medium-tuple array is sorted and packed, so inserting into the
     middle requires `memmove`&apos;ing all tuples down one slot --
     so ThreadA does so.
     At this point, slot[M] still points to the old entry,
     and still has the old begin/end.
  3. ThreadA then begins overwriting the slot[M], first
     overwriting the directory-pointer.
     At this point, slot[M] still has the old begin/end,
     but points to the new directory.
  4. ThreadB tries allocating an object Y. It should take the seqlock
     here, but incorrectly assumes that it holds the heap-lock and thus
     doesn&apos;t need to.
  5. ThreadB searches for a matching medium-size-directory, and finds
     slot[M] has a begin/end pair that matches its expectations.
  6. ThreadB then reads slot[M]&apos;s directory pointer, thus
     getting a directory with a mismatched size.
  7. ThreadB then asks that directory for an allocation-slot,
     and gets one back: however, the size of this slot is
     necessarily too small (because of the sorted-insertion
     requirement in #3 above).
     Therefore, the caller thinks that it got e.g. an 8192B
     slot but in fact only got a 7162B slot. A write to the
     latter bytes of the slot will corrupt the memory of the
     subsequent allocation.
N.b. step #3 is also a race on its own, but it&apos;s harder to capture
since we can&apos;t hook in the middle of the memmove.

Best as I can tell, at some point this hardcoded heap-lock hold mode
was actually correct, since the primary path to get here does acquire
the lock. However, there&apos;s another path (perhaps added later?
unfortunately it&apos;s all lumped into the commit that added libpas to the
repo) that doesn&apos;t do so. So the correct fix is to pipe the heap-lock
hold status up far enough that we either get to a function that takes
the hold-mode as a parameter, or one which asserts that the heap-lock
is held.

* Source/bmalloc/libpas/src/libpas/test/RaceTests.cpp: added
  new test to exhibit the race described above.

Identifier: 305413.966@safari-7624-branch

Identifier: 305413.810@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.901@webkitglib/2.52">https://commits.webkit.org/305877.901@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 70ede0ef05420aa218b8e0f0e8adfd86df5e68f6
<pre>
Cherry-pick 347b3963d6ca. <a href="https://bugs.webkit.org/show_bug.cgi?id=314086">https://bugs.webkit.org/show_bug.cgi?id=314086</a>

[web-animations] accelerated animation with view progress timeline range but no timeline yields a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314086">https://bugs.webkit.org/show_bug.cgi?id=314086</a>
<a href="https://rdar.apple.com/175530372">rdar://175530372</a>

Reviewed by Ryosuke Niwa.

Ensure we only attempt to resolve animated styles for keyframes with a computed
offset in `KeyframeEffect::computeExtentOfTransformAnimation()`.

Test: webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html

* LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline-expected.txt: Added.
* LayoutTests/webanimations/accelerated-animation-with-view-progress-timeline-range-but-no-timeline.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):

Identifier: 305413.835@safari-7624-branch

Identifier: 305413.814@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.900@webkitglib/2.52">https://commits.webkit.org/305877.900@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5e4cc2f51cff725b7e252d7bb449a8441fa5c79b
<pre>
Cherry-pick f41030176464. <a href="https://bugs.webkit.org/show_bug.cgi?id=312540">https://bugs.webkit.org/show_bug.cgi?id=312540</a>

Data race in JSStyleSheet::visitAdditionalChildren during GC leading to use-after-free
<a href="https://bugs.webkit.org/show_bug.cgi?id=312540">https://bugs.webkit.org/show_bug.cgi?id=312540</a>
<a href="https://rdar.apple.com/174207086">rdar://174207086</a>

Reviewed by Antti Koivisto.

JSStyleSheet::visitAdditionalChildren is called by the JSC garbage collector on a GC thread.
It calls addWebCoreOpaqueRoot(visitor, wrapped()) with root(StyleSheet*), which reads
styleSheet-&gt;ownerNode() and styleSheet-&gt;ownerRule(). Both are WeakPtr member variables on
CSSStyleSheet or XSLStyleSheet with .get() returning a raw pointer with no ref count increment,
and the backing WeakPtrImpl can be freed by the main thread between the read and the subsequent
dereference, causing a heap use-after-free.

The same root(StyleSheet*) function is the convergence point for JSCSSRule&apos;s
visitAdditionalChildren and JSCSSStyleDeclaration&apos;s visitAdditionalChildren, so all three GC
visitor paths are affected.

To address this bug, this PR adds a pure virtual opaqueRootForGCThread() to so root(StyleSheet*)
becomes a single virtual dispatch, eliminating the unsafe inline chain traversal. This function
then uses a newly added lock (m_opaqueRootLockForGC in CSSStyleSheet and XSLStyleSheet) to
guard against m_ownerNode being modified while the main thread is mutating it.

In addition, we had a GC correctness bug that @import child stylesheets (which have m_ownerRule
but no m_ownerNode) would not keep its parent stylesheet&apos;s JS wrapper alive even though it&apos;s
accessible via parentStyleSheet property.

To implement these changes and to avoid thread safety issues, this PR changes the type of
m_ownerNode and m_ownerRule in CSSStyleSheet and XSLStyleSheet from WeakPtr to CheckedPtr since
WeakPtr loads the pointee address via WeakPtrImpl, which may be concurrently free&apos;ed in the main
thread while we&apos;re accessing it in a GC thread. Note that all owner element destructors
(HTMLStyleElement, HTMLLinkElement, SVGStyleElement, ProcessingInstruction) call clearOwnerNode()
before the Node base-class destructor, so the CheckedPtr count reaches zero in time. Similarly,
learOwnerRule() is called from the CSSImportRule and StyleRuleImport destructors before
CSSImportRule is freed so CheckedPtr&apos;s assertion should not fire.

No new tests for the data race issue itself since there is no reliable way of testing it.

Test: fast/dom/StyleSheet/gc-import-rule-stylesheet.html

* LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet-expected.txt: Added.
* LayoutTests/fast/dom/StyleSheet/gc-import-rule-stylesheet.html: Added.
* Source/WebCore/bindings/js/JSStyleSheetCustom.h:
(WebCore::root):
* Source/WebCore/css/CSSImportRule.cpp:
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::clearOwnerNode):
(WebCore::CSSStyleSheet::opaqueRootForGCThread):
(WebCore::CSSStyleSheet::clearOwnerRule):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/StyleSheet.h:
* Source/WebCore/xml/XSLStyleSheet.h:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::XSLStyleSheet):
(WebCore::XSLStyleSheet::clearOwnerNode):
(WebCore::XSLStyleSheet::opaqueRootForGCThread):

Identifier: 305413.691@safari-7624-branch

Identifier: 305413.813@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.899@webkitglib/2.52">https://commits.webkit.org/305877.899@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### aa1dbc722be32b64e7ab29de7a0dd8a105cea38e
<pre>
Cherry-pick cf6a686e2e58. <a href="https://bugs.webkit.org/show_bug.cgi?id=315591">https://bugs.webkit.org/show_bug.cgi?id=315591</a>

Crash in CloseWatcherManager::remove
<a href="https://bugs.webkit.org/show_bug.cgi?id=315591">https://bugs.webkit.org/show_bug.cgi?id=315591</a>
<a href="https://rdar.apple.com/177972424">rdar://177972424</a>

Reviewed by Darin Adler and Geoffrey Garen.

Don&apos;t mutate m_groups while iterating over it.

Test: fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html

* LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash-expected.txt: Added.
* LayoutTests/fast/dom/close-watcher/remove-watcher-from-non-last-group-crash.html: Added.
* Source/WebCore/html/closewatcher/CloseWatcherManager.cpp:
(WebCore::CloseWatcherManager::remove):

Identifier: 305413.973@safari-7624-branch

Identifier: 305413.811@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.898@webkitglib/2.52">https://commits.webkit.org/305877.898@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 66cde51161379e158cf63df19a873277eec02c3d
<pre>
Cherry-pick 2b4933eb1658. <a href="https://bugs.webkit.org/show_bug.cgi?id=314747">https://bugs.webkit.org/show_bug.cgi?id=314747</a>

[JSC] Insert barrier for MultiPutByOffset when it can reallocate storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=314747">https://bugs.webkit.org/show_bug.cgi?id=314747</a>
<a href="https://rdar.apple.com/176792407">rdar://176792407</a>

Reviewed by Keith Miller.

The DFG barrier insertion phase works by tracking an &quot;epoch&quot; serial number,
which is bumped every time it encounters a node that can GC. The assumption is
that each DFG node either does a store, which would need to be considered for
barrier insertion, or performs a GC.

MultiPutByOffset is a &quot;fat&quot; node that can GC and perform a store after that GC,
in sequence. The current analysis therefore incorrectly elides the barrier for
it. This PR fixes by special casing.

Test: JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js

* JSTests/stress/multi-put-by-offset-reallocating-storage-needs-write-barrier.js: Added.
(foo):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:

Identifier: 305413.909@safari-7624-branch

Identifier: 305413.807@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.897@webkitglib/2.52">https://commits.webkit.org/305877.897@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cbb6f0833c756119ae768698399d4d681a782b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172418 "33 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46336 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181872 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129974 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174283 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47629 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46005 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129974 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175376 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47629 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114596 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47629 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46005 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30475 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47629 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184406 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33679 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37086 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46005 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142875 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46008 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142755 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46686 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111433 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26163 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46686 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118437 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205096 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45203 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39764 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54758 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44603 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44835 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44662 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->