### PR TITLE
Create methods to get Darwin temp and cache directories

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -189,6 +189,9 @@ WTF_EXPORT_PRIVATE String createTemporaryDirectory();
 WTF_EXPORT_PRIVATE NSString *createTemporaryDirectory(NSString *directoryPrefix = nil);
 WTF_EXPORT_PRIVATE NSString *systemDirectoryPath();
 
+WTF_EXPORT_PRIVATE String darwinCacheDirectory();
+WTF_EXPORT_PRIVATE String darwinTempDirectory();
+
 // Allow reading cloud files with no local copy.
 enum class PolicyScope : uint8_t { Process, Thread };
 WTF_EXPORT_PRIVATE bool setAllowsMaterializingDatalessFiles(bool, PolicyScope);

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -31,6 +31,8 @@
 
 #import <sys/resource.h>
 #import <wtf/FileHandle.h>
+#import <wtf/Logging.h>
+#import <wtf/SafeStrerror.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
@@ -317,6 +319,40 @@ NSString *systemDirectoryPath()
     }();
 
     return path.get().get();
+}
+
+String darwinCacheDirectory()
+{
+    char temp[PATH_MAX];
+    size_t length = confstr(_CS_DARWIN_USER_CACHE_DIR, temp, sizeof(temp));
+    if (!length) {
+        RELEASE_LOG_ERROR(Process, "Could not retrieve cache directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    RELEASE_ASSERT(length <= sizeof(temp));
+    char resolvedPath[PATH_MAX];
+    if (!realpath(temp, resolvedPath)) {
+        RELEASE_LOG_ERROR(Process, "Could not canonicalize cache directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    return String::fromUTF8(resolvedPath);
+}
+
+String darwinTempDirectory()
+{
+    char temp[PATH_MAX];
+    size_t length = confstr(_CS_DARWIN_USER_TEMP_DIR, temp, sizeof(temp));
+    if (!length) {
+        RELEASE_LOG_ERROR(Process, "Could not retrieve temporary directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    RELEASE_ASSERT(length <= sizeof(temp));
+    char resolvedPath[PATH_MAX];
+    if (!realpath(temp, resolvedPath)) {
+        RELEASE_LOG_ERROR(Process, "Could not canonicalize temporary directory path: %s\n", safeStrerror(errno).data());
+        return { };
+    }
+    return String::fromUTF8(resolvedPath);
 }
 
 } // namespace FileSystemImpl

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -253,19 +253,7 @@ static std::optional<CString> setAndSerializeSandboxParameters(const SandboxInit
 
 static String sandboxDataVaultParentDirectory()
 {
-    char temp[PATH_MAX];
-    size_t length = confstr(_CS_DARWIN_USER_CACHE_DIR, temp, sizeof(temp));
-    if (!length) {
-        WTFLogAlways("%s: Could not retrieve user temporary directory path: %s\n", getprogname(), safeStrerror(errno).data());
-        exitProcess(EX_NOPERM);
-    }
-    RELEASE_ASSERT(length <= sizeof(temp));
-    char resolvedPath[PATH_MAX];
-    if (!realpath(temp, resolvedPath)) {
-        WTFLogAlways("%s: Could not canonicalize user temporary directory path: %s\n", getprogname(), safeStrerror(errno).data());
-        exitProcess(EX_NOPERM);
-    }
-    return String::fromUTF8(resolvedPath);
+    return WTF::FileSystemImpl::darwinCacheDirectory();
 }
 
 static String sandboxDirectory(WTF::AuxiliaryProcessType processType, const String& parentDirectory)


### PR DESCRIPTION
#### 158f737725b773d4919f9d583052ecef88714d33
<pre>
Create methods to get Darwin temp and cache directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=318532">https://bugs.webkit.org/show_bug.cgi?id=318532</a>
<a href="https://rdar.apple.com/181301368">rdar://181301368</a>

Reviewed by Alex Christensen.

To avoid code duplication, create methods to get Darwin temp and cache directories.
This is in preparation of upcoming work.

* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::darwinCacheDirectory):
(WTF::FileSystemImpl::darwinTempDirectory):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::sandboxDataVaultParentDirectory):

Canonical link: <a href="https://commits.webkit.org/318121@main">https://commits.webkit.org/318121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b5665654ee3c99102c9baedd9f6f85bc3eaa3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/177345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/51283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/45077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186948 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/140592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f522cdb9-4ba7-4511-abad-b594d880e329) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/52575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/138214 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/140592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c072efaa-e6ac-4080-bef3-34433e1014ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/180301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/118679 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/985445aa-efca-4a99-8d43-e5a5a2ef1079) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/40370 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/38743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7462 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/38460 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/35416 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/38616 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/43068 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/42977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/189377 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50949 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/147299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/51632 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/35087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/147091 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41812 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123847 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/118185 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/50140 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/13438 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/49536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/49776 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/49598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->