### PR TITLE
[JSC] Tweak number of GC threads for Apple platforms

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -105,6 +105,34 @@ int32_t hwPhysicalCPUMax()
 
 #endif // #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 
+#if CPU(ARM64) && OS(DARWIN)
+static int32_t hwPerfLevelPhysicalCPUMax(const char* name)
+{
+    int32_t val = 0;
+    size_t valSize = sizeof(val);
+    int rc = sysctlbyname(name, &val, &valSize, nullptr, 0);
+    if (rc < 0)
+        return 0;
+    return val;
+}
+
+// The highest performance cores.
+int32_t hwNumberOfP0Cores()
+{
+    return hwPerfLevelPhysicalCPUMax("hw.perflevel0.physicalcpu_max");
+}
+
+int32_t hwNumberOfP1Cores()
+{
+    return hwPerfLevelPhysicalCPUMax("hw.perflevel1.physicalcpu_max");
+}
+
+int32_t hwNumberOfP2Cores()
+{
+    return hwPerfLevelPhysicalCPUMax("hw.perflevel2.physicalcpu_max");
+}
+#endif // #if CPU(ARM64) && OS(DARWIN)
+
 #if CPU(ARM64) && !(CPU(ARM64E) || OS(MACOS))
 bool isARM64_LSE()
 {

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -206,6 +206,12 @@ ALWAYS_INLINE int64_t hwL3CacheSize() { return 0; }
 ALWAYS_INLINE int32_t hwPhysicalCPUMax() { return kernTCSMAwareNumberOfProcessorCores(); }
 #endif
 
+#if CPU(ARM64) && OS(DARWIN)
+int32_t hwNumberOfP0Cores();
+int32_t hwNumberOfP1Cores();
+int32_t hwNumberOfP2Cores();
+#endif
+
 constexpr size_t prologueStackPointerDelta()
 {
 #if ENABLE(C_LOOP)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -582,7 +582,31 @@ static void overrideDefaults()
     }
 
 #if OS(DARWIN) && CPU(ARM64)
-    Options::numberOfGCMarkers() = std::min<unsigned>(4, kernTCSMAwareNumberOfProcessorCores());
+    {
+        // Example topologies.
+        //                P0       P1       GC
+        // M1       :      4        4        6
+        // M1 Pro   :      6        2        6
+        // M1 Max   :      8        2        7
+        // M1 Ultra :     16        4        7
+        // M4       :    3-4      4-6      6-7
+        // M4 Pro   :   8-10        4        7
+        // M4 Max   :  10-12        4        7
+        // M5       :    3-4        6        7
+        // M5 Pro   :    5-6    10-12        7
+        // M5 Max   :      6       12        7
+        // A18      :      2        4        4
+        unsigned p0 = hwNumberOfP0Cores();
+        unsigned p1 = hwNumberOfP1Cores();
+        unsigned gcMarkers = 0;
+        if (p0 < 3)
+            gcMarkers = std::min<unsigned>(4, kernTCSMAwareNumberOfProcessorCores());
+        else if ((p0 + p1) < 9)
+            gcMarkers = std::min<unsigned>(6, kernTCSMAwareNumberOfProcessorCores());
+        else
+            gcMarkers = std::min<unsigned>(7, kernTCSMAwareNumberOfProcessorCores());
+        Options::numberOfGCMarkers() = gcMarkers;
+    }
 
     Options::minNumberOfWorklistThreads() = 1;
     Options::maxNumberOfWorklistThreads() = std::min<unsigned>(4, kernTCSMAwareNumberOfProcessorCores());


### PR DESCRIPTION
#### f0df03efe38c9dacfdb67ec002251ee110d7939f
<pre>
[JSC] Tweak number of GC threads for Apple platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=318534">https://bugs.webkit.org/show_bug.cgi?id=318534</a>
<a href="https://rdar.apple.com/181304464">rdar://181304464</a>

Reviewed by Tadeu Zagallo.

With our recent GC throughput optimizations etc.[1], GC scalability gets
improved and now we are seeing the best GC thread numbers are changed
from the previous static number &quot;4&quot; on Apple platforms. This patch
tweaks the heuristics based on P0 core and P1 core counts. The best
numbers are selected with A/B testing with various benchmarks on various
devices, and summarizing the characteristics and selecting the # of
threads based on that with the current JSC implementation. It is
possible that the number may be changed with the future JSC
development, so the formula and numbers are current snapshot.

[1]: <a href="https://commits.webkit.org/316327@main">https://commits.webkit.org/316327@main</a>

* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::hwPerfLevelPhysicalCPUMax):
(JSC::hwNumberOfP0Cores):
(JSC::hwNumberOfP1Cores):
(JSC::hwNumberOfP2Cores):
* Source/JavaScriptCore/assembler/CPU.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):

Canonical link: <a href="https://commits.webkit.org/316502@main">https://commits.webkit.org/316502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daf5df355aa1ba7f6658f58abeae432791129715

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172538 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130094 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa35499d-1159-4dfe-90f8-d3e7281f922f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3aea8c9-5a5f-4ff3-a63a-88ae3057b2b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154728 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57f2420c-d1c6-4d96-9d3c-b686fbc8aebb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36244 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30595 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3260 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184528 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33799 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38754 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142982 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46128 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142861 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46806 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111640 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26185 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37886 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118558 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205216 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45323 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9181 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54791 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44782 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->