### PR TITLE
[Web Inspector] Uninitialized bool members in InspectorOverlay Config structs

### DIFF
--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -82,8 +82,8 @@ struct InspectorOverlayHighlight {
         Color padding;
         Color border;
         Color margin;
-        bool showInfo;
-        bool usePageCoordinates;
+        bool showInfo { false };
+        bool usePageCoordinates { false };
     };
 
     struct GridHighlightOverlay {
@@ -158,12 +158,12 @@ public:
             WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Config);
 
             Color gridColor;
-            bool showLineNames;
-            bool showLineNumbers;
-            bool showExtendedGridLines;
-            bool showTrackSizes;
-            bool showAreaNames;
-            bool showOrderNumbers;
+            bool showLineNames { false };
+            bool showLineNumbers { false };
+            bool showExtendedGridLines { false };
+            bool showTrackSizes { false };
+            bool showAreaNames { false };
+            bool showOrderNumbers { false };
         };
 
         WeakPtr<Node, WeakPtrImplWithEventTargetData> gridNode;
@@ -177,7 +177,7 @@ public:
             WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(Config);
 
             Color flexColor;
-            bool showOrderNumbers;
+            bool showOrderNumbers { false };
         };
 
         WeakPtr<Node, WeakPtrImplWithEventTargetData> flexNode;


### PR DESCRIPTION
#### 6d2dd05162ce464e5eb67856fc65964a65a907f0
<pre>
[Web Inspector] Uninitialized bool members in InspectorOverlay Config structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=318536">https://bugs.webkit.org/show_bug.cgi?id=318536</a>
<a href="https://rdar.apple.com/181307120">rdar://181307120</a>

Reviewed by Devin Rousso.

The Highlight/Grid/Flex Config structs declared bool members without
default initializers. They are always assigned before use today, so this
is latent, but give each a { false } default to match the existing idiom.
No behavior change.

* Source/WebCore/inspector/InspectorOverlay.h:

Canonical link: <a href="https://commits.webkit.org/316508@main">https://commits.webkit.org/316508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48ceecb598aabf3a853387b731a05854f7121a51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32691f53-04ab-4f2e-9933-ff7cbcf1ec3d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46155 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cabe2b2f-8042-45c7-965a-a9f2344afba8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37626 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114692 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/247d1703-5070-4db0-a41c-9a989628eafd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30622 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146690 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184555 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143003 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46155 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46833 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111695 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37901 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118585 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45350 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9200 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44982 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44809 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->