### PR TITLE
Cherry-pick f118e35bcfa5. https://bugs.webkit.org/show_bug.cgi?id=312832

### DIFF
--- a/JSTests/stress/regexp-many-non-greedy-paren-groups.js
+++ b/JSTests/stress/regexp-many-non-greedy-paren-groups.js
@@ -1,0 +1,25 @@
+// Test that regular expressions with many sequential non-greedy quantified
+// parenthesized groups produce correct results at various sizes.
+
+function testLargeNonGreedyParens(n) {
+    let s = '(?:a){0,2}?'.repeat(n);
+
+    let r = new RegExp(s);
+
+    let result = 'aaa'.match(r);
+    if (result === null)
+        throw new Error("Expected match for n=" + n);
+    if (result.index !== 0)
+        throw new Error("Expected index 0 for n=" + n + ", got " + result.index);
+
+    let replaced = 'a'.replace(r, 'x');
+    if (typeof replaced !== 'string')
+        throw new Error("replace failed for n=" + n);
+}
+
+testLargeNonGreedyParens(10);
+testLargeNonGreedyParens(100);
+testLargeNonGreedyParens(1000);
+testLargeNonGreedyParens(2000);
+testLargeNonGreedyParens(4000);
+testLargeNonGreedyParens(8193);

--- a/LayoutTests/fast/dom/trusted-types-iframe-removal-crash-expected.txt
+++ b/LayoutTests/fast/dom/trusted-types-iframe-removal-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not hit assertions or crash under ASAN
+
+PASS

--- a/LayoutTests/fast/dom/trusted-types-iframe-removal-crash.html
+++ b/LayoutTests/fast/dom/trusted-types-iframe-removal-crash.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner && window.GCController) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    targetElement = document.createElement('div');
+
+    let iframe = document.createElement('iframe');
+
+    iframe.srcdoc = `<!DOCTYPE html>
+    <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for \'script\'">
+    <body><script>document.body.appendChild(parent.targetElement); parent.innerTrustedTypes = trustedTypes;</` + 'script>';
+
+    iframe.onload = () => setTimeout(() => {
+        TrustedTypePolicyFactory.prototype.createPolicy.call(window.innerTrustedTypes, 'default', { createHTML: function () {
+            document.adoptNode(targetElement);
+            iframe.remove();
+            iframe = null;
+            GCController.collect();
+        } });
+        window.innerTrustedTypes = null;
+
+        GCController.collect();
+        try {
+            targetElement.innerHTML = 'x';
+        } catch (e) {
+            e.toString();
+        }
+
+        document.body.innerHTML = '<p>This test passes if WebKit does not hit assertions or crash under ASAN</p>PASS';
+
+        testRunner.notifyDone();
+    }, 0);
+
+    document.body.appendChild(iframe);
+} else
+    document.write('<p>This test requires testRunner and GCController</p>');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-child.xsl
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-child.xsl
@@ -1,0 +1,4 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="xslt-import-delayed-subresource-grandchild.py"/>
+  <xsl:template match="/"/>
+</xsl:stylesheet>

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-grandchild.py
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-grandchild.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+import time
+
+# Delay must be longer than 500ms (the initial setTimeout in the HTML
+# test) so the grandchild has not yet arrived when the PI injection
+# triggers compilation, but shorter than 3500ms (500ms + 3000ms total
+# test timeout). After the delay, this response arrives and
+# XSLImportRule::setXSLStyleSheet() -> parseString() runs on the
+# grandchild -- which, without the fix, dereferences the freed
+# m_stylesheetDoc of the parent (child.xsl).
+time.sleep(1)
+
+sys.stdout.write('Content-Type: text/xml\r\n\r\n')
+sys.stdout.write('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"/>')

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-root.xsl
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-root.xsl
@@ -1,0 +1,4 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:import href="xslt-import-delayed-subresource-child.xsl"/>
+  <xsl:template match="/"/>
+</xsl:stylesheet>

--- a/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-target.xml
+++ b/LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-target.xml
@@ -1,0 +1,2 @@
+<?xml-stylesheet type="text/xsl" href="xslt-import-delayed-subresource-root.xsl"?>
+<root/>

--- a/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt
+++ b/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash.html
+++ b/LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<!-- Test that compiling an XSL stylesheet with a still-loading import subresource does not
+     cause a use-after-free when the delayed subresource later arrives. -->
+<p>This test passes if it does not crash.</p>
+<iframe id="f" src="resources/xslt-import-delayed-subresource-target.xml"></iframe>
+<script>
+// Wait for root.xsl and child.xsl to load (but not the delayed grandchild).
+// Then inject and immediately remove an embedded XSL processing instruction
+// to trigger scheduleToApplyXSLTransforms(), which will attempt to compile
+// the partially-loaded import chain.
+setTimeout(() => {
+    try {
+        const doc = document.getElementById('f').contentDocument;
+        // Create an embedded XSL PI (href="#x") which unconditionally calls
+        // scheduleToApplyXSLTransforms() via the embedded branch of
+        // ProcessingInstruction::checkStyleSheet().
+        const pi = doc.createProcessingInstruction("xml-stylesheet", 'type="text/xsl" href="#x"');
+        doc.insertBefore(pi, doc.firstChild);
+        pi.remove();
+    } catch (e) {
+        // Cross-origin or other access error is OK - test still verifies no crash.
+    }
+
+    // Wait long enough for the delayed grandchild to arrive and trigger
+    // parseString() on the grandchild stylesheet. Without the fix, this
+    // dereferences a freed m_stylesheetDoc in the parent (child.xsl).
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 3000);
+}, 500);
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Keyframes with timeline-offsets reported using a scroll timeline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="help" src="https://drafts.csswg.org/scroll-animations-1/#named-timeline-range">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+<script src="support/testcommon.js"></script>
+<script src="/web-animations/resources/keyframe-utils.js"></script>
+<title>Animation range and scroll timeline</title>
+</head>
+<style type="text/css">
+  @keyframes anim {
+    cover 100% {
+      opacity: 1;
+    }
+    cover 0% {
+      opacity: 0;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+  #scroller {
+    border:  10px solid lightgray;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    width: 300px;
+    height: 200px;
+  }
+  #target {
+    margin-bottom: 800px;
+    margin-top:  800px;
+    margin-left:  10px;
+    margin-right:  10px;
+    width: 100px;
+    height: 100px;
+    z-index: -1;
+    background-color: green;
+    animation:  anim auto both linear;
+    animation-timeline: scroll();
+  }
+</style>
+<body>
+  <div id="scroller">
+    <div id="target"></div>
+  </div>
+</body>
+<script>
+  async function runTest() {
+    promise_test(async t => {
+      await waitForNextFrame();
+      const anim = document.getAnimations()[0];
+      await anim.ready;
+      await waitForNextFrame();
+
+      let frames = anim.effect.getKeyframes();
+      let expected = [
+        { offset: 0.5, computedOffset: 0.5, opacity: "0.5", easing: "linear",
+          composite: "auto" },
+        { offset: { rangeName: "cover", offset: CSS.percent(0) },
+          computedOffset: 0, opacity:  "0", composite: "auto",
+          easing: "linear" },
+        { offset: { rangeName: "cover", offset: CSS.percent(100) },
+          computedOffset: 1, opacity:  "1", composite: "auto",
+          easing: "linear" }
+      ];
+      assert_frame_lists_equal(frames, expected);
+    }, 'Keyframes with timeline-offsets reported using a scroll timeline');
+  }
+
+  window.onload = runTest;
+</script>

--- a/LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt
+++ b/LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt
@@ -1,0 +1,4 @@
+Test that a WebContent process cannot forge a persistent storage-access grant by sending storageAccessUnderTopFrameDomains via NetworkConnectionToWebProcess::ResourceLoadStatisticsUpdated.
+
+PASS: no storage-access grant was created from forged statistics
+

--- a/LayoutTests/ipc/forged-resource-load-statistics-storage-access.html
+++ b/LayoutTests/ipc/forged-resource-load-statistics-storage-access.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<p>Test that a WebContent process cannot forge a persistent storage-access grant by sending
+storageAccessUnderTopFrameDomains via NetworkConnectionToWebProcess::ResourceLoadStatisticsUpdated.</p>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText(); }
+function out(s) { document.getElementById('log').textContent += s + '\n'; }
+function J(v) { return JSON.stringify(v, (k, x) => typeof x === 'bigint' ? x.toString() + 'n' : x); }
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function main() {
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+    const fix = (o) => {
+        if (Array.isArray(o))
+            o.forEach(fix); 
+        else if (o && typeof o === 'object') {
+            for (const k in o) {
+                if (o[k] === 'std::monostate')
+                    o[k] = 'std::nullptr_t';
+                else
+                    fix(o[k]);
+            }
+        }
+    };
+    fix(CoreIPC.typeInfo);
+    const so = ArgumentSerializer.serializeOptional;
+    ArgumentSerializer.serializeOptional = (t, a) => so.call(ArgumentSerializer, t, a ?? { });
+
+    const VICTIM = 'victim.example';
+    const ATTACKER = 'attacker.example';
+    const frameID = Array.isArray(IPC.frameID) ? IPC.frameID[0] : IPC.frameID;
+    const pageID = IPC.pageID;
+    const now = Date.now() / 1000;
+    const RD = (d) => ({ "string": d });
+    const WT = (t) => ({ "secondsSinceEpochSeconds": t });
+
+    const stat = (dom, storageAccessUnder) => ({
+        registrableDomain: RD(dom),
+        lastSeen: WT(now),
+        hadUserInteraction: true,
+        mostRecentUserInteractionTime: WT(now),
+        grandfathered: true,
+        storageAccessUnderTopFrameDomains: (storageAccessUnder || []).map(RD),
+        topFrameUniqueRedirectsTo: [],
+        topFrameUniqueRedirectsToSinceSameSiteStrictEnforcement: [],
+        topFrameUniqueRedirectsFrom: [],
+        topFrameLinkDecorationsFrom: [],
+        gotLinkDecorationFromPrevalentResource: false,
+        topFrameLoadedThirdPartyScripts: [],
+        subframeUnderTopFrameDomains: [],
+        subresourceUnderTopFrameDomains: [],
+        subresourceUniqueRedirectsTo: [],
+        subresourceUniqueRedirectsFrom: [],
+        isPrevalentResource: true,
+        isVeryPrevalentResource: false,
+        dataRecordsRemoved: 0,
+        timesAccessedAsFirstPartyDueToUserInteraction: 0,
+        timesAccessedAsFirstPartyDueToStorageAccessAPI: 0,
+        topFrameRegistrableDomainsWhichAccessedWebAPIs: [],
+        fontsFailedToLoad: [],
+        fontsSuccessfullyLoaded: [],
+        canvasActivityRecord: { textWritten: [], wasDataRead: false },
+        navigatorFunctionsAccessed: 0,
+        screenFunctionsAccessed: 0,
+    });
+
+    let rlsDone = false;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.ResourceLoadStatisticsUpdated(0, {
+        statistics: [stat(ATTACKER), stat(VICTIM, [ATTACKER])]
+    }, () => { rlsDone = true; });
+    for (let i = 0; i < 40 && !rlsDone; i++) await sleep(100);
+
+    let rsaReply = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.RequestStorageAccess(0, {
+        subFrameDomain: RD(VICTIM),
+        topFrameDomain: RD(ATTACKER),
+        frameID: frameID,
+        webPageID: pageID,
+        webPageProxyID: IPC.webPageProxyID,
+        scope: 1,
+        hasOrShouldIgnoreUserGesture: 1,
+    }, (r) => { rsaReply = r; });
+    for (let i = 0; i < 40 && !rsaReply; i++) await sleep(100);
+
+    let hsaReply = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.HasStorageAccess(0, {
+        subFrameDomain: RD(VICTIM),
+        topFrameDomain: RD(ATTACKER),
+        frameID: frameID,
+        pageID: pageID,
+    }, (r) => { hsaReply = r; });
+    for (let i = 0; i < 40 && !hsaReply; i++) await sleep(100);
+
+    if (hsaReply && hsaReply.hasStorageAccess)
+        out('FAIL: forged storageAccessUnderTopFrameDomains produced a live storage-access grant');
+    else
+        out('PASS: no storage-access grant was created from forged statistics');
+}
+
+if (window.IPC)
+    main().catch(e => out('FAIL: ' + e)).finally(() => testRunner.notifyDone());
+else {
+    out('PASS: no storage-access grant was created from forged statistics');
+    testRunner?.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/load-image-for-decoding-file-url-expected.txt
+++ b/LayoutTests/ipc/load-image-for-decoding-file-url-expected.txt
@@ -1,0 +1,2 @@
+PASS: file:// rejected by MESSAGE_CHECK
+

--- a/LayoutTests/ipc/load-image-for-decoding-file-url.html
+++ b/LayoutTests/ipc/load-image-for-decoding-file-url.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html><body>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+function log(s) { document.getElementById('log').textContent += s + '\n'; }
+
+async function main() {
+    if (!window.IPC) {
+        log('PASS: file:// rejected by MESSAGE_CHECK');
+        return;
+    }
+
+    const { CoreIPC, ArgumentSerializer } = await import('./coreipc.js');
+
+    const fileRequest = {
+        getRequestDataToSerialize: {
+            variantType: 'WebCore::ResourceRequest::RequestData',
+            variant: {
+                m_url: { string: 'file:///private/etc/hosts' },
+                m_firstPartyForCookies: { string: 'file:///private/etc/hosts' },
+                m_timeoutInterval: 60.0,
+                m_httpMethod: 'GET',
+                m_httpHeaderFields: { commonHeaders: [], uncommonHeaders: [] },
+                m_responseContentDispositionEncodingFallbackArray: [],
+                m_cachePolicy: 0,
+                m_sameSiteDisposition: 1,
+                m_priority: 2,
+                m_requester: 0,
+                m_allowCookies: true,
+                m_isTopSite: true,
+                m_isAppInitiated: true,
+                m_privacyProxyFailClosedForUnreachableNonMainHosts: false,
+                m_useAdvancedPrivacyProtections: false,
+                m_didFilterLinkDecoration: false,
+                m_isPrivateTokenUsageByThirdPartyAllowed: false,
+                m_wasSchemeOptimisticallyUpgraded: false,
+                m_targetAddressSpace: 0,
+            },
+        },
+        cachePartition: '',
+        hiddenFromInspector: false,
+    };
+
+    const definition = IPC.messages.NetworkConnectionToWebProcess_LoadImageForDecoding;
+    const args = ArgumentSerializer.serializeArguments(definition.arguments,
+        { request: fileRequest, pageID: BigInt(IPC.webPageProxyID), maximumBytesFromNetwork: 1024n });
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    IPC.connectionForProcessTarget('Networking').sendWithAsyncReply(0, definition.name, args, () => { });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    if (messageCheck && messageCheck.includes('Message check failed') && messageCheck.includes('protocolIsInHTTPFamily'))
+        log('PASS: file:// rejected by MESSAGE_CHECK');
+    else
+        log('FAIL: expected MESSAGE_CHECK on protocolIsInHTTPFamily, got: "' + messageCheck + '"');
+}
+
+main().catch(e => log('FAIL: ' + e + '\n' + (e.stack || ''))).finally(() => window.testRunner?.notifyDone());
+</script>
+</body></html>

--- a/LayoutTests/ipc/register-file-backed-blob-path-validation-expected.txt
+++ b/LayoutTests/ipc/register-file-backed-blob-path-validation-expected.txt
@@ -1,0 +1,2 @@
+Unauthorized file-backed blob registration rejected: PASS
+

--- a/LayoutTests/ipc/register-file-backed-blob-path-validation.html
+++ b/LayoutTests/ipc/register-file-backed-blob-path-validation.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true BlobFileAccessEnforcementEnabled=true allowTestOnlyIPC=true ] -->
+<pre id="out"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+<script type="module">
+const out = document.getElementById('out');
+const log = s => { out.textContent += s + '\n'; };
+
+if (!window.IPC) {
+    log('Unauthorized file-backed blob registration rejected: PASS');
+    testRunner?.notifyDone();
+} else {
+
+const { CoreIPC } = await import("./coreipc.js");
+
+function blobSize(u) {
+    return new Promise(res => {
+        CoreIPC.Networking.NetworkConnectionToWebProcess.BlobSize(0, { url: { string: u } },
+            (parsed) => res(parsed && parsed.resultSize !== undefined ? Number(parsed.resultSize) : -1));
+    });
+}
+
+function generalStoragePath() {
+    return new Promise(res => {
+        CoreIPC.Networking.NetworkConnectionToWebProcess.GeneralStoragePathForTesting(0, {},
+            (parsed) => res(parsed && parsed.path ? parsed.path : ''));
+    });
+}
+
+(async () => {
+
+    localStorage.setItem('seed', '1');
+
+    let storagePath = await generalStoragePath();
+    if (!storagePath) {
+        log('FAIL: could not retrieve general storage path');
+        testRunner?.notifyDone();
+        return;
+    }
+
+    let targetPath = storagePath + '/salt';
+    let blobURL = URL.createObjectURL(new Blob([new Uint8Array([0])]));
+    CoreIPC.Networking.NetworkConnectionToWebProcess.RegisterInternalBlobURLOptionallyFileBacked(0, {
+        url: { string: blobURL },
+        srcURL: { string: `blob:webkit-internal://${crypto.randomUUID()}` },
+        fileBackedPath: targetPath,
+        contentType: 'application/octet-stream',
+    });
+    let size = await blobSize(blobURL);
+    log('Unauthorized file-backed blob registration rejected: ' + (size === 1 ? 'PASS' : 'FAIL (BlobSize=' + size + ')'));
+
+    testRunner?.notifyDone();
+})().catch(e => { log('FAIL: ' + e); testRunner?.notifyDone(); });
+
+}
+</script>

--- a/LayoutTests/ipc/usermedia-capture-start-producing-data-race-expected.txt
+++ b/LayoutTests/ipc/usermedia-capture-start-producing-data-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/usermedia-capture-start-producing-data-race.html
+++ b/LayoutTests/ipc/usermedia-capture-start-producing-data-race.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.setUserMediaPermission(true);
+}
+
+function done() {
+    document.body.textContent = "This test passes if it does not crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+function failTest(error) {
+    document.body.textContent = `Fail: ${error.message}`;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+async function runTest()
+{
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    let stream;
+    try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+        throw error;
+    }
+
+    const sourceId = 100n;
+    const emptyConstraintMap = {
+        m_width: {}, m_height: {}, m_sampleRate: {}, m_sampleSize: {},
+        m_aspectRatio: {}, m_frameRate: {}, m_volume: {},
+        m_echoCancellation: {}, m_displaySurface: {}, m_logicalSurface: {},
+        m_facingMode: {}, m_deviceId: {}, m_groupId: {}, m_whiteBalanceMode: {},
+        m_zoom: {}, m_torch: {}, m_backgroundBlur: {}, m_powerEfficient: {}
+    };
+
+    let timer;
+    await new Promise((resolve, reject) => {
+        CoreIPC.GPU.UserMediaCaptureManagerProxy.CreateMediaSourceForCaptureDeviceWithConstraints(0, {
+            id: sourceId,
+            device: {
+                persistentId: '239c24b0-2b15-11e3-8224-0800200c9a66',
+                type: 2,
+                label: 'Mock audio device 1',
+                groupId: 'microphonegroup',
+                enabled: true,
+                isDefault: true,
+                isMockDevice: true,
+                isEphemeral: false
+            },
+            hashSalts: { persistentDeviceSalt: 'a', ephemeralDeviceSalt: 'b' },
+            constraints: { mandatoryConstraints: emptyConstraintMap, advancedConstraints: [], isValid: true },
+            shouldUseGPUProcessRemoteFrames: false,
+            pageIdentifier: IPC.pageID
+        }, () => { 
+            resolve();
+        });
+
+        timer = setTimeout(() => reject(`Timed out waiting for CreateMediaSourceForCaptureDeviceWithConstraints`), 5000);
+    });
+    clearTimeout(timer);
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.StartProducingData(0, { id: sourceId, pageIdentifier: IPC.pageID });
+
+    let count = 0;
+    const interval = setInterval(() => {
+        for (let i = 0; i < 10; i++)
+            CoreIPC.GPU.UserMediaCaptureManagerProxy.StartProducingData(0, { id: sourceId, pageIdentifier: IPC.pageID });
+        if (++count > 20) {
+            clearInterval(interval);
+            stream.getTracks().forEach(t => t.stop());
+            done();
+        }
+    }, 10);
+}
+
+window.addEventListener('load', async event => {
+    runTest().catch((error) => {
+        failTest(error);
+    });
+});
+
+</script>
+</head>
+<body onload="runTest()">
+</body>
+</html>

--- a/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash-expected.txt
+++ b/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash-expected.txt
@@ -1,0 +1,18 @@
+Tests that navigation.navigate() called with zero arguments returns a valid NavigationResult and does not leak a raw JSC::Exception cell to JavaScript.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof result is 'object'
+PASS 'committed' in result is true
+PASS 'finished' in result is true
+PASS result.committed instanceof Promise is true
+PASS result.finished instanceof Promise is true
+PASS committedError.constructor.name is "TypeError"
+PASS finishedError.constructor.name is "TypeError"
+PASS result.foo is 0xdead
+PASS did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash.html
+++ b/LayoutTests/navigation-api/navigation-navigate-no-arguments-crash.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that navigation.navigate() called with zero arguments returns a valid NavigationResult and does not leak a raw JSC::Exception cell to JavaScript.");
+
+jsTestIsAsync = true;
+
+var result;
+var committedError;
+var finishedError;
+
+window.onload = async () => {
+    // Calling navigate() with zero arguments hits the mandatory-argument check
+    // in the generated bindings, which previously returned a raw encoded
+    // JSC::Exception* cell to JavaScript instead of a NavigationResult. That
+    // cell could then be type-confused as a JSObject (e.g. by setting a
+    // property on it), corrupting its m_value field and crashing GC.
+    result = navigation.navigate();
+
+    shouldBe("typeof result", "'object'");
+    shouldBeTrue("'committed' in result");
+    shouldBeTrue("'finished' in result");
+    shouldBeTrue("result.committed instanceof Promise");
+    shouldBeTrue("result.finished instanceof Promise");
+
+    try {
+        await result.committed;
+        testFailed("committed promise should be rejected");
+    } catch (e) {
+        committedError = e;
+    }
+    shouldBeEqualToString("committedError.constructor.name", "TypeError");
+
+    try {
+        await result.finished;
+        testFailed("finished promise should be rejected");
+    } catch (e) {
+        finishedError = e;
+    }
+    shouldBeEqualToString("finishedError.constructor.name", "TypeError");
+
+    // Set a property on the result and force GC. If a raw JSC::Exception cell
+    // were exposed here, this would corrupt Exception::m_value with a Butterfly
+    // pointer, and the subsequent GC would crash when visitChildren tried to
+    // mark m_value as a JSCell.
+    result.foo = 0xdead;
+    shouldBe("result.foo", "0xdead");
+
+    if (window.GCController)
+        GCController.collect();
+
+    testPassed("did not crash");
+    finishJSTest();
+};
+</script>

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -329,6 +329,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumBinaryStringSwitchCaseLength, 50, Normal, nullptr) \
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
     v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
+    v(Unsigned, maximumRegExpJITCodeSize, 16 * MB, Normal, "Maximum generated code size in bytes for RegExp JIT compilation before falling back to the interpreter."_s) \
     \
     v(Unsigned, wasmInliningMaximumDepth, 7, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
     v(Unsigned, wasmInliningMaximumWasmCalleeSize, 500, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3800,7 +3800,7 @@ class YarrGenerator final : public YarrJITInfo {
             }
 
             ++opIndex;
-        } while (opIndex < m_ops.size());
+        } while (opIndex < m_ops.size() && !hasExceededCodeSizeLimit());
 
         termMatchTargets.takeLast();
     }
@@ -4476,7 +4476,18 @@ class YarrGenerator final : public YarrJITInfo {
             case YarrOpCode::MatchFailed:
                 break;
             }
-        } while (opIndex);
+        } while (opIndex && !hasExceededCodeSizeLimit());
+    }
+
+    bool hasExceededCodeSizeLimit()
+    {
+        if (m_failureReason)
+            return true;
+        if (m_jit.m_assembler.buffer().codeSize() > Options::maximumRegExpJITCodeSize()) [[unlikely]] {
+            m_failureReason = JITFailureReason::GeneratedCodeSizeTooLarge;
+            return true;
+        }
+        return false;
     }
 
     // Compilation methods:
@@ -5346,9 +5357,17 @@ public:
         generate();
         if (m_disassembler)
             m_disassembler->setEndOfGenerate(m_jit.label());
+        if (m_failureReason) {
+            codeBlock.setFallBackWithFailureReason(*m_failureReason);
+            return;
+        }
         backtrack();
         if (m_disassembler)
             m_disassembler->setEndOfBacktrack(m_jit.label());
+        if (m_failureReason) {
+            codeBlock.setFallBackWithFailureReason(*m_failureReason);
+            return;
+        }
 
         ptrdiff_t codeSize = MacroAssembler::differenceBetween(startOfMainCode, m_jit.label());
         bool canInline = ([&] -> bool {
@@ -5941,6 +5960,9 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::OffsetTooLarge:
         dataLog("Can't JIT because pattern exceeds string length limits\n");
+        break;
+    case JITFailureReason::GeneratedCodeSizeTooLarge:
+        dataLog("Can't JIT because generated code size exceeds limit\n");
         break;
     }
 }

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -67,6 +67,7 @@ enum class JITFailureReason : uint8_t {
     ParenthesisNestedTooDeep,
     ExecutableMemoryAllocationFailure,
     OffsetTooLarge,
+    GeneratedCodeSizeTooLarge,
 };
 
 class BoyerMooreFastCandidates {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h
@@ -640,6 +640,7 @@ inline constexpr const char *kTransformFeedbackNotPaused = "The active Transform
 inline constexpr const char *kTransformFeedbackPaused = "The active Transform Feedback object is paused.";
 inline constexpr const char *kTransformFeedbackProgramBinary = "Cannot change program binary while program is associated with an active transform feedback object.";
 inline constexpr const char *kTransformFeedbackTargetActive = "Target is TRANSFORM_FEEDBACK_BUFFER and transform feedback is currently active.";
+inline constexpr const char *kTransformFeedbackProgramNotActive = "The program being used by the current transform feedback object is not the active program.";
 inline constexpr const char *kTransformFeedbackUseProgram = "Cannot change active program while transform feedback is unpaused.";
 inline constexpr const char *kTransformFeedbackVaryingIndexOutOfRange = "Index must be less than the transform feedback varying count in the program.";
 inline constexpr const char *kTypeNotUnsignedShortByte = "Only UNSIGNED_SHORT and UNSIGNED_BYTE types are supported.";

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES3.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES3.cpp
@@ -4144,6 +4144,13 @@ bool ValidateResumeTransformFeedback(const Context *context, angle::EntryPoint e
         return false;
     }
 
+    const Program *currentProgram = context->getState().getProgram();
+    if (!currentProgram || !transformFeedback->hasBoundProgram(currentProgram->id()))
+    {
+        ANGLE_VALIDATION_ERROR(GL_INVALID_OPERATION, kTransformFeedbackProgramNotActive);
+        return false;
+    }
+
     if (!ValidateProgramExecutableXFBBuffersPresent(
             context, context->getState().getLinkedProgramExecutable(context)))
     {

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/TransformFeedbackTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/TransformFeedbackTest.cpp
@@ -4735,6 +4735,95 @@ TEST_P(WebGLTransformFeedbackTest, TooSmallBuffers)
     glEndTransformFeedback();
 }
 
+// Test that UseProgram generates INVALID_OPERATION when transform feedback is active and not paused.
+TEST_P(TransformFeedbackTest, UseProgramWhileActiveAndNotPaused)
+{
+    std::vector<std::string> tfVaryings = {"gl_Position"};
+    compileDefaultProgram(tfVaryings, GL_INTERLEAVED_ATTRIBS);
+    ANGLE_GL_PROGRAM(otherProgram, essl3_shaders::vs::Simple(), essl3_shaders::fs::Red());
+    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, mTransformFeedbackBuffer);
+    glUseProgram(mProgram);
+    glBeginTransformFeedback(GL_POINTS);
+    ASSERT_GL_NO_ERROR();
+    glUseProgram(otherProgram);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+    GLint currentProgram = 0;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &currentProgram);
+    EXPECT_EQ(static_cast<GLuint>(currentProgram), mProgram);
+    glEndTransformFeedback();
+    EXPECT_GL_NO_ERROR();
+}
+
+// Test that LinkProgram generates INVALID_OPERATION when the program is used by an active
+// transform feedback object, even if it is paused.
+TEST_P(TransformFeedbackTest, LinkProgramWhileActiveAndPaused)
+{
+    std::vector<std::string> tfVaryings = {"gl_Position"};
+    compileDefaultProgram(tfVaryings, GL_INTERLEAVED_ATTRIBS);
+    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, mTransformFeedbackBuffer);
+    glUseProgram(mProgram);
+    glBeginTransformFeedback(GL_POINTS);
+    glPauseTransformFeedback();
+    ASSERT_GL_NO_ERROR();
+    glLinkProgram(mProgram);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+    glEndTransformFeedback();
+    EXPECT_GL_NO_ERROR();
+}
+
+// Test that BindBufferBase, BindBufferRange with TRANSFORM_FEEDBACK_BUFFER generates INVALID_OPERATION when
+// transform feedback is active.
+TEST_P(TransformFeedbackTest, BindBufferBaseWhileActive)
+{
+    std::vector<std::string> tfVaryings = {"gl_Position"};
+    compileDefaultProgram(tfVaryings, GL_INTERLEAVED_ATTRIBS);
+
+    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, mTransformFeedbackBuffer);
+    glUseProgram(mProgram);
+    glBeginTransformFeedback(GL_POINTS);
+    ASSERT_GL_NO_ERROR();
+    GLBuffer otherBuffer;
+    glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, otherBuffer);
+    glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, 1024, nullptr, GL_STATIC_DRAW);
+    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, otherBuffer);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+    glBindBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, 0, otherBuffer, 0, 512);
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+    glEndTransformFeedback();
+    EXPECT_GL_NO_ERROR();
+}
+
+// Test that ResumeTransformFeedback generates INVALID_OPERATION when a different program is
+// current than the one used to begin transform feedback on the current TFO.
+TEST_P(TransformFeedbackTest, ResumeWithDifferentProgram)
+{
+    std::vector<std::string> tfVaryings = {"gl_Position"};
+    compileDefaultProgram(tfVaryings, GL_INTERLEAVED_ATTRIBS);
+
+    ANGLE_GL_PROGRAM_TRANSFORM_FEEDBACK(otherProgram, essl3_shaders::vs::Simple(),
+                                        essl3_shaders::fs::Red(), tfVaryings,
+                                        GL_INTERLEAVED_ATTRIBS);
+
+    glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, mTransformFeedbackBuffer);
+    glUseProgram(mProgram);
+    glBeginTransformFeedback(GL_POINTS);
+    ASSERT_GL_NO_ERROR();
+
+    glPauseTransformFeedback();
+    glUseProgram(otherProgram);
+    ASSERT_GL_NO_ERROR();
+
+    glResumeTransformFeedback();
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+
+    glUseProgram(mProgram);
+    glResumeTransformFeedback();
+    EXPECT_GL_NO_ERROR();
+
+    glEndTransformFeedback();
+    EXPECT_GL_NO_ERROR();
+}
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(TransformFeedbackTest);
 ANGLE_INSTANTIATE_TEST_ES3_AND(TransformFeedbackTest,
                                ES3_VULKAN().disable(Feature::SupportsTransformFeedbackExtension),

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -67,6 +67,7 @@
 #include "RenderElement.h"
 #include "RenderObjectInlines.h"
 #include "RenderStyle+SettersInlines.h"
+#include "ScrollTimeline.h"
 #include "Settings.h"
 #include "StyleAdjuster.h"
 #include "StyleEasingFunction.h"
@@ -231,17 +232,19 @@ static std::optional<KeyframeEffect::KeyframeOffset> validateKeyframeOffset(cons
     return nullptr;
 };
 
-static double computedOffset(Style::SingleAnimationRangeName rangeName, double offset, const ViewTimeline* viewTimeline, WebAnimation* animation)
+static double computedOffset(Style::SingleAnimationRangeName rangeName, double offset, const ScrollTimeline* scrollTimeline, WebAnimation* animation)
 {
     if ((rangeName == Style::SingleAnimationRangeName::Normal || rangeName == Style::SingleAnimationRangeName::Omitted))
         return offset;
 
-    if (!viewTimeline)
+    if (!scrollTimeline)
         return std::numeric_limits<double>::quiet_NaN();
 
-    Ref timeline { *viewTimeline };
+    RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(scrollTimeline);
+    if (!viewTimeline)
+        return offset;
 
-    auto [namedRangeStartOffset, namedRangeEndOffset] = timeline->offsetIntervalForTimelineRangeName(rangeName);
+    auto [namedRangeStartOffset, namedRangeEndOffset] = viewTimeline->offsetIntervalForTimelineRangeName(rangeName);
     auto namedRangeOffsetDelta = namedRangeEndOffset - namedRangeStartOffset;
     auto computedOffsetWithinNamedRange = namedRangeStartOffset + offset * namedRangeOffsetDelta;
 
@@ -252,12 +255,12 @@ static double computedOffset(Style::SingleAnimationRangeName rangeName, double o
     if (attachmentRange.isDefault())
         return computedOffsetWithinNamedRange;
 
-    auto [attachmentRangeStartOffset, attachmentRangeEndOffset] = timeline->offsetIntervalForAttachmentRange(attachmentRange);
+    auto [attachmentRangeStartOffset, attachmentRangeEndOffset] = viewTimeline->offsetIntervalForAttachmentRange(attachmentRange);
     auto attachmentRangeOffsetDelta = attachmentRangeEndOffset - attachmentRangeStartOffset;
     return (computedOffsetWithinNamedRange - attachmentRangeStartOffset) / attachmentRangeOffsetDelta;
 }
 
-static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKeyframe>& keyframes, const ViewTimeline* viewTimeline, WebAnimation* animation)
+static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKeyframe>& keyframes, const ScrollTimeline* scrollTimeline, WebAnimation* animation)
 {
     // https://drafts.csswg.org/web-animations-1/#compute-missing-keyframe-offsets
 
@@ -276,7 +279,7 @@ static inline void computeMissingKeyframeOffsets(Vector<KeyframeEffect::ParsedKe
             auto rangeName = Style::convertRangeStringToSingleTimelineRangeName(timelineRangeOffset->rangeName);
             RefPtr offsetUnitValue = dynamicDowncast<CSSUnitValue>(timelineRangeOffset->offset);
             ASSERT(offsetUnitValue && offsetUnitValue->unitEnum() == CSSUnitType::CSS_PERCENTAGE);
-            keyframe.computedOffset = computedOffset(rangeName, offsetUnitValue->value() / 100, viewTimeline, animation);
+            keyframe.computedOffset = computedOffset(rangeName, offsetUnitValue->value() / 100, scrollTimeline, animation);
         } else {
             keyframesWithDoubleOrNullOffset.append(&keyframe);
             if (auto* doubleValue = std::get_if<double>(&offset))
@@ -914,7 +917,7 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
     BlendingKeyframes computedBlendingKeyframes(m_blendingKeyframes.identifier());
     computedBlendingKeyframes.copyKeyframes(m_blendingKeyframes);
 
-    if (computedBlendingKeyframes.hasKeyframeNotUsingRangeOffset() || activeViewTimeline())
+    if (computedBlendingKeyframes.hasKeyframeNotUsingRangeOffset() || activeScrollTimeline())
         computedBlendingKeyframes.fillImplicitKeyframes(*this, elementStyle);
 
     auto keyframeRules = [&]() -> const Vector<Ref<StyleRuleKeyframe>> {
@@ -1169,7 +1172,7 @@ ExceptionOr<void> KeyframeEffect::processKeyframes(JSGlobalObject& lexicalGlobal
 
     // We take a slight detour from the spec text and compute the missing keyframe offsets right away
     // since they can be computed up-front.
-    computeMissingKeyframeOffsets(parsedKeyframes, activeViewTimeline().get(), animation());
+    computeMissingKeyframeOffsets(parsedKeyframes, activeScrollTimeline().get(), animation());
 
     CSSParserContext parserContext(document);
 
@@ -2079,7 +2082,7 @@ void KeyframeEffect::animationDidTick()
     invalidate();
     updateAcceleratedActions();
 
-    if (RefPtr viewTimeline = activeViewTimeline())
+    if (RefPtr viewTimeline = activeScrollTimeline())
         computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation());
 }
 
@@ -3192,15 +3195,15 @@ bool KeyframeEffect::isPropertyAdditiveOrCumulative(KeyframeInterpolation::Prope
     });
 }
 
-RefPtr<const ViewTimeline> KeyframeEffect::activeViewTimeline() const
+RefPtr<const ScrollTimeline> KeyframeEffect::activeScrollTimeline() const
 {
     RefPtr animation = this->animation();
     if (!animation)
         return nullptr;
 
-    RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(animation->timeline());
-    if (viewTimeline && viewTimeline->currentTime())
-        return viewTimeline;
+    RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(animation->timeline());
+    if (scrollTimeline && scrollTimeline->currentTime())
+        return scrollTimeline;
 
     return nullptr;
 }
@@ -3222,15 +3225,15 @@ void KeyframeEffect::updateComputedKeyframeOffsetsIfNeeded()
     if (!animation)
         return;
 
-    RefPtr viewTimeline = dynamicDowncast<ViewTimeline>(animation->timeline());
-    if (viewTimeline && !viewTimeline->currentTime())
+    RefPtr scrollTimeline = dynamicDowncast<ScrollTimeline>(animation->timeline());
+    if (scrollTimeline && !scrollTimeline->currentTime())
         return;
 
     if (!m_parsedKeyframes.isEmpty())
-        computeMissingKeyframeOffsets(m_parsedKeyframes, viewTimeline.get(), animation.get());
+        computeMissingKeyframeOffsets(m_parsedKeyframes, scrollTimeline.get(), animation.get());
 
     m_blendingKeyframes.updatedComputedOffsets([&](auto& specifiedOffset) {
-        return computedOffset(specifiedOffset.name, specifiedOffset.value, viewTimeline.get(), animation.get());
+        return computedOffset(specifiedOffset.name, specifiedOffset.value, scrollTimeline.get(), animation.get());
     });
 
     m_needsComputedKeyframeOffsetsUpdate = false;

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -286,7 +286,7 @@ private:
     bool preventsAnimationReadiness() const final;
     void animationProgressBasedTimelineSourceDidChangeMetrics(const Style::SingleAnimationRange&) final;
 
-    RefPtr<const ViewTimeline> activeViewTimeline() const;
+    RefPtr<const ScrollTimeline> activeScrollTimeline() const;
     void updateComputedKeyframeOffsetsIfNeeded();
 
     // KeyframeInterpolation

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -423,16 +423,24 @@ inline JSC::EncodedJSValue callPromisePairFunction(JSC::JSGlobalObject& lexicalG
 
     auto result = functor(globalObject, callFrame, DeferredPromise::create(globalObject, *promise1, DeferredPromise::Mode::RetainPromiseOnResolve), DeferredPromise::create(globalObject, *promise2, DeferredPromise::Mode::RetainPromiseOnResolve));
 
+    // The functor may have thrown — e.g. the generated missing-argument check
+    // returns throwVMError(...), which encodes a JSC::Exception* cell rather
+    // than an empty JSValue sentinel. Detect that before
+    // rejectPromisesWithExceptionIfAny clears the exception, so we never
+    // expose the raw Exception cell to JavaScript below.
+    bool functorThrew = !!catchScope.exception();
+
     rejectPromisesWithExceptionIfAny(lexicalGlobalObject, globalObject, *promise1, *promise2, catchScope);
 
     // FIXME: We could have error since any JS call can throw stack-overflow errors.
     // https://bugs.webkit.org/show_bug.cgi?id=203402
     RETURN_IF_EXCEPTION(catchScope, JSC::encodedJSValue());
 
-    // When the functor threw (e.g. during IDL argument conversion), its return
-    // value is an empty JSValue sentinel. Rebuild a valid result dictionary from
-    // the (now rejected) promises via convertDictionaryToJS.
-    if (!JSC::JSValue::decode(result)) [[unlikely]] {
+    // When the functor threw or returned an empty JSValue sentinel (e.g. IDL
+    // argument conversion failure), rebuild a valid result dictionary from the
+    // (now rejected) promises via convertDictionaryToJS rather than returning
+    // the functor's return value.
+    if (functorThrew || !JSC::JSValue::decode(result)) [[unlikely]] {
         result = JSC::JSValue::encode(convertDictionaryToJS(lexicalGlobalObject, globalObject, DictionaryType { DOMPromise::create(globalObject, *promise1), DOMPromise::create(globalObject, *promise2) }));
         RETURN_IF_EXCEPTION(catchScope, JSC::encodedJSValue());
     }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8102,6 +8102,12 @@ void Document::applyPendingXSLTransformsTimerFired()
         if (transformSourceDocument() || !processingInstruction->sheet())
             return;
 
+        // Don't attempt to compile a stylesheet whose import chain is still loading.
+        // Compiling a partially-loaded tree can cause libxslt to free imported docs
+        // that WebKit still references, leading to use-after-free.
+        if (processingInstruction->sheet()->isLoading())
+            continue;
+
         // If the Document has already been detached from the frame, or the frame is currently in the process of
         // changing to a new document, don't attempt to create a new Document from the XSLT.
         if (!frame() || frame()->documentIsBeingReplaced())

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1240,7 +1240,7 @@ void Document::setMarkupUnsafe(const String& markup, OptionSet<ParserContentPoli
 
 ExceptionOr<Ref<Document>> Document::parseHTMLUnsafe(Document& context, Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(context.contextDocument(), WTF::move(html), "Document parseHTMLUnsafe"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(context.contextDocument()), WTF::move(html), "Document parseHTMLUnsafe"_s);
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
 
@@ -4583,7 +4583,7 @@ ExceptionOr<void> Document::write(Document* entryDocument, FixedVector<Variant<R
     }
 
     String textString = text.toString();
-    auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedHTML, contextDocument(), textString, lineFeed.isEmpty() ? "Document write"_s : "Document writeln"_s);
+    auto stringValueHolder = trustedTypeCompliantString(TrustedType::TrustedHTML, protect(contextDocument()), textString, lineFeed.isEmpty() ? "Document write"_s : "Document writeln"_s);
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
     SegmentedString trustedText(stringValueHolder.releaseReturnValue());
@@ -7996,7 +7996,7 @@ ExceptionOr<bool> Document::execCommand(const String& commandName, bool userInte
         [&commandName, this](const String& str) -> ExceptionOr<String> {
             if (commandName != "insertHTML"_s)
                 return String(str);
-            return trustedTypeCompliantString(TrustedType::TrustedHTML, contextDocument(), str, "Document execCommand"_s);
+            return trustedTypeCompliantString(TrustedType::TrustedHTML, protect(contextDocument()), str, "Document execCommand"_s);
         },
         [](const RefPtr<TrustedHTML>& trustedHtml) -> ExceptionOr<String> {
             return trustedHtml->toString();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4414,7 +4414,7 @@ ExceptionOr<void> Element::replaceChildrenWithMarkup(const String& markup, Optio
 
 ExceptionOr<void> Element::setHTMLUnsafe(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTF::move(html), "Element setHTMLUnsafe"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document().contextDocument()), WTF::move(html), "Element setHTMLUnsafe"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -4448,7 +4448,7 @@ String Element::outerHTML() const
 
 ExceptionOr<void> Element::setOuterHTML(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTF::move(html), "Element outerHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document().contextDocument()), WTF::move(html), "Element outerHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -4489,7 +4489,7 @@ ExceptionOr<void> Element::setOuterHTML(Variant<RefPtr<TrustedHTML>, String>&& h
 
 ExceptionOr<void> Element::setInnerHTML(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTF::move(html), "Element innerHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document().contextDocument()), WTF::move(html), "Element innerHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -6097,7 +6097,7 @@ ExceptionOr<void> Element::insertAdjacentHTML(const String& where, const String&
 
 ExceptionOr<void> Element::insertAdjacentHTML(const String& where, Variant<RefPtr<TrustedHTML>, String>&& markup)
 {
-    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTF::move(markup), "Element insertAdjacentHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document().contextDocument()), WTF::move(markup), "Element insertAdjacentHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -759,7 +759,7 @@ String Range::toString() const
 ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(Variant<RefPtr<TrustedHTML>, String>&& markup)
 {
     Ref node = startContainer();
-    auto stringValueHolder = trustedTypeCompliantString(node->document().contextDocument(), WTF::move(markup), "Range createContextualFragment"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(node->document().contextDocument()), WTF::move(markup), "Range createContextualFragment"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -250,7 +250,7 @@ ExceptionOr<void> ShadowRoot::replaceChildrenWithMarkup(const String& markup, Op
 
 ExceptionOr<void> ShadowRoot::setHTMLUnsafe(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTF::move(html), "ShadowRoot setHTMLUnsafe"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document().contextDocument()), WTF::move(html), "ShadowRoot setHTMLUnsafe"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
@@ -270,7 +270,7 @@ String ShadowRoot::innerHTML() const
 
 ExceptionOr<void> ShadowRoot::setInnerHTML(Variant<RefPtr<TrustedHTML>, String>&& html)
 {
-    auto stringValueHolder = trustedTypeCompliantString(document().contextDocument(), WTF::move(html), "ShadowRoot innerHTML"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document().contextDocument()), WTF::move(html), "ShadowRoot innerHTML"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -165,13 +165,16 @@ bool XSLStyleSheet::parseString(const String& string)
     if (!ctxt)
         return false;
 
-    if (m_parentStyleSheet && m_parentStyleSheet->m_stylesheetDoc) {
+    if (m_parentStyleSheet && m_parentStyleSheet->m_stylesheetDoc && !m_parentStyleSheet->m_stylesheetDocTaken) {
         // The XSL transform may leave the newly-transformed document
         // with references to the symbol dictionaries of the style sheet
         // and any of its children. XML document disposal can corrupt memory
         // if a document uses more than one symbol dictionary, so we
         // ensure that all child stylesheets use the same dictionaries as their
         // parents.
+        // Only share the parent's dict if the parent still owns the document.
+        // Once m_stylesheetDocTaken is set, libxslt owns the doc and may free
+        // it at any time (e.g. on compilation failure), making the pointer unsafe.
         SUPPRESS_FORWARD_DECL_ARG xmlDictFree(ctxt->dict);
         ctxt->dict = m_parentStyleSheet->m_stylesheetDoc->dict;
         SUPPRESS_FORWARD_DECL_ARG xmlDictReference(ctxt->dict);

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -303,6 +303,13 @@ bool XSLTProcessor::transformToString(Node& sourceNode, String& mimeType, String
     xsltStylesheetPtr sheet = xsltStylesheetPointer(m_stylesheet, m_stylesheetRootNode.get());
     if (!sheet) {
         setXSLTLoadCallBack(nullptr, nullptr, nullptr);
+        // Clear dangling document pointers in the stylesheet tree. When compilation
+        // fails, libxslt may have already freed imported child docs via
+        // xsltParseStylesheetImport() → xmlFreeDoc(). Without this call, child
+        // stylesheets retain dangling m_stylesheetDoc pointers that can be
+        // dereferenced if a delayed subresource later triggers parseString().
+        if (RefPtr stylesheet = m_stylesheet)
+            stylesheet->clearDocuments();
         m_stylesheet = nullptr;
         return false;
     }

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -137,6 +137,11 @@ public:
 
     void start()
     {
+        // A compromised WebContent process may send StartProducingData repeatedly. Once we are
+        // observing, prepareAudioDescription() would race the capture thread's audioSamplesAvailable().
+        if (m_isObservingMedia)
+            return;
+
         m_shouldReset = true;
         m_isStopped = false;
         m_source->start();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -232,7 +232,8 @@ void NetworkConnectionToWebProcess::hasUploadStateChanged(bool hasUpload)
 void NetworkConnectionToWebProcess::loadImageForDecoding(WebCore::ResourceRequest&& request, WebPageProxyIdentifier pageID, uint64_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::FragmentedSharedBuffer>, WebCore::ResourceError>&&)>&& completionHandler)
 {
     auto url = request.url();
-    MESSAGE_CHECK_COMPLETION(url.isValid(), completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
+    MESSAGE_CHECK_COMPLETION(url.isValid() && url.protocolIsInHTTPFamily(), completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
+    MESSAGE_CHECK_COMPLETION(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) == NetworkProcess::AllowCookieAccess::Allow, completionHandler(makeUnexpected<WebCore::ResourceError>({ })));
     CheckedPtr networkSession = this->networkSession();
     if (!networkSession)
         return completionHandler(makeUnexpected<WebCore::ResourceError>({ }));

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1330,14 +1330,32 @@ void NetworkConnectionToWebProcess::removeStorageAccessForFrame(FrameIdentifier 
 
 void NetworkConnectionToWebProcess::logUserInteraction(RegistrableDomain&& domain)
 {
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domain) == NetworkProcess::AllowCookieAccess::Allow);
+
     if (CheckedPtr networkSession = this->networkSession()) {
         if (RefPtr resourceLoadStatistics = networkSession->resourceLoadStatistics())
             resourceLoadStatistics->logUserInteraction(WTF::move(domain), [] { });
     }
 }
 
+// Validate that the WebContent process is not setting fields it has no authority over. The WCP-side ResourceLoadObserver
+// never populates these; only the network grocess grant/classification paths should write them.
+static bool resourceLoadStatisticsContainsOnlyObservableFields(const ResourceLoadStatistics& statistics)
+{
+    return statistics.storageAccessUnderTopFrameDomains.isEmpty()
+        && !statistics.grandfathered
+        && !statistics.isPrevalentResource
+        && !statistics.isVeryPrevalentResource
+        && !statistics.dataRecordsRemoved
+        && !statistics.timesAccessedAsFirstPartyDueToUserInteraction
+        && !statistics.timesAccessedAsFirstPartyDueToStorageAccessAPI;
+}
+
 void NetworkConnectionToWebProcess::resourceLoadStatisticsUpdated(Vector<ResourceLoadStatistics>&& statistics, CompletionHandler<void()>&& completionHandler)
 {
+    for (auto& statistic : statistics)
+        MESSAGE_CHECK_COMPLETION(resourceLoadStatisticsContainsOnlyObservableFields(statistic), completionHandler());
+
     if (CheckedPtr networkSession = this->networkSession()) {
         if (networkSession->sessionID().isEphemeral()) {
             completionHandler();
@@ -1425,6 +1443,9 @@ void NetworkConnectionToWebProcess::storageAccessQuirkForTopFrameDomain(URL&& to
 
 void NetworkConnectionToWebProcess::requestStorageAccessUnderOpener(WebCore::RegistrableDomain&& domainInNeedOfStorageAccess, PageIdentifier openerPageID, WebCore::RegistrableDomain&& openerDomain)
 {
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, domainInNeedOfStorageAccess) == NetworkProcess::AllowCookieAccess::Allow);
+    MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, openerDomain) == NetworkProcess::AllowCookieAccess::Allow);
+
     if (CheckedPtr networkSession = this->networkSession()) {
         if (RefPtr resourceLoadStatistics = networkSession->resourceLoadStatistics())
             resourceLoadStatistics->requestStorageAccessUnderOpener(WTF::move(domainInNeedOfStorageAccess), openerPageID, WTF::move(openerDomain));

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1118,12 +1118,12 @@ void NetworkConnectionToWebProcess::cookieEnabledStateMayHaveChanged()
     m_connection->send(Messages::NetworkProcessConnection::UpdateCachedCookiesEnabled(), 0);
 }
 
-bool NetworkConnectionToWebProcess::isFilePathAllowed(NetworkSession& session, String path)
+bool NetworkConnectionToWebProcess::isFilePathAllowed(String path)
 {
     path = FileSystem::lexicallyNormal(path);
     auto parentPath = FileSystem::parentPath(path);
     while (parentPath != path) {
-        if (m_allowedFilePaths.contains(path) || parentPath == session.storageManager().path() || parentPath == session.storageManager().customIDBStoragePath())
+        if (m_allowedFilePaths.contains(path))
             return true;
         path = parentPath;
         parentPath = FileSystem::parentPath(path);
@@ -1148,7 +1148,7 @@ void NetworkConnectionToWebProcess::registerInternalFileBlobURL(const URL& url, 
     if (!session)
         return;
     if (blobFileAccessEnforcementEnabled() && shouldCheckBlobFileAccess())
-        MESSAGE_CHECK(isFilePathAllowed(*session, path));
+        MESSAGE_CHECK(isFilePathAllowed(path));
 
     RefPtr sandboxExtension = SandboxExtension::create(WTF::move(extensionHandle));
 
@@ -1164,9 +1164,9 @@ void NetworkConnectionToWebProcess::registerInternalFileBlobURL(const URL& url, 
                 MESSAGE_CHECK(false);
             }
         } else // No sandbox extension provided, fall back to path allowlist check
-            MESSAGE_CHECK(isFilePathAllowed(*session, replacementPath));
+            MESSAGE_CHECK(isFilePathAllowed(replacementPath));
 #else
-        MESSAGE_CHECK(isFilePathAllowed(*session, replacementPath));
+        MESSAGE_CHECK(isFilePathAllowed(replacementPath));
 #endif
     }
 
@@ -1201,7 +1201,7 @@ void NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked(
     if (!session)
         return;
     if (blobFileAccessEnforcementEnabled() && shouldCheckBlobFileAccess())
-        MESSAGE_CHECK(isFilePathAllowed(*session, fileBackedPath));
+        MESSAGE_CHECK(isFilePathAllowed(fileBackedPath));
 
     m_blobURLs.add({ url, std::nullopt });
     session->blobRegistry().registerInternalBlobURLOptionallyFileBacked(url, srcURL, BlobDataFileReferenceWithSandboxExtension::create(fileBackedPath), contentType, { });
@@ -1295,6 +1295,14 @@ void NetworkConnectionToWebProcess::registerBlobPathForTesting(const String& pat
         return completion();
     allowAccessToFile(path);
     completion();
+}
+
+void NetworkConnectionToWebProcess::generalStoragePathForTesting(CompletionHandler<void(String&&)>&& completion)
+{
+    CheckedPtr session = networkSession();
+    if (!session)
+        return completion({ });
+    completion(String { session->storageManager().path() });
 }
 
 void NetworkConnectionToWebProcess::allowAccessToFile(const String& path)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -339,7 +339,8 @@ private:
     void unregisterBlobURL(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&&)>&&);
     void registerBlobPathForTesting(const String& path, CompletionHandler<void()>&&);
-    bool isFilePathAllowed(NetworkSession&, String path);
+    void generalStoragePathForTesting(CompletionHandler<void(String&&)>&&);
+    bool isFilePathAllowed(String path);
 
     void registerBlobURLHandle(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);
     void unregisterBlobURLHandle(const URL&, const std::optional<WebCore::SecurityOriginData>& topOrigin);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -76,6 +76,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     RegisterBlobURLHandle(URL url, std::optional<WebCore::SecurityOriginData> topOrigin);
     UnregisterBlobURLHandle(URL url, std::optional<WebCore::SecurityOriginData> topOrigin);
     RegisterBlobPathForTesting(String path) -> ();
+    [EnabledBy=AllowTestOnlyIPC] GeneralStoragePathForTesting() -> (String path);
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IDBStorageConnectionToClient.h"
 
+#include "NetworkStorageManager.h"
 #include "WebIDBConnectionToServerMessages.h"
 #include "WebIDBResult.h"
 #include <WebCore/IDBRequestData.h>
@@ -37,8 +38,9 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageConnectionToClient);
 
-IDBStorageConnectionToClient::IDBStorageConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
-    : m_connection(connection)
+IDBStorageConnectionToClient::IDBStorageConnectionToClient(NetworkStorageManager& manager, IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
+    : m_manager(manager)
+    , m_connection(connection)
     , m_identifier(identifier)
     , m_connectionToClient(WebCore::IDBServer::IDBConnectionToClient::create(*this))
 {
@@ -119,14 +121,43 @@ void IDBStorageConnectionToClient::didPutOrAdd(const WebCore::IDBResultData& res
     IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidPutOrAdd(resultData), 0);
 }
 
+static Vector<String> resultBlobFilePaths(const WebCore::IDBResultData& resultData)
+{
+    Vector<String> paths;
+    switch (resultData.type()) {
+    case WebCore::IDBResultType::GetRecordSuccess:
+    case WebCore::IDBResultType::OpenCursorSuccess:
+    case WebCore::IDBResultType::IterateCursorSuccess:
+        paths.appendVector(resultData.getResult().value().blobFilePaths());
+        for (auto& record : resultData.getResult().prefetchedRecords())
+            paths.appendVector(record.value.blobFilePaths());
+        break;
+    case WebCore::IDBResultType::GetAllRecordsSuccess:
+        for (auto& value : resultData.getAllResult().values())
+            paths.appendVector(value.blobFilePaths());
+        break;
+    default:
+        break;
+    }
+    return paths;
+}
+
+template<typename Message>
+void IDBStorageConnectionToClient::sendResultWithBlobFileAccess(const WebCore::IDBResultData& resultData)
+{
+    m_manager.get()->allowAccessToBlobFilesForProcess(m_identifier, resultBlobFilePaths(resultData), [connection = m_connection, resultData] {
+        IPC::Connection::send(connection, Message(resultData), 0);
+    });
+}
+
 void IDBStorageConnectionToClient::didGetRecord(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetRecord(resultData), 0);
+    sendResultWithBlobFileAccess<Messages::WebIDBConnectionToServer::DidGetRecord>(resultData);
 }
 
 void IDBStorageConnectionToClient::didGetAllRecords(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetAllRecords(resultData), 0);
+    sendResultWithBlobFileAccess<Messages::WebIDBConnectionToServer::DidGetAllRecords>(resultData);
 }
 
 void IDBStorageConnectionToClient::didGetCount(const WebCore::IDBResultData& resultData)
@@ -141,12 +172,12 @@ void IDBStorageConnectionToClient::didDeleteRecord(const WebCore::IDBResultData&
 
 void IDBStorageConnectionToClient::didOpenCursor(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidOpenCursor(resultData), 0);
+    sendResultWithBlobFileAccess<Messages::WebIDBConnectionToServer::DidOpenCursor>(resultData);
 }
 
 void IDBStorageConnectionToClient::didIterateCursor(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidIterateCursor(resultData), 0);
+    sendResultWithBlobFileAccess<Messages::WebIDBConnectionToServer::DidIterateCursor>(resultData);
 }
 
 void IDBStorageConnectionToClient::didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier& requestIdentifier, Vector<WebCore::IDBDatabaseNameAndVersion>&& databases)
@@ -161,7 +192,9 @@ void IDBStorageConnectionToClient::fireVersionChangeEvent(WebCore::IDBServer::Un
 
 void IDBStorageConnectionToClient::generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const std::optional<WebCore::IDBKeyPath>& keyPath, const WebCore::IDBKeyData& key, const WebCore::IDBValue& value, std::optional<int64_t> recordID)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::GenerateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID), 0);
+    m_manager.get()->allowAccessToBlobFilesForProcess(m_identifier, Vector<String> { value.blobFilePaths() }, [connection = m_connection, requestIdentifier, indexInfo, keyPath, key, value, recordID] {
+        IPC::Connection::send(connection, Messages::WebIDBConnectionToServer::GenerateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID), 0);
+    });
 }
 
 void IDBStorageConnectionToClient::didCloseFromServer(WebCore::IDBServer::UniqueIDBDatabaseConnection& connection, const WebCore::IDBError& error)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -32,11 +32,13 @@
 
 namespace WebKit {
 
+class NetworkStorageManager;
+
 class IDBStorageConnectionToClient final : public WebCore::IDBServer::IDBConnectionToClientDelegate {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageConnectionToClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBStorageConnectionToClient);
 public:
-    IDBStorageConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
+    IDBStorageConnectionToClient(NetworkStorageManager&, IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
     ~IDBStorageConnectionToClient();
 
     std::optional<WebCore::IDBConnectionIdentifier> identifier() const final { return m_identifier; }
@@ -69,7 +71,9 @@ private:
     void fireVersionChangeEvent(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion) final;
     void generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const std::optional<WebCore::IDBKeyPath>&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, std::optional<int64_t> recordID);
     void didCloseFromServer(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBError&) final;
+    template<typename Message> void sendResultWithBlobFileAccess(const WebCore::IDBResultData&);
 
+    ThreadSafeWeakRef<NetworkStorageManager> m_manager;
     IPC::Connection::UniqueID m_connection;
     WebCore::IDBConnectionIdentifier m_identifier;
     const Ref<WebCore::IDBServer::IDBConnectionToClient> m_connectionToClient;

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -28,6 +28,7 @@
 
 #include "IDBStorageConnectionToClient.h"
 #include "Logging.h"
+#include "NetworkStorageManager.h"
 #include <WebCore/UniqueIDBDatabaseConnection.h>
 #include <WebCore/UniqueIDBDatabaseTransaction.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -36,7 +37,10 @@
 
 namespace WebKit {
 
-IDBStorageRegistry::IDBStorageRegistry() = default;
+IDBStorageRegistry::IDBStorageRegistry(NetworkStorageManager& manager)
+    : m_manager(manager)
+{
+}
 
 IDBStorageRegistry::~IDBStorageRegistry() = default;
 
@@ -48,7 +52,7 @@ WebCore::IDBServer::IDBConnectionToClient* IDBStorageRegistry::ensureConnectionT
     auto identifier = *requestIdentifier.connectionIdentifier();
     auto addResult = m_connectionsToClient.add(identifier, nullptr);
     if (addResult.isNewEntry)
-        addResult.iterator->value = makeUnique<IDBStorageConnectionToClient>(ipcConnection.uniqueID(), identifier);
+        addResult.iterator->value = makeUnique<IDBStorageConnectionToClient>(m_manager.get(), ipcConnection.uniqueID(), identifier);
 
     MESSAGE_CHECK_WITH_RETURN_VALUE(addResult.iterator->value->ipcConnection() == ipcConnection.uniqueID(), ipcConnection, nullptr);
     return &addResult.iterator->value->connectionToClient();

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -42,12 +42,13 @@ class UniqueIDBDatabaseTransaction;
 namespace WebKit {
 
 class IDBStorageConnectionToClient;
+class NetworkStorageManager;
 
 class IDBStorageRegistry : public CanMakeThreadSafeCheckedPtr<IDBStorageRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageRegistry);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBStorageRegistry);
 public:
-    IDBStorageRegistry();
+    explicit IDBStorageRegistry(NetworkStorageManager&);
     ~IDBStorageRegistry();
     WebCore::IDBServer::IDBConnectionToClient* ensureConnectionToClient(IPC::Connection&, const WebCore::IDBResourceIdentifier&);
     void removeConnectionToClient(IPC::Connection::UniqueID);
@@ -61,6 +62,7 @@ public:
 private:
     bool isValidConnectionForIPC(WebCore::IDBServer::UniqueIDBDatabaseConnection&, IPC::Connection&);
 
+    ThreadSafeWeakRef<NetworkStorageManager> m_manager;
     HashMap<WebCore::IDBConnectionIdentifier, std::unique_ptr<IDBStorageConnectionToClient>> m_connectionsToClient;
     HashMap<WebCore::IDBDatabaseConnectionIdentifier, WeakPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection>> m_connections;
     HashMap<WebCore::IDBResourceIdentifier, WeakPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction>> m_transactions;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -209,7 +209,7 @@ NetworkStorageManager::NetworkStorageManager(NetworkProcess& process, PAL::Sessi
         setStorageSiteValidationEnabledInternal(storageSiteValidationEnabled);
         m_fileSystemStorageHandleRegistry = FileSystemStorageHandleRegistry::create();
         lazyInitialize(m_storageAreaRegistry, makeUnique<StorageAreaRegistry>());
-        lazyInitialize(m_idbStorageRegistry, makeUnique<IDBStorageRegistry>());
+        lazyInitialize(m_idbStorageRegistry, makeUnique<IDBStorageRegistry>(*this));
         lazyInitialize(m_cacheStorageRegistry, CacheStorageRegistry::create());
         m_unifiedOriginStorageLevel = level;
         m_path = path;
@@ -980,7 +980,7 @@ void NetworkStorageManager::resolve(WebCore::FileSystemHandleIdentifier identifi
     completionHandler(handle->resolve(targetIdentifier));
 }
 
-void NetworkStorageManager::getFile(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&& completionHandler)
+void NetworkStorageManager::getFile(IPC::Connection& connection, WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
 
@@ -988,7 +988,15 @@ void NetworkStorageManager::getFile(WebCore::FileSystemHandleIdentifier identifi
     if (!handle)
         return completionHandler(makeUnexpected(FileSystemStorageError::Unknown));
 
-    completionHandler(handle->path());
+    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, connection = Ref { connection }, path = crossThreadCopy(handle->path()), completionHandler = WTF::move(completionHandler)] mutable {
+        if (RefPtr process = protectedThis->m_process.get()) {
+            if (RefPtr webConnection = process->protectedWebProcessConnection(connection.get()))
+                webConnection->allowAccessToFile(path);
+        }
+        protectedThis->workQueue().dispatch([path = crossThreadCopy(WTF::move(path)), completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler(WTF::move(path));
+        });
+    });
 }
 
 void NetworkStorageManager::createSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&& completionHandler)
@@ -1443,6 +1451,23 @@ void NetworkStorageManager::registerTemporaryBlobFilePaths(IPC::Connection& conn
             return HashSet<String> { };
         }).iterator->value;
         temporaryBlobPaths.addAll(WTF::move(filePaths));
+    });
+}
+
+void NetworkStorageManager::allowAccessToBlobFilesForProcess(WebCore::ProcessIdentifier processIdentifier, Vector<String>&& filePaths, CompletionHandler<void()>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
+
+    if (filePaths.isEmpty())
+        return completionHandler();
+
+    RunLoop::mainSingleton().dispatch([protectedThis = Ref { *this }, processIdentifier, filePaths = crossThreadCopy(WTF::move(filePaths)), completionHandler = WTF::move(completionHandler)] mutable {
+        RefPtr process = protectedThis->m_process.get();
+        if (!process)
+            return protectedThis->workQueue().dispatch(WTF::move(completionHandler));
+        process->allowFilesAccessFromWebProcess(processIdentifier, filePaths, [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)] mutable {
+            protectedThis->workQueue().dispatch(WTF::move(completionHandler));
+        });
     });
 }
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -145,6 +145,7 @@ public:
     void fetchLocalStorage(CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreLocalStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
     void registerTemporaryBlobFilePaths(IPC::Connection&, const Vector<String>&);
+    void allowAccessToBlobFilesForProcess(WebCore::ProcessIdentifier, Vector<String>&&, CompletionHandler<void()>&&);
     void requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&&);
     void resetQuotaForTesting(CompletionHandler<void()>&&);
     void resetQuotaUpdatedBasedOnUsageForTesting(WebCore::ClientOrigin&&);
@@ -204,7 +205,7 @@ private:
     void getDirectoryHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, bool createIfNecessary, CompletionHandler<void(Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError>)>&&);
     void removeEntry(WebCore::FileSystemHandleIdentifier, const String& name, bool deleteRecursively, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void resolve(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
-    void getFile(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&&);
+    void getFile(IPC::Connection&, WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<String, FileSystemStorageError>)>&&);
     void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&&);
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);
     void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10134,7 +10134,7 @@ void WebPageProxy::dataTaskWithRequest(WebCore::ResourceRequest&& request, const
 
 void WebPageProxy::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::optional<WebCore::FloatSize> sizeConstraint, size_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&& completionHandler)
 {
-    if (isClosed())
+    if (isClosed() || !request.url().isValid() || !request.url().protocolIsInHTTPFamily())
         return completionHandler(makeUnexpected(decodeError(request.url())));
 
     if (!hasRunningProcess())


### PR DESCRIPTION
#### f038a7ddceed35ec4ed853492c8ac208e31c3d00
<pre>
Cherry-pick f118e35bcfa5. <a href="https://bugs.webkit.org/show_bug.cgi?id=312832">https://bugs.webkit.org/show_bug.cgi?id=312832</a>

Add scheme and cookie access validation to LoadImageForDecoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=312832">https://bugs.webkit.org/show_bug.cgi?id=312832</a>
<a href="https://rdar.apple.com/174708372">rdar://174708372</a>

Reviewed by Rupin Mittal.

LoadImageForDecoding accepted arbitrary ResourceRequest fields with only a url.isValid() check. This
allowed file:// reads of NetworkProcess-sandbox files and credentialed cross-origin body reads via
spoofed firstPartyForCookies.

Restrict the URL to HTTP(S) and enforce allowsFirstPartyForCookies, matching every other
cookie-touching IPC entry point.

Test: ipc/load-image-for-decoding-file-url.html

* LayoutTests/ipc/load-image-for-decoding-file-url-expected.txt: Added.
* LayoutTests/ipc/load-image-for-decoding-file-url.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::loadImageForDecoding):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadAndDecodeImage):

Identifier: 305413.744@safari-7624-branch

Identifier: 305413.846@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.917@webkitglib/2.52">https://commits.webkit.org/305877.917@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 036d7bd40f9a65fb0793b454469c543e703b49a7
<pre>
Cherry-pick 305413.721@safari-7624-branch (146668c5ca43). <a href="https://bugs.webkit.org/show_bug.cgi?id=312977">https://bugs.webkit.org/show_bug.cgi?id=312977</a>

ANGLE: ResumeTransformFeedback does not validate the active program
<a href="https://bugs.webkit.org/show_bug.cgi?id=312977">https://bugs.webkit.org/show_bug.cgi?id=312977</a>
&lt;<a href="https://rdar.apple.com/174740337">rdar://174740337</a>&gt;

Reviewed by Dan Glastonbury.

ResumeTransformFeedback should succeed only when the current
program is the program of the active transform feedback.

Fix by adding a validation step for this.

* Source/ThirdParty/ANGLE/src/libANGLE/ErrorStrings.h:
* Source/ThirdParty/ANGLE/src/libANGLE/validationES3.cpp:
(gl::ValidateResumeTransformFeedback):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/TransformFeedbackTest.cpp:

Identifier: 305413.721@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.916@webkitglib/2.52">https://commits.webkit.org/305877.916@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c09e47d8262de61edb965bd2671b5d13aeb40d0b
<pre>
Cherry-pick defe0187e742. <a href="https://bugs.webkit.org/show_bug.cgi?id=313085">https://bugs.webkit.org/show_bug.cgi?id=313085</a>

Remove blanket storage-root file path allow from blob access enforcement
<a href="https://bugs.webkit.org/show_bug.cgi?id=313085">https://bugs.webkit.org/show_bug.cgi?id=313085</a>
<a href="https://rdar.apple.com/174405888">rdar://174405888</a>

Reviewed by Sihui Liu.

isFilePathAllowed() accepted any path under the per-session general storage directory or custom IDB
storage path. This allowed a WebContent process to read any origin&apos;s persisted data via file-backed
blob registration.

Replace the directory-level allow with per-file grants: IDB result handlers now call
allowAccessToBlobFilesForProcess() to allow only the specific blob file paths being returned to the
WebContent process.

Test: ipc/register-file-backed-blob-path-validation.html

* LayoutTests/ipc/register-file-backed-blob-path-validation-expected.txt: Added.
* LayoutTests/ipc/register-file-backed-blob-path-validation.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::isFilePathAllowed):
(WebKit::NetworkConnectionToWebProcess::registerInternalFileBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked):
(WebKit::NetworkConnectionToWebProcess::generalStoragePathForTesting):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp:
(WebKit::IDBStorageConnectionToClient::IDBStorageConnectionToClient):
(WebKit::IDBStorageConnectionToClient::allowAccessToResultBlobFiles):
(WebKit::IDBStorageConnectionToClient::didGetRecord):
(WebKit::IDBStorageConnectionToClient::didGetAllRecords):
(WebKit::IDBStorageConnectionToClient::didOpenCursor):
(WebKit::IDBStorageConnectionToClient::didIterateCursor):
(WebKit::IDBStorageConnectionToClient::generateIndexKeyForRecord):
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
(WebKit::IDBStorageRegistry::IDBStorageRegistry):
(WebKit::IDBStorageRegistry::ensureConnectionToClient):
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::allowAccessToBlobFilesForProcess):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Identifier: 305413.737@safari-7624-branch

Identifier: 305413.840@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.915@webkitglib/2.52">https://commits.webkit.org/305877.915@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c55a7e4e9b52799ecee3074a9e62c7fbc9072fdd
<pre>
Cherry-pick 4a52a36ff580. <a href="https://bugs.webkit.org/show_bug.cgi?id=314104">https://bugs.webkit.org/show_bug.cgi?id=314104</a>

[web-animations] accelerated animation with view progress timeline range and a scroll time yields a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314104">https://bugs.webkit.org/show_bug.cgi?id=314104</a>
<a href="https://rdar.apple.com/176274648">rdar://176274648</a>

Reviewed by Anne van Kesteren.

If the timeline associated with an animation is a plain scroll timeline, but not a view timeline,
we must resolve any offset using a view progress timeline range by simply disregarding the keyword.
This ensures we have resolved computed offsets in such a case, ensuring we do not crash when attempting
to create the `AcceleratedEffect` representation for this keyframe effect.

Test: imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline.html

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-offset-keyframes-with-scroll-timeline.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::computedOffset):
(WebCore::computeMissingKeyframeOffsets):
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::processKeyframes):
(WebCore::KeyframeEffect::animationDidTick):
(WebCore::KeyframeEffect::activeScrollTimeline const):
(WebCore::KeyframeEffect::updateComputedKeyframeOffsetsIfNeeded):
(WebCore::KeyframeEffect::activeViewTimeline const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:

Identifier: 305413.839@safari-7624-branch

Identifier: 305413.836@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.914@webkitglib/2.52">https://commits.webkit.org/305877.914@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 927e1206e5b1b53d5694bfdd15940e60ab482278
<pre>
Cherry-pick 64d15c23216d. <a href="https://bugs.webkit.org/show_bug.cgi?id=313703">https://bugs.webkit.org/show_bug.cgi?id=313703</a>

Use-after-free of Document in trustedTypeCompliantString
<a href="https://bugs.webkit.org/show_bug.cgi?id=313703">https://bugs.webkit.org/show_bug.cgi?id=313703</a>
<a href="https://rdar.apple.com/175673135">rdar://175673135</a>

Reviewed by Wenson Hsieh and Chris Dumez.

Fixed the bug by deploying more smart pointers.

Test: fast/dom/trusted-types-iframe-removal-crash.html

* LayoutTests/fast/dom/trusted-types-iframe-removal-crash-expected.txt: Added.
* LayoutTests/fast/dom/trusted-types-iframe-removal-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::parseHTMLUnsafe):
(WebCore::Document::write):
(WebCore::Document::execCommand):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setHTMLUnsafe):
(WebCore::Element::setOuterHTML):
(WebCore::Element::setInnerHTML):
(WebCore::Element::insertAdjacentHTML):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::setHTMLUnsafe):
(WebCore::ShadowRoot::setInnerHTML):

Identifier: 305413.805@safari-7624-branch

Identifier: 305413.832@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.913@webkitglib/2.52">https://commits.webkit.org/305877.913@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b577b7842a1f7aa6283503ef0bee37be300cf80c
<pre>
Cherry-pick 651097467a79. <a href="https://bugs.webkit.org/show_bug.cgi?id=314115">https://bugs.webkit.org/show_bug.cgi?id=314115</a>

[CoreIPC][GPUProcess] UserMediaCaptureManagerProxy::startProducingData races prepareAudioDescription() against audioSamplesAvailable() lead to various UAF/write-after-unmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=314115">https://bugs.webkit.org/show_bug.cgi?id=314115</a>
<a href="https://rdar.apple.com/174411400">rdar://174411400</a>

Reviewed by Youenn Fablet and Jer Noble.

A compromised WebContent process can send StartProducingData repeatedly
for the same source. After the first call, the source proxy is registered
as an AudioSampleObserver and the capture unit is invoking
audioSamplesAvailable() on a background WorkQueue. On subsequent calls,
prepareAudioDescription() runs on the GPU main thread and reassigns
m_captureSemaphore, m_ringBuffer, m_audioHandle and m_description without
removing the observer or taking any lock, while the capture thread is
concurrently dereferencing them. This leads to heap-use-after-free on the
freed ProducerSharedCARingBuffer / IPC::Semaphore and write-after-unmap
into the old SharedMemory ring buffer.

Make UserMediaCaptureManagerProxySourceProxy::start() a no-op when the
proxy is already observing media. Legitimate stop()/start() sequences are
unaffected since stop() removes the observer.

Test: ipc/usermedia-capture-start-producing-data-race.html

* LayoutTests/ipc/usermedia-capture-start-producing-data-race-expected.txt: Added.
* LayoutTests/ipc/usermedia-capture-start-producing-data-race.html: Added.
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:

Identifier: 305413.863@safari-7624-branch

Identifier: 305413.830@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.912@webkitglib/2.52">https://commits.webkit.org/305877.912@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 33f08e62c4918f25074826d5b2928c8053362a5b
<pre>
Cherry-pick 9d8f969c538a. <a href="https://bugs.webkit.org/show_bug.cgi?id=312798">https://bugs.webkit.org/show_bug.cgi?id=312798</a>

Validate several ITP and storage access IPC messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=312798">https://bugs.webkit.org/show_bug.cgi?id=312798</a>
<a href="https://rdar.apple.com/174708437">rdar://174708437</a>

Reviewed by Matthew Finkel.

ResourceLoadStatisticsUpdated, LogUserInteraction, and RequestStorageAccessUnderOpener accept
WebContent-supplied data with no validation. A WCP can forge storageAccessUnderTopFrameDomains and
isPrevalentResource in the ITP database, then obtain cross-origin cookie access without a user
prompt.

Verify that ResourceLoadStatisticsUpdated only contains fields the WebContent process legitimately
observes, and that LogUserInteraction and RequestStorageAccessUnderOpener are called with domains
the process owns.

Test: ipc/forged-resource-load-statistics-storage-access.html

* LayoutTests/ipc/forged-resource-load-statistics-storage-access-expected.txt: Added.
* LayoutTests/ipc/forged-resource-load-statistics-storage-access.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::logUserInteraction):
(WebKit::resourceLoadStatisticsContainsOnlyObservableFields):
(WebKit::NetworkConnectionToWebProcess::resourceLoadStatisticsUpdated):
(WebKit::NetworkConnectionToWebProcess::requestStorageAccessUnderOpener):

Identifier: 305413.716@safari-7624-branch

Identifier: 305413.827@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.911@webkitglib/2.52">https://commits.webkit.org/305877.911@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 2eb2233ab1340d3c8e11d48f70607fa2baaeab9c
<pre>
Cherry-pick 3d12363860e5. <a href="https://bugs.webkit.org/show_bug.cgi?id=312337">https://bugs.webkit.org/show_bug.cgi?id=312337</a>

Heap use-after-free of XSLStyleSheet::m_stylesheetDoc after libxslt frees imported doc on compile failure
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=312337">https://bugs.webkit.org/show_bug.cgi?id=312337</a>&gt;
&lt;<a href="https://rdar.apple.com/174646751">rdar://174646751</a>&gt;

Reviewed by David Kilzer and Ryosuke Niwa.

When libxslt fails to compile an imported stylesheet, it frees the
imported doc. The child XSLStyleSheet&apos;s m_stylesheetDoc becomes
dangling. If a delayed subresource later arrives and triggers
parseString(), it dereferences the freed pointer

Fix with three layers of defense:

1. Call clearDocuments() on the failure path in transformToString(),
  matching the success path, to null out dangling doc pointers.
2. Skip dict-sharing in parseString() when the parent&apos;s doc has been
  handed to libxslt (m_stylesheetDocTaken), since libxslt may have
  freed it.
3. Check isLoading() in applyPendingXSLTransformsTimerFired() to
  avoid compiling partially-loaded import chains in the first place.

* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-child.xsl: Added.
* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-grandchild.py: Added.
* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-root.xsl: Added.
* LayoutTests/http/tests/xsl/resources/xslt-import-delayed-subresource-target.xml: Added.
* LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash-expected.txt: Added.
* LayoutTests/http/tests/xsl/xslt-import-delayed-subresource-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::applyPendingXSLTransformsTimerFired):
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::parseString):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::XSLTProcessor::transformToString):

Identifier: 305413.786@safari-7624-branch

Identifier: 305413.826@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.910@webkitglib/2.52">https://commits.webkit.org/305877.910@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f4bdc9a4c75395f4a30f7921875744677b93bbed
<pre>
Cherry-pick e6d449d59b50. <a href="https://bugs.webkit.org/show_bug.cgi?id=314589">https://bugs.webkit.org/show_bug.cgi?id=314589</a>

Add size limit to Yarr generated code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314589">https://bugs.webkit.org/show_bug.cgi?id=314589</a>
<a href="https://rdar.apple.com/176137052">rdar://176137052</a>

Reviewed by Yusuke Suzuki.

Patterns with many sequential non-greedy quantified parenthesized groups
(e.g. (?:a){0,2}? repeated thousands of times) cause O(N^2) code emission
in saveParenContext/restoreParenContext, as each group saves/restores all
frame slots for the entire pattern. This patch adds a code size limit in
VM options above which the code bails out to the interpreter.

Test: JSTests/stress/regexp-many-non-greedy-paren-groups.js

* JSTests/stress/regexp-many-non-greedy-paren-groups.js: Added.
(testLargeNonGreedyParens):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):
* Source/JavaScriptCore/yarr/YarrJIT.h:

Identifier: 305413.923@safari-7624-branch

Identifier: 305413.825@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.909@webkitglib/2.52">https://commits.webkit.org/305877.909@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b5e427226b97fe5d9aa37778760218cac4d292a0
<pre>
Cherry-pick 5977997682c7. <a href="https://bugs.webkit.org/show_bug.cgi?id=314944">https://bugs.webkit.org/show_bug.cgi?id=314944</a>

Type confusion via raw Exception cell returned to script from callPromisePairFunction when throwVMError bypasses sentinel check
<a href="https://bugs.webkit.org/show_bug.cgi?id=314944">https://bugs.webkit.org/show_bug.cgi?id=314944</a>
<a href="https://rdar.apple.com/177031898">rdar://177031898</a>

Reviewed by Ryosuke Niwa.

callPromisePairFunction&apos;s sentinel check `!JSValue::decode(result)` only catches the
zero empty-value sentinel returned by IDL argument conversion failures. When a
[ReturnsPromisePair] operation is called with fewer than the mandatory number of
arguments, the generated bindings hit the missing-argument check emitted by
CodeGeneratorJS.pm and `return throwVMError(...)`, which encodes a non-zero
JSC::Exception* cell rather than the empty sentinel. After
rejectPromisesWithExceptionIfAny clears the pending exception, the sentinel check
evaluates false and the raw Exception cell is returned to JavaScript.

The Exception cell has JSType=CellType (0), not JSObject. A subsequent property
store such as `victim.foo = 0xdead` goes through JSCell::putInline -&gt;
overridesPut() == false -&gt; asObject(this) -&gt; jsCast&lt;JSObject*&gt;. On production
ARM64 builds, ASSERT_WITH_SECURITY_IMPLICATION compiles to ((void)0), so the cast
is a bare static_cast — type confusion. The resulting put allocates a Butterfly,
clobbers Exception::m_value (offset +0x08) with the Butterfly pointer, and
writes the attacker-controlled value into property storage. The next GC then
crashes in Exception::visitChildrenImpl when visitor.append(m_value) treats the
Butterfly as a JSCell and SlotVisitor::drain dereferences an invalid StructureID.

This affects all [ReturnsPromisePair] IDL operations with mandatory arguments,
notably Navigation.navigate() / reload() / traverseTo() / back() / forward().

Fix callPromisePairFunction to capture catchScope.exception() before
rejectPromisesWithExceptionIfAny clears it. If the functor threw, always rebuild
a valid result dictionary from the (now rejected) promises via
convertDictionaryToJS rather than returning the functor&apos;s return value. This
covers throwVMError, any future throw paths inside the functor, and the existing
empty-sentinel case from IDL argument conversion failures.

The non-pair callPromiseFunction is unaffected: it already discards the functor&apos;s
return value.

Test: navigation-api/navigation-navigate-no-arguments-crash.html

* LayoutTests/navigation-api/navigation-navigate-no-arguments-crash-expected.txt: Added.
* LayoutTests/navigation-api/navigation-navigate-no-arguments-crash.html: Added.
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::callPromisePairFunction):

Identifier: 305413.921@safari-7624-branch

Identifier: 305413.824@safari-7624.4-branch
Canonical link: <a href="https://commits.webkit.org/305877.908@webkitglib/2.52">https://commits.webkit.org/305877.908@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3344388d1f51a9ad2f5f49baff56e38aaa767ffd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172457 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46375 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181912 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130013 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174322 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47668 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46044 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134137 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130013 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175415 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47668 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114609 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47668 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46044 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30514 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47668 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184446 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/33718 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37125 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46044 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142912 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46047 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142790 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46725 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111497 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26165 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46725 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118476 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205135 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45242 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39803 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54772 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44642 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44874 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44701 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->