### PR TITLE
Suppress core.FixedAddressDereference static analyzer warnings in bmalloc's BCRASH() macro

### DIFF
--- a/Source/bmalloc/bmalloc/BAssert.h
+++ b/Source/bmalloc/bmalloc/BAssert.h
@@ -62,12 +62,12 @@
 
 #if defined(__GNUC__) // GCC or Clang
 #define BCRASH() do { \
-    *(int*)0xbbadbeef = 0; \
+    BIGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE("core.FixedAddressDereference") *(int*)0xbbadbeef = 0; \
     __builtin_trap(); \
 } while (0)
 #else
 #define BCRASH() do { \
-    *(int*)0xbbadbeef = 0; \
+    BIGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE("core.FixedAddressDereference") *(int*)0xbbadbeef = 0; \
     ((void(*)())0)(); \
 } while (0)
 #endif // defined(__GNUC__)

--- a/Source/bmalloc/bmalloc/BCompiler.h
+++ b/Source/bmalloc/bmalloc/BCompiler.h
@@ -135,6 +135,17 @@
 #define BALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
+/* BIGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE() - suppress a clang static analyzer warning on the following statement.
+ * https://clang.llvm.org/docs/AttributeReference.html#suppress */
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::suppress)
+#define BIGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE(warning, ...) [[clang::suppress]]
+#endif
+#endif
+#if !defined(BIGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE)
+#define BIGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE(warning, ...)
+#endif
+
 /* MUST_TAIL_CALL */
 
 // 32-bit platforms use different calling conventions, so a MUST_TAIL_CALL function


### PR DESCRIPTION
#### 4ae295c2bf8b7d67a86067e5b24be9faa3346548
<pre>
Suppress core.FixedAddressDereference static analyzer warnings in bmalloc&apos;s BCRASH() macro
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=318543">https://bugs.webkit.org/show_bug.cgi?id=318543</a>&gt;
&lt;<a href="https://rdar.apple.com/181315666">rdar://181315666</a>&gt;

Reviewed by Yusuke Suzuki.

The clang static analyzer&apos;s `core.FixedAddressDereference` checker
reports a dereference of a fixed address wherever an assertion-failure
path reaches `BCRASH()` because the macro&apos;s deliberate
`*(int*)0xbbadbeef = 0;` fail-fast store writes through a literal
address.

Mark the store as an intentional false positive with a leading
`[[clang::suppress]]` attribute inside `BCRASH()` itself.

No new tests since this change is not directly testable.

* Source/bmalloc/bmalloc/BAssert.h:
* Source/bmalloc/bmalloc/BCompiler.h:

Canonical link: <a href="https://commits.webkit.org/316513@main">https://commits.webkit.org/316513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/470008e0c8bd744dfe292d9188d2fd9bc4b0b095

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be9e1b71-f790-4eab-85b7-c3ae4606c20c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/295d0d8a-681d-4dbc-91c5-99f22193ca84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03ae65c2-d082-4cbb-9e0f-b0fe09abbc7f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34501 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30538 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3213 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184470 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33742 "Built successfully and passed tests") | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38705 "Found 2 new test failures: http/tests/blink/sendbeacon/beacon-same-origin.html http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142928 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46071 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142806 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46749 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111535 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26191 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37839 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205159 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45266 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9131 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54778 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44898 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->