### PR TITLE
TestWebKitAPIBundle visionOS build intermittently fails to resolve _Testing_CoreTransferable cross-import overlay

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -25,6 +25,15 @@
 			name = "Apply Configuration to XCFileLists";
 			productName = "Apply Configuration to XCFileLists";
 		};
+		07A11A5702F9C0FE00000001 /* Testing.framework Overlays */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 07A11A5702F9C0FE00000002 /* Build configuration list for PBXAggregateTarget "Testing.framework Overlays" */;
+			buildPhases = (
+				0777713A2F887DCE00A1C903 /* Embed Testing.framework */,
+			);
+			name = "Testing.framework Overlays";
+			productName = "Testing.framework Overlays";
+		};
 		5C9D921422D7DA02008E9266 /* Generate Unified Sources */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 5C9D921922D7DA02008E9266 /* Build configuration list for PBXAggregateTarget "Generate Unified Sources" */;
@@ -186,6 +195,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 0723A7492F80357300CB96E7;
 			remoteInfo = "Derived Sources";
+		};
+		07A11A5702F9C0FE00000005 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07A11A5702F9C0FE00000001;
+			remoteInfo = "Testing.framework Overlays";
+		};
+		07A11A5702F9C0FE00000006 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 07A11A5702F9C0FE00000001;
+			remoteInfo = "Testing.framework Overlays";
 		};
 		0723A7562F80359900CB96E7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2010,7 +2033,6 @@
 			buildConfigurationList = 1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "TestWebKitAPI" */;
 			buildPhases = (
 				A1508C552DAF1F8000C3E213 /* Process Entitlements */,
-				0777713A2F887DCE00A1C903 /* Embed Testing.framework */,
 				8DD76F990486AA7600D96B5E /* Sources */,
 				8DD76F9B0486AA7600D96B5E /* Frameworks */,
 			);
@@ -2018,6 +2040,7 @@
 			);
 			dependencies = (
 				0723A75B2F8035A300CB96E7 /* PBXTargetDependency */,
+				07A11A5702F9C0FE00000007 /* PBXTargetDependency */,
 				BC575A96126E74E7006F0F12 /* PBXTargetDependency */,
 				7CCE7F511A4124DB00447C4C /* PBXTargetDependency */,
 				A17C48562C98EBF50023F3C7 /* PBXTargetDependency */,
@@ -2098,6 +2121,7 @@
 			);
 			dependencies = (
 				A18898FE2CA9F70B00FEB09A /* PBXTargetDependency */,
+				07A11A5702F9C0FE00000008 /* PBXTargetDependency */,
 			);
 			name = TestWebKitAPIBundle;
 			productName = TestBundle;
@@ -2189,6 +2213,7 @@
 			targets = (
 				7C83E02B1D0A5E1000FEBCF3 /* All */,
 				0723A7492F80357300CB96E7 /* Derived Sources */,
+				07A11A5702F9C0FE00000001 /* Testing.framework Overlays */,
 				5C9D921422D7DA02008E9266 /* Generate Unified Sources */,
 				7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */,
 				7C83DE951D0A590C00FEBCF3 /* TestWTFLibrary */,
@@ -2480,6 +2505,16 @@
 			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
 			targetProxy = 0723A7542F80358F00CB96E7 /* PBXContainerItemProxy */;
 		};
+		07A11A5702F9C0FE00000007 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 07A11A5702F9C0FE00000001 /* Testing.framework Overlays */;
+			targetProxy = 07A11A5702F9C0FE00000005 /* PBXContainerItemProxy */;
+		};
+		07A11A5702F9C0FE00000008 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 07A11A5702F9C0FE00000001 /* Testing.framework Overlays */;
+			targetProxy = 07A11A5702F9C0FE00000006 /* PBXContainerItemProxy */;
+		};
 		0723A7572F80359900CB96E7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0723A7492F80357300CB96E7 /* Derived Sources */;
@@ -2580,6 +2615,22 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
+		};
+		07A11A5702F9C0FE00000003 /* Debug configuration for PBXAggregateTarget "Testing.framework Overlays" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		07A11A5702F9C0FE00000004 /* Release configuration for PBXAggregateTarget "Testing.framework Overlays" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
 		};
 		0723A74B2F80357300CB96E7 /* Release configuration for PBXAggregateTarget "Derived Sources" */ = {
 			isa = XCBuildConfiguration;
@@ -2841,6 +2892,14 @@
 			buildConfigurations = (
 				0723A74A2F80357300CB96E7 /* Debug configuration for PBXAggregateTarget "Derived Sources" */,
 				0723A74B2F80357300CB96E7 /* Release configuration for PBXAggregateTarget "Derived Sources" */,
+			);
+			defaultConfigurationName = Release;
+		};
+		07A11A5702F9C0FE00000002 /* Build configuration list for PBXAggregateTarget "Testing.framework Overlays" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				07A11A5702F9C0FE00000003 /* Debug configuration for PBXAggregateTarget "Testing.framework Overlays" */,
+				07A11A5702F9C0FE00000004 /* Release configuration for PBXAggregateTarget "Testing.framework Overlays" */,
 			);
 			defaultConfigurationName = Release;
 		};


### PR DESCRIPTION
#### a4734252959df8cd532e70b8f6afbe7009ab2035
<pre>
TestWebKitAPIBundle visionOS build intermittently fails to resolve _Testing_CoreTransferable cross-import overlay
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=318544">https://bugs.webkit.org/show_bug.cgi?id=318544</a>&gt;
&lt;<a href="https://rdar.apple.com/181316388">rdar://181316388</a>&gt;

Unreviewed build fix.

Follow-on to 315261@main, which fixed this failure for the
`TestWebKitAPI` target by adding the &quot;Embed Testing.framework&quot; phase.

`TestWebKitAPIBundle` fails intermittently in the same way, so it
needs to depend on the same workaround:

error: Unable to resolve module dependency: &apos;_Testing_CoreTransferable&apos; (in target &apos;TestWebKitAPIBundle&apos; from project &apos;TestWebKitAPI&apos;)
  note: A dependency of main module &apos;_TestWebKitAPIBundle-CrossImportOverlays&apos;

Move the phase to a new &quot;Testing.framework Overlays&quot; aggregate target
that both `TestWebKitAPI` and `TestWebKitAPIBundle` depend on, so the
overlays are always dittoed before either target&apos;s Swift scan.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/316514@main">https://commits.webkit.org/316514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/899f3f318a1a31f6a7a77f04e3f9fe19cd1d2516

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46495 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182035 "Failed to checkout and rebase branch from PR 68618") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46167 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/182035 "Failed to checkout and rebase branch from PR 68618") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175535 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/182035 "Failed to checkout and rebase branch from PR 68618") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/30634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146698 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184568 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46167 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/142892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46845 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111728 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26192 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/37909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45362 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44762 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44821 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->