### PR TITLE
Rebuild umbrella modules and dependencies when header set changes

### DIFF
--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -118,6 +118,7 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
     # FIXME(rdar://177840132): swiftc -emit-dependencies records imported
     # clang modulemaps, but sometimes skips individual C++ headers.
     set(PAL_SWIFT_INTEROP_HEADERS ${PAL_PUBLIC_HEADERS})
+    WEBKIT_INVALIDATE_UMBRELLA_MODULE_ON_HEADER_SET_CHANGE(pal "${PAL_DIR}/pal/module.modulemap" ${PAL_SWIFT_INTEROP_HEADERS})
 
     WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(PAL pal
         "${PAL_FRAMEWORK_HEADERS_DIR}/pal"

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1031,6 +1031,31 @@ function(_webkit_setup_swift_header_deps _target _stamp _header _resp)
     add_dependencies(${_target}_SwiftInterop ${_target}_SwiftCxxHeader)
 endfunction()
 
+# Keeps a Clang module (and the Swift modules that import it) from going stale
+# when a header is added to or removed from it. This is the cmake replacement for
+# the manual "touch count" comment that umbrella modulemaps otherwise need in
+# Xcode builds.
+#
+# Background: for an umbrella modulemap (`umbrella "."`), adding a header to the
+# directory does not change the modulemap's contents, and neither swiftc's
+# -emit-dependencies (rdar://177840132) nor Clang's implicit module machinery
+# reliably notices the new header. The cached PCM then stays stale until the
+# modulemap itself changes.
+#
+# ARGN is the set of headers that constitute the module.
+function(WEBKIT_INVALIDATE_UMBRELLA_MODULE_ON_HEADER_SET_CHANGE _id _modulemap)
+    string(SHA1 _header_set_hash "${ARGN}")
+    set(_hash_file "${CMAKE_CURRENT_BINARY_DIR}/${_id}-module-header-set.hash")
+    set(_previous_hash "")
+    if (EXISTS "${_hash_file}")
+        file(READ "${_hash_file}" _previous_hash)
+    endif ()
+    if (NOT _previous_hash STREQUAL _header_set_hash)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E touch "${_modulemap}")
+        file(WRITE "${_hash_file}" "${_header_set_hash}")
+    endif ()
+endfunction()
+
 macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_name _interop_module_path _output_header)
     if (SWIFT_REQUIRED)
         set_target_properties(${_target} PROPERTIES Swift_MODULE_NAME ${_module_name})


### PR DESCRIPTION
#### 801f732a540b1189291b8afac047c4a9c424aa15
<pre>
Rebuild umbrella modules and dependencies when header set changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=318547">https://bugs.webkit.org/show_bug.cgi?id=318547</a>
<a href="https://rdar.apple.com/181320247">rdar://181320247</a>

Reviewed by NOBODY (OOPS!).

This ensures that Swift-consumed clang modules are rebuilt (and thus so is
dependent Swift) if the set of files within the module changes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/801f732a540b1189291b8afac047c4a9c424aa15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130012 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b9e2376-8933-4b11-807b-b710c33c039e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134136 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94636 "1 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eaa377ea-2263-442d-9461-f5ad398361f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114608 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d01a223-48c4-4268-b28c-4b5fa311c21c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34487 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30513 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3198 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146617 "Found 1 new API test failure: TestWebKitAPI.CopyURL.UnescapedURL (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184445 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33717 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142911 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46046 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142789 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111507 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37827 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118475 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205134 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45241 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9116 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54771 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44641 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->