### PR TITLE
[css-mixins-1] Fix minor @function issues

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt
@@ -15,7 +15,7 @@ PASS Dashed-function, self-cycle
 PASS Cycle through other function (--g)
 PASS Cycle through other function (--f)
 PASS Cycle through local, self
-FAIL Cycle through unused local assert_equals: expected "PASS" but got "FAIL-result"
+PASS Cycle through unused local
 PASS Cycle through global, self
 PASS Cycle through local, other function
 PASS Cycle through local, other function, fallback in function

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt
@@ -28,7 +28,7 @@ PASS Multiple parameters with defaults, typed
 PASS Default referencing another parameter
 PASS Default referencing another parameter, local interference
 PASS Default referencing another defaulted parameter
-FAIL Typed default with reference assert_equals: expected "5px 6px" but got ""
+PASS Typed default with reference
 PASS IACVT arguments are defaulted
 PASS IACVT arguments are defaulted, typed
 PASS Arguments are defaulted on type mismatch
@@ -70,7 +70,7 @@ PASS Local variable with initial keyword
 PASS Local variable with initial keyword, defaulted
 PASS Local variable with initial keyword, no value via IACVT-capture
 PASS Default with initial keyword
-FAIL initial appearing via fallback assert_equals: expected "PASS" but got ""
+PASS initial appearing via fallback
 PASS Local variable with inherit keyword
 PASS Local variable with inherit keyword (nested)
 PASS Inheriting an invalid value
@@ -86,6 +86,6 @@ PASS unset keyword left unresolved on result descriptor
 PASS revert keyword left unresolved on result descriptor
 PASS revert-layer keyword left unresolved on result descriptor
 PASS revert-rule keyword left unresolved on result descriptor
-FAIL Keyword can be returned from function into local variable assert_equals: expected "PASS" but got ""
+PASS Keyword can be returned from function into local variable
 PASS Can not return CSS-wide keyword as length
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-invalidation-expected.txt
@@ -2,5 +2,5 @@
 PASS Appending a rule
 PASS Prepending a rule
 PASS Deleting a rule
-FAIL Prepending a rule, then deleting last assert_equals: expected "10px" but got "42px"
+PASS Prepending a rule, then deleting last
 

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1177,9 +1177,17 @@ RefPtr<StyleRuleFunction> CSSParser::consumeFunctionRule(CSSParserTokenRange pre
 
                 auto defaultRange = defaultRangeStart.rangeUntil(parametersRange);
 
-                // "If a default value and a parameter type are both provided, then the default value must parse
-                // successfully according to that parameter type’s syntax. Otherwise, the @function rule is invalid."
-                if (!CSSPropertyParser::isValidCustomPropertyValueForSyntax(parameter.type, defaultRange, m_context))
+                auto isValidDefault = [&] {
+                    // "If a default value and a parameter type are both provided, then the default value
+                    // must parse successfully according to that parameter type's syntax. Otherwise, the
+                    // @function rule is invalid." A default containing arbitrary substitution functions
+                    // (var(), a dashed-function) is assumed valid at parse time and validated after
+                    // substitution.
+                    if (CSSSubstitutionParser::containsSubstitutionFunctions(defaultRange, m_context))
+                        return true;
+                    return CSSPropertyParser::isValidCustomPropertyValueForSyntax(parameter.type, defaultRange, m_context);
+                };
+                if (!isValidDefault())
                     return { };
 
                 parameter.defaultValue = CSSVariableData::create(defaultRange);

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -570,6 +570,8 @@ void RuleSetBuilder::addMutatingRulesToResolver()
             auto declarationsList = m_functionDeclarationsMap.get(*functionRule);
             CheckedRef registry = resolver->ensureCustomFunctionRegistry();
             registry->registerFunction(*functionRule, declarationsList);
+            // The cache keys on matched properties, not on the function registry. Mirrors @property.
+            resolver->invalidateMatchedDeclarationsCache();
         }
     }
 }

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -670,13 +670,28 @@ RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(c
     );
 }
 
-std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveFunctionResult(const CSSCustomPropertyValue& value)
+std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveFunctionResult()
 {
+    // resolveFunctionResult is only called while evaluating a custom function.
+    ASSERT(m_state->callingContextBuilder());
+
+    if (!m_cascade.hasNormalProperty(CSSPropertyResult))
+        return { };
+
     SetForScope resultScope(m_state->m_currentProperty, &m_cascade.functionResultProperty());
+
+    // Apply all local variables, not just those reached by result. A local can be in a cycle with the
+    // function even when result never references it.
+    // https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+    applyCustomProperties();
+
+    RefPtr resultValue = dynamicDowncast<CSSCustomPropertyValue>(m_cascade.functionResultProperty().cssValue[SelectorChecker::MatchDefault]);
+    if (!resultValue)
+        return { };
 
     // The caller (custom function evaluation) handles a CSS-wide keyword result, which per spec is
     // left unresolved. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
-    return resolveCustomPropertyValue(const_cast<CSSCustomPropertyValue&>(value));
+    return resolveCustomPropertyValue(*resultValue);
 }
 
 std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyValue(CSSCustomPropertyValue& value)
@@ -721,15 +736,15 @@ std::optional<Builder::CustomPropertyOrKeyword> Builder::resolveCustomPropertyVa
     if (!resolvedData)
         return { };
 
-    if (!registered) {
-        // CSS-wide keywords are allowed in var() fallbacks of unregistered properties.
-        auto tokens = resolvedData->tokenRange();
-        tokens.consumeWhitespace();
-        if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(tokens))
-            return { { *keyword } };
+    // A CSS-wide keyword can surface after substitution, e.g. from a var() fallback or a custom
+    // function result. https://drafts.csswg.org/css-mixins/#evaluating-custom-functions
+    auto keywordTokens = resolvedData->tokenRange();
+    keywordTokens.consumeWhitespace();
+    if (auto keyword = CSSPropertyParserHelpers::consumeCSSWideKeyword(keywordTokens))
+        return { { *keyword } };
 
+    if (!registered)
         return { { CustomProperty::createForVariableData(name, *resolvedData) } };
-    }
 
     auto dependencies = CSSPropertyParser::collectParsedCustomPropertyValueDependencies(registered->syntax, resolvedData->tokens(), resolvedData->context());
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -57,7 +57,7 @@ public:
     using CustomPropertyOrKeyword = Variant<Ref<const Style::CustomProperty>, CSSWideKeyword>;
 
     RefPtr<const CustomProperty> resolveCustomPropertyForContainerQueries(const CSSCustomPropertyValue&);
-    std::optional<CustomPropertyOrKeyword> resolveFunctionResult(const CSSCustomPropertyValue&);
+    std::optional<CustomPropertyOrKeyword> resolveFunctionResult();
 
     BuilderState& state() { return m_state; }
     const MatchResult& matchResult() const { return m_cascade.matchResult(); }

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -375,10 +375,6 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     if (!substitutedArguments)
         return false;
 
-    auto resultValue = dynamicDowncast<CSSCustomPropertyValue>(protect(customFunction->properties)->getPropertyCSSValue(CSSPropertyResult));
-    if (!resultValue)
-        return false;
-
     // "Let registrations be an initially empty set of custom property registrations."
     auto registrations = LocalPropertyRegistry { };
 
@@ -418,8 +414,7 @@ bool SubstitutionResolver::substituteDashedFunction(StringView functionName, CSS
     bodyBuilder.state().addGuardedFunctionContexts(m_styleBuilder.state());
 
     // "Return the value of the result property in body styles."
-    // Body custom properties are applied lazily as result's var() references reach them.
-    auto resolvedResult = bodyBuilder.resolveFunctionResult(*resultValue);
+    auto resolvedResult = bodyBuilder.resolveFunctionResult();
     if (!resolvedResult)
         return false;
 


### PR DESCRIPTION
#### 9e267886b98d77c1c8e0247c7db29b9f6b3f81cb
<pre>
[css-mixins-1] Fix minor @function issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=318548">https://bugs.webkit.org/show_bug.cgi?id=318548</a>
<a href="https://rdar.apple.com/181322776">rdar://181322776</a>

Reviewed by Alan Baradlay.

Minor WPT fixes and code cleanups.

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-cycles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/dashed-function-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-invalidation-expected.txt:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeFunctionRule):

Don&apos;t validate default value eagerly if it contains substitution functions like var().

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveFunctionResult):

Apply function body properties eagerly to detect cycles through unreferenced local variables.
Remove the unnecessary result value argument.

(WebCore::Style::Builder::resolveCustomPropertyValue):

Allow CSS-wide keywords after substitution on registered properties too.

* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteDashedFunction):

* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):

Invalidate the matched declarations cache when registering a function. The cache keys on
matched properties, not on the function registry, so an unchanged declaration like width: --f()
would keep a stale value after the function is added or removed. Mirrors @property registration.

Canonical link: <a href="https://commits.webkit.org/316478@main">https://commits.webkit.org/316478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d160f457fe2118d93e3910b34bf389579a2edb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130032 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0aeb0d34-c841-41f6-b695-4034faa1319e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134148 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8bdd113-f437-4d3a-837d-fe3803e85eae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37561 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114620 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5a28940-2f9e-4c2e-adc1-4fff1b1c8303) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36196 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30533 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184465 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37144 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142925 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46066 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142803 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38558 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46744 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111524 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37834 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45261 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9125 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44893 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->