### PR TITLE
FilterRenderingOption::FastAndLowQuality should be added to serialization.in

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
@@ -2857,7 +2857,8 @@ header: <WebCore/FilterRenderingMode.h>
 
 header: <WebCore/Filter.h>
 [OptionSet] enum class WebCore::FilterRenderingOption : uint8_t {
-    ShowDebugOverlay
+    ShowDebugOverlay,
+    FastAndLowQuality
 };
 
 header: <WebCore/FEComponentTransfer.h>


### PR DESCRIPTION
#### aa5d33136b6fe84d175361947adbd3c8d9dec6df
<pre>
FilterRenderingOption::FastAndLowQuality should be added to serialization.in
<a href="https://bugs.webkit.org/show_bug.cgi?id=318560">https://bugs.webkit.org/show_bug.cgi?id=318560</a>
<a href="https://rdar.apple.com/181335254">rdar://181335254</a>

Reviewed by Alex Christensen.

FastAndLowQuality was added to the enum FilterRenderingOption In 313563@main. The
main purpose of adding it was to make snapshot for page color sampling fast. This snapshotting happens in WebContent process right now so it does not need to be
serialized to GPUProcess.

But in the future we may move this snapshotting to GPUProcess, like for site-
isolation for example. Or other uses for FastAndLowQuality are discovered.

* Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316567@main">https://commits.webkit.org/316567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f8cfc719c3bf7a648f2e3545c4d93ff5dac554

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181945 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130045 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5b142e6-07fe-44f1-89a7-22473060fe12) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134159 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94650 "20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9deaee35-18a5-4d0c-ba86-0d50360ec0a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114631 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04383912-44de-46b0-84fc-dbbcd2d665b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36206 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34504 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30546 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184478 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37157 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38708 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142935 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46079 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111552 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26226 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37840 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118508 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45274 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9133 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44674 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44733 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->