### PR TITLE
[JSC] JSON.stringify's fast path skips a non-enumerable own toJSON and a replaced array prototype

### DIFF
--- a/JSTests/stress/json-stringify-array-prototype-to-json.js
+++ b/JSTests/stress/json-stringify-array-prototype-to-json.js
@@ -1,0 +1,82 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// https://tc39.es/ecma262/#sec-serializejsonproperty
+// A replaced prototype can carry a toJSON, and only the global Array.prototype is checked.
+{
+    let prototype = { __proto__: Array.prototype, toJSON() { return 'replaced'; } };
+    let array = [1, 2, 3];
+    Object.setPrototypeOf(array, prototype);
+    shouldBe(JSON.stringify(array), '"replaced"');
+    shouldBe(JSON.stringify({ array }), '{"array":"replaced"}');
+    shouldBe(JSON.stringify([array]), '["replaced"]');
+    shouldBe(JSON.stringify(array, null, 2), '"replaced"');
+}
+
+{
+    let prototype = Object.create(Array.prototype);
+    Object.defineProperty(prototype, 'toJSON', { value() { return this.length; }, enumerable: false });
+    let array = [1, 2];
+    Object.setPrototypeOf(array, prototype);
+    shouldBe(JSON.stringify(array), '2');
+}
+
+// A plain array keeps taking the fast path.
+{
+    shouldBe(JSON.stringify([1, 2, 3]), '[1,2,3]');
+    shouldBe(JSON.stringify(Object.setPrototypeOf([1, 2, 3], Array.prototype)), '[1,2,3]');
+    let arrayWithProperty = [1];
+    arrayWithProperty.extra = 2;
+    shouldBe(JSON.stringify(arrayWithProperty), '[1]');
+}
+
+// An array with no prototype has no toJSON to find.
+{
+    let array = [1, 2];
+    Object.setPrototypeOf(array, null);
+    shouldBe(JSON.stringify(array), '[1,2]');
+}
+
+// An own toJSON still wins over the prototype's.
+{
+    let prototype = { __proto__: Array.prototype, toJSON() { return 'prototype'; } };
+    let array = [1];
+    Object.setPrototypeOf(array, prototype);
+    Object.defineProperty(array, 'toJSON', { value() { return 'own'; }, enumerable: false });
+    shouldBe(JSON.stringify(array), '"own"');
+}
+
+// A callable replacer forces the general stringifier; both must agree.
+{
+    let prototype = { __proto__: Array.prototype, toJSON() { return { length: this.length }; } };
+    let values = [
+        Object.setPrototypeOf([1, 2, 3], prototype),
+        Object.setPrototypeOf(['string'], prototype),
+        [Object.setPrototypeOf([1], prototype)],
+        { nested: Object.setPrototypeOf([1], prototype) },
+        Object.setPrototypeOf([], prototype),
+    ];
+    for (let value of values) {
+        for (let space of [undefined, 2, '\t']) {
+            shouldBe(JSON.stringify(value, null, space), JSON.stringify(value, (key, x) => x, space));
+        }
+    }
+}
+
+// A subclass instance is ArrayType with the subclass prototype, so it reaches the fast path.
+{
+    class MyArray extends Array {
+        toJSON() { return 'subclass'; }
+    }
+    let array = new MyArray();
+    array.push(1, 2, 3);
+    shouldBe(JSON.stringify(array), '"subclass"');
+    shouldBe(JSON.stringify(MyArray.of(1, 2)), '"subclass"');
+    shouldBe(JSON.stringify({ array }), '{"array":"subclass"}');
+
+    class PlainSubclass extends Array { }
+    shouldBe(JSON.stringify(PlainSubclass.of(1, 2, 3)), '[1,2,3]');
+}

--- a/JSTests/stress/json-stringify-non-enumerable-to-json.js
+++ b/JSTests/stress/json-stringify-non-enumerable-to-json.js
@@ -1,0 +1,77 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorType)
+{
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+// https://tc39.es/ecma262/#sec-serializejsonproperty
+// An own toJSON is called regardless of its enumerability.
+function withNonEnumerableToJSON(object, toJSON)
+{
+    Object.defineProperty(object, 'toJSON', { value: toJSON, enumerable: false, writable: false, configurable: false });
+    return object;
+}
+
+{
+    let object = withNonEnumerableToJSON({ uri: 'u', cid: 'c', text: 't' }, function () { return { uri: this.uri, cid: this.cid }; });
+    Object.freeze(object);
+    shouldBe(JSON.stringify(object), '{"uri":"u","cid":"c"}');
+    shouldBe(JSON.stringify({ record: object }), '{"record":{"uri":"u","cid":"c"}}');
+    shouldBe(JSON.stringify([object]), '[{"uri":"u","cid":"c"}]');
+    shouldBe(JSON.stringify(object, null, 2), '{\n  "uri": "u",\n  "cid": "c"\n}');
+}
+
+{
+    shouldBe(JSON.stringify(withNonEnumerableToJSON({ a: 1 }, function () { return 'replaced'; })), '"replaced"');
+    shouldBe(JSON.stringify(withNonEnumerableToJSON({ a: 1 }, function () { return undefined; })), undefined);
+    shouldBe(JSON.stringify(withNonEnumerableToJSON({ a: 1 }, function (key) { return key; })), '""');
+    shouldBe(JSON.stringify({ key: withNonEnumerableToJSON({ a: 1 }, function (key) { return key; }) }), '{"key":"key"}');
+}
+
+// A non-reified static table can hold a toJSON. Date.prototype.toJSON throws on a non-Date.
+{
+    shouldThrow(() => JSON.stringify(Date.prototype), TypeError);
+    Object.getOwnPropertyNames(Date.prototype);
+    shouldThrow(() => JSON.stringify(Date.prototype), TypeError);
+}
+
+// An own toJSON that is not callable is serialized as a normal property.
+{
+    shouldBe(JSON.stringify(withNonEnumerableToJSON({ a: 1 }, 42)), '{"a":1}');
+    shouldBe(JSON.stringify({ a: 1, toJSON: 42 }), '{"a":1,"toJSON":42}');
+}
+
+// An enumerable own toJSON keeps working.
+{
+    shouldBe(JSON.stringify({ a: 1, toJSON() { return 'enumerable'; } }), '"enumerable"');
+    shouldBe(JSON.stringify(Object.freeze({ a: 1, toJSON() { return 'frozen'; } })), '"frozen"');
+}
+
+// A callable replacer forces the general stringifier; both must agree.
+{
+    let values = [
+        withNonEnumerableToJSON({ a: 1 }, function () { return { b: 2 }; }),
+        withNonEnumerableToJSON({ a: 1 }, function () { return 'string'; }),
+        withNonEnumerableToJSON({ a: 1 }, 'not callable'),
+        { nested: withNonEnumerableToJSON({ a: 1 }, function () { return [1, 2]; }) },
+        [withNonEnumerableToJSON({ a: 1 }, function () { return null; })],
+        withNonEnumerableToJSON({ 'キー': '値' }, function () { return this['キー']; }),
+    ];
+    for (let value of values) {
+        for (let space of [undefined, 2, '\t']) {
+            shouldBe(JSON.stringify(value, null, space), JSON.stringify(value, (key, x) => x, space));
+        }
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1420,10 +1420,21 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
             recordFastPropertyEnumerationFailure(object);
             return;
         }
+        // A non-reified static table can hold a toJSON that is not in the property table yet.
+        if (structure.hasNonReifiedStaticProperties()) [[unlikely]] {
+            recordFailure("object has non-reified static properties"_s);
+            return;
+        }
         if constexpr (hasGap == HasGap::Yes)
             ++m_depth;
         const unsigned newLineAndIndent = hasGap == HasGap::Yes ? newLineAndIndentSize() : 0;
         structure.forEachProperty(m_vm, [&](const auto& entry) -> bool {
+            // https://tc39.es/ecma262/#sec-serializejsonproperty
+            // Step 2.a's GetV finds an own toJSON regardless of enumerability.
+            if (entry.key() == m_vm.propertyNames->toJSON) [[unlikely]] {
+                recordFailure("object has toJSON"_s);
+                return false;
+            }
             if (entry.attributes() & PropertyAttribute::DontEnum)
                 return true;
             auto& name = *entry.key();
@@ -1538,6 +1549,14 @@ void FastStringifier<CharType, bufferMode>::append(JSValue value)
         }
         auto& structure = *array.structure();
         if (!m_globalObject.isOriginalArrayStructure(&structure)) [[unlikely]] {
+            if (structure.hasPolyProto()) [[unlikely]] {
+                recordFailure("hasPolyProto"_s);
+                return;
+            }
+            if (structure.storedPrototype() != m_globalObject.arrayPrototype()) [[unlikely]] {
+                recordFailure("non-standard array prototype"_s);
+                return;
+            }
             structure.forEachProperty(m_vm, [&](const PropertyTableEntry& entry) -> bool {
                 if (entry.key() == m_vm.propertyNames->toJSON) [[unlikely]] {
                     recordFailure("array has toJSON"_s);


### PR DESCRIPTION
#### 80ed2d1b3a685945a1072e7df0da0444f656168b
<pre>
[JSC] JSON.stringify's fast path skips a non-enumerable own toJSON and a replaced array prototype
<a href="https://bugs.webkit.org/show_bug.cgi?id=318507">https://bugs.webkit.org/show_bug.cgi?id=318507</a>

Reviewed by NOBODY (OOPS!).

FastStringifier decides for itself whether a value can have a toJSON, and
misses three cases. All three silently produce wrong JSON, or in the last
case skip a TypeError.

The object property loop skips DontEnum entries, but SerializeJSONProperty
looks toJSON up with GetV, so an own toJSON applies even when it is not
enumerable. Check for the toJSON key before skipping DontEnum entries.

For arrays only the global Array.prototype is checked, while
Object.setPrototypeOf, Array subclasses and other realms all keep
ArrayType, so an array can reach the fast path with a prototype nobody
looked at. Bail out when a non-original array structure has a stored
prototype other than Array.prototype, mirroring the object case.

An object with a non-reified static property table can have a toJSON that
is not in the property table yet, so the loop above cannot see it. Bail
out on those, like objectAssignFast does. JSON.stringify(Date.prototype)
returned "{}" instead of throwing.

All three bail out to the general stringifier, which is correct in these
cases. Plain objects and plain arrays are unaffected.

* JSTests/stress/json-stringify-array-prototype-to-json.js: Added.
* JSTests/stress/json-stringify-non-enumerable-to-json.js: Added.
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::FastStringifier&lt;CharType, bufferMode&gt;::append):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ed2d1b3a685945a1072e7df0da0444f656168b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130050 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46083 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134163 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94655 "1 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37576 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154684 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34509 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30551 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3219 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184484 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33755 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142940 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46084 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46762 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31034 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111562 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37845 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118513 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205172 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45279 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9138 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54780 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->