### PR TITLE
Web Inspector: fix typos when updating virtualized `WI.DataGrid` and `WI.Table`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
@@ -1186,7 +1186,7 @@ WI.DataGrid = class DataGrid extends WI.View
             this._topDataTableMarginElement.style.height = marginTop + "px";
         }
 
-        if (this._bottomDataTableMarginElement !== marginBottom) {
+        if (this._bottomDataTableMarginHeight !== marginBottom) {
             this._bottomDataTableMarginHeight = marginBottom;
             this._bottomDataTableMarginElement.style.height = marginBottom + "px";
         }

--- a/Source/WebInspectorUI/UserInterface/Views/Table.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.js
@@ -1152,7 +1152,7 @@ WI.Table = class Table extends WI.View
             this._topSpacerElement.style.height = marginTop + "px";
         }
 
-        if (this._bottomDataTableMarginElement !== marginBottom) {
+        if (this._bottomSpacerHeight !== marginBottom) {
             this._bottomSpacerHeight = marginBottom;
             this._bottomSpacerElement.style.height = marginBottom + "px";
         }


### PR DESCRIPTION
#### 287518bc5d7dd0b630d78f3ba6ce649c2618c711
<pre>
Web Inspector: fix typos when updating virtualized `WI.DataGrid` and `WI.Table`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318563">https://bugs.webkit.org/show_bug.cgi?id=318563</a>

Reviewed by Tim Nguyen.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.js:
(WI.DataGrid.prototype.updateVisibleRows):
* Source/WebInspectorUI/UserInterface/Views/Table.js:
(WI.Table.prototype._updateVisibleRows):

Canonical link: <a href="https://commits.webkit.org/316792@main">https://commits.webkit.org/316792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08b6a63078f76649d1eee958c3a35725b7c185a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181956 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130056 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134166 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94661 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34513 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30557 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184490 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37168 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38717 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142945 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46090 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38752 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46768 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111569 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37848 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118519 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45285 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->