### PR TITLE
Web Inspector: Timelines: unify record bar selection code

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineOverviewGraph.js
@@ -77,16 +77,7 @@ WI.LayoutTimelineOverviewGraph = class LayoutTimelineOverviewGraph extends WI.Ti
     {
         super.updateSelectedRecord();
 
-        for (let recordRow of [this._timelineLayoutRecordRow, this._timelinePaintRecordRow]) {
-            for (let recordBar of recordRow.recordBars) {
-                if (recordBar.records.includes(this.selectedRecord)) {
-                    this.selectedRecordBar = recordBar;
-                    return;
-                }
-            }
-        }
-
-        this.selectedRecordBar = null;
+        this.updateSelectedRecordBar([this._timelineLayoutRecordRow.recordBars, this._timelinePaintRecordRow.recordBars]);
     }
 
     // Private

--- a/Source/WebInspectorUI/UserInterface/Views/MediaTimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/MediaTimelineOverviewGraph.js
@@ -117,16 +117,7 @@ WI.MediaTimelineOverviewGraph = class MediaTimelineOverviewGraph extends WI.Time
     {
         super.updateSelectedRecord();
 
-        for (let {recordBars} of this._timelineRecordGridRows) {
-            for (let recordBar of recordBars) {
-                if (recordBar.records.includes(this.selectedRecord)) {
-                    this.selectedRecordBar = recordBar;
-                    return;
-                }
-            }
-        }
-
-        this.selectedRecordBar = null;
+        this.updateSelectedRecordBar(Array.from(this._timelineRecordGridRows, ({recordBars}) => recordBars));
     }
 
     // Private

--- a/Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.js
@@ -109,16 +109,7 @@ WI.ScriptTimelineOverviewGraph = class ScriptTimelineOverviewGraph extends WI.Ti
     {
         super.updateSelectedRecord();
 
-        for (let recordBars of this._recordBarsForTarget.values()) {
-            for (let recordBar of recordBars) {
-                if (recordBar.records.includes(this.selectedRecord)) {
-                    this.selectedRecordBar = recordBar;
-                    return;
-                }
-            }
-        }
-
-        this.selectedRecordBar = null;
+        this.updateSelectedRecordBar(this._recordBarsForTarget.values());
     }
 
     // Private

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverviewGraph.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverviewGraph.js
@@ -274,6 +274,20 @@ WI.TimelineOverviewGraph = class TimelineOverviewGraph extends WI.View
         // Implemented by sub-classes if needed.
     }
 
+    updateSelectedRecordBar(recordBarsList)
+    {
+        for (let recordBars of recordBarsList) {
+            for (let recordBar of recordBars) {
+                if (recordBar.records.includes(this.selectedRecord)) {
+                    this.selectedRecordBar = recordBar;
+                    return;
+                }
+            }
+        }
+
+        this.selectedRecordBar = null;
+    }
+
     // Private
 
     _needsSelectedRecordLayout()


### PR DESCRIPTION
#### eab5fd3f0b72ba3610918338bcbb049b97efae63
<pre>
Web Inspector: Timelines: unify record bar selection code
<a href="https://bugs.webkit.org/show_bug.cgi?id=318566">https://bugs.webkit.org/show_bug.cgi?id=318566</a>

Reviewed by BJ Burg.

These all were almost identical code, so create a common shared function to use instead.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverviewGraph.js:
(WI.TimelineOverviewGraph.prototype.updateSelectedRecordBar): Added.
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineOverviewGraph.js:
(WI.LayoutTimelineOverviewGraph.prototype.updateSelectedRecord):
* Source/WebInspectorUI/UserInterface/Views/MediaTimelineOverviewGraph.js:
(WI.MediaTimelineOverviewGraph.prototype.updateSelectedRecord):
* Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.js:
(WI.ScriptTimelineOverviewGraph.prototype.updateSelectedRecord):

Canonical link: <a href="https://commits.webkit.org/317565@main">https://commits.webkit.org/317565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/374e982098735818220348aaaaabfe246f879dae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185192 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/137768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/50825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136738 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/137768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117216 "Passed tests") | 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/38806 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37193 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/36993 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33662 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187612 "Built successfully") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49200 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145711 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39218 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/49880 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145549 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40365 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122075 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/115899 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48387 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/11970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/47789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/47846 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->