### PR TITLE
Web Inspector: batch DOM updates in `updateVisibleRows`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
@@ -1201,14 +1201,16 @@ WI.DataGrid = class DataGrid extends WI.View
 
         this.dataTableBodyElement.removeChildren();
 
+        let dataTableBodyElementFragment = document.createDocumentFragment();
         for (let i = topHiddenRowCount; i < topHiddenRowCount + visibleRowCount; ++i) {
             let rowDataGridNode = revealedRows[i];
             if (!rowDataGridNode)
                 continue;
-            this.dataTableBodyElement.appendChild(rowDataGridNode.element);
+            dataTableBodyElementFragment.appendChild(rowDataGridNode.element);
         }
 
-        this.dataTableBodyElement.appendChild(this._fillerRowElement);
+        dataTableBodyElementFragment.appendChild(this._fillerRowElement);
+        this.dataTableBodyElement.appendChild(dataTableBodyElementFragment);
     }
 
     addPlaceholderNode()

--- a/Source/WebInspectorUI/UserInterface/Views/Table.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.js
@@ -1166,12 +1166,14 @@ WI.Table = class Table extends WI.View
         // If there are an odd number of rows hidden, the first visible row must be an even row.
         this._listElement.classList.toggle("even-first-zebra-stripe", !!(topHiddenRowCount % 2));
 
+        let listElementFragment = document.createDocumentFragment();
         for (let i = this._visibleRowIndexStart; i < this._visibleRowIndexEnd && i < numberOfRows; ++i) {
             let row = this._getOrCreateRow(i);
-            this._listElement.appendChild(row);
+            listElementFragment.appendChild(row);
         }
 
-        this._listElement.appendChild(this._fillerRow);
+        listElementFragment.appendChild(this._fillerRow);
+        this._listElement.appendChild(listElementFragment);
     }
 
     _updateFillerRowWithNewHeight()


### PR DESCRIPTION
#### 7680d6700159c773aaeae99830d01f7f18c537ff
<pre>
Web Inspector: batch DOM updates in `updateVisibleRows`
<a href="https://bugs.webkit.org/show_bug.cgi?id=318567">https://bugs.webkit.org/show_bug.cgi?id=318567</a>

Reviewed by Alexey Proskuryakov.

Use a `DocumentFragment` to update the DOM all-at-once instead of repeatedly adding children.

Given how frequently `WI.DataGrid` and `WI.Table` update, this might help performance.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.js:
(WI.DataGrid.prototype.updateVisibleRows):
* Source/WebInspectorUI/UserInterface/Views/Table.js:
(WI.Table.prototype._updateVisibleRows):

Canonical link: <a href="https://commits.webkit.org/316595@main">https://commits.webkit.org/316595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/478f26b1bf47e45611681301e6926bce8fe91f04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181962 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130062 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134172 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94665 "1 flakes 20 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36217 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34521 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184496 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142951 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46096 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142829 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38641 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111576 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37855 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118525 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45291 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9147 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44750 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->