### PR TITLE
Cherry-pick 305937@main (1f89cbb0564a). https://bugs.webkit.org/show_bug.cgi?id=305897

### DIFF
--- a/LayoutTests/fast/inline/inline-content-with-ellipsis-after-partial-layout-crash-expected.txt
+++ b/LayoutTests/fast/inline/inline-content-with-ellipsis-after-partial-layout-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/inline/inline-content-with-ellipsis-after-partial-layout-crash.html
+++ b/LayoutTests/fast/inline/inline-content-with-ellipsis-after-partial-layout-crash.html
@@ -1,0 +1,22 @@
+<style>
+html {
+ columns: 0;
+ widows: 4;
+}
+
+body {
+ text-overflow: ellipsis;
+}
+
+body, canvas, textarea {
+ width: 40px;
+ overflow-y: auto;
+}
+
+canvas {
+  border-right-style: solid;
+}
+</style><textarea></textarea>PASS if no crash<textarea></textarea><canvas>or assert.</canvas>
+<script>
+window.testRunner?.dumpAsText();
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp
@@ -95,6 +95,15 @@ void Content::setLineEllipsis(size_t lineIndex, Line::Ellipsis&& ellipsis)
     lineEllipses->at(lineIndex) = WTF::move(ellipsis);
 }
 
+void Content::setEllipsisOnTrailingLine(Line::Ellipsis&& ellipsis)
+{
+    if (lines.isEmpty()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    setLineEllipsis(lines.size() - 1, WTF::move(ellipsis));
+}
+
 std::optional<Line::Ellipsis> Content::lineEllipsis(size_t lineIndex) const
 {
     if (!lines[lineIndex].hasEllipsis())

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.h
@@ -46,6 +46,7 @@ struct Content {
 
     std::optional<Line::Ellipsis> lineEllipsis(size_t) const;
     void setLineEllipsis(size_t line, Line::Ellipsis&&);
+    void setEllipsisOnTrailingLine(Line::Ellipsis&&);
 
     void moveLineInBlockDirection(size_t, float offset);
     void shrinkLineInBlockDirection(size_t, float delta);


### PR DESCRIPTION
#### 5de3c38624ecf9eda1c16d3464df4818aa615eb0
<pre>
Cherry-pick 305937@main (1f89cbb0564a). <a href="https://bugs.webkit.org/show_bug.cgi?id=305897">https://bugs.webkit.org/show_bug.cgi?id=305897</a>

    [IFC] Crash in EllipsisBoxPainter::paint when inline content had partial layout
    <a href="https://bugs.webkit.org/show_bug.cgi?id=305897">https://bugs.webkit.org/show_bug.cgi?id=305897</a>
    &lt;<a href="https://rdar.apple.com/168453702">rdar://168453702</a>&gt;

    Reviewed by Antti Koivisto.

    1. LineBox&apos;s index is always relative to the whole content (line index 5 is the 5th line overall).
    2. Partial content layout may start at an in-between index.
    3. &apos;display content&apos; structure only contains the lines being laid out.

    If partial content layout starts at line 4, and we finished with 2 lines already (4th and 5th)
    in createDisplayContentForInlineContent when constructing the display content for the 3rd line (6th overall)
    - LineBox&apos;s index is 5.
    - display content size (excluding the new content) is 2.

    displayContent.setLineEllipsis(5, WTF::move(*ellipsis)) on &apos;display content&apos; with 3 lines overinflates the lineEllipsis vector causing ellipsis mismatch at paint time.

    Test: fast/inline/inline-content-with-ellipsis-after-partial-layout-crash.html

    * LayoutTests/fast/inline/inline-content-with-ellipsis-after-partial-layout-crash-expected.txt: Added.
    * LayoutTests/fast/inline/inline-content-with-ellipsis-after-partial-layout-crash.html: Added.
    * Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
    (WebCore::Layout::InlineFormattingContext::createDisplayContentForInlineContent):
    * Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp:
    (WebCore::InlineDisplay::Content::setEllipsisOnTrailingLine):
    * Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.h:

    Canonical link: <a href="https://commits.webkit.org/305937@main">https://commits.webkit.org/305937@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.940@webkitglib/2.52">https://commits.webkit.org/305877.940@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69240d14702603cd6206f722f7ada1788e5381d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172509 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46427 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181965 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130065 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174374 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/47720 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46098 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134187 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130065 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175467 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/47720 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114659 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/47720 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46098 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30566 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/47720 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184499 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37177 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46098 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142960 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46099 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142838 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46777 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/111580 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26179 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46777 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118528 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45294 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/39856 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44694 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44926 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44753 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->