### PR TITLE
PlatformKeyboardEvent::syntheticEventFromText fails to synthesize "{" due to trailing space in lookup table key

### DIFF
--- a/Source/WebCore/platform/PlatformKeyboardEvent.cpp
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.cpp
@@ -119,7 +119,7 @@ static const KeyToEventDataMap& nonAlphaNumericKeys()
             { "\\"_s,           { "\\"_s,                                       92,     "U+005C"_s,     VK_OEM_5,       "Backslash"_s,        { { "insertText"_s, "\\"_s } } } },
             { "|"_s,            { "|"_s,                                        124,    "U+007C"_s,     VK_OEM_5,       "Backslash"_s,        { { "insertText"_s, "|"_s } } } },
             { "["_s,            { "["_s,                                        91,     "U+005B"_s,     VK_OEM_4,       "BracketLeft"_s,      { { "insertText"_s, "["_s } } } },
-            { "{ "_s,           { "{ "_s,                                       123,    "U+007B"_s,     VK_OEM_4,       "BracketLeft"_s,      { { "insertText"_s, "{"_s } } } },
+            { "{"_s,            { "{"_s,                                        123,    "U+007B"_s,     VK_OEM_4,       "BracketLeft"_s,      { { "insertText"_s, "{"_s } } } },
             { "]"_s,            { "]"_s,                                        93,     "U+005D"_s,     VK_OEM_6,       "BracketRight"_s,     { { "insertText"_s, "]"_s } } } },
             { "}"_s,            { "}"_s,                                        125,    "U+007D"_s,     VK_OEM_6,       "BracketRight"_s,     { { "insertText"_s, "}"_s } } } },
             { ";"_s,            { ";"_s,                                        59,     "U+003B"_s,     VK_OEM_1,       "Semicolon"_s,        { { "insertText"_s, ";"_s } } } },

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -2169,6 +2169,25 @@ TEST(TextExtractionTests, KeyPressInsertsCharactersInOrder)
     EXPECT_WK_STREQ("abc", [webView stringByEvaluatingJavaScript:@"document.getElementById('q').value"]);
 }
 
+TEST(TextExtractionTests, KeyPressInsertsBracketCharacters)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<input type='text' id='q'>"];
+    [webView stringByEvaluatingJavaScript:@"document.getElementById('q').focus()"];
+
+    for (NSString *character in @[ @"[", @"{", @"]", @"}" ]) {
+        RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionKeyPress]);
+        [interaction setText:character];
+        RetainPtr result = [webView synchronouslyPerformInteraction:interaction.get()];
+        EXPECT_NULL([result error]);
+    }
+
+    EXPECT_WK_STREQ("[{]}", [webView stringByEvaluatingJavaScript:@"document.getElementById('q').value"]);
+}
+
 #endif // PLATFORM(MAC)
 
 #if ENABLE(TEXT_EXTRACTION_FILTER) && HAVE(SAFARI_SAFE_BROWSING_NAMESPACED_LISTS)


### PR DESCRIPTION
#### 44975cdcef67f525328f49e337221201f6c3148b
<pre>
PlatformKeyboardEvent::syntheticEventFromText fails to synthesize &quot;{&quot; due to trailing space in lookup table key
<a href="https://bugs.webkit.org/show_bug.cgi?id=318573">https://bugs.webkit.org/show_bug.cgi?id=318573</a>
<a href="https://rdar.apple.com/181341300">rdar://181341300</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

The &quot;{&quot; entry in nonAlphaNumericKeys() was keyed under &quot;{ &quot; (trailing
space) in both the map key and the text field, unlike every neighboring
punctuation entry. As a result, a &quot;{&quot; lookup missed the table, fell
through the alphanumeric branches, and returned nullopt, so the key
could never be synthesized (this is the only client of the table, used
by the TextExtraction key-press interaction).

Drop the stray space so the key and inserted text are both &quot;{&quot;.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm

* Source/WebCore/platform/PlatformKeyboardEvent.cpp:
(WebCore::nonAlphaNumericKeys):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::(TextExtractionTests, KeyPressInsertsCharactersInOrder)):
(TestWebKitAPI::(TextExtractionTests, KeyPressInsertsBracketCharacters)):

Canonical link: <a href="https://commits.webkit.org/316506@main">https://commits.webkit.org/316506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28dfff08540498d22e2cc385eef83e31c2dd2e31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130070 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/748ccef4-39dc-4516-98e4-2abcc20ee906) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134181 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51c93181-4ca4-46cc-85e1-010e843d2273) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114653 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbd163ff-ede3-4c73-8f1c-7cf099fcef1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36223 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34527 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30571 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184504 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142959 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46104 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38580 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46782 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111590 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37864 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118533 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44699 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44758 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->