### PR TITLE
PODIntervalTree::nextIntervalAfter can return a non-nearest following interval

### DIFF
--- a/Source/WebCore/platform/PODIntervalTree.h
+++ b/Source/WebCore/platform/PODIntervalTree.h
@@ -122,7 +122,7 @@ private:
         if (!(point < node->data().low()))
             return smallestNodeGreaterThanFrom(point, node->right());
 
-        if (auto left = smallestNodeGreaterThanFrom(point, node->right()))
+        if (auto left = smallestNodeGreaterThanFrom(point, node->left()))
             return left;
 
         return node;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -246,6 +246,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/MixedContentChecker.cpp
         Tests/WebCore/MonospaceFontTests.cpp
         Tests/WebCore/NowPlayingInfoTests.cpp
+        Tests/WebCore/PODIntervalTree.cpp
         Tests/WebCore/ParsedContentRange.cpp
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PixelBufferConversionTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -783,6 +783,7 @@
 				WebCore/PixelBufferConversionTests.cpp,
 				WebCore/PlatformCAAnimationKeyPath.cpp,
 				WebCore/PlatformDynamicRangeLimitTests.cpp,
+				WebCore/PODIntervalTree.cpp,
 				WebCore/PrivateClickMeasurement.cpp,
 				WebCore/PublicSuffix.cpp,
 				WebCore/PushDatabase.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/PODIntervalTree.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PODIntervalTree.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/PODIntervalTree.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+using IntTree = PODIntervalTree<int, unsigned>;
+using IntInterval = IntTree::IntervalType;
+
+// nextIntervalAfter() must return the interval with the smallest low endpoint
+// that is strictly greater than the query point. Because the tree is a BST
+// keyed by the low endpoint, when the query point is below a node's low, a
+// still-smaller candidate can only live in that node's *left* subtree. A
+// regression that recursed into the right subtree instead would overshoot and
+// return a farther-following interval (or none).
+
+TEST(PODIntervalTree, NextIntervalAfterReturnsNearestFollowing)
+{
+    IntTree tree;
+    // Inserting 10, 20, 30 in order yields a balanced tree rooted at 20 with
+    // 10 on the left and 30 on the right, so the query below is forced to
+    // descend past a node whose left subtree holds the correct answer.
+    tree.add(IntInterval(10, 15, 1));
+    tree.add(IntInterval(20, 25, 2));
+    tree.add(IntInterval(30, 35, 3));
+
+    // Point below every interval: nearest following starts at 10, not 30.
+    auto result = tree.nextIntervalAfter(5);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(10, result->low());
+    EXPECT_EQ(1u, result->data());
+
+    // Point sitting on an existing low: next strictly-greater low is 20.
+    result = tree.nextIntervalAfter(10);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(20, result->low());
+
+    // Point inside the first interval: still 20.
+    result = tree.nextIntervalAfter(12);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(20, result->low());
+
+    // Point between intervals: 30.
+    result = tree.nextIntervalAfter(26);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(30, result->low());
+
+    // Point at or past the last low: nothing follows.
+    EXPECT_FALSE(tree.nextIntervalAfter(30).has_value());
+    EXPECT_FALSE(tree.nextIntervalAfter(100).has_value());
+}
+
+// Exhaustively cross-check nextIntervalAfter() against a brute-force scan over
+// a larger, less-balanced set so the assertion holds independent of the tree's
+// internal shape.
+TEST(PODIntervalTree, NextIntervalAfterMatchesBruteForce)
+{
+    Vector<int> lows { 50, 25, 75, 12, 37, 62, 87, 6, 18, 31, 43, 55, 70, 80, 95 };
+
+    IntTree tree;
+    for (int low : lows)
+        tree.add(IntInterval(low, low + 5, 0));
+
+    for (int point = -5; point <= 100; ++point) {
+        std::optional<int> expected;
+        for (int low : lows) {
+            if (low > point && (!expected || low < *expected))
+                expected = low;
+        }
+
+        auto actual = tree.nextIntervalAfter(point);
+        if (expected) {
+            ASSERT_TRUE(actual.has_value()) << "point=" << point;
+            EXPECT_EQ(*expected, actual->low()) << "point=" << point;
+        } else
+            EXPECT_FALSE(actual.has_value()) << "point=" << point;
+    }
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 12ad3756dfcfcd9bf05eb81f17b803b9b2a6f041
<pre>
PODIntervalTree::nextIntervalAfter can return a non-nearest following interval
<a href="https://bugs.webkit.org/show_bug.cgi?id=318575">https://bugs.webkit.org/show_bug.cgi?id=318575</a>
<a href="https://rdar.apple.com/181342988">rdar://181342988</a>

Reviewed by Chris Dumez.

smallestNodeGreaterThanFrom() is meant to find the interval with the
smallest low endpoint strictly greater than the query point. The tree is
a binary search tree keyed by low endpoint, so when the point is below a
node&apos;s low, the node is a candidate but a still-smaller candidate can
only live in its left subtree. The code recursed into node-&gt;right()
instead — whose lows are all &gt;= node.low and therefore never smaller —
so it overshot and returned a farther-following interval (or none). The
local was even named &quot;left&quot;, confirming the intent.

This backs nextIntervalAfter(), used by HTMLMediaElement for next-text-
track-cue selection, so the wrong cue could be chosen.

Recurse into node-&gt;left().

Test: Tools/TestWebKitAPI/Tests/WebCore/PODIntervalTree.cpp

* Source/WebCore/platform/PODIntervalTree.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/PODIntervalTree.cpp: Added.
(TestWebKitAPI::TEST(PODIntervalTree, NextIntervalAfterReturnsNearestFollowing)):
(TestWebKitAPI::TEST(PODIntervalTree, NextIntervalAfterMatchesBruteForce)):

Canonical link: <a href="https://commits.webkit.org/317018@main">https://commits.webkit.org/317018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1a87a208dd853fc5bfff79c9863cb4b568f4d95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130072 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ade98cc-611c-4488-a226-fdefd98ed754) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134184 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94674 "1 flakes 21 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/288bdccc-f62c-4264-af38-86b6b4ce0110) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114656 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f378b9bb-0580-497d-9bb7-70d2e18e379b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34531 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30573 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184506 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142963 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46106 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38859 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46784 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111595 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37867 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118535 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45301 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9160 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->