### PR TITLE
Web Inspector: [SI] AutoFill / user-script sources missing in Sources tab

### DIFF
--- a/Source/WebCore/inspector/FrameDebugger.cpp
+++ b/Source/WebCore/inspector/FrameDebugger.cpp
@@ -32,10 +32,12 @@
 #include "Document.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWindowCustom.h"
+#include "JSWindowProxy.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "ScriptController.h"
 #include "Timer.h"
+#include "WindowProxy.h"
 #include <JavaScriptCore/JSLock.h>
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
@@ -64,13 +66,12 @@ void FrameDebugger::attachDebugger()
     if (!frame)
         return;
 
-    Ref world = mainThreadNormalWorldSingleton();
-    CheckedRef script = frame->script();
-    auto* globalObject = script->globalObject(world);
-    // globalObject() may lazily create the JSWindowProxy, which fires didClearWindowObjectInWorld
-    // and attaches us via FrameDebuggerAgent::didClearWindowObjectInWorld. Guard against double-attach.
-    if (globalObject && !globalObject->debugger())
-        attach(globalObject);
+    Ref windowProxy = frame->windowProxy();
+    for (auto& jsWindowProxy : windowProxy->jsWindowProxiesAsVector()) {
+        auto* globalObject = jsWindowProxy->window();
+        if (globalObject && !globalObject->debugger())
+            attach(globalObject);
+    }
 }
 
 void FrameDebugger::detachDebugger(bool isBeingDestroyed)

--- a/Source/WebCore/inspector/agents/frame/FrameDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDebuggerAgent.cpp
@@ -183,14 +183,18 @@ InjectedScript FrameDebuggerAgent::injectedScriptForEval(Inspector::Protocol::Er
 
 void FrameDebuggerAgent::didClearWindowObjectInWorld(DOMWrapperWorld& world)
 {
-    if (&world != &mainThreadNormalWorldSingleton())
-        return;
-
     RefPtr frame = m_inspectedFrame.get();
     if (!frame)
         return;
 
-    // Reattach the debugger to the new globalObject after navigation.
+    if (&world != &mainThreadNormalWorldSingleton()) {
+        CheckedRef script = frame->script();
+        auto* globalObject = script->globalObject(world);
+        if (globalObject && !globalObject->debugger())
+            debugger().attach(globalObject);
+        return;
+    }
+
     Ref normalWorld = mainThreadNormalWorldSingleton();
     CheckedRef script = frame->script();
     auto* globalObject = script->globalObject(normalWorld);
@@ -199,9 +203,6 @@ void FrameDebuggerAgent::didClearWindowObjectInWorld(DOMWrapperWorld& world)
         return;
     }
 
-    // The globalObject may already have a debugger attached (e.g., by initScriptForWindowProxy
-    // in non-site-isolation configurations). Under site isolation, FrameDebugger is the sole
-    // debugger, but detach any stale debugger as defense-in-depth.
     if (auto* existingDebugger = globalObject->debugger()) {
         if (existingDebugger == &debugger()) {
             didClearGlobalObject();


### PR DESCRIPTION
#### eb7c162108e248d2a63d561d3c3ccbb7aaa71407
<pre>
Web Inspector: [SI] AutoFill / user-script sources missing in Sources tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=318471">https://bugs.webkit.org/show_bug.cgi?id=318471</a>
<a href="https://rdar.apple.com/181254900">rdar://181254900</a>

Reviewed by Sihui Liu.

Under Site Isolation, user scripts (e.g. AutoFill) run in isolated worlds but
FrameDebugger only attached to the frame&apos;s main world, so their sources were
never reported. Attach to every world, matching FrameRuntimeAgent.

* Source/WebCore/inspector/FrameDebugger.cpp:
(WebCore::FrameDebugger::attachDebugger):
* Source/WebCore/inspector/agents/frame/FrameDebuggerAgent.cpp:
(WebCore::FrameDebuggerAgent::didClearWindowObjectInWorld):

Canonical link: <a href="https://commits.webkit.org/316554@main">https://commits.webkit.org/316554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f36c5ed8a49c2dc2ec79475e55b636f496eea976

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130073 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90c8aaab-9ba6-4c9a-9f0a-625be74efc59) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134185 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94676 "20 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6331ca7b-e87c-4345-9528-42c0805a792e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114657 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7747a419-11b3-4b77-902a-e243edc39108) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36227 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34530 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30574 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184507 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142965 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46107 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142844 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38618 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46785 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111597 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37866 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118536 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9161 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44702 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->