### PR TITLE
[Filters] FEComponentTransfer software path should use vImage (vImageTableLookUp_ARGB8888) when Accelerate is available

### DIFF
--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -33,19 +33,43 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if USE(ACCELERATE)
+#include <Accelerate/Accelerate.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(FEComponentTransferSoftwareApplier);
 
 void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 {
-    auto data = pixelBuffer.bytes();
-    auto pixelByteLength = pixelBuffer.bytes().size();
-
     auto redTable   = FEComponentTransfer::computeLookupTable(m_effect->redFunction());
     auto greenTable = FEComponentTransfer::computeLookupTable(m_effect->greenFunction());
     auto blueTable  = FEComponentTransfer::computeLookupTable(m_effect->blueFunction());
     auto alphaTable = FEComponentTransfer::computeLookupTable(m_effect->alphaFunction());
+
+#if USE(ACCELERATE)
+    auto* pixelBytes = pixelBuffer.bytes().data();
+    auto bufferSize = pixelBuffer.size();
+
+    vImage_Buffer src;
+    src.width = bufferSize.width();
+    src.height = bufferSize.height();
+    src.rowBytes = bufferSize.width() * 4;
+    src.data = pixelBytes;
+
+    vImage_Buffer dest;
+    dest.width = bufferSize.width();
+    dest.height = bufferSize.height();
+    dest.rowBytes = bufferSize.width() * 4;
+    dest.data = pixelBytes;
+
+    // The pixel buffer is in RGBA8 memory order, so the four table arguments map to bytes 0-3 as R, G, B, A
+    // (the vImage parameter names follow an ARGB convention but are applied in memory order).
+    vImageTableLookUp_ARGB8888(&src, &dest, redTable.data(), greenTable.data(), blueTable.data(), alphaTable.data(), kvImageNoFlags);
+#else
+    auto data = pixelBuffer.bytes();
+    auto pixelByteLength = pixelBuffer.bytes().size();
 
     for (unsigned pixelOffset = 0; pixelOffset < pixelByteLength; pixelOffset += 4) {
         data[pixelOffset]     = redTable[data[pixelOffset]];
@@ -53,6 +77,7 @@ void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer)
         data[pixelOffset + 2] = blueTable[data[pixelOffset + 2]];
         data[pixelOffset + 3] = alphaTable[data[pixelOffset + 3]];
     }
+#endif
 }
 
 bool FEComponentTransferSoftwareApplier::apply(const Filter&, std::span<const Ref<FilterImage>> inputs, FilterImage& result) const


### PR DESCRIPTION
#### 1e904423f2d2d5fd9043f1ca9e5fa49c3d14d3d4
<pre>
[Filters] FEComponentTransfer software path should use vImage (vImageTableLookUp_ARGB8888) when Accelerate is available
<a href="https://bugs.webkit.org/show_bug.cgi?id=318583">https://bugs.webkit.org/show_bug.cgi?id=318583</a>
<a href="https://rdar.apple.com/181349795">rdar://181349795</a>

Reviewed by NOBODY (OOPS!).

FEComponentTransferSoftwareApplier::applyPlatform() walked the pixel
buffer with a scalar loop, doing four byte-indexed table lookups per
pixel. The four transfer functions are already materialized as 256-entry
LUTs (FEComponentTransfer::computeLookupTable), which map directly onto
vImageTableLookUp_ARGB8888, mirroring the existing vImage branch in
FEColorMatrixSoftwareApplier.

Add a USE(ACCELERATE) path that builds an in-place source/destination
vImage_Buffer and applies all four channel tables in a single call. The
pixel buffer is in RGBA8 memory order, so the tables are passed in R, G,
B, A order to match bytes 0-3 (the vImage parameter names follow an ARGB
convention but are applied in memory order). Unlike FEColorMatrix, no
fallback guard is needed: table lookup covers every transfer-function
type uniformly. The prior scalar loop is retained for non-Accelerate
platforms.

No change in behavior; covered by existing tests.

* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp:
(WebCore::FEComponentTransferSoftwareApplier::applyPlatform const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e904423f2d2d5fd9043f1ca9e5fa49c3d14d3d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130079 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33ec4212-4726-48fa-b329-0037de0ee156) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134190 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94680 "23 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f77c74b4-f88d-4562-b814-60b38fdfc291) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114662 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/882ab98e-1c34-4bc2-934c-fc7032490249) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34536 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184513 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142969 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46113 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142848 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46791 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111604 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37873 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118542 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45308 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9168 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44767 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->