### PR TITLE
[Swift Testing] Allow tests that require NSApplications to be run in automation

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/AppKit+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/AppKit+Extras.swift
@@ -41,4 +41,24 @@ extension NSWindow {
     }
 }
 
+extension NSApplication {
+    /// Suspends execution until this application is active.
+    ///
+    /// - Note: This must be called prior to any test that depends on having a "real" NSApplication.
+    @MainActor
+    public func waitForActivation() async {
+        // Activation is processed asynchronously by the AppKit event loop, so wait for it to take
+        // effect before synthesizing events.
+        var attempts = 0
+        while !NSApp.isActive && attempts < 500 {
+            try? await Task.sleep(for: .milliseconds(10))
+            attempts += 1
+        }
+
+        guard NSApp.isActive else {
+            fatalError("NSApp is not active; unable to properly run test")
+        }
+    }
+}
+
 #endif // os(macOS)

--- a/Tools/TestWebKitAPI/Runner/GoogleTestsController.swift
+++ b/Tools/TestWebKitAPI/Runner/GoogleTestsController.swift
@@ -28,10 +28,12 @@ import struct Swift.String
 final class GoogleTestsController: TestRunner {
     static let shared = GoogleTestsController()
 
-    func run(with configuration: Configuration) async throws -> Bool {
+    func run(with configuration: Configuration) async throws -> (status: Bool, didRunAnyTest: Bool) {
         let arguments = Self.parseArguments(configuration: configuration)
         return unsafe withUnsafeMutableCStyleArguments(arguments) { argc, argv in
-            unsafe TestWebKitAPIRunTests(argc, argv)
+            var didRunAnyTest = false
+            let status = unsafe TestWebKitAPIRunTests(argc, argv, &didRunAnyTest)
+            return (status, didRunAnyTest)
         }
     }
 }

--- a/Tools/TestWebKitAPI/Runner/SwiftTestsController.swift
+++ b/Tools/TestWebKitAPI/Runner/SwiftTestsController.swift
@@ -94,12 +94,7 @@ actor SwiftTestsController: TestRunner {
         }
     }
 
-    nonisolated private func handleRecord(_ record: SwiftTestingABI.Record) {
-        saveRecord(record)
-        writeOutputIfNeeded(record)
-    }
-
-    func run(with configuration: Configuration) async throws -> Bool {
+    func run(with configuration: Configuration) async throws -> (status: Bool, didRunAnyTest: Bool) {
         let abiConfiguration = SwiftTestingABI.__CommandLineArguments_v0(configuration)
         let encodedConfiguration = try encoder.encode(abiConfiguration)
 
@@ -112,9 +107,9 @@ actor SwiftTestsController: TestRunner {
         unsafe encodedConfiguration.copyBytes(to: mutableBuffer)
         let buffer = UnsafeRawBufferPointer(mutableBuffer)
 
-        return unsafe try await Self.entryPoint(buffer) { [self, abiConfiguration] recordJSON in
-            // Either use custom logging, or Swift Testing logging, not both
-            guard abiConfiguration.verbosity == .min else {
+        let status = unsafe try await Self.entryPoint(buffer) { [self, abiConfiguration] recordJSON in
+            // Nothing runs when only listing tests, so there is nothing to record or log.
+            guard abiConfiguration.listTests == false else {
                 return
             }
 
@@ -122,8 +117,19 @@ actor SwiftTestsController: TestRunner {
             // The program should terminate if this `try` fails, any other behavior would lead to unexpected results.
             // swift-format-ignore: NeverUseForceTry
             let decoded = try! decoder.decode(SwiftTestingABI.Record.self, from: data)
-            handleRecord(decoded)
+
+            saveRecord(decoded)
+
+            // Either use custom logging, or Swift Testing logging, not both.
+            guard abiConfiguration.verbosity == .min else {
+                return
+            }
+
+            writeOutputIfNeeded(decoded)
         }
+
+        let didRunAnyTest = storage.withLock { !$0.tests.isEmpty }
+        return (status, didRunAnyTest)
     }
 }
 

--- a/Tools/TestWebKitAPI/Runner/TestRunner.swift
+++ b/Tools/TestWebKitAPI/Runner/TestRunner.swift
@@ -27,7 +27,7 @@ import struct Swift.String
 protocol TestRunner {
     typealias Configuration = TestRunnerConfiguration
 
-    func run(with configuration: Configuration) async throws -> Bool
+    func run(with configuration: Configuration) async throws -> (status: Bool, didRunAnyTest: Bool)
 }
 
 struct TestRunnerConfiguration {

--- a/Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift
+++ b/Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift
@@ -67,7 +67,7 @@ struct TestWebKitAPI {
     }
 
     @MainActor
-    private func run() async throws {
+    private func configure() -> TestRunner.Configuration {
         #if WTF_PLATFORM_MACCATALYST
         UINSApplicationInstantiate()
         #endif
@@ -100,16 +100,59 @@ struct TestWebKitAPI {
         _ = NSApplication.shared
         #endif
 
-        let configuration = TestRunner.Configuration(parsing: CommandLine.arguments)
+        return TestRunner.Configuration(parsing: CommandLine.arguments)
+    }
 
-        let passedGTests = try await GoogleTestsController.shared.run(with: configuration)
-        let passedSwiftTests = try await SwiftTestsController.shared.run(with: configuration)
+    @MainActor
+    private func runGoogleTests(with configuration: TestRunner.Configuration) async throws -> (passed: Bool, didRun: Bool) {
+        let (passed, didRun) = try await GoogleTestsController.shared.run(with: configuration)
+        if didRun && !configuration.listTests {
+            exit(passed ? EXIT_SUCCESS : EXIT_FAILURE)
+        }
 
-        exit(passedGTests && passedSwiftTests ? EXIT_SUCCESS : EXIT_FAILURE)
+        return (passed, didRun)
+    }
+
+    @MainActor
+    private func runSwiftTests(with configuration: TestRunner.Configuration, googleTestsPassed: Bool) async throws {
+        let (passed, didRun) = try await SwiftTestsController.shared.run(with: configuration)
+        if didRun && !configuration.listTests {
+            exit(passed ? EXIT_SUCCESS : EXIT_FAILURE)
+        }
+
+        exit(googleTestsPassed && passed ? EXIT_SUCCESS : EXIT_FAILURE)
     }
 
     static func main() async throws {
         let instance = TestWebKitAPI()
-        try await instance.run()
+
+        let configuration = instance.configure()
+
+        let (googleTestsPassed, didRunGoogleTests) = try await instance.runGoogleTests(with: configuration)
+
+        #if WTF_PLATFORM_MAC
+        // Some tests synthesize HID events that the system delivers only to the frontmost app, and
+        // delivery requires a running AppKit event loop. Only start it when we will actually run
+        // Swift tests: i.e. when running (not listing) tests and no GoogleTest tests have run.
+        if !configuration.listTests && !didRunGoogleTests {
+            let application = NSApplication.shared
+            application.setActivationPolicy(.regular)
+
+            Task { @MainActor in
+                do {
+                    try await instance.runSwiftTests(with: configuration, googleTestsPassed: googleTestsPassed)
+                } catch {
+                    exit(EXIT_FAILURE)
+                }
+            }
+
+            application.activate(ignoringOtherApps: true)
+            application.run()
+            return
+        }
+        #endif
+
+        // Non-macOS, or macOS when listing tests / after GoogleTest tests ran: no event loop needed.
+        try await instance.runSwiftTests(with: configuration, googleTestsPassed: googleTestsPassed)
     }
 }

--- a/Tools/TestWebKitAPI/Runner/TestWebKitAPISupport.h
+++ b/Tools/TestWebKitAPI/Runner/TestWebKitAPISupport.h
@@ -37,7 +37,7 @@ extern "C" {
 
 void TestWebKitAPIEnableAllSDKAlignedBehaviors(void);
 
-BOOL TestWebKitAPIRunTests(int argc, char * _Nullable * _Nonnull argv);
+BOOL TestWebKitAPIRunTests(int argc, char * _Nullable * _Nonnull argv, bool * _Nonnull didRunAnyTest);
 
 const void * _Nonnull swt_abiv0_getEntryPoint(void); // Defined in Swift Testing
 

--- a/Tools/TestWebKitAPI/Runner/TestWebKitAPISupport.mm
+++ b/Tools/TestWebKitAPI/Runner/TestWebKitAPISupport.mm
@@ -33,7 +33,7 @@ void TestWebKitAPIEnableAllSDKAlignedBehaviors(void)
     WTF::enableAllSDKAlignedBehaviors();
 }
 
-BOOL TestWebKitAPIRunTests(int argc, char** argv)
+BOOL TestWebKitAPIRunTests(int argc, char** argv, bool *didRunAnyTest)
 {
-    return TestWebKitAPI::TestsController::singleton().run(argc, argv);
+    return TestWebKitAPI::TestsController::singleton().run(argc, argv, didRunAnyTest);
 }

--- a/Tools/TestWebKitAPI/Runner/TestsController.cpp
+++ b/Tools/TestWebKitAPI/Runner/TestsController.cpp
@@ -78,7 +78,7 @@ TestsController::TestsController()
     WTF::setProcessPrivileges(allPrivileges());
 }
 
-bool TestsController::run(int argc, char** argv)
+bool TestsController::run(int argc, char** argv, bool* didRunAnyTest)
 {
     bool useDefaultPrinter = false;
     for (int i = 1; i < argc; ++i) {
@@ -94,7 +94,17 @@ bool TestsController::run(int argc, char** argv)
         listeners.Append(new Printer);
     }
 
-    return !RUN_ALL_TESTS();
+    bool status = !RUN_ALL_TESTS();
+
+    // A run only actually executes tests when we are not merely listing them and the
+    // filter selected at least one test to run.
+    auto& unitTest = *::testing::UnitTest::GetInstance();
+    bool outDidRunAnyTest = !GTEST_FLAG_GET(list_tests) && unitTest.test_to_run_count() > 0;
+
+    if (didRunAnyTest)
+        *didRunAnyTest = outDidRunAnyTest;
+
+    return status;
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Runner/TestsController.h
+++ b/Tools/TestWebKitAPI/Runner/TestsController.h
@@ -34,7 +34,7 @@ class TestsController {
 public:
     static TestsController& singleton();
 
-    bool run(int argc, char** argv);
+    bool run(int argc, char** argv, bool* didRunAnyTest = nullptr);
 
 private:
     TestsController();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -61,6 +61,8 @@ extension AppKitGesturesTests {
             self.window.setFrameOrigin(.zero)
             NSApp.activate(ignoringOtherApps: true)
             self.window.makeKeyAndOrderFront(nil)
+
+            await NSApp.waitForActivation()
         }
     }
 }
@@ -93,8 +95,6 @@ extension AppKitGesturesTests.Basic {
 
         let toBounds = try await screenBoundsOfText("to")
 
-        guard NSApp.isActive else { return }
-
         await recap.play { composer in
             composer._wk_click(at: toBounds.center, for: .seconds(0.05))
         }
@@ -121,11 +121,6 @@ extension AppKitGesturesTests.Basic {
         let crazyBounds = try await screenBoundsOfText("crazy")
 
         let editorStateSnapshots = page.editorStateSnapshots()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         await recap.play { composer in
             composer._wk_click(at: toBounds.center, for: .seconds(0.1))
@@ -157,11 +152,6 @@ extension AppKitGesturesTests.Basic {
 
         let startViewportCoordinates = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "line97"))
         let startBounds = screenBounds(ofRectInViewportCoordinates: startViewportCoordinates)
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
         #expect(CGPoint(initialScrollPosition) == .zero)
@@ -200,11 +190,6 @@ extension AppKitGesturesTests.Basic {
         await page.waitForNextPresentationUpdate()
 
         let startBounds = try await screenBounds(ofElementWithID: "line97")
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         // Record (timestamp, scrollY) on every scroll event so we can observe that scrolling continues
         // throughout the hold, rather than scrolling in one burst and stopping early (the pre-fix bug).
@@ -252,11 +237,6 @@ extension AppKitGesturesTests.Basic {
 
         let startBounds = try await screenBounds(ofElementWithID: "line97")
 
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
         let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
         #expect(CGPoint(initialScrollPosition) == .zero)
 
@@ -284,11 +264,6 @@ extension AppKitGesturesTests.Basic {
 
         let startBounds = try await screenBounds(ofElementWithID: "line97")
 
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
         let dragEnd = screenBounds(ofPointInWindowCoordinates: NSPoint(x: window.frame.width / 2, y: 20))
 
         await recap.play { composer in
@@ -315,11 +290,6 @@ extension AppKitGesturesTests.Basic {
     func draggingSelectionToTopEdgeScrollsUp() async throws {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         // Start partway down the page so there is room to scroll back up.
         try await page.callJavaScript { "window.scrollTo(0, 3000);" }
@@ -352,11 +322,6 @@ extension AppKitGesturesTests.Basic {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
 
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
         // Begin the selection inside the bottom edge band (~70pt from the bottom; the band is 100pt) and
         // drag only a short distance toward the edge - less than the ~50pt threshold. The selection
         // originates near the edge but the drag is too small to be a deliberate "scroll past the edge"
@@ -384,11 +349,6 @@ extension AppKitGesturesTests.Basic {
     func selectionOriginatingNearEdgeAutoscrollsAfterDraggingPastThreshold() async throws {
         try await loadScrollableText()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         // Same near-edge origin as the short-drag test, but now drag well past the threshold (and past the
         // window edge) and hold, so the deliberate gesture engages autoscroll.
@@ -427,11 +387,6 @@ extension AppKitGesturesTests.Basic {
 
         await page.waitForNextPresentationUpdate()
 
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
         await withSwizzledContextMenu {
             await recap.play { composer in
                 composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
@@ -450,11 +405,6 @@ extension AppKitGesturesTests.Basic {
         try await loadHTML(contentEditable: contentEditable)
 
         let middleOfWindow = screenBounds(ofPointInWindowCoordinates: window.frame.center)
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         await withSwizzledContextMenu {
             await recap.play { composer in
@@ -491,11 +441,6 @@ extension AppKitGesturesTests.Basic {
         let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
         await page.waitForNextPresentationUpdate()
 
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
         await recap.play { composer in
             composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(1))
         }
@@ -520,11 +465,6 @@ extension AppKitGesturesTests.Basic {
         let crazyBoundsInScreenCoordinates = try await screenBoundsOfText("crazy")
 
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         await recap.play { composer in
             composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
@@ -562,11 +502,6 @@ extension AppKitGesturesTests.Basic {
 
         await page.waitForNextPresentationUpdate()
 
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
-
         await recap.play { composer in
             composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
             composer.advanceTime(0.1)
@@ -587,11 +522,6 @@ extension AppKitGesturesTests.Basic {
         let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
         try await page.load(pdfURL).wait()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         let clickPoint = screenBounds(ofPointInWindowCoordinates: .init(x: 100, y: 350))
 
@@ -626,11 +556,6 @@ extension AppKitGesturesTests.Basic {
         try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
 
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         await recap.play { composer in
             composer._wk_click(at: point, for: .seconds(0.1))
@@ -703,10 +628,6 @@ extension AppKitGesturesTests.Basic {
 
         await page.waitForNextPresentationUpdate()
 
-        guard NSApp.isActive else {
-            return
-        }
-
         let initialScrollPosition = try await page.callJavaScript(JavaScriptMessages.ScrollPosition())
         #expect(CGPoint(initialScrollPosition) == .zero)
 
@@ -735,11 +656,6 @@ extension AppKitGesturesTests.Basic {
         let initialURL = try #require(URL(string: "http://webkit.org/"))
         try await page.load(html: html, baseURL: initialURL).wait()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
         let scrollEnd = CGPoint(x: center.x, y: center.y - 200)
@@ -795,10 +711,6 @@ extension AppKitGesturesTests.Basic {
 
         await page.waitForNextPresentationUpdate()
 
-        guard NSApp.isActive else {
-            return
-        }
-
         await recap.play { composer in
             composer._wk_click(at: convertedBounds.center, for: .seconds(0.1))
         }
@@ -831,10 +743,6 @@ extension AppKitGesturesTests.Basic {
 
         try await page.callJavaScript(arguments: ["elementID": "custom-slider"], script: styleAdjustmentForCustomWidgetScript)
         await page.waitForNextPresentationUpdate()
-
-        guard NSApp.isActive else {
-            return
-        }
 
         let sliderBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: elementID))
         let convertedSliderBounds = screenBounds(ofRectInViewportCoordinates: sliderBounds)
@@ -885,8 +793,6 @@ extension AppKitGesturesTests.Basic {
         try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
         await page.waitForNextPresentationUpdate()
 
-        guard NSApp.isActive else { return }
-
         await recap.play { composer in
             composer._wk_drag(
                 withStart: toBounds.center,
@@ -936,8 +842,6 @@ extension AppKitGesturesTests.Basic {
         }()
 
         let dragEnd = CGPoint(x: linkBounds.maxX + 50, y: linkBounds.midY)
-
-        guard NSApp.isActive else { return }
 
         let dragInitiated = Future()
 
@@ -994,8 +898,6 @@ extension AppKitGesturesTests.Basic {
 
         let dragEnd = CGPoint(x: imgBounds.maxX + 50, y: imgBounds.midY)
 
-        guard NSApp.isActive else { return }
-
         let dragInitiated = Future()
 
         let implementation: @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession? = { _, _, _, _ in
@@ -1048,8 +950,6 @@ extension AppKitGesturesTests.Basic {
 
         let crazyBounds = try await screenBoundsOfText("crazy")
         let onesBounds = try await screenBoundsOfText("ones")
-
-        guard NSApp.isActive else { return }
 
         let dragInitiated = Future()
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift
@@ -85,6 +85,8 @@ extension AppKitGesturesTests {
             self.window.setFrameOrigin(.zero)
             NSApp.activate(ignoringOtherApps: true)
             self.window.makeKeyAndOrderFront(nil)
+
+            await NSApp.waitForActivation()
         }
     }
 }
@@ -103,11 +105,6 @@ extension AppKitGesturesTests.Embedded {
 
         try await page.load(html: html, baseURL: baseURL).wait()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         let cgScreenOrigin = screenBounds(ofPointInWindowCoordinates: .init(x: 0, y: windowSize.height))
         let viewportInCGScreen = CGRect(origin: cgScreenOrigin, size: windowSize)
@@ -142,11 +139,6 @@ extension AppKitGesturesTests.Embedded {
 
         try await page.load(html: html).wait()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         let toBounds = try await screenBoundsOfText("to")
         let crazyBounds = try await screenBoundsOfText("crazy")
@@ -183,11 +175,6 @@ extension AppKitGesturesTests.Embedded {
 
         try await page.load(html: html).wait()
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         let crazyBounds = try await screenBoundsOfText("crazy")
 
@@ -231,11 +218,6 @@ extension AppKitGesturesTests.Embedded {
         let crazyBounds = try await screenBoundsOfText("crazy")
 
         await page.waitForNextPresentationUpdate()
-
-        // Recap requires this test to be ran within an app host.
-        guard NSApp.isActive else {
-            return
-        }
 
         await recap.play { composer in
             composer._wk_click(at: crazyBounds.center, for: .seconds(0.1))


### PR DESCRIPTION
#### c973837a1ce5afd395dda139c3c8e4fb5fcdca20
<pre>
[Swift Testing] Allow tests that require NSApplications to be run in automation
<a href="https://bugs.webkit.org/show_bug.cgi?id=318585">https://bugs.webkit.org/show_bug.cgi?id=318585</a>
<a href="https://rdar.apple.com/181352028">rdar://181352028</a>

Reviewed by Abrar Rahman Protyasha.

Previously, such tests could only be ran manually since TestWebKitAPIBundle used a real
NSApplication, but TestWebKitAPI didn&apos;t. Fix by imbuing the latter with an NSApplication
and an AppKit event loop to allow these tests to run in EWS.

* Tools/TestWebKitAPI/Helpers/cocoa/AppKit+Extras.swift:
(NSApplication.waitForActivation):
* Tools/TestWebKitAPI/Runner/TestWebKitAPI.swift:
(TestWebKitAPI.run):
(TestWebKitAPI.main):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
(AppKitGesturesTests.singleClickFiresPointerMouseAndClickEvents(_:)):
(AppKitGesturesTests.updatingTextRangeSelectionByUserInteractionUpdatesEditorState(_:)):
(AppKitGesturesTests.draggingSelectionToWindowEdgeAutoscrolls(_:)):
(AppKitGesturesTests.holdingSelectionDragNearEdgeKeepsScrolling):
(AppKitGesturesTests.holdingSelectionDragMidContentDoesNotAutoscroll):
(AppKitGesturesTests.selectionAutoscrollStopsAfterGestureEnds):
(AppKitGesturesTests.draggingSelectionToTopEdgeScrollsUp):
(AppKitGesturesTests.selectionOriginatingNearEdgeWithShortDragDoesNotAutoscroll):
(AppKitGesturesTests.selectionOriginatingNearEdgeAutoscrollsAfterDraggingPastThreshold):
(AppKitGesturesTests.clickingOnSelectedWordOpensContextMenu(_:)):
(AppKitGesturesTests.clickingAndHoldingOnEmptyContentOpensContextMenu(_:)):
(AppKitGesturesTests.longPressOverTextSelectsWordAndDoesNotOpenContextMenu):
(AppKitGesturesTests.scrollingDoesNotRemoveTextSelection):
(AppKitGesturesTests.doubleClickingInWordSelectsWord(_:clickHandler:)):
(AppKitGesturesTests.tripleClickingInPDFSelectsLine):
(AppKitGesturesTests.clickingInWordChangesSelection(_:)):
(AppKitGesturesTests.scrollingChangesScrollPosition(_:)):
(AppKitGesturesTests.interruptingDeceleratingScrollDoesNotFollowLink):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/EmbeddedAppKitGesturesTests.swift:
(AppKitGesturesTests.scrollOverNonScrollableWebViewPropagatesToEnclosingScrollView):
(AppKitGesturesTests.pressDragOverTextInWebViewInsideEnclosingScrollViewCreatesSelection):
(AppKitGesturesTests.quickDragOverTextInWebViewInsideEnclosingScrollViewScrolls):
(AppKitGesturesTests.doubleClickingSelectsWordWhenScrolledToTopWithObscuredContentInset):

Canonical link: <a href="https://commits.webkit.org/316517@main">https://commits.webkit.org/316517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef8864613c7648263dcc88d7e4fad6ebb8d5fdaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172562 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130118 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1854d05e-b355-4d8c-ad4c-fef5450a94e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134217 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/359c6712-b721-4a57-98e0-a116c4036f75) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4fbdc7b-1f45-40d1-bd35-a688196511c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36258 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34565 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30619 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184552 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143000 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46152 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38589 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46830 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111686 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37898 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45347 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9197 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44747 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44806 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->