### PR TITLE
"Pipeline layout is invalid" opening grenzwert.net/wasm-modules/MedicalViewer/MedicalViewe

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -96,6 +96,7 @@ static GPUFeatureName convertFeatureNameToEnum(const String& stringValue)
         { "texture-compression-bc-sliced-3d"_s, GPUFeatureName::TextureCompressionBcSliced3d },
         { "texture-compression-etc2"_s, GPUFeatureName::TextureCompressionEtc2 },
         { "texture-formats-tier1"_s, GPUFeatureName::TextureFormatsTier1 },
+        { "texture-formats-tier2"_s, GPUFeatureName::TextureFormatsTier2 },
         { "timestamp-query"_s, GPUFeatureName::TimestampQuery },
     }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.h
@@ -51,6 +51,7 @@ enum class GPUFeatureName : uint8_t {
     Float32Renderable,
     CoreFeaturesAndLimits,
     TextureFormatsTier1,
+    TextureFormatsTier2,
     PrimitiveIndex,
 };
 
@@ -97,6 +98,8 @@ inline WebGPU::FeatureName convertToBacking(GPUFeatureName featureName)
         return WebGPU::FeatureName::CoreFeaturesAndLimits;
     case GPUFeatureName::TextureFormatsTier1:
         return WebGPU::FeatureName::TextureFormatsTier1;
+    case GPUFeatureName::TextureFormatsTier2:
+        return WebGPU::FeatureName::TextureFormatsTier2;
     case GPUFeatureName::PrimitiveIndex:
         return WebGPU::FeatureName::PrimitiveIndex;
     }

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -48,5 +48,6 @@
     "float32-renderable",
     "core-features-and-limits",
     "texture-formats-tier1",
+    "texture-formats-tier2",
     "primitive-index",
 };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -186,6 +186,9 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
         return convertToBackingContext.convertToBacking(featureName);
     });
 
+    if (features.contains(WGPUFeatureName_TextureFormatsTier2) && !features.contains(WGPUFeatureName_TextureFormatsTier1))
+        features.append(WGPUFeatureName_TextureFormatsTier1);
+
     if (features.contains(WGPUFeatureName_TextureFormatsTier1) && !features.contains(WGPUFeatureName_RG11B10UfloatRenderable))
         features.append(WGPUFeatureName_RG11B10UfloatRenderable);
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -236,6 +236,8 @@ WGPUFeatureName ConvertToBackingContext::convertToBacking(FeatureName featureNam
         return WGPUFeatureName_CoreFeaturesAndLimits;
     case FeatureName::TextureFormatsTier1:
         return WGPUFeatureName_TextureFormatsTier1;
+    case FeatureName::TextureFormatsTier2:
+        return WGPUFeatureName_TextureFormatsTier2;
     case FeatureName::PrimitiveIndex:
         return WGPUFeatureName_PrimitiveIndex;
     }

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
@@ -50,6 +50,7 @@ enum class FeatureName : uint8_t {
     Float32Renderable,
     CoreFeaturesAndLimits,
     TextureFormatsTier1,
+    TextureFormatsTier2,
     PrimitiveIndex,
 };
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -143,6 +143,7 @@ static Vector<WGPUFeatureName> baseFeatures(id<MTLDevice> device, const Hardware
     features.append(WGPUFeatureName_BGRA8UnormStorage);
 #if CPU(ARM64)
     features.append(WGPUFeatureName_TextureFormatsTier1);
+    features.append(WGPUFeatureName_TextureFormatsTier2);
 #endif
 
 #if !PLATFORM(WATCHOS)

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -1186,6 +1186,8 @@ String wgpuAdapterFeatureName(WGPUFeatureName feature)
         return "core-features-and-limits"_s;
     case WGPUFeatureName_TextureFormatsTier1:
         return "texture-formats-tier1"_s;
+    case WGPUFeatureName_TextureFormatsTier2:
+        return "texture-formats-tier2"_s;
     case WGPUFeatureName_Force32:
         return emptyString();
     }

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -1643,17 +1643,20 @@ bool Texture::hasStorageBindingCapability(WGPUTextureFormat format, const Device
 {
     // https://gpuweb.github.io/gpuweb/#plain-color-formats
     switch (format) {
+    // These formats always support read-only and write-only storage access;
+    // texture-formats-tier2 additionally grants read-write storage access.
     case WGPUTextureFormat_RGBA8Unorm:
-    case WGPUTextureFormat_RGBA8Snorm:
     case WGPUTextureFormat_RGBA8Uint:
     case WGPUTextureFormat_RGBA8Sint:
     case WGPUTextureFormat_RGBA16Uint:
     case WGPUTextureFormat_RGBA16Sint:
     case WGPUTextureFormat_RGBA16Float:
-    case WGPUTextureFormat_RG32Float:
     case WGPUTextureFormat_RGBA32Float:
     case WGPUTextureFormat_RGBA32Uint:
     case WGPUTextureFormat_RGBA32Sint:
+        return (!access || *access != WGPUStorageTextureAccess_ReadWrite) || device.hasFeature(WGPUFeatureName_TextureFormatsTier2);
+    case WGPUTextureFormat_RGBA8Snorm:
+    case WGPUTextureFormat_RG32Float:
     case WGPUTextureFormat_RG32Uint:
     case WGPUTextureFormat_RG32Sint:
         return !access || *access != WGPUStorageTextureAccess_ReadWrite;
@@ -1663,17 +1666,20 @@ bool Texture::hasStorageBindingCapability(WGPUTextureFormat format, const Device
     case WGPUTextureFormat_R32Uint:
     case WGPUTextureFormat_R32Sint:
         return true;
+    // These formats support storage access only with texture-formats-tier1;
+    // texture-formats-tier2 additionally grants read-write storage access.
     case WGPUTextureFormat_R8Unorm:
-    case WGPUTextureFormat_R8Snorm:
     case WGPUTextureFormat_R8Uint:
     case WGPUTextureFormat_R8Sint:
+    case WGPUTextureFormat_R16Float:
+    case WGPUTextureFormat_R16Uint:
+    case WGPUTextureFormat_R16Sint:
+        return ((!access || *access != WGPUStorageTextureAccess_ReadWrite) || device.hasFeature(WGPUFeatureName_TextureFormatsTier2)) && device.hasFeature(WGPUFeatureName_TextureFormatsTier1);
+    case WGPUTextureFormat_R8Snorm:
     case WGPUTextureFormat_RG8Unorm:
     case WGPUTextureFormat_RG8Snorm:
     case WGPUTextureFormat_RG8Uint:
     case WGPUTextureFormat_RG8Sint:
-    case WGPUTextureFormat_R16Float:
-    case WGPUTextureFormat_R16Uint:
-    case WGPUTextureFormat_R16Sint:
     case WGPUTextureFormat_R16Unorm:
     case WGPUTextureFormat_R16Snorm:
     case WGPUTextureFormat_RG16Uint:

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -395,6 +395,7 @@ typedef enum WGPUFeatureName {
     WGPUFeatureName_Float32Renderable = 0x00000013,
     WGPUFeatureName_CoreFeaturesAndLimits = 0x00000014,
     WGPUFeatureName_TextureFormatsTier1 = 0x00000015,
+    WGPUFeatureName_TextureFormatsTier2 = 0x00000016,
     WGPUFeatureName_Force32 = 0x7FFFFFFF
 } WGPUFeatureName WGPU_ENUM_ATTRIBUTE;
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in
@@ -42,6 +42,7 @@ enum class WebCore::WebGPU::FeatureName : uint8_t {
     Float32Renderable,
     CoreFeaturesAndLimits,
     TextureFormatsTier1,
+    TextureFormatsTier2,
     PrimitiveIndex,
 };
 #endif


### PR DESCRIPTION
#### 7acb7e51d3a86bbbf7bebcf52abf3f3d28a59e93
<pre>
&quot;Pipeline layout is invalid&quot; opening grenzwert.net/wasm-modules/MedicalViewer/MedicalViewe
<a href="https://bugs.webkit.org/show_bug.cgi?id=318576">https://bugs.webkit.org/show_bug.cgi?id=318576</a>
<a href="https://rdar.apple.com/181343044">rdar://181343044</a>

Reviewed by Dan Glastonbury.

Site works in Chrome but was failing in Safari since it assumed enabling
all features also enabled texture-formaters-tier2, which is supported on all
Apple hardware, but we didn&apos;t report it as supported.

Adding support fixes the site error.

* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::convertFeatureNameToEnum):
* Source/WebCore/Modules/WebGPU/GPUFeatureName.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h:
* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::baseFeatures):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(wgpuAdapterFeatureName):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::hasStorageBindingCapability):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/Shared/WebGPU/WebGPUFeatureName.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316561@main">https://commits.webkit.org/316561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be8d7fb35e3961a2113305be58537c8b46707bf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181985 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130084 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48ed889a-c2f3-4848-9b0c-65ad0e276ada) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134195 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94685 "21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1aaadd65-458c-49ba-856f-29352a54c31b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114667 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b885d859-674b-495f-9de1-f9180622c9e1) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34541 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30585 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184518 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142974 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46118 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142853 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38622 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46796 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31067 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111610 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37877 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118547 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45313 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9173 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->