### PR TITLE
[Text Extraction] Include human-readable query parameters and fragments for links that navigate within the same page

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -20,6 +20,12 @@ root
 		link url=example.com/3 'Plain link (3)'
 		link url=/test/cat.png 'Local file'
 		link 'Self link'
+		link url=debug-text-extraction-shorten-urls.html?tab=details 'Self link (query)'
+		link 'Self link (multi query)'
+		link 'Self link (opaque query)'
+		link url=debug-text-extraction-shorten-urls.html#installation 'Self link (fragment)'
+		link 'Self link (opaque fragment)'
+		link url=debug-text-extraction-shorten-urls.html?tab=details 'Self link (query and fragment)'
 	section
 		image src=image alt='SVG data URL'
 		image src=image2 alt='PNG data URL'
@@ -51,7 +57,13 @@ root
 [Plain link \(2\)](example.com/2)
 [Plain link \(3\)](example.com/3)
 [Local file](/test/cat.png)
-[Self link](/text-extraction/debug-text-extraction-shorten-urls.html)
+Self link
+[Self link \(query\)](debug-text-extraction-shorten-urls.html?tab=details)
+Self link \(multi query\)
+Self link \(opaque query\)
+[Self link \(fragment\)](debug-text-extraction-shorten-urls.html#installation)
+Self link \(opaque fragment\)
+[Self link \(query and fragment\)](debug-text-extraction-shorten-urls.html?tab=details)
 
 ![SVG data URL](image)
 ![PNG data URL](image2)
@@ -63,5 +75,48 @@ root
 ![Image with high entropy name \(duplicate\)](image2.gif)
 ![Image with high entropy name, no extension](image.png)
 ![File extension with trailing text](image.jpg)
+
+-- html
+
+<body>
+	<section>
+		<a href='example.com/search'>Multiple query parameters</a>
+		<a href='example.com/search2'>Multiple query parameter 2</a>
+		<a href='example.com/path/to/file.html'>Path components 1</a>
+		<a href='example.com/oiiai_cat'>Path components 2</a>
+		<a href='javascript:'>JavaScript link</a>
+		<a href='data:'>HTML data URL</a>
+		<a href='mailto:test@example.com'>Email with params</a>
+		<a href='mailto:test@example.com'>
+		<a href='tel:+1-555-123-4567'>Phone number</a>
+		<a href='blob:'>Blob URL</a>
+		<a href='example.com/docs/guide.html'>Path, query, and fragment</a>
+		<a href='example.com/docs/guide2.html'>Query parameter</a>
+		<a href='example.com/docs/guide2.html'>Query parameter (duplicate)</a>
+		<a href='example.com'>Plain link</a>
+		<a href='example.com/2'>Plain link (2)</a>
+		<a href='example.com/3'>Plain link (3)</a>
+		<a href='/test/cat.png'>Local file</a>
+		<a>Self link</a>
+		<a href='debug-text-extraction-shorten-urls.html?tab=details'>Self link (query)</a>
+		<a>Self link (multi query)</a>
+		<a>Self link (opaque query)</a>
+		<a href='debug-text-extraction-shorten-urls.html#installation'>Self link (fragment)</a>
+		<a>Self link (opaque fragment)</a>
+		<a href='debug-text-extraction-shorten-urls.html?tab=details'>Self link (query and fragment)</a>
+	</section>
+	<section>
+		<img src='image' alt='SVG data URL'>
+		<img src='image2' alt='PNG data URL'>
+		<img src='vacation-2024-summer-beach.jpg' alt='Long image path'>
+		<img src='thumbnail.png' alt='Image with path'>
+		<img src='thumbnail2.png' alt='Image with query params'>
+		<img src='image.gif' alt='Image with high entropy name'>
+		<img src='image2.gif' alt='Image with high entropy name 2'>
+		<img src='image2.gif' alt='Image with high entropy name (duplicate)'>
+		<img src='image.png' alt='Image with high entropy name, no extension'>
+		<img src='image.jpg' alt='File extension with trailing text'>
+	</section>
+</body>
 
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -51,6 +51,12 @@ a, img {
         <a href="https://example.com/b3029797-1fb8-4edf-97bd-63e3d9fb0bf5?cid=4edf97bd">Plain link (3)</a>
         <a href="file:///Users/test/089bac2e873e45608912886c4e028584/cat.png">Local file</a>
         <a href="debug-text-extraction-shorten-urls.html">Self link</a>
+        <a href="?tab=details">Self link (query)</a>
+        <a href="?q=webkit&lang=en">Self link (multi query)</a>
+        <a href="?cid=63e3d9fb0bf5">Self link (opaque query)</a>
+        <a href="#installation">Self link (fragment)</a>
+        <a href="#7e61b3f78d8142258d68f646f977ce33">Self link (opaque fragment)</a>
+        <a href="?tab=details#installation">Self link (query and fragment)</a>
     </section>
     <section class="test-section" title="Images">
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Ccircle cx='50' cy='50' r='40' fill='red'/%3E%3C/svg%3E" alt="SVG data URL">
@@ -75,7 +81,7 @@ addEventListener("load", async () => {
     testRunner.waitUntilDone();
 
     const results = [];
-    for (let outputFormat of ["texttree", "markdown"]) {
+    for (let outputFormat of ["texttree", "markdown", "html"]) {
         const heading = document.createElement("h1");
         heading.textContent = `-- ${outputFormat}`;
 

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -618,14 +618,26 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                     return { WTF::move(url) };
 
                 auto shortenedString = shortenedURLString(url);
-                bool linksToCurrentURL = [&] {
-                    auto urlAsView = [](const URL& url) -> StringView {
-                        if (url.hasFragmentIdentifier() && url.fragmentIdentifier().isEmpty())
-                            return url.viewWithoutFragmentIdentifier();
-                        return url.string();
-                    };
-                    return urlAsView(url) == urlAsView(protect(element->document())->url());
-                }();
+                bool linksToCurrentURL = url.viewWithoutQueryOrFragmentIdentifier() == element->document().url().viewWithoutQueryOrFragmentIdentifier();
+
+                String shortenedSelfLinkURLString;
+                if (linksToCurrentURL) {
+                    using namespace StringEntropyHelpers;
+                    String tail;
+                    auto params = queryParameters(url);
+                    if (params.size() == 1 && isProbablyHumanReadable(params[0].key) && isProbablyHumanReadable(params[0].value))
+                        tail = url.queryWithLeadingQuestionMark().toString();
+                    else if (url.hasFragmentIdentifier() && !url.fragmentIdentifier().isEmpty() && isProbablyHumanReadable(url.fragmentIdentifier()))
+                        tail = url.fragmentIdentifierWithLeadingNumberSign().toString();
+
+                    if (!tail.isEmpty()) {
+                        auto lastPathComponent = url.lastPathComponent();
+                        if (isProbablyHumanReadable(lastPathComponent))
+                            shortenedSelfLinkURLString = makeString(lastPathComponent, WTF::move(tail));
+                        else
+                            shortenedSelfLinkURLString = WTF::move(tail);
+                    }
+                }
 
                 String target;
                 if (RefPtr anchor = dynamicDowncast<HTMLAnchorElement>(*element))
@@ -636,6 +648,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                     WTF::move(url),
                     WTF::move(shortenedString),
                     linksToCurrentURL,
+                    WTF::move(shortenedSelfLinkURLString),
                 } };
             }
         }

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -144,6 +144,7 @@ struct LinkItemData {
     URL completedURL;
     String shortenedURLString;
     bool linksToCurrentURL { false };
+    String shortenedSelfLinkURLString;
 };
 
 struct IFrameData {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -860,6 +860,13 @@ public:
             containers.append(WTF::move(identifiers));
     }
 
+    String shortenedURLStringForLink(const TextExtraction::LinkItemData& data)
+    {
+        if (shortenURLs() && data.linksToCurrentURL)
+            return data.shortenedSelfLinkURLString;
+        return stringForURL(data);
+    }
+
 private:
     void filterRecursive(const String& originalText, const std::optional<FrameIdentifier>& frameIdentifier, const std::optional<NodeIdentifier>& identifier, size_t index, CompletionHandler<void(String&&)>&& completion)
     {
@@ -1546,7 +1553,7 @@ static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector
                     auto escapedText = escapeStringForMarkdown(trimmedContent);
                     if (valueOrDefault(urlString).containsIgnoringASCIICase(escapedText))
                         escapedText = { };
-                    escapedText = urlString ? makeString('[', WTF::move(escapedText), "]("_s, WTF::move(*urlString), ')') : escapedText;
+                    escapedText = (urlString && !urlString->isEmpty()) ? makeString('[', WTF::move(escapedText), "]("_s, WTF::move(*urlString), ')') : escapedText;
                     if (isStrikethrough)
                         escapedText = makeString("~~"_s, WTF::move(escapedText), "~~"_s);
                     textParts.append(WTF::move(escapedText));
@@ -1807,8 +1814,11 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
             if (aggregator.useHTMLOutput()) {
                 auto attributes = partsForItem(item, aggregator, includeRectForParentItem);
 
-                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs())
-                    attributes.append(makeString("href='"_s, aggregator.stringForURL(linkData), '\''));
+                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs()) {
+                    auto urlString = aggregator.shortenedURLStringForLink(linkData);
+                    if (!urlString.isEmpty())
+                        attributes.append(makeString("href='"_s, urlString, '\''));
+                }
 
                 if (attributes.isEmpty())
                     parts.append(makeString('<', item.nodeName.convertToASCIILowercase(), '>'));
@@ -1818,9 +1828,11 @@ static void addPartsForItem(const TextExtraction::Item& item, std::optional<Node
                 parts.append("link"_s);
                 parts.appendVector(partsForItem(item, aggregator, includeRectForParentItem));
 
-                bool omitSelfLinkURL = aggregator.useTextTreeOutput() && aggregator.shortenURLs() && linkData.linksToCurrentURL;
-                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs() && !omitSelfLinkURL)
-                    parts.append(makeString("url="_s, quoteValue(aggregator.stringForURL(linkData), streamlined)));
+                if (!linkData.completedURL.isEmpty() && aggregator.includeURLs()) {
+                    auto urlString = aggregator.shortenedURLStringForLink(linkData);
+                    if (!urlString.isEmpty())
+                        parts.append(makeString("url="_s, quoteValue(urlString, streamlined)));
+                }
             }
 
             aggregator.addResult(line, WTF::move(parts));
@@ -2009,7 +2021,7 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
         if (auto attributeFromClient = item.clientAttributes.get("href"_s); !attributeFromClient.isEmpty())
             linkURLString = WTF::move(attributeFromClient);
         else if (aggregator.includeURLs())
-            linkURLString = aggregator.stringForURL(*link);
+            linkURLString = aggregator.shortenedURLStringForLink(*link);
         aggregator.pushURLString(WTF::move(linkURLString));
         isLink = true;
     }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2901,6 +2901,7 @@ header: <WebCore/TextExtractionTypes.h>
     URL completedURL;
     String shortenedURLString;
     bool linksToCurrentURL;
+    String shortenedSelfLinkURLString;
 };
 
 header: <WebCore/TextExtractionTypes.h>


### PR DESCRIPTION
#### 732ab0a8407576cbca271ee19d278a6088ace703
<pre>
[Text Extraction] Include human-readable query parameters and fragments for links that navigate within the same page
<a href="https://bugs.webkit.org/show_bug.cgi?id=318582">https://bugs.webkit.org/show_bug.cgi?id=318582</a>
<a href="https://rdar.apple.com/181349810">rdar://181349810</a>

Reviewed by Abrar Rahman Protyasha.

Adjust the URL shortening heuristic: for links that navigate to the same URL as the current page
(ignoring query and fragment), we currently omit the URL from the text extraction entirely. Instead,
add the query only if there&apos;s only one human-readable (`isProbablyHumanReadable`) key/value pair,
and fall back to the fragment only if it&apos;s human-readable.

This prevents us from losing information about links in some cases, where the rendered text alone
doesn&apos;t provide enough context.

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::shortenedURLStringForLink):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/316503@main">https://commits.webkit.org/316503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52727363c45bc5e3a05fe5ba69744dac69af5a9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130097 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc99393a-fc84-4d65-80fd-7a3d70370c1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134201 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/283c65b5-732f-4d99-9adc-6bb1d9879d59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94af1dc8-cedc-4d2c-8960-1e6d417f8550) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36245 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30598 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184531 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37214 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142984 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142863 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38577 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46809 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111645 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37885 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118561 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45326 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9183 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44726 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44785 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->