### PR TITLE
[CMake] Fix the CMake build after 316448@main

### DIFF
--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -113,7 +113,7 @@ public:
 
     static Ref<DeferredWorkTimer> create(VM& vm) { return adoptRef(*new DeferredWorkTimer(vm)); }
 private:
-    DeferredWorkTimer(VM&);
+    JS_EXPORT_PRIVATE DeferredWorkTimer(VM&);
 
     Lock m_taskLock;
     bool m_runTasks { true };


### PR DESCRIPTION
#### dd186f5a3502de386ee96ceba7dfd3202d5c3466
<pre>
[CMake] Fix the CMake build after 316448@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=318590">https://bugs.webkit.org/show_bug.cgi?id=318590</a>
<a href="https://rdar.apple.com/181368662">rdar://181368662</a>

Reviewed by Pascoe.

316448@main moved DeferredWorkTimer::create() into an inline definition in
the class body of DeferredWorkTimer.h (the JSC-internal DeferredWorkTimerInlines.h
was deleted). create() calls the out-of-line, non-exported private constructor
DeferredWorkTimer(VM&amp;).

Because create() is now inline in a header included across the JSC/WebKit dylib
boundary, the CMake build emits a definition of create() into the shared
precompiled-header object (WebKitUIProcess_pch_obj.cpp.o, produced via clang&apos;s
-building-pch-with-obj codegen mode). That definition references the constructor,
which is hidden (local) in the JavaScriptCore dylib, so linking WebKitUIProcess
fails with:

Undefined symbols for architecture arm64:
    &quot;JSC::DeferredWorkTimer::DeferredWorkTimer(JSC::VM&amp;)&quot;, referenced from:
        JSC::DeferredWorkTimer::create(JSC::VM&amp;) in WebKitUIProcess_pch_obj.cpp.o

The Xcode build is unaffected because it does not use the shared PCH-object
codegen mode, so create() is only emitted where it is actually used (VM.cpp,
inside JSC).

Mark the constructor JS_EXPORT_PRIVATE so the exported symbol is available to
the header-inlined create() outside the JavaScriptCore dylib.

* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:

Canonical link: <a href="https://commits.webkit.org/316504@main">https://commits.webkit.org/316504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5b4279f3f87b15037f216c4d8f9ce2cc7f2b8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130106 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4859fff-5f71-4a4f-8aff-d162399f0349) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46140 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c909689a-6077-40c6-9611-3f6c9dc0c5d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114680 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfa9cdad-a5b8-4444-bff4-df23f6d4d06d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36252 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30607 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3269 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184540 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33811 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142989 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46140 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142868 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38578 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46818 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111664 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26187 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37893 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118570 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205228 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45335 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9191 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54794 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->