### PR TITLE
Cherry-pick 313392@main (f2c9beb2a707). https://bugs.webkit.org/show_bug.cgi?id=255748

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2002,10 +2002,8 @@ css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html [ Skip ]
 
 webkit.org/b/257624 http/tests/security/video-cross-origin-caching.html [ Pass Timeout ]
 
-webkit.org/b/201270 [ Release ] http/tests/security/navigate-when-restoring-cached-page.html [ Timeout ]
-webkit.org/b/201270 [ Debug ] http/tests/security/navigate-when-restoring-cached-page.html [ Crash ]
-webkit.org/b/201270 [ Release ] http/tests/security/showModalDialog-sync-cross-origin-page-load2.html [ Timeout ]
-webkit.org/b/201270 [ Debug ] http/tests/security/showModalDialog-sync-cross-origin-page-load2.html [ Crash ]
+webkit.org/b/201270 http/tests/security/navigate-when-restoring-cached-page.html [ Timeout ]
+webkit.org/b/201270 http/tests/security/showModalDialog-sync-cross-origin-page-load2.html [ Timeout ]
 
 webkit.org/b/263720 http/tests/security/redirect-BLOCKED-to-localURL.html [ Crash ]
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -304,12 +304,6 @@ void DocumentLoader::mainReceivedError(const ResourceError& error, LoadWillConti
         protectedFrameLoader()->protectedClient()->dispatchDidFailLoading(this, *m_identifierForLoadWithoutResourceLoader, error);
     }
 
-    // There is a bug in CFNetwork where callbacks can be dispatched even when loads are deferred.
-    // See <rdar://problem/6304600> for more details.
-#if !USE(CF)
-    ASSERT(!mainResourceLoader() || !mainResourceLoader()->defersLoading());
-#endif
-
     setMainDocumentError(error);
     clearMainResourceLoader();
     protectedFrameLoader()->receivedMainResourceError(error, loadWillContinueInAnotherProcess);
@@ -477,12 +471,6 @@ void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadM
 
 void DocumentLoader::finishedLoading()
 {
-    // There is a bug in CFNetwork where callbacks can be dispatched even when loads are deferred.
-    // See <rdar://problem/6304600> for more details.
-#if !USE(CF)
-    ASSERT(!m_frame->page()->defersLoading() || protectedFrameLoader()->stateMachine().creatingInitialEmptyDocument() || InspectorInstrumentation::isDebuggerPaused(m_frame.get()));
-#endif
-
     Ref<DocumentLoader> protectedThis(*this);
 
     if (m_identifierForLoadWithoutResourceLoader) {
@@ -990,12 +978,6 @@ void DocumentLoader::responseReceived(ResourceResponse&& response, CompletionHan
         }
     }
 
-    // There is a bug in CFNetwork where callbacks can be dispatched even when loads are deferred.
-    // See <rdar://problem/6304600> for more details.
-#if !USE(CF)
-    ASSERT(!mainResourceLoader() || !mainResourceLoader()->defersLoading());
-#endif
-
     if (m_isLoadingMultipartContent) {
         setupForMultipartReplace();
         m_mainResource->clear();
@@ -1426,12 +1408,6 @@ void DocumentLoader::dataReceived(const SharedBuffer& buffer)
 
     ASSERT(!buffer.span().empty());
     ASSERT(!m_response.isNull());
-
-    // There is a bug in CFNetwork where callbacks can be dispatched even when loads are deferred.
-    // See <rdar://problem/6304600> for more details.
-#if !USE(CF)
-    ASSERT(!mainResourceLoader() || !mainResourceLoader()->defersLoading());
-#endif
 
     if (m_identifierForLoadWithoutResourceLoader)
         protectedFrameLoader()->notifier().dispatchDidReceiveData(this, *m_identifierForLoadWithoutResourceLoader, &buffer, buffer.size(), -1);


### PR DESCRIPTION
#### 488eba4eb206406dfa39ea0b60a27b59380921df
<pre>
Cherry-pick 313392@main (f2c9beb2a707). <a href="https://bugs.webkit.org/show_bug.cgi?id=255748">https://bugs.webkit.org/show_bug.cgi?id=255748</a>

    ASSERTION FAILED: !mainResourceLoader() || !mainResourceLoader()-&gt;defersLoading()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=255748">https://bugs.webkit.org/show_bug.cgi?id=255748</a>

    Reviewed by Claudio Saavedra.

    Some assertions in DocumentLoader failed for some layout tests using
    showModalDialog. Those assertions ensured that the loading doesn&apos;t proceed
    while it defers loading. Those assertions were added for Chromium port. Apple
    ports have disabled the assertions. And, in WebKit2,
    WebLoaderStrategy::setDefersLoading() does nothing. Those assertions are no
    longer needed. Removed them.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/loader/DocumentLoader.cpp:
    (WebCore::DocumentLoader::mainReceivedError):
    (WebCore::DocumentLoader::finishedLoading):
    (WebCore::DocumentLoader::responseReceived):
    (WebCore::DocumentLoader::dataReceived):

    Canonical link: <a href="https://commits.webkit.org/313392@main">https://commits.webkit.org/313392@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.942@webkitglib/2.52">https://commits.webkit.org/305877.942@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30885bdfc1c147a87b0ef52cd6335f9aa510d1a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172554 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46472 "The change is no longer eligible for processing.") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182011 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130110 "Build is in progress. Recent messages:") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174419 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running bindings-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47765 "Build is in progress. Recent messages:") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134211 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/130110 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175512 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/47765 "Build is in progress. Recent messages:") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114683 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/171875 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/47765 "Build is in progress. Recent messages:") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30611 "Built successfully") | 
| [⏳ 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/47765 "Build is in progress. Recent messages:") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184544 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37229 "Build is in progress. Recent messages:") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142992 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46144 "Build is in progress. Recent messages:") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142871 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/46822 "The change is no longer eligible for processing.") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111674 "Build is in progress. Recent messages:") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26188 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/46822 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118574 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205232 "Build is in progress. Recent messages:") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45339 "Build is in progress. Recent messages:") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/205232 "Build is in progress. Recent messages:") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44739 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/44971 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/44798 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->