### PR TITLE
CSS style 'filter: drop-shadow...' does not render correctly without repaint.

### DIFF
--- a/LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt
+++ b/LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt
@@ -7,14 +7,14 @@
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer
-          (offsetFromRenderer width=-100 height=-100)
-          (position 230.00 230.00)
-          (anchor 0.75 0.75)
-          (bounds 200.00 200.00)
+          (offsetFromRenderer width=-150 height=-150)
+          (position 180.00 180.00)
+          (anchor 0.80 0.80)
+          (bounds 250.00 250.00)
           (drawsContent 1)
         )
         (GraphicsLayer
-          (bounds 200.00 200.00)
+          (bounds 250.00 250.00)
           (drawsContent 1)
         )
       )

--- a/LayoutTests/compositing/geometry/bounds-with-filters-expected.txt
+++ b/LayoutTests/compositing/geometry/bounds-with-filters-expected.txt
@@ -1,0 +1,35 @@
+Not
+overflowing
+Have some layout overflow
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 58.00 50.00)
+          (bounds 100.00 100.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 58.00 200.00)
+          (bounds 100.00 100.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-28 height=-28)
+          (position 30.00 322.00)
+          (anchor 0.34 0.50)
+          (bounds 228.00 156.00)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/geometry/bounds-with-filters.html
+++ b/LayoutTests/compositing/geometry/bounds-with-filters.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            margin: 50px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            filter: drop-shadow(0 0 10px);
+        }
+
+        .composited {
+            transform: translateZ(0);
+        }
+        
+        .overflowing {
+            width: 200px;
+        }
+    </style>
+</head>
+<body>
+    <div class="composited box"></div>
+    <div class="composited box">
+        <div>Not<br>overflowing</div>
+    </div>
+    <div class="composited box">
+        <div class="overflowing">Have some layout overflow</div>
+    </div>
+<pre id="layers"></pre>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+        }
+    </script>
+</body>
+</html>

--- a/LayoutTests/css3/filters/drop-shadow-target-clipped.html
+++ b/LayoutTests/css3/filters/drop-shadow-target-clipped.html
@@ -6,19 +6,19 @@
         background-color: black;
     }
     .drop-shadow-red {
-        top: -1000px;
-        left: -1000px;
-        filter: drop-shadow(1000px 1000px 0 red);
+        top: -800px;
+        left: -800px;
+        filter: drop-shadow(800px 800px 0 red);
     }
     .drop-shadow-green {
-        top: -1000px;
-        left: -1000px;
-        filter: drop-shadow(900px 900px 0 green);
+        top: -800px;
+        left: -800px;
+        filter: drop-shadow(700px 700px 0 green);
     }
     .drop-shadow-blue {
-        top: -1000px;
-        left: -1000px;
-        filter: drop-shadow(800px 800px 0 blue);
+        top: -800px;
+        left: -800px;
+        filter: drop-shadow(600px 600px 0 blue);
     }
 </style>
 <body>

--- a/LayoutTests/fast/hidpi/filters-drop-shadow.html
+++ b/LayoutTests/fast/hidpi/filters-drop-shadow.html
@@ -1,14 +1,14 @@
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-1200" />
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-2400" />
 <script src="resources/ensure-hidpi.js"></script>
 <style>
     div {
         width: 300px;
         height: 300px;
-        top: -1000px;
-        left: -1000px;
+        top: -800px;
+        left: -800px;
         background-color: red;
         position: relative;
-        filter: drop-shadow(1000px 1000px 0 green);
+        filter: drop-shadow(800px 800px 0 green);
     }
 </style>
 <body>

--- a/LayoutTests/fast/repaint/blur-change-expected.txt
+++ b/LayoutTests/fast/repaint/blur-change-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 24 36 268 268)
+  (rect 24 256 268 268)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/blur-change.html
+++ b/LayoutTests/fast/repaint/blur-change.html
@@ -1,0 +1,58 @@
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            margin: 120px 100px;
+            background-color: silver;
+        }
+        
+        .box.bigtosmall {
+            filter: blur(30px);
+        }
+        
+        .box.smalltobig {
+            filter: blur(1px);
+        }
+        
+        body.changed .box.bigtosmall {
+            filter: blur(1px);
+        }
+
+        body.changed .box.smalltobig {
+            filter: blur(30px);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when the drop-shadow filter property changes");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+            
+            await UIHelper.delayFor(1500);
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box smalltobig"></div>
+    <div class="box bigtosmall"></div>
+
+    <div id="console"></div>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt
@@ -1,0 +1,13 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 192 192 206 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-box-change.html
+++ b/LayoutTests/fast/repaint/drop-shadow-box-change.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+    <style>
+        .box {
+            position: absolute;
+            top: 200px;
+            left: 200px;
+            width: 100px;
+            height: 100px;
+            background-color: silver;
+            filter: drop-shadow(20px 20px 10px black);
+        }
+        
+        body.changed .box {
+            width: 150px;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when a box with drop-shadow changes size");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+    <div id="console"></div>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-change-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 108 100 100 100)
+  (rect 100 92 156 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 200 200 100 100)
+  (rect 172 174 156 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-change-full-repaint.html
+++ b/LayoutTests/fast/repaint/drop-shadow-change-full-repaint.html
@@ -1,0 +1,51 @@
+<html>
+<head>
+    <style>
+        #box {
+            position: absolute;
+            top: 200px;
+            left: 200px;
+            filter: drop-shadow(0 2px 10px black);
+        }
+
+        #child {
+            height: 100px;
+            width: 100px;
+            background-color: green;
+        }
+
+        #child.hidden {
+            display: none;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when a box with drop-shadow changes size");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+
+            document.getElementById('child').classList.add('hidden');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="box">
+        <div id="child"></div>
+    </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-change.html
+++ b/LayoutTests/fast/repaint/drop-shadow-change.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            margin: 100px;
+            background-color: silver;
+        }
+        
+        body.changed .box {
+            filter: drop-shadow(20px 20px 10px black);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when the drop-shadow filter property changes");
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                internals.startTrackingRepaints();
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+    <div id="console"></div>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt
@@ -1,0 +1,14 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+(repaint rects
+  (rect 108 100 100 100)
+  (rect 60 92 156 156)
+)
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-writing-modes.html
+++ b/LayoutTests/fast/repaint/drop-shadow-writing-modes.html
@@ -1,0 +1,43 @@
+<html>
+<head>
+    <style>
+        .box {
+            writing-mode:vertical-rl;
+            width: 100px;
+            height: 100px;
+            margin: 100px;
+            background-color: silver;
+        }
+        
+        body.changed .box {
+            filter: drop-shadow(-20px 20px 10px black);
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        var layerTreeAsText;
+        window.addEventListener('load', async () => {
+            description("Test repaint rects when the drop-shadow filter property changes");
+            await UIHelper.renderingUpdate();
+            
+            if (window.internals)
+                internals.startTrackingRepaints();
+        
+            document.body.classList.add('changed');
+
+            if (window.internals) {
+                debug(window.internals.repaintRectsAsText());
+                internals.stopTrackingRepaints();
+            }
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+    <div id="console"></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html
@@ -4,7 +4,8 @@
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterProperty">
 <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=350411">
 <link rel="match" href="reference/filters-drop-shadow-002-ref.html">
-<meta name="assert" content="Check that clipping gets correctly applied on children of a container with a drop-shadow filter in effect."/>
+<meta name="assert" content="Check that clipping gets correctly applied on children of a container with a drop-shadow filter in effect.">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-1640">
 
 <style>
 .container {

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4744,6 +4744,7 @@ imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-functi
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-linear-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-repeating-radial-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-mask-large.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-003.html [ Pass ImageOnlyFailure ]
 
 http/tests/site-isolation/mouse-events/ [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip ]

--- a/LayoutTests/platform/win/compositing/geometry/bounds-with-filters-expected.txt
+++ b/LayoutTests/platform/win/compositing/geometry/bounds-with-filters-expected.txt
@@ -1,0 +1,39 @@
+Not
+overflowing
+Have some layout overflow
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (usingTiledLayer 1)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 58.00 50.00)
+          (bounds 100.00 100.00)
+          (usingTiledLayer 1)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 58.00 200.00)
+          (bounds 100.00 100.00)
+          (usingTiledLayer 1)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-28 height=-28)
+          (position 30.00 322.00)
+          (anchor 0.34 0.50)
+          (bounds 228.00 156.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html
+++ b/LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html
@@ -4,9 +4,8 @@
     <style>
         .shadow-box {
             position: absolute;
-            top: 10px;
-            left: 10px;
-            display: inline-block;
+            top: 180px;
+            left: 30px;
             width: 200px;
             height: 200px;
             background-color: green;

--- a/LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html
+++ b/LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html
@@ -4,14 +4,14 @@
     <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-18081" />
     <style>
         svg {
-            width: 0;
-            height: 0;
+            width: 0px;
+            height: 0px;
+            border: 1px solid black;
         }
         .shadow-box {
             position: absolute;
-            top: 30px;
-            left: 30px;
-            display: inline-block;
+            top: 200px;
+            left: 50px;
             width: 200px;
             height: 200px;
             background-color: green;
@@ -20,7 +20,7 @@
     </style>
 </head>
 <body>
-	<svg viewBox="0 0 1440 300">
+    <svg viewBox="0 0 400 400">
         <defs>
             <filter id="filter">
                 <feDropShadow dx="0" dy="0" stdDeviation="100" flood-color="black" result="drop-shadow" />
@@ -43,6 +43,7 @@
                 </feMerge>
             </filter>
         </defs>
+        <rect x=50 y=50 width=200 height=200 filter=url(#filter) fill="green">
     </svg>
     <div class="shadow-box"></div>
 </body>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -31,6 +31,7 @@
 #include "BorderPainter.h"
 #include "BorderShape.h"
 #include "ContainerNodeInlines.h"
+#include "CSSFilter.h"
 #include "CSSFontSelector.h"
 #include "Document.h"
 #include "EditingInlines.h"
@@ -4425,7 +4426,9 @@ void RenderBox::addVisualEffectOverflow()
     bool hasBoxShadow = style().hasBoxShadow();
     bool hasBorderImageOutsets = style().hasBorderImageOutsets();
     bool hasOutline = outlineStyleForRepaint().hasOutlineInVisualOverflow();
-    if (!hasBoxShadow && !hasBorderImageOutsets && !hasOutline)
+    bool hasInflatingFilters = hasFilter() && !filterOutsets().isZero();
+
+    if (!hasBoxShadow && !hasBorderImageOutsets && !hasOutline && !hasInflatingFilters)
         return;
 
     addVisualOverflow(applyVisualEffectOverflow(borderBoxRect()));
@@ -4434,7 +4437,8 @@ void RenderBox::addVisualEffectOverflow()
         fragmentedFlow->addFragmentsVisualEffectOverflow(*this);
 }
 
-static void convertOutsetsToOverflowCoordinates(LayoutBoxExtent& outsets, WritingMode writingMode)
+template<typename T>
+static void convertOutsetsToOverflowCoordinates(RectEdges<T>& outsets, WritingMode writingMode)
 {
     switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:
@@ -4449,7 +4453,7 @@ static void convertOutsetsToOverflowCoordinates(LayoutBoxExtent& outsets, Writin
     }
 }
 
-LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) const
+LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox, EnumSet<VisualEffectOverflowOption> options) const
 {
     LayoutUnit overflowMinX = borderBox.x();
     LayoutUnit overflowMaxX = borderBox.maxX();
@@ -4482,12 +4486,24 @@ LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) con
     }
 
     if (outlineStyleForRepaint().hasOutlineInVisualOverflow()) {
-        LayoutUnit outlineSize { outlineStyleForRepaint().usedOutlineSize() };
+        auto outlineSize = LayoutUnit { outlineStyleForRepaint().usedOutlineSize() };
+
         overflowMinX = std::min(overflowMinX, borderBox.x() - outlineSize);
         overflowMaxX = std::max(overflowMaxX, borderBox.maxX() + outlineSize);
         overflowMinY = std::min(overflowMinY, borderBox.y() - outlineSize);
         overflowMaxY = std::max(overflowMaxY, borderBox.maxY() + outlineSize);
     }
+
+    if (hasFilter() && !options.contains(VisualEffectOverflowOption::ExcludeFilterOutsets)) {
+        auto outsets = filterOutsets();
+        convertOutsetsToOverflowCoordinates(outsets, writingMode());
+
+        overflowMinX = std::min(overflowMinX, borderBox.x() - outsets.left());
+        overflowMaxX = std::max(overflowMaxX, borderBox.maxX() + outsets.right());
+        overflowMinY = std::min(overflowMinY, borderBox.y() - outsets.top());
+        overflowMaxY = std::max(overflowMaxY, borderBox.maxY() + outsets.bottom());
+    }
+
     // Add in the final overflow with shadows and outsets combined.
     return LayoutRect(overflowMinX, overflowMinY, overflowMaxX - overflowMinX, overflowMaxY - overflowMinY);
 }
@@ -4575,6 +4591,14 @@ void RenderBox::addOverflowWithRendererOffset(const RenderBox& renderer, LayoutS
     if (!childVisualOverflowRect)
         computeChildVisualOverflowRect();
     addVisualOverflow(*childVisualOverflowRect);
+}
+
+bool RenderBox::hasLayoutOverflow() const
+{
+    if (!m_overflow)
+        return false;
+
+    return !flippedClientBoxRect().contains(m_overflow->layoutOverflowRect());
 }
 
 LayoutOptionalOutsets RenderBox::allowedLayoutOverflow() const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -156,6 +156,7 @@ public:
     // but it is on the right in vertical-rl.
     WEBCORE_EXPORT LayoutRect flippedClientBoxRect() const;
     LayoutRect layoutOverflowRect() const { return m_overflow ? m_overflow->layoutOverflowRect() : flippedClientBoxRect(); }
+    bool hasLayoutOverflow() const;
     inline LayoutUnit logicalLeftLayoutOverflow() const;
     inline LayoutUnit logicalRightLayoutOverflow() const;
     
@@ -171,7 +172,10 @@ public:
     RenderOverflow& ensureOverflow();
 
     void addVisualEffectOverflow();
-    LayoutRect applyVisualEffectOverflow(const LayoutRect&) const;
+    enum class VisualEffectOverflowOption : uint8_t {
+        ExcludeFilterOutsets,
+    };
+    LayoutRect applyVisualEffectOverflow(const LayoutRect&, EnumSet<VisualEffectOverflowOption> = { }) const;
 
     enum class ComputeOverflowOptions {
         None,

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1348,6 +1348,18 @@ void RenderElement::layout()
     clearNeedsLayout();
 }
 
+IntBoxExtent RenderElement::filterOutsets() const
+{
+    if (!hasFilter())
+        return { };
+
+    if (auto outsets = style().filter().outsets())
+        return *outsets;
+
+    // FIXME: Need to compute outsets for reference filters: webkit.org/b/237538.
+    return { };
+}
+
 template<typename FillLayers> static bool mustRepaintFillLayers(const RenderElement& renderer, const FillLayers& layers)
 {
     // Nobody will use multiple layers without wanting fancy positioning.
@@ -1394,8 +1406,11 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
     if (oldClippedOverflowRect.isEmpty() && newClippedOverflowRect.isEmpty())
         return true;
 
-    auto mustRepaintBackgroundOrBorderOnSizeChange = [&](LayoutRect oldOutlineBounds, LayoutRect newOutlineBounds) {
+    auto mustFullRepaintOnSizeChange = [&](LayoutRect oldOutlineBounds, LayoutRect newOutlineBounds) {
         if (hasMask() && mustRepaintFillLayers(*this, style().maskLayers()))
+            return true;
+
+        if (hasFilter() && !filterOutsets().isZero())
             return true;
 
         if (style().hasBorderRadius()) {
@@ -1441,7 +1456,7 @@ bool RenderElement::repaintAfterLayoutIfNeeded(SingleThreadWeakPtr<const RenderL
 
         // If our outline bounds rect resized (as a proxy for a border box resize),
         // we have to repaint if we paint content that scales with the size.
-        if (oldRects.outlineBoundsRect->size() != newRects.outlineBoundsRect->size() && mustRepaintBackgroundOrBorderOnSizeChange(*oldRects.outlineBoundsRect, *newRects.outlineBoundsRect))
+        if (oldRects.outlineBoundsRect->size() != newRects.outlineBoundsRect->size() && mustFullRepaintOnSizeChange(*oldRects.outlineBoundsRect, *newRects.outlineBoundsRect))
             return true;
 
         return false;

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <WebCore/BoxExtents.h>
 #include <WebCore/HitTestRequest.h>
 #include <WebCore/RenderObject.h>
 #include <WebCore/RenderPtr.h>
@@ -224,6 +225,8 @@ public:
     inline bool hasBackdropFilter() const; // Defined in RenderElementStyleInlines.h.
     inline bool hasBlendMode() const; // Defined in RenderElementStyleInlines.h.
     inline bool hasShapeOutside() const; // Defined in RenderElementStyleInlines.h.
+
+    IntBoxExtent filterOutsets() const;
 
 #if HAVE(CORE_MATERIAL)
     inline bool hasAppleVisualEffect() const; // Defined in RenderElementStyleInlines.h.

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5585,6 +5585,9 @@ LayoutRect RenderLayer::localBoundingBox(OptionSet<CalculateLayerBoundsFlag> fla
         if (!(flags & DontConstrainForMask) && box->hasMask()) {
             result = box->maskClipRect(LayoutPoint());
             box->flipForWritingMode(result); // The mask clip rect is in physical coordinates, so we have to flip, since localBoundingBox is not.
+        } else if (flags.contains(ExcludeFilterOutsetsFromSelfBounds) && !box->hasLayoutOverflow()) {
+            ASSERT(box->hasFilter());
+            result = box->applyVisualEffectOverflow(box->borderBoxRect(), { RenderBox::VisualEffectOverflowOption::ExcludeFilterOutsets });
         } else
             result = box->visualOverflowRect();
 
@@ -5678,6 +5681,7 @@ LayoutRect RenderLayer::overlapBounds() const
 
     return localBoundingBox();
 }
+
 LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, const LayoutSize& offsetFromRoot, OptionSet<CalculateLayerBoundsFlag> flags) const
 {
     if (!isSelfPaintingLayer())
@@ -5695,7 +5699,14 @@ LayoutRect RenderLayer::calculateLayerBounds(const RenderLayer* ancestorLayer, c
         return renderer().view().unscaledDocumentRect();
     }
 
-    LayoutRect boundingBoxRect = localBoundingBox(flags | IncludeRootBackgroundPaintingArea);
+    auto localBoundingBoxFlags = flags | IncludeRootBackgroundPaintingArea;
+    // When filters are composited, the compositor applies the filter effect, so the backing
+    // layer should not be inflated by filter outsets; compute bounds excluding
+    // filter outsets when possible.
+    if (isComposited() && renderer().hasFilter() && !shouldPaintWithFilters())
+        localBoundingBoxFlags.add(ExcludeFilterOutsetsFromSelfBounds);
+
+    LayoutRect boundingBoxRect = localBoundingBox(localBoundingBoxFlags);
     if (renderer().view().frameView().hasFlippedBlockRenderers()) {
         if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer()))
             box->flipForWritingMode(boundingBoxRect);
@@ -6512,9 +6523,16 @@ void RenderLayer::updateFilterPaintingStrategy()
 
 IntOutsets RenderLayer::filterOutsets() const
 {
+    if (!renderer().hasFilter())
+        return { };
+
     if (m_filters)
         return m_filters->calculateOutsets(renderer(), localBoundingBox());
-    return renderer().style().filter().outsets();
+
+    if (CheckedPtr boxRenderer = renderBox())
+        return boxRenderer->filterOutsets();
+
+    return { };
 }
 
 static RenderLayer* parentLayerCrossFrame(const RenderLayer& layer)

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -767,6 +767,7 @@ public:
         PreserveAncestorFlags                          = 1 << 10,
         UseLocalClipRectExcludingCompositingIfPossible = 1 << 11,
         ExcludeViewTransitionCapturedDescendants       = 1 << 12,
+        ExcludeFilterOutsetsFromSelfBounds             = 1 << 13,
     };
     static constexpr OptionSet<CalculateLayerBoundsFlag> defaultCalculateLayerBoundsFlags() { return { IncludeSelfTransform, UseLocalClipRectIfPossible, IncludePaintedFilterOutsets, UseFragmentBoxesExcludingCompositing }; }
 

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -71,9 +71,17 @@ public:
             if (&a.nonInheritedData() == &b.nonInheritedData())
                 return false;
 
-            if (a.nonInheritedData().miscData.ptr() != b.nonInheritedData().miscData.ptr()
-                && a.nonInheritedData().miscData->boxShadow != b.nonInheritedData().miscData->boxShadow)
-                return true;
+            if (a.nonInheritedData().miscData.ptr() != b.nonInheritedData().miscData.ptr()) {
+                if (a.nonInheritedData().miscData->boxShadow != b.nonInheritedData().miscData->boxShadow)
+                    return true;
+
+                if (a.nonInheritedData().miscData->filter.ptr() != b.nonInheritedData().miscData->filter.ptr()) {
+                    auto aOutsets = a.nonInheritedData().miscData->filter->filter.outsets();
+                    auto bOutsets = b.nonInheritedData().miscData->filter->filter.outsets();
+                    if (aOutsets != bOutsets)
+                        return true;
+                }
+            }
 
             if (a.nonInheritedData().backgroundData.ptr() != b.nonInheritedData().backgroundData.ptr()) {
                 auto aHasOutlineInVisualOverflow = a.hasOutlineInVisualOverflow();

--- a/Source/WebCore/style/values/filter-effects/StyleFilter.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleFilter.cpp
@@ -79,9 +79,10 @@ bool Filter::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
     return std::ranges::any_of(*this, [](auto& op) { return op->shouldBeRestrictedBySecurityOrigin(); });
 }
 
-IntOutsets Filter::outsets() const
+std::optional<IntOutsets> Filter::outsets() const
 {
     IntOutsets totalOutsets;
+    bool haveReferenceFilter = false;
     for (auto& value : *this) {
         Ref operation = value.value;
         switch (operation->type()) {
@@ -109,12 +110,16 @@ IntOutsets Filter::outsets() const
             break;
         }
         case FilterOperation::Type::Reference:
-            ASSERT_NOT_REACHED();
+            haveReferenceFilter = true;
             break;
         default:
             break;
         }
     }
+
+    if (haveReferenceFilter)
+        return { };
+
     return totalOutsets;
 }
 

--- a/Source/WebCore/style/values/filter-effects/StyleFilter.h
+++ b/Source/WebCore/style/values/filter-effects/StyleFilter.h
@@ -79,7 +79,7 @@ struct Filter : ListOrNone<FilterValueList> {
     bool hasReferenceFilter() const;
     bool isReferenceFilter() const;
 
-    IntOutsets outsets() const;
+    std::optional<IntOutsets> outsets() const;
 
     enum class PlatformConversionAllowsCurrentColor : bool { No, Yes };
 };


### PR DESCRIPTION
#### b10717a4d8779c307ed1e6aea4d01b19911d5508
<pre>
CSS style &apos;filter: drop-shadow...&apos; does not render correctly without repaint.

Reviewed by Simon Fraser and Alan Baradlay.

This is a backport of both 313382@main and 316450@main

* LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt:
* LayoutTests/compositing/geometry/bounds-with-filters-expected.txt: Added.
* LayoutTests/compositing/geometry/bounds-with-filters.html: Added.
* LayoutTests/css3/filters/drop-shadow-target-clipped.html:
* LayoutTests/fast/hidpi/filters-drop-shadow.html:
* LayoutTests/fast/repaint/blur-change-expected.txt: Added.
* LayoutTests/fast/repaint/blur-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-box-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-change-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-change-full-repaint.html: Added.
* LayoutTests/fast/repaint/drop-shadow-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-writing-modes.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filters-drop-shadow-002.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/win/compositing/geometry/bounds-with-filters-expected.txt: Added.
* LayoutTests/svg/filters/feMerge-nodes-unite-outsets-expected.html:
* LayoutTests/svg/filters/feMerge-nodes-unite-outsets.html:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::addVisualEffectOverflow):
(WebCore::convertOutsetsToOverflowCoordinates):
(WebCore::RenderBox::applyVisualEffectOverflow const):
(WebCore::RenderBox::hasLayoutOverflow const):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::applyVisualEffectOverflow):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::filterOutsets const):
(WebCore::RenderElement::repaintAfterLayoutIfNeeded):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/values/filter-effects/StyleFilter.cpp:
(WebCore::Style::Filter::outsets const):
* Source/WebCore/style/values/filter-effects/StyleFilter.h:

Canonical link: <a href="https://commits.webkit.org/305877.959@webkitglib/2.52">https://commits.webkit.org/305877.959@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97b3741e521378c033f47ea23b088152f1ded1b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172801 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/46720 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182259 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130357 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174666 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/48012 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46395 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130357 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175759 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/48012 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/114866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/48012 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/46395 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30858 "Built successfully") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/48012 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184792 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37520 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/46395 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/46391 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/47069 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112058 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26218 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/47069 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118821 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/45586 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/40180 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/44986 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45218 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/45045 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->