### PR TITLE
Nested textLength: ancestor <text> stretches its own content instead of reserving the descendant <tspan>'s textLength

### DIFF
--- a/LayoutTests/svg/text/nested-textLength-spacingAndGlyphs-expected.svg
+++ b/LayoutTests/svg/text/nested-textLength-spacingAndGlyphs-expected.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <!-- Reference for nested-textLength-spacingAndGlyphs.svg (webkit.org/b/139210): both "hello"s
+       render 50px, reproduced here with two independent <text textLength="50"> at the same positions. -->
+  <text x="100" y="100" style="font: 32px sans-serif" textLength="50" lengthAdjust="spacingAndGlyphs">hello</text>
+  <text x="100" y="140" style="font: 32px sans-serif" textLength="50" lengthAdjust="spacingAndGlyphs">hello</text>
+</svg>

--- a/LayoutTests/svg/text/nested-textLength-spacingAndGlyphs.svg
+++ b/LayoutTests/svg/text/nested-textLength-spacingAndGlyphs.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <!-- webkit.org/b/139210: the descendant <tspan textLength="50"> owns its content, so the
+       ancestor <text textLength="100"> governs only the rest (100 - 50 = 50). Both "hello"s render 50px. -->
+  <text x="100" y="100" style="font: 32px sans-serif" textLength="100" lengthAdjust="spacingAndGlyphs">hello<tspan x="100" y="140" textLength="50" lengthAdjust="spacingAndGlyphs">hello</tspan></text>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGTextChunk.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.cpp
@@ -27,6 +27,7 @@
 #include "SVGTextContentElement.h"
 #include "SVGTextFragment.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include "TypedElementDescendantIteratorInlines.h"
 #include <ranges>
 
 namespace WebCore {
@@ -56,10 +57,17 @@ SVGTextChunk::SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>& lin
         break;
     }
 
+    for (auto box : lineLayoutBoxes.subspan(first, limit - first)) {
+        auto it = fragmentMap.find(makeKey(*box));
+        if (it == fragmentMap.end())
+            continue;
+        m_boxes.append({ box, it->value });
+    }
+
     if (RefPtr textContentElement = SVGTextContentElement::elementFromRenderer(firstBox->renderer().parent())) {
         m_textContentElement = textContentElement.get();
         SVGLengthContext lengthContext(textContentElement.get());
-        m_desiredTextLength = textContentElement->specifiedTextLength().value(lengthContext);
+        m_desiredTextLength = adjustedDesiredTextLength(*textContentElement, textContentElement->specifiedTextLength().value(lengthContext));
 
         switch (textContentElement->lengthAdjust()) {
         case SVGLengthAdjustUnknown:
@@ -72,13 +80,52 @@ SVGTextChunk::SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>& lin
             break;
         }
     }
+}
 
-    for (auto box : lineLayoutBoxes.subspan(first, limit - first)) {
-        auto it = fragmentMap.find(makeKey(*box));
-        if (it == fragmentMap.end())
+float SVGTextChunk::adjustedDesiredTextLength(const SVGTextContentElement& owner, float desiredTextLength) const
+{
+    // Nested 'textLength' (SVG2 §11.2.1, text.html#TextElementTextLengthAttribute): a descendant's own
+    // 'textLength' governs its content exclusively, so the ancestor's covers only the rest, with
+    // advance (ancestor - descendant). Subtract each topmost descendant laid out in a separate
+    // chunk (its advance isn't in our totalLength()). webkit.org/b/139210.
+    if (desiredTextLength <= 0)
+        return desiredTextLength;
+
+    for (Ref descendant : descendantsOfType<SVGTextContentElement>(owner)) {
+        SVGLengthContext descendantLengthContext(descendant.ptr());
+        float descendantTextLength = descendant->specifiedTextLength().value(descendantLengthContext);
+        if (descendantTextLength <= 0)
             continue;
-        m_boxes.append({ box, it->value });
+
+        // Skip nested ones; they're accounted for by their nearest 'textLength' ancestor.
+        bool hasIntermediateTextLength = false;
+        for (RefPtr ancestor = descendant->parentElement(); ancestor && ancestor != &owner; ancestor = ancestor->parentElement()) {
+            RefPtr intermediate = dynamicDowncast<SVGTextContentElement>(*ancestor);
+            if (intermediate && intermediate->specifiedTextLength().value(SVGLengthContext(intermediate.get())) > 0) {
+                hasIntermediateTextLength = true;
+                break;
+            }
+        }
+        if (hasIntermediateTextLength)
+            continue;
+
+        // Skip descendants sharing this chunk; their advance is already in totalLength().
+        bool contentInThisChunk = false;
+        for (auto& boxAndFragments : m_boxes) {
+            auto* container = boxAndFragments.box->renderer().parent();
+            RefPtr containerElement = container ? container->element() : nullptr;
+            if (containerElement && descendant->contains(*containerElement)) {
+                contentInThisChunk = true;
+                break;
+            }
+        }
+        if (contentInThisChunk)
+            continue;
+
+        desiredTextLength -= descendantTextLength;
     }
+
+    return std::max(0.0f, desiredTextLength);
 }
 
 unsigned SVGTextChunk::totalCharacters() const

--- a/Source/WebCore/rendering/svg/SVGTextChunk.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.h
@@ -61,6 +61,9 @@ private:
     void buildBoxTransformations(SVGChunkTransformMap&) const;
     void processTextLengthSpacingCorrection() const;
 
+    // Reduces a 'textLength' value by the 'textLength' of separately-chunked descendants (nested textLength). webkit.org/b/139210.
+    float adjustedDesiredTextLength(const SVGTextContentElement&, float desiredTextLength) const;
+
     bool isVerticalText() const { return m_chunkStyle.contains(ChunkStyle::VerticalText); }
     float desiredTextLength() const { return m_desiredTextLength; }
 


### PR DESCRIPTION
#### 4c64959eb8f492fb53bc82c30e6727425b2c8593
<pre>
Nested textLength: ancestor &lt;text&gt; stretches its own content instead of reserving the descendant &lt;tspan&gt;&apos;s textLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=139210">https://bugs.webkit.org/show_bug.cgi?id=139210</a>
<a href="https://rdar.apple.com/19121927">rdar://19121927</a>

Reviewed by NOBODY (OOPS!).

Per the SVG2 &apos;textLength&apos; definition [1], when &apos;textLength&apos; is specified on an
element and also on an ancestor, the descendant&apos;s &apos;textLength&apos; controls its own
content exclusively, and the ancestor&apos;s &apos;textLength&apos; governs only the remaining
content: &quot;the total advance values for the other content within that ancestor is
the difference between the advance value on that ancestor and the advance value
for this element.&quot;

WebKit built one SVGTextChunk per element and applied each element&apos;s &apos;textLength&apos;
in isolation. For &lt;text textLength=&quot;100&quot;&gt;&lt;tspan textLength=&quot;50&quot;&gt;, the &lt;tspan&gt; chunk
was correctly compressed to 50, but the &lt;text&gt; chunk stretched its own &quot;hello&quot; to the
full 100 instead of the remaining 100 - 50 = 50, so it overshot the tspan below it.

Fix this by reducing an ancestor chunk&apos;s desired length by the &apos;textLength&apos; of every
topmost descendant that is laid out in a separate chunk (so its advance is not already
part of this chunk&apos;s totalLength()). Descendants whose content shares the chunk, and
more deeply nested &apos;textLength&apos; descendants already accounted for by an intermediate
ancestor, are skipped.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementTextLengthAttribute">https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementTextLengthAttribute</a>

Tests: svg/text/nested-textLength-spacingAndGlyphs-expected.svg
       svg/text/nested-textLength-spacingAndGlyphs.svg

* LayoutTests/svg/text/nested-textLength-spacingAndGlyphs-expected.svg: Added.
* LayoutTests/svg/text/nested-textLength-spacingAndGlyphs.svg: Added.
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
(WebCore::SVGTextChunk::SVGTextChunk):
(WebCore::SVGTextChunk::adjustedDesiredTextLength const):
* Source/WebCore/rendering/svg/SVGTextChunk.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c64959eb8f492fb53bc82c30e6727425b2c8593

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39906 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182014 "Hash 4c64959e for PR 68655 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130113 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46147 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/182014 "Hash 4c64959e for PR 68655 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94701 "2 flakes 22 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154740 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/182014 "Hash 4c64959e for PR 68655 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34560 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30614 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184547 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37232 "Found 1 new failure in rendering/svg/SVGTextChunk.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142995 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142874 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46825 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111677 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37894 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118577 "Found 1 new failure in rendering/svg/SVGTextChunk.cpp") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45342 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9192 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44742 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44974 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->