### PR TITLE
[JSC] `TypedArray.from()` spuriously throws when `mapFn` detaches or shrinks

### DIFF
--- a/JSTests/stress/typedarray-from-oob-not-detached.js
+++ b/JSTests/stress/typedarray-from-oob-not-detached.js
@@ -1,0 +1,74 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+// Source is a fixed-length view on a resizable ArrayBuffer. Shrinking the
+// buffer inside mapFn makes the view out-of-bounds without detaching it.
+// TypedArray.from must stop writing without throwing.
+function testSourceShrunkOutOfBounds() {
+    const rab = new ArrayBuffer(32, { maxByteLength: 64 });
+    const source = new Int32Array(rab, 0, 8);
+    for (let i = 0; i < 8; i++)
+        source[i] = i + 1;
+    source[Symbol.iterator] = null;
+
+    let calls = 0;
+    const result = Int32Array.from(source, (value, k) => {
+        calls++;
+        if (k === 4)
+            rab.resize(16);
+        return value;
+    });
+    shouldBe(calls, 5);
+    shouldBe(result.length, 8);
+    shouldBe(result[4], 5);
+    shouldBe(result[5], 0);
+}
+
+// Result is a fixed-length view on a resizable ArrayBuffer. Shrinking the
+// buffer inside mapFn makes the result out-of-bounds without detaching it.
+function testResultShrunkOutOfBounds() {
+    let rab;
+    class FixedLengthOnResizable extends Int32Array {
+        constructor(length) {
+            rab = new ArrayBuffer(4 * length, { maxByteLength: 8 * length });
+            super(rab, 0, length);
+        }
+    }
+
+    let calls = 0;
+    const result = FixedLengthOnResizable.from({ length: 8 }, (value, k) => {
+        calls++;
+        if (k === 2)
+            rab.resize(4);
+        return k;
+    });
+    shouldBe(calls, 3);
+}
+
+// Result's buffer is detached by transfer() inside mapFn.
+function testResultDetached() {
+    let buffer;
+    class ViewOnTransferableBuffer extends Int32Array {
+        constructor(length) {
+            buffer = new ArrayBuffer(4 * length);
+            super(buffer);
+        }
+    }
+
+    let calls = 0;
+    const result = ViewOnTransferableBuffer.from({ length: 8 }, (value, k) => {
+        calls++;
+        if (k === 2)
+            buffer.transfer();
+        return k;
+    });
+    shouldBe(calls, 3);
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testSourceShrunkOutOfBounds();
+    testResultShrunkOutOfBounds();
+    testResultDetached();
+}

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -142,6 +142,7 @@ namespace JSC {
     macro(isSharedTypedArrayView) \
     macro(isResizableOrGrowableSharedTypedArrayView) \
     macro(isDetached) \
+    macro(isTypedArrayOutOfBounds) \
     macro(typedArrayFromFast) \
     macro(instanceOf) \
     macro(isArray) \

--- a/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayConstructor.js
@@ -109,14 +109,14 @@ function from(items /* [ , mapfn [ , thisArg ] ] */)
         @throwTypeError("TypedArray.from constructed typed array of insufficient length");
 
     for (var k = 0; k < arrayLikeLength; k++) {
-        if (@isTypedArrayView(arrayLike) && (@isDetached(arrayLike) || k >= @typedArrayLength(arrayLike)))
+        if (@isTypedArrayView(arrayLike) && (@isTypedArrayOutOfBounds(arrayLike) || k >= @typedArrayLength(arrayLike)))
             break;
         var value = arrayLike[k];
         if (mapFn === @undefined)
             result[k] = value;
         else {
             var mapped = thisArg === @undefined ? mapFn(value, k) : mapFn.@call(thisArg, value, k);
-            if (@isTypedArrayView(result) && (k >= @typedArrayLength(result) || @isDetached(result)))
+            if (@isTypedArrayView(result) && (@isTypedArrayOutOfBounds(result) || k >= @typedArrayLength(result)))
                 break;
             result[k] = mapped;
         }

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -80,6 +80,7 @@ class JSGlobalObject;
     v(isResizableOrGrowableSharedTypedArrayView, nullptr) \
     v(typedArrayFromFast, nullptr) \
     v(isDetached, nullptr) \
+    v(isTypedArrayOutOfBounds, nullptr) \
     v(isFinite, nullptr) \
     v(instanceOf, nullptr) \
     v(BuiltinLog, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2076,6 +2076,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isDetached)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 1, "typedArrayViewIsDetached"_s, typedArrayViewPrivateFuncIsDetached, ImplementationVisibility::Private));
         });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isTypedArrayOutOfBounds)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, init.owner, 1, "typedArrayViewIsOutOfBounds"_s, typedArrayViewPrivateFuncIsOutOfBounds, ImplementationVisibility::Private));
+    });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::instanceOf)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 0, "instanceOf"_s, objectPrivateFuncInstanceOf, ImplementationVisibility::Private));
         });

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -68,6 +68,13 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsDetached, (JSGlobalObject*, 
     return JSValue::encode(jsBoolean(uncheckedDowncast<JSArrayBufferView>(argument)->isDetached()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncIsOutOfBounds, (JSGlobalObject*, CallFrame* callFrame))
+{
+    JSValue argument = callFrame->uncheckedArgument(0);
+    ASSERT(argument.isCell() && isTypedView(argument.asCell()->type()));
+    return JSValue::encode(jsBoolean(uncheckedDowncast<JSArrayBufferView>(argument)->isOutOfBounds()));
+}
+
 JSC_DEFINE_HOST_FUNCTION(typedArrayViewPrivateFuncLength, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h
@@ -56,6 +56,7 @@ JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsSharedTypedArrayView);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsResizableOrGrowableSharedTypedArrayView);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncTypedArrayFromFast);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsDetached);
+JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncIsOutOfBounds);
 JSC_DECLARE_HOST_FUNCTION(typedArrayViewPrivateFuncLength);
 
 } // namespace JSC


### PR DESCRIPTION
#### 8f27e23da3f50ea65b0eac233f4a84069cf17459
<pre>
[JSC] `TypedArray.from()` spuriously throws when `mapFn` detaches or shrinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=318596">https://bugs.webkit.org/show_bug.cgi?id=318596</a>

Reviewed by Yusuke Suzuki.

The guards added in 316137@main stop writing when mapFn detaches or shrinks
the source/result typed array, but they consult @typedArrayLength before
(or instead of) checking out-of-bounds-ness, and @typedArrayLength throws a
TypeError for detached or out-of-bounds views. As a result,

    const rab = new ArrayBuffer(32, { maxByteLength: 64 });
    const source = new Int32Array(rab, 0, 8);
    source[Symbol.iterator] = null;
    Int32Array.from(source, (v, k) =&gt; { if (k === 4) rab.resize(16); return v; });

throws a TypeError where the spec requires Get/Set on the now out-of-bounds
view to be silent. The same happens when mapFn detaches the result&apos;s buffer,
where the intended @isDetached(result) operand was unreachable dead code.

This change adds a non-throwing @isTypedArrayOutOfBounds private function
exposing JSArrayBufferView::isOutOfBounds() (the spec&apos;s
IsArrayBufferViewOutOfBounds, which also covers detached views) and makes
both guards check it before calling @typedArrayLength.

Test: JSTests/stress/typedarray-from-oob-not-detached.js

* JSTests/stress/typedarray-from-oob-not-detached.js: Added.
(shouldBe):
(testResultShrunkOutOfBounds.FixedLengthOnResizable):
(testResultShrunkOutOfBounds):
(testResultDetached.ViewOnTransferableBuffer):
(testResultDetached):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/TypedArrayConstructor.js:
(from):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.h:

Canonical link: <a href="https://commits.webkit.org/316525@main">https://commits.webkit.org/316525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32030fa30855fd9d456187c237f9b63b28e0a936

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134226 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34572 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30628 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3283 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184562 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33832 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143009 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46161 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142888 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38596 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46839 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111713 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37905 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118591 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205249 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45356 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9205 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54797 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44756 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->