### PR TITLE
Web Inspector: 'arguments' should be accessible from the console

### DIFF
--- a/LayoutTests/inspector/debugger/breakpoint-scope-expected.txt
+++ b/LayoutTests/inspector/debugger/breakpoint-scope-expected.txt
@@ -4,10 +4,12 @@ Testing that we can access scope in various functions.
 Starting Test
 Hit breakpoint at line: 4, column: 8
 scope-chain-type-closure properties:
+    arguments
     reject
     resolve
 scope-chain-type-closure properties:
     p
+    arguments
 scope-chain-type-global-lexical-environment properties:
     lexicalVariable
 scope-chain-type-global (properties not listed)

--- a/LayoutTests/inspector/debugger/paused-scopes-expected.txt
+++ b/LayoutTests/inspector/debugger/paused-scopes-expected.txt
@@ -11,15 +11,18 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:21:29)
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:21:29)
+    - arguments
     - barVarVariable1
   SCOPE: Name (firstPause) - Type (FunctionName) - Hash (firstPause:<sourceID>:21:29)
     - firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -30,13 +33,16 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Block) - Hash (firstPause:<sourceID>:21:29)
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (Local) - Hash (firstPause:<sourceID>:21:29)
+    - arguments
     - barVarVariable1
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (FunctionName) - Hash (firstPause:<sourceID>:21:29)
     - firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -50,9 +56,11 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -61,8 +69,10 @@ CALLFRAME: firstPause
 
 ---- Merged Scope Chain ----
   SCOPE: Name (firstPause) - Type (Local) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -76,6 +86,7 @@ CALLFRAME: entry
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -84,6 +95,7 @@ CALLFRAME: entry
 
 ---- Merged Scope Chain ----
   SCOPE: Name (entry) - Type (Local) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -101,6 +113,7 @@ CALLFRAME: secondPause
   SCOPE: Name (secondPause) - Type (Closure) - Hash (secondPause:<sourceID>:6:21)
     - shoeLexicalVariable1
   SCOPE: Name (secondPause) - Type (Closure) - Hash (secondPause:<sourceID>:6:21)
+    - arguments
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
   SCOPE: Name () - Type (Global) - Hash ()
@@ -109,6 +122,7 @@ CALLFRAME: secondPause
   SCOPE: Name (secondPause) - Type (Block) - Hash (secondPause:<sourceID>:6:21)
     - blockLexicalVariable
   SCOPE: Name (secondPause) - Type (Local) - Hash (secondPause:<sourceID>:6:21)
+    - arguments
     - shoeLexicalVariable1
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
@@ -122,15 +136,18 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:21:29)
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:21:29)
+    - arguments
     - barVarVariable1
   SCOPE: Name (firstPause) - Type (FunctionName) - Hash (firstPause:<sourceID>:21:29)
     - firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -141,13 +158,16 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Block) - Hash (firstPause:<sourceID>:21:29)
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (Local) - Hash (firstPause:<sourceID>:21:29)
+    - arguments
     - barVarVariable1
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (FunctionName) - Hash (firstPause:<sourceID>:21:29)
     - firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -161,9 +181,11 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -172,8 +194,10 @@ CALLFRAME: firstPause
 
 ---- Merged Scope Chain ----
   SCOPE: Name (firstPause) - Type (Local) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -187,6 +211,7 @@ CALLFRAME: entry
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -195,6 +220,7 @@ CALLFRAME: entry
 
 ---- Merged Scope Chain ----
   SCOPE: Name (entry) - Type (Local) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -210,17 +236,21 @@ CALLFRAME:
   SCOPE: Name () - Type (Closure) - Hash (:<sourceID>:36:14)
     - localVariableInsideAnonymousFunction
   SCOPE: Name () - Type (Closure) - Hash (:<sourceID>:36:14)
+    - arguments
   SCOPE: Name (thirdPause) - Type (Closure) - Hash (thirdPause:<sourceID>:34:20)
     - closureVariableInsideThirdPause
   SCOPE: Name (thirdPause) - Type (Closure) - Hash (thirdPause:<sourceID>:34:20)
+    - arguments
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
   SCOPE: Name () - Type (Global) - Hash ()
 
 ---- Merged Scope Chain ----
   SCOPE: Name () - Type (Local) - Hash (:<sourceID>:36:14)
+    - arguments
     - localVariableInsideAnonymousFunction
   SCOPE: Name (thirdPause) - Type (Closure) - Hash (thirdPause:<sourceID>:34:20)
+    - arguments
     - closureVariableInsideThirdPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
@@ -232,12 +262,14 @@ CALLFRAME: thirdPause
   SCOPE: Name (thirdPause) - Type (Closure) - Hash (thirdPause:<sourceID>:34:20)
     - closureVariableInsideThirdPause
   SCOPE: Name (thirdPause) - Type (Closure) - Hash (thirdPause:<sourceID>:34:20)
+    - arguments
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
   SCOPE: Name () - Type (Global) - Hash ()
 
 ---- Merged Scope Chain ----
   SCOPE: Name (thirdPause) - Type (Local) - Hash (thirdPause:<sourceID>:34:20)
+    - arguments
     - closureVariableInsideThirdPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
@@ -251,15 +283,18 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:21:29)
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:21:29)
+    - arguments
     - barVarVariable1
   SCOPE: Name (firstPause) - Type (FunctionName) - Hash (firstPause:<sourceID>:21:29)
     - firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -270,13 +305,16 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Block) - Hash (firstPause:<sourceID>:21:29)
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (Local) - Hash (firstPause:<sourceID>:21:29)
+    - arguments
     - barVarVariable1
     - barLexicalVariable2
   SCOPE: Name (firstPause) - Type (FunctionName) - Hash (firstPause:<sourceID>:21:29)
     - firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -290,9 +328,11 @@ CALLFRAME: firstPause
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (firstPause) - Type (Closure) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -301,8 +341,10 @@ CALLFRAME: firstPause
 
 ---- Merged Scope Chain ----
   SCOPE: Name (firstPause) - Type (Local) - Hash (firstPause:<sourceID>:19:24)
+    - arguments
     - fakeFirstPauseLexicalVariable
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -316,6 +358,7 @@ CALLFRAME: entry
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
     - fooLexicalVariable2
   SCOPE: Name (entry) - Type (Closure) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
@@ -324,6 +367,7 @@ CALLFRAME: entry
 
 ---- Merged Scope Chain ----
   SCOPE: Name (entry) - Type (Local) - Hash (entry:<sourceID>:14:15)
+    - arguments
     - fooVarVariable1
     - firstPause
     - fooLexicalVariable2
@@ -338,6 +382,7 @@ CALLFRAME: pause
 
 ---- Scope Chain ----
   SCOPE: Name (pause) - Type (Local) - Hash (pause:<sourceID>:7:10)
+    - arguments
   SCOPE: Name (<global>) - Type (Block) - Hash (<global>:<sourceID>:1:1)
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2
@@ -345,6 +390,7 @@ CALLFRAME: pause
 
 ---- Merged Scope Chain ----
   SCOPE: Name (pause) - Type (Local) - Hash (pause:<sourceID>:7:10)
+    - arguments
   SCOPE: Name (<global>) - Type (Block) - Hash (<global>:<sourceID>:1:1)
   SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
     - globalLet2

--- a/LayoutTests/inspector/debugger/tail-deleted-frames/tail-deleted-frames-scopes-expected.txt
+++ b/LayoutTests/inspector/debugger/tail-deleted-frames/tail-deleted-frames-scopes-expected.txt
@@ -19,7 +19,7 @@ CALL STACK:
   -------------
 3: [F] startABC
   ----Scope----
-  --  empty  --
+  arguments: Arguments
   -------------
 4: [P] Global Code
   ----Scope----

--- a/LayoutTests/inspector/debugger/tail-deleted-frames/tail-deleted-frames-vm-entry-expected.txt
+++ b/LayoutTests/inspector/debugger/tail-deleted-frames/tail-deleted-frames-vm-entry-expected.txt
@@ -7,46 +7,57 @@ PAUSED
 CALL STACK:
 0: [F] bar
   ----Scope----
+  arguments: Arguments
   i: 0
   -------------
 1: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 1
   -------------
 2: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 2
   -------------
 3: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 3
   -------------
 4: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 4
   -------------
 5: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 5
   -------------
 6: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 6
   -------------
 7: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 7
   -------------
 8: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 8
   -------------
 9: -F- bar
   ----Scope----
+  arguments: Arguments
   i: 9
   -------------
 10: -F- timeout
   ----Scope----
+  arguments: Arguments
   foo: 25
   -------------
 ASYNC CALL STACK:

--- a/LayoutTests/inspector/model/scope-chain-node-expected.txt
+++ b/LayoutTests/inspector/model/scope-chain-node-expected.txt
@@ -28,6 +28,7 @@ SCOPE CHAIN:
     Closure
       - localVariable2: 12
     Closure
+      - arguments: Arguments
       - localVariable1: 11
     FunctionName
       - functionName: function functionName() {
@@ -42,10 +43,12 @@ SCOPE CHAIN:
     Closure
       - innerClosureVariable2: 6
     Closure
+      - arguments: Arguments
       - innerClosureVariable1: 5
     Closure
       - closureVariable2: 4
     Closure
+      - arguments: Arguments
       - innerScope: function innerScope() {
       - closureVariable1: 3
     GlobalLexicalEnvironment
@@ -55,11 +58,11 @@ SCOPE CHAIN:
 -- Running test case: WI.ScopeChainNode.FunctionNameInFunctionExpression
 SCOPE CHAIN:
     Closure
-      (empty)
+      - arguments: Arguments
     FunctionName
       - functionName: function functionName() {
     Closure
-      (empty)
+      - arguments: Arguments
     GlobalLexicalEnvironment
       - lexicalGlobalVariable: 2
     Global
@@ -67,11 +70,11 @@ SCOPE CHAIN:
 -- Running test case: WI.ScopeChainNode.FunctionNameInClassMethod
 SCOPE CHAIN:
     Closure
-      (empty)
+      - arguments: Arguments
     Block
       - MyClass: class MyClass
     Closure
-      (empty)
+      - arguments: Arguments
     GlobalLexicalEnvironment
       - lexicalGlobalVariable: 2
     Global
@@ -105,33 +108,33 @@ SCOPE CHAIN:
     Closure
       - a: 1
     Closure
-      (empty)
+      - arguments: Arguments
     GlobalLexicalEnvironment
       - lexicalGlobalVariable: 2
     Global
 PASS: Pause #17 - Contains a Block scope.
 SCOPE CHAIN:
     Closure
-      (empty)
+      - arguments: Arguments
     Block
       - MyClass: class MyClass
     Closure
       - a: 1
     Closure
-      (empty)
+      - arguments: Arguments
     GlobalLexicalEnvironment
       - lexicalGlobalVariable: 2
     Global
 PASS: Pause #18 - Contains a Block scope.
 SCOPE CHAIN:
     Closure
-      (empty)
+      - arguments: Arguments
     Block
       - MyClassWithStaticMethod: class MyClassWithStaticMethod
     Closure
       - a: 1
     Closure
-      (empty)
+      - arguments: Arguments
     GlobalLexicalEnvironment
       - lexicalGlobalVariable: 2
     Global

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -480,7 +480,21 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
     bool shouldCaptureSomeOfTheThings = shouldEmitDebugHooks() || functionNode->needsActivation() || containsArrowOrEvalButNotInArrowBlock;
 
     bool shouldCaptureAllOfTheThings = shouldEmitDebugHooks() || usesEval();
-    m_needsArguments = ((functionNode->usesArguments() && !codeBlock->isArrowFunction()) || usesEval() || (functionNode->usesArrowFunction() && !codeBlock->isArrowFunction() && isArgumentsUsedInInnerArrowFunction())) && parseMode != SourceParseMode::ClassFieldInitializerMode;
+    m_needsArguments = ([&] () {
+        if (parseMode != SourceParseMode::ClassFieldInitializerMode) {
+            if (!codeBlock->isArrowFunction()) {
+                if (functionNode->usesArrowFunction() && isArgumentsUsedInInnerArrowFunction())
+                    return true;
+                if (functionNode->usesArguments())
+                    return true;
+                if (shouldEmitDebugHooks())
+                    return true;
+            }
+            if (usesEval())
+                return true;
+        }
+        return false;
+    })();
 
     if (isGeneratorOrAsyncFunctionBodyParseMode(parseMode)) {
         m_needsGeneratorification = true;


### PR DESCRIPTION
#### 080d15ac450c9264e900ac141810ce8e71f39cca
<pre>
Web Inspector: &apos;arguments&apos; should be accessible from the console
<a href="https://bugs.webkit.org/show_bug.cgi?id=121208">https://bugs.webkit.org/show_bug.cgi?id=121208</a>
&lt;<a href="https://rdar.apple.com/problem/14972198">rdar://problem/14972198</a>&gt;

Reviewed by Keith Miller.

* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
Force `arguments` to be created even if it&apos;s not used when the debugger is enabled.

* LayoutTests/inspector/debugger/breakpoint-scope-expected.txt:
* LayoutTests/inspector/debugger/paused-scopes-expected.txt:
* LayoutTests/inspector/debugger/tail-deleted-frames/tail-deleted-frames-scopes-expected.txt:
* LayoutTests/inspector/debugger/tail-deleted-frames/tail-deleted-frames-vm-entry-expected.txt:
* LayoutTests/inspector/model/scope-chain-node-expected.txt:

Canonical link: <a href="https://commits.webkit.org/316515@main">https://commits.webkit.org/316515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b35e7ad38d42dd433cc20789fd07f5a9785869d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130135 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134231 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114703 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34579 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30636 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3290 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184570 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33840 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143015 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46169 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142894 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38588 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46847 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111732 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37911 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118599 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205257 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45364 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9213 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54799 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->