### PR TITLE
Web Inspector: Assertion hit in Models/ResourceTimingData.js

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/ResourceTimingData.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ResourceTimingData.js
@@ -71,11 +71,10 @@ WI.ResourceTimingData = class ResourceTimingData
         if (isNaN(fetchStart) || fetchStart < startTime)
             fetchStart = startTime;
 
-        if (redirectStart < startTime || redirectStart > fetchStart || redirectStart > redirectEnd)
+        if (redirectStart < startTime || redirectEnd < startTime || redirectStart > fetchStart || redirectEnd > fetchStart || redirectStart > redirectEnd) {
             redirectStart = NaN;
-
-        if (redirectEnd < startTime || redirectEnd > fetchStart || redirectEnd < redirectStart)
             redirectEnd = NaN;
+        }
 
         function offsetToTimestamp(offset) {
             return offset > 0 ? fetchStart + (offset / 1000) : NaN;


### PR DESCRIPTION
#### 86249d6089d996c1b3190359781e4ba5251c687d
<pre>
Web Inspector: Assertion hit in Models/ResourceTimingData.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=244260">https://bugs.webkit.org/show_bug.cgi?id=244260</a>
&lt;<a href="https://rdar.apple.com/problem/99047027">rdar://problem/99047027</a>&gt;

Reviewed by Taher Ali.

If one of `redirectStart` or `redirectEnd` is invalid, mark both as such instead of just that one.

* Source/WebInspectorUI/UserInterface/Models/ResourceTimingData.js:
(WI.ResourceTimingData.fromPayload):

Canonical link: <a href="https://commits.webkit.org/317511@main">https://commits.webkit.org/317511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80035b63d547da80ce7695b9955f0c5706b49521

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130141 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134234 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94721 "22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114706 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36282 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34583 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30642 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184576 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143018 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46175 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142897 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39173 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111739 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37916 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118605 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45370 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9224 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->