### PR TITLE
Web Inspector: Elements Tab: every <input> has a Scroll badge

### DIFF
--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt
@@ -18,6 +18,12 @@ PASS: Should have become scrollable
 Changing content length
 PASS: Should have become non-scrollable
 
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.SingleLineTextInput
+PASS: A single-line text input should not be scrollable.
+
+-- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.TextArea
+PASS: A textarea with overflowing content should be scrollable.
+
 -- Running test case: CSS.nodeLayoutFlagsChanged.Scrollable.IFrameContents
 PASS: iframe element should not be scrollable.
 PASS: iframe's #document node should not be scrollable

--- a/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html
+++ b/LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html
@@ -114,6 +114,24 @@ function test()
     });
 
     addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.SingleLineTextInput",
+        description: "Test that a single-line text input with overflowing inner text is not treated as a scrollable container.",
+        selector: "#text-input",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectFalse(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "A single-line text input should not be scrollable.");
+        },
+    });
+
+    addTestCase({
+        name: "CSS.nodeLayoutFlagsChanged.Scrollable.TextArea",
+        description: "Test that a textarea with overflowing content is still treated as a scrollable container.",
+        selector: "#text-area",
+        async domNodeHandler(domNode) {
+            InspectorTest.expectTrue(domNode.layoutFlags.includes(WI.DOMNode.LayoutFlag.Scrollable), "A textarea with overflowing content should be scrollable.");
+        },
+    });
+
+    addTestCase({
         name: "CSS.nodeLayoutFlagsChanged.Scrollable.IFrameContents",
         description: "Test scrollability of document nodes in an iframe",
         selector: "#iframe",
@@ -174,6 +192,10 @@ function test()
     <div class="scroller" id="content-shrinking">
         <div class="contents"></div>
     </div>
+
+    <input id="text-input" style="width: 50px;" value="a very long value that overflows the width of this narrow input to force horizontal scrolling of the inner text">
+
+    <textarea id="text-area" style="width: 50px; height: 50px;">a very long value that overflows the textarea both horizontally and vertically to force it to become scrollable so that it keeps the scrollable badge</textarea>
 
     <iframe id="iframe" srcdoc="
     <html><style>body { height: 3000px; }</style><body>iframe document</body></html>

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -68,6 +68,7 @@
 #include "RenderFlexibleBox.h"
 #include "RenderGrid.h"
 #include "RenderStyleConstants.h"
+#include "RenderTextControlSingleLine.h"
 #include "SVGStyleElement.h"
 #include "SelectorChecker.h"
 #include "ShadowRoot.h"
@@ -918,8 +919,10 @@ OptionSet<InspectorCSSAgent::LayoutFlag> InspectorCSSAgent::layoutFlagsForNode(N
                 if (frameView->isScrollable())
                     layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
             }
-        } else if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(*renderer); renderBox && renderBox->canBeScrolledAndHasScrollableArea())
-            layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
+        } else if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(*renderer)) {
+            if (renderBox->canBeScrolledAndHasScrollableArea() && !is<RenderTextControlSingleLine>(*renderBox))
+                layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
+        }
     }
 
     if (auto contextType = layoutFlagContextType(renderer))


### PR DESCRIPTION
#### 60b1a661632c6d0351d35db4bd6dd04fdadf65c9
<pre>
Web Inspector: Elements Tab: every &lt;input&gt; has a Scroll badge
<a href="https://bugs.webkit.org/show_bug.cgi?id=247161">https://bugs.webkit.org/show_bug.cgi?id=247161</a>
&lt;<a href="https://rdar.apple.com/problem/101661656">rdar://problem/101661656</a>&gt;

Reviewed by Tim Nguyen.

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::layoutFlagsForNode):

* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable.html:
* LayoutTests/inspector/css/nodeLayoutFlagsChanged-Scrollable-expected.txt:

Canonical link: <a href="https://commits.webkit.org/316773@main">https://commits.webkit.org/316773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66d7ed93f9142d506e1b5da3d3e19c658335f642

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182045 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134236 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94722 "1 flakes 22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114708 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184578 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143020 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38742 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46855 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111741 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37912 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118607 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45372 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9227 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->