### PR TITLE
Searching for a regular expression that matches the empty string in the web inspector causes it to hang irrecoverably

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js
@@ -180,8 +180,14 @@ WI.SearchSidebarPanel = class SearchSidebarPanel extends WI.NavigationSidebarPan
         function forEachMatch(lineContent, callback)
         {
             var lineMatch;
-            while ((searchRegex.lastIndex < lineContent.length) && (lineMatch = searchRegex.exec(lineContent)))
+            while ((searchRegex.lastIndex < lineContent.length) && (lineMatch = searchRegex.exec(lineContent))) {
+                if (lineMatch.index === searchRegex.lastIndex) {
+                    ++searchRegex.lastIndex;
+                    continue;
+                }
+
                 callback(lineMatch, searchRegex.lastIndex);
+            }
         }
 
         let resourceCallback = (frameId, url, {result}) => {
@@ -196,15 +202,17 @@ WI.SearchSidebarPanel = class SearchSidebarPanel extends WI.NavigationSidebarPan
             if (!resource)
                 return;
 
-            let resourceTreeElement = this._searchTreeElementForResource(resource);
             let searchMatchObjects = [];
-            this._pendingSearchMatchObjectsForResourceTreeElement.set(resourceTreeElement, searchMatchObjects);
-
             for (let match of result) {
                 forEachMatch(match.lineContent, (lineMatch, lastIndex) => {
                     searchMatchObjects.push(new WI.SourceCodeSearchMatchObject(resource, match.lineContent, searchQuery, new WI.TextRange(match.lineNumber, lineMatch.index, match.lineNumber, lastIndex)));
                 });
             }
+            if (!searchMatchObjects.length)
+                return;
+
+            let resourceTreeElement = this._searchTreeElementForResource(resource);
+            this._pendingSearchMatchObjectsForResourceTreeElement.set(resourceTreeElement, searchMatchObjects);
 
             let remainingSearchResults = this._renderResultsForSourceCodeTreeElement(resourceTreeElement, WI.SearchSidebarPanel._resultsIncrementCount);
             this._createSearchResultsPlaceholderTreeElementIfNeeded(resourceTreeElement, remainingSearchResults);
@@ -239,15 +247,17 @@ WI.SearchSidebarPanel = class SearchSidebarPanel extends WI.NavigationSidebarPan
             if (!result || !result.length)
                 return;
 
-            let scriptTreeElement = this._searchTreeElementForScript(script);
             let searchMatchObjects = [];
-            this._pendingSearchMatchObjectsForResourceTreeElement.set(scriptTreeElement, searchMatchObjects);
-
             for (let match of result) {
                 forEachMatch(match.lineContent, (lineMatch, lastIndex) => {
                     searchMatchObjects.push(new WI.SourceCodeSearchMatchObject(script, match.lineContent, searchQuery, new WI.TextRange(match.lineNumber, lineMatch.index, match.lineNumber, lastIndex)));
                 });
             }
+            if (!searchMatchObjects.length)
+                return;
+
+            let scriptTreeElement = this._searchTreeElementForScript(script);
+            this._pendingSearchMatchObjectsForResourceTreeElement.set(scriptTreeElement, searchMatchObjects);
 
             let remainingSearchResults = this._renderResultsForSourceCodeTreeElement(scriptTreeElement, WI.SearchSidebarPanel._resultsIncrementCount);
             this._createSearchResultsPlaceholderTreeElementIfNeeded(scriptTreeElement, remainingSearchResults);


### PR DESCRIPTION
#### 434d012149df7c0ec24f418d594699be2f1805eb
<pre>
Searching for a regular expression that matches the empty string in the web inspector causes it to hang irrecoverably
<a href="https://bugs.webkit.org/show_bug.cgi?id=251622">https://bugs.webkit.org/show_bug.cgi?id=251622</a>
&lt;<a href="https://rdar.apple.com/problem/105231661">rdar://problem/105231661</a>&gt;

Reviewed by Alexey Proskuryakov.

In the case that the search regex can match nothing, increment the `lastIndex` to move forward.

If every match is an empty string, don&apos;t show any results.

* Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.js:
(WI.SearchSidebarPanel.prototype.performSearch.forEachMatch):
(WI.SearchSidebarPanel.prototype.performSearch.resourceCallback):
(WI.SearchSidebarPanel.prototype.performSearch.scriptCallback):

Canonical link: <a href="https://commits.webkit.org/316613@main">https://commits.webkit.org/316613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dc7099e60685a15d5360cf0c085f384bb29eb00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182432 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46567 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37920 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114997 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31030 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184967 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46562 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143206 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38647 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47240 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112250 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119000 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45757 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45158 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->