### PR TITLE
Web Inspector: Search doesn't find results in the Shadow DOM

### DIFF
--- a/LayoutTests/inspector/dom/dom-search-shadow-dom-expected.txt
+++ b/LayoutTests/inspector/dom/dom-search-shadow-dom-expected.txt
@@ -1,0 +1,16 @@
+Tests that DOM.performSearch descends into open shadow trees.
+
+
+== Running test suite: DOM.performSearch.ShadowDOM
+-- Running test case: DOM.performSearch.ShadowDOM.PlainText
+query "needle-text-in-shadow" -> resultCount 2
+PASS: Should find at least one node inside the shadow tree.
+
+-- Running test case: DOM.performSearch.ShadowDOM.CSSSelector
+query ".needle-class" -> resultCount 2
+PASS: Should find at least one node inside the shadow tree.
+
+-- Running test case: DOM.performSearch.ShadowDOM.TagName
+query "section" -> resultCount 2
+PASS: Should find at least one node inside the shadow tree.
+

--- a/LayoutTests/inspector/dom/dom-search-shadow-dom.html
+++ b/LayoutTests/inspector/dom/dom-search-shadow-dom.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script>
+function setup() {
+    let host = document.getElementById("host");
+    let shadow = host.attachShadow({mode: "open"});
+    shadow.innerHTML = `<section><span class="needle-class" data-needle-attr="1">needle-text-in-shadow</span></section>`;
+}
+
+function test()
+{
+    let suite = ProtocolTest.createAsyncSuite("DOM.performSearch.ShadowDOM");
+
+    async function search(query) {
+        await InspectorProtocol.awaitCommand({method: "DOM.getDocument", params: {}});
+        let {resultCount} = await InspectorProtocol.awaitCommand({method: "DOM.performSearch", params: {query}});
+        return resultCount;
+    }
+
+    for (let {name, query} of [
+        {name: "PlainText", query: "needle-text-in-shadow"},
+        {name: "CSSSelector", query: ".needle-class"},
+        {name: "TagName", query: "section"},
+    ]) {
+        suite.addTestCase({
+            name: `DOM.performSearch.ShadowDOM.${name}`,
+            description: `Search inside an open shadow root should find nodes (query: ${name}).`,
+            async test() {
+                let resultCount = await search(query);
+                ProtocolTest.log(`query ${JSON.stringify(query)} -> resultCount ${resultCount}`);
+                ProtocolTest.expectGreaterThanOrEqual(resultCount, 1, "Should find at least one node inside the shadow tree.");
+            },
+        });
+    }
+
+    ProtocolTest.evaluateInPage("setup()").then(() => {
+        suite.runTestCasesAndFinish();
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that DOM.performSearch descends into open shadow trees.</p>
+<div id="host"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorNodeFinder.cpp
+++ b/Source/WebCore/inspector/InspectorNodeFinder.cpp
@@ -93,6 +93,8 @@ void InspectorNodeFinder::searchUsingDOMTreeTraversal(Node& parentNode)
                 m_results.add(node);
             if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*node))
                 performSearch(protect(frameOwner->contentDocument()).get());
+            if (RefPtr shadowRoot = downcast<Element>(*node).shadowRoot())
+                performSearch(shadowRoot.get());
             break;
         default:
             break;


### PR DESCRIPTION
#### 4326ae9fda1b8498c56286d85826f51af7a559e3
<pre>
Web Inspector: Search doesn&apos;t find results in the Shadow DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=272313">https://bugs.webkit.org/show_bug.cgi?id=272313</a>
&lt;<a href="https://rdar.apple.com/problem/126458322">rdar://problem/126458322</a>&gt;

Reviewed by Taher Ali.

* Source/WebCore/inspector/InspectorNodeFinder.cpp:
(WebCore::InspectorNodeFinder::searchUsingDOMTreeTraversal):

* LayoutTests/inspector/dom/dom-search-shadow-dom.html: Added.
* LayoutTests/inspector/dom/dom-search-shadow-dom-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317500@main">https://commits.webkit.org/317500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db2b1cdd46756d125abe2d298439ade3478268d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182056 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134246 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94731 "9 flakes 22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37649 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154771 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34593 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184589 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37284 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143031 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142910 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39167 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31114 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111754 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118618 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45383 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->