### PR TITLE
Web Inspector: JavaScript breakpoint on a line with just a semicolon doesn't get triggered

### DIFF
--- a/LayoutTests/inspector/debugger/breakpoint-empty-statement-expected.txt
+++ b/LayoutTests/inspector/debugger/breakpoint-empty-statement-expected.txt
@@ -1,0 +1,8 @@
+Testing that a breakpoint on a line containing only an empty statement is triggered.
+
+line 2 -> actualLocation line 2 col 4
+line 3 -> actualLocation line 4 col 4
+line 4 -> actualLocation line 4 col 4
+Paused at line: 4
+PASS: breakpoint on the empty statement was triggered.
+

--- a/LayoutTests/inspector/debugger/breakpoint-empty-statement.html
+++ b/LayoutTests/inspector/debugger/breakpoint-empty-statement.html
@@ -1,0 +1,56 @@
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script src="resources/empty-statement.js"></script>
+<script>
+function test()
+{
+    InspectorProtocol.sendCommand("Debugger.enable", {});
+    InspectorProtocol.sendCommand("Debugger.setBreakpointsActive", {active: true});
+
+    let paused = false;
+
+    InspectorProtocol.eventHandler["Debugger.scriptParsed"] = function(messageObject)
+    {
+        if (!/resources\/empty-statement\.js$/.test(messageObject.params.url))
+            return;
+
+        let scriptId = messageObject.params.scriptId;
+
+        function probe(lineNumber, next) {
+            InspectorProtocol.sendCommand("Debugger.setBreakpoint", {location: {scriptId, lineNumber, columnNumber: 0}}, function(response) {
+                let actual = response.result ? response.result.actualLocation : null;
+                ProtocolTest.log(`line ${lineNumber} -> actualLocation ${actual ? "line " + actual.lineNumber + " col " + actual.columnNumber : "(none)"}`);
+                if (response.result && response.result.breakpointId)
+                    InspectorProtocol.sendCommand("Debugger.removeBreakpoint", {breakpointId: response.result.breakpointId}, next);
+                else
+                    next();
+            });
+        }
+
+        probe(2, () => probe(3, () => probe(4, () => {
+            let location = {scriptId, lineNumber: 3, columnNumber: 0};
+            InspectorProtocol.sendCommand("Debugger.setBreakpoint", {location}, function(response) {
+                InspectorProtocol.checkForError(response);
+                InspectorProtocol.sendCommand("Runtime.evaluate", {expression: "testEmptyStatementBreakpoint()"}, function() {
+                    ProtocolTest.log(paused ? "PASS: breakpoint on the empty statement was triggered." : "FAIL: breakpoint on the empty statement was NOT triggered.");
+                    InspectorProtocol.sendCommand("Debugger.disable");
+                    ProtocolTest.completeTest();
+                });
+            });
+        })));
+    };
+
+    InspectorProtocol.eventHandler["Debugger.paused"] = function(messageObject)
+    {
+        paused = true;
+        ProtocolTest.log("Paused at line: " + messageObject.params.callFrames[0].location.lineNumber);
+        InspectorProtocol.sendCommand("Debugger.resume", {});
+    };
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing that a breakpoint on a line containing only an empty statement is triggered.</p>
+</body>
+</html>

--- a/LayoutTests/inspector/debugger/resources/empty-statement.js
+++ b/LayoutTests/inspector/debugger/resources/empty-statement.js
@@ -1,0 +1,6 @@
+function testEmptyStatementBreakpoint()
+{
+    let s = "hello";
+    ;
+    return s;
+}

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2150,7 +2150,6 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatement(Tre
         JSTokenLocation location(tokenLocation());
         next();
         result = context.createEmptyStatement(location);
-        shouldSetPauseLocation = true;
         break;
     }
     case IF:


### PR DESCRIPTION
#### 3df7f122b6c75b2cc4f0e4dfb4022d2351d5bc8a
<pre>
Web Inspector: JavaScript breakpoint on a line with just a semicolon doesn&apos;t get triggered
<a href="https://bugs.webkit.org/show_bug.cgi?id=272916">https://bugs.webkit.org/show_bug.cgi?id=272916</a>
&lt;<a href="https://rdar.apple.com/problem/126707973">rdar://problem/126707973</a>&gt;

Reviewed by Keith Miller.

Don&apos;t add a pause location for empty statements as there&apos;s nothing to execute.

* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseStatement):

* LayoutTests/inspector/debugger/breakpoint-empty-statement.html: Added.
* LayoutTests/inspector/debugger/breakpoint-empty-statement-expected.txt: Added.
* LayoutTests/inspector/debugger/resources/empty-statement.js: Added.

Canonical link: <a href="https://commits.webkit.org/316519@main">https://commits.webkit.org/316519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c12a38ad2830206b98da565cfb98cb79a856749b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130155 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134248 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36285 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34595 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30656 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3301 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184590 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33860 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143037 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38591 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46867 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111755 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37926 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118619 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205277 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45384 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9225 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->