### PR TITLE
Uncaught Exception: Uncaught TypeError: Cannot read properties of null (reading 'collapseToEnd')

### DIFF
--- a/LayoutTests/inspector/css/add-css-property-without-source-range-expected.txt
+++ b/LayoutTests/inspector/css/add-css-property-without-source-range-expected.txt
@@ -1,0 +1,13 @@
+Testing that adding a CSS property to a style with no source range does not throw.
+
+
+== Running test suite: AddCSSPropertyWithoutSourceRange
+-- Running test case: AddCSSPropertyWithoutSourceRange
+PASS: Should have a matched style with no source range.
+PASS: newBlankProperty(0) should not throw for a style with no source range.
+PASS: newBlankProperty(0) should return a property.
+PASS: newBlankProperty(1) should not throw for a style with no source range.
+PASS: newBlankProperty(1) should return a property.
+PASS: newBlankProperty(2) should not throw for a style with no source range.
+PASS: newBlankProperty(2) should return a property.
+

--- a/LayoutTests/inspector/css/add-css-property-without-source-range.html
+++ b/LayoutTests/inspector/css/add-css-property-without-source-range.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("AddCSSPropertyWithoutSourceRange");
+
+    suite.addTestCase({
+        name: "AddCSSPropertyWithoutSourceRange",
+        description: "newBlankProperty should not throw for a style that has no source range, such as a user agent rule.",
+        async test() {
+            let documentNode = await WI.domManager.requestDocument();
+            let nodeId = await documentNode.querySelector("#target");
+            let domNode = WI.domManager.nodeForId(nodeId);
+            let nodeStyles = WI.cssManager.stylesForNode(domNode);
+            await nodeStyles.refreshIfNeeded();
+
+            let style = nodeStyles.matchedRules.map((rule) => rule.style).find((rule) => !rule.styleSheetTextRange);
+            InspectorTest.expectThat(style, "Should have a matched style with no source range.");
+            if (!style)
+                return;
+
+            for (let index of [0, 1, 2]) {
+                let threw = false;
+                let property = null;
+                try {
+                    property = style.newBlankProperty(index);
+                } catch (exception) {
+                    threw = true;
+                    InspectorTest.log(`newBlankProperty(${index}) threw: ${exception}`);
+                }
+                InspectorTest.expectThat(!threw, `newBlankProperty(${index}) should not throw for a style with no source range.`);
+                InspectorTest.expectThat(property, `newBlankProperty(${index}) should return a property.`);
+            }
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing that adding a CSS property to a style with no source range does not throw.</p>
+<div id="target"></div>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
@@ -634,13 +634,13 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
     _rangeAfterPropertyAtIndex(index)
     {
         if (index < 0)
-            return this._styleSheetTextRange.collapseToStart();
+            return this._styleSheetTextRange?.collapseToStart() || null;
 
         if (index >= this.visibleProperties.length)
-            return this._styleSheetTextRange.collapseToEnd();
+            return this._styleSheetTextRange?.collapseToEnd() || null;
 
         let property = this.visibleProperties[index];
-        return property.styleSheetTextRange.collapseToEnd();
+        return property.styleSheetTextRange?.collapseToEnd() || null;
     }
 };
 


### PR DESCRIPTION
#### eac201ada8db46bfc8ca0f453e24c2a1203732b1
<pre>
Uncaught Exception: Uncaught TypeError: Cannot read properties of null (reading &apos;collapseToEnd&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=273760">https://bugs.webkit.org/show_bug.cgi?id=273760</a>
&lt;<a href="https://rdar.apple.com/problem/127991410">rdar://problem/127991410</a>&gt;

Reviewed by Taher Ali.

This can happen when a property to a style that has no source range (e.g. UserAgent styles).

Match the existing guard in `WI.DOMNodeStyles.prototype.changeStyleText` that allows for this.

* Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js:
(WI.CSSStyleDeclaration.prototype._rangeAfterPropertyAtIndex):

* LayoutTests/inspector/css/add-css-property-without-source-range.html: Added.
* LayoutTests/inspector/css/add-css-property-without-source-range-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/317513@main">https://commits.webkit.org/317513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/245e45a324372fbcea58aa3bbb5a73e9c8fe86db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134249 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94733 "1 flakes 21 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36289 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184591 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38799 "Found 1 new test failure: http/tests/site-isolation/page-zoom.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143033 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142912 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39175 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46868 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31119 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111758 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37927 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118620 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45385 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9228 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->