### PR TITLE
Web Inspector: Crash when opened with CSS Variable @keyframes Animation

### DIFF
--- a/LayoutTests/inspector/animation/keyframes-custom-property-expected.txt
+++ b/LayoutTests/inspector/animation/keyframes-custom-property-expected.txt
@@ -1,0 +1,29 @@
+Tests that getting the keyframes of a CSS animation that animates a registered custom property does not crash. Bug 283981
+
+
+== Running test suite: Animation.CustomPropertyKeyframes
+-- Running test case: Animation.CustomPropertyKeyframes.NoCrash
+PASS: Animation created 'spin'.
+PASS: Animation type should be CSS Animation.
+iterationCount: 1
+iterationDuration: 10000
+timingFunction: "linear"
+playbackDirection: "normal"
+fillMode: "none"
+keyframes:
+[
+  {
+    "offset": 0,
+    "easing": "linear",
+    "style": "--angle: 0deg;"
+  },
+  {
+    "offset": 1,
+    "easing": "linear",
+    "style": "--angle: 360deg;"
+  }
+]
+
+PASS: Animation should have keyframes.
+PASS: Keyframes should include the animated custom property.
+

--- a/LayoutTests/inspector/animation/keyframes-custom-property.html
+++ b/LayoutTests/inspector/animation/keyframes-custom-property.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="resources/lifecycle-utilities.js"></script>
+<style>
+@property --angle {
+    syntax: "<angle>";
+    initial-value: 0turn;
+    inherits: false;
+}
+
+@keyframes spin {
+    from { --angle: 0turn; }
+    to { --angle: 1turn; }
+}
+
+#target.active {
+    animation: spin 10s linear;
+}
+</style>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Animation.CustomPropertyKeyframes");
+
+    suite.addTestCase({
+        name: "Animation.CustomPropertyKeyframes.NoCrash",
+        description: "Getting the keyframes of a CSS animation that animates a registered custom property should not crash.",
+        async test() {
+            let [animation] = await Promise.all([
+                InspectorTest.AnimationLifecycleUtilities.awaitAnimationCreated(WI.Animation.Type.CSSAnimation),
+                InspectorTest.evaluateInPage(`document.getElementById("target").classList.add("active")`),
+            ]);
+
+            await animation.ensureEffect();
+
+            InspectorTest.expectNotEmpty(animation.keyframes, "Animation should have keyframes.");
+            InspectorTest.expectTrue(animation.keyframes.some((keyframe) => keyframe.style?.includes("--angle")), "Keyframes should include the animated custom property.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that getting the keyframes of a CSS animation that animates a registered custom property does not crash. <a href="https://webkit.org/b/283981">Bug 283981</a></p>
+<div id="target"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -175,7 +175,7 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Animation::Keyframe>> buildObjectF
                         stylePayloadBuilder.append(
                             customProperty,
                             ": "_s,
-                            computedStyleExtractor.customPropertyValueSerialization(customProperty, CSS::defaultSerializationContext())
+                            computedStyleExtractor.customPropertyValueSerializationInStyle(style, customProperty, CSS::defaultSerializationContext())
                         );
                     }
                 );


### PR DESCRIPTION
#### 401e156fe3e88acc612597a6c68358b534c7ccd2
<pre>
Web Inspector: Crash when opened with CSS Variable @keyframes Animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=283981">https://bugs.webkit.org/show_bug.cgi?id=283981</a>
&lt;<a href="https://rdar.apple.com/problem/140880870">rdar://problem/140880870</a>&gt;

Reviewed by Antoine Quint.

Custom properties in a keyframe should be serialized from the keyframe&apos;s own style instead of the current computed style.

* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):

* LayoutTests/inspector/animation/keyframes-custom-property.html: Added.
* LayoutTests/inspector/animation/keyframes-custom-property-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/316540@main">https://commits.webkit.org/316540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/361578f4b9e87ee130e0afacfb3120c36d5c2985

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134250 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36290 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34599 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184592 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143034 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142913 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38607 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46869 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111759 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37928 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118621 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45386 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9231 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44786 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->