### PR TITLE
Web Inspector: Allow redefinition of let and const in REPL

### DIFF
--- a/LayoutTests/inspector/runtime/evaluate-CommandLineAPI-expected.txt
+++ b/LayoutTests/inspector/runtime/evaluate-CommandLineAPI-expected.txt
@@ -19,8 +19,9 @@ PASS: Should be able to access created const in global scope.
 -- Running test case: CreateGlobalClass
 PASS: Should be able to access class created in earlier evaluation.
 
--- Running test case: ExpectedExceptionCreatingDuplicateLexicalGlobalVariables
-PASS: Should be an exception defining a lexical global multiple times.
+-- Running test case: RedeclaringLexicalGlobalVariableRebinds
+PASS: Should be able to access the lexical global.
+PASS: Re-declaring a lexical global should rebind it to the new value.
 
 -- Running test case: NonStrictAndStrictEvaluations
 PASS: Non-strict evaluation. Should be able to access arguments.callee.

--- a/LayoutTests/inspector/runtime/evaluate-CommandLineAPI.html
+++ b/LayoutTests/inspector/runtime/evaluate-CommandLineAPI.html
@@ -106,12 +106,16 @@ function test()
     });
 
     suite.addTestCase({
-        name: "ExpectedExceptionCreatingDuplicateLexicalGlobalVariables",
-        description: "Test evaluate produces expected exception creating duplicate lexical global variables across evaluations.",
+        name: "RedeclaringLexicalGlobalVariableRebinds",
+        description: "Test evaluate rebinds a lexical global when it is re-declared across evaluations instead of throwing.",
         test(resolve, reject) {
             testEvaluate(`let duplicateGlobalVariable = 1`);
-            testEvaluateThrow(`let duplicateGlobalVariable = 1`, (wasThrown) => {
-                InspectorTest.expectThat(wasThrown, "Should be an exception defining a lexical global multiple times.");
+            testEvaluate(`duplicateGlobalVariable`, (resultValue) => {
+                InspectorTest.expectThat(resultValue === 1, "Should be able to access the lexical global.");
+            });
+            testEvaluate(`let duplicateGlobalVariable = 2`);
+            testEvaluate(`duplicateGlobalVariable`, (resultValue) => {
+                InspectorTest.expectThat(resultValue === 2, "Re-declaring a lexical global should rebind it to the new value.");
                 resolve();
             });
         }

--- a/LayoutTests/inspector/runtime/repl-redeclaration-expected.txt
+++ b/LayoutTests/inspector/runtime/repl-redeclaration-expected.txt
@@ -1,0 +1,27 @@
+Tests that re-declaring a top-level let/const/class in the console rebinds it instead of throwing "has already been declared". Bug 285757
+
+
+== Running test suite: Runtime.evaluate.REPLRedeclaration
+-- Running test case: Runtime.evaluate.REPLRedeclaration.let
+PASS: `let replLet = 1;` should not throw.
+PASS: `replLet` should be 1.
+PASS: Re-declaring `let replLet = 2;` should not throw.
+PASS: `replLet` should now be 2.
+
+-- Running test case: Runtime.evaluate.REPLRedeclaration.const
+PASS: `const replConst = 1;` should not throw.
+PASS: `replConst` should be 1.
+PASS: Re-declaring `const replConst = 2;` should not throw.
+PASS: `replConst` should now be 2.
+
+-- Running test case: Runtime.evaluate.REPLRedeclaration.class
+PASS: First `class ReplClass` should not throw.
+PASS: `new ReplClass().m()` should be 1.
+PASS: Re-declaring `class ReplClass` should not throw.
+PASS: `new ReplClass().m()` should now be 2.
+
+-- Running test case: Runtime.evaluate.REPLRedeclaration.CrossKind
+PASS: `const replCross = 1;` should not throw.
+PASS: Re-declaring as `let replCross = 2;` should not throw.
+PASS: `replCross` should now be 2.
+

--- a/LayoutTests/inspector/runtime/repl-redeclaration.html
+++ b/LayoutTests/inspector/runtime/repl-redeclaration.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    const objectGroup = "test";
+    const includeCommandLineAPI = true;
+    const returnByValue = true;
+
+    function evaluate(expression) {
+        return new Promise((resolve, reject) => {
+            RuntimeAgent.evaluate.invoke({expression, objectGroup, includeCommandLineAPI, returnByValue}, (error, resultValue, wasThrown) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve({value: resultValue.value, wasThrown: !!wasThrown});
+            });
+        });
+    }
+
+    let suite = InspectorTest.createAsyncSuite("Runtime.evaluate.REPLRedeclaration");
+
+    suite.addTestCase({
+        name: "Runtime.evaluate.REPLRedeclaration.let",
+        description: "Re-declaring a top-level `let` in the console should rebind it instead of throwing.",
+        async test() {
+            InspectorTest.expectFalse((await evaluate("let replLet = 1;")).wasThrown, "`let replLet = 1;` should not throw.");
+            InspectorTest.expectEqual((await evaluate("replLet")).value, 1, "`replLet` should be 1.");
+
+            InspectorTest.expectFalse((await evaluate("let replLet = 2;")).wasThrown, "Re-declaring `let replLet = 2;` should not throw.");
+            InspectorTest.expectEqual((await evaluate("replLet")).value, 2, "`replLet` should now be 2.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Runtime.evaluate.REPLRedeclaration.const",
+        description: "Re-declaring a top-level `const` in the console should rebind it instead of throwing.",
+        async test() {
+            InspectorTest.expectFalse((await evaluate("const replConst = 1;")).wasThrown, "`const replConst = 1;` should not throw.");
+            InspectorTest.expectEqual((await evaluate("replConst")).value, 1, "`replConst` should be 1.");
+
+            InspectorTest.expectFalse((await evaluate("const replConst = 2;")).wasThrown, "Re-declaring `const replConst = 2;` should not throw.");
+            InspectorTest.expectEqual((await evaluate("replConst")).value, 2, "`replConst` should now be 2.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Runtime.evaluate.REPLRedeclaration.class",
+        description: "Re-declaring a top-level `class` in the console should rebind it instead of throwing.",
+        async test() {
+            InspectorTest.expectFalse((await evaluate("class ReplClass { m() { return 1; } };")).wasThrown, "First `class ReplClass` should not throw.");
+            InspectorTest.expectEqual((await evaluate("new ReplClass().m()")).value, 1, "`new ReplClass().m()` should be 1.");
+
+            InspectorTest.expectFalse((await evaluate("class ReplClass { m() { return 2; } };")).wasThrown, "Re-declaring `class ReplClass` should not throw.");
+            InspectorTest.expectEqual((await evaluate("new ReplClass().m()")).value, 2, "`new ReplClass().m()` should now be 2.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Runtime.evaluate.REPLRedeclaration.CrossKind",
+        description: "Re-declaring across `let`/`const` in the console should not throw and should update the value.",
+        async test() {
+            InspectorTest.expectFalse((await evaluate("const replCross = 1;")).wasThrown, "`const replCross = 1;` should not throw.");
+            InspectorTest.expectFalse((await evaluate("let replCross = 2;")).wasThrown, "Re-declaring as `let replCross = 2;` should not throw.");
+            InspectorTest.expectEqual((await evaluate("replCross")).value, 2, "`replCross` should now be 2.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that re-declaring a top-level <code>let</code>/<code>const</code>/<code>class</code> in the console rebinds it instead of throwing "has already been declared". <a href="https://webkit.org/b/285757">Bug 285757</a></p>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -75,6 +75,7 @@
 #include <wtf/Lock.h>
 #include <wtf/MathExtras.h>
 #include <wtf/PrintStream.h>
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
@@ -128,7 +129,15 @@ JSValue JSInjectedScriptHost::evaluateWithScopeExtension(JSGlobalObject* globalO
 
     NakedPtr<Exception> exception;
     JSObject* scopeExtension = callFrame->argument(1).getObject();
+
+    bool didAllowRedeclaringSymbols = vm.allowRedeclaringSymbols();
+    vm.setAllowRedeclaringSymbols(true);
+    auto resetAllowRedeclaringSymbols = makeScopeExit([&] {
+        vm.setAllowRedeclaringSymbols(didAllowRedeclaringSymbols);
+    });
+
     JSValue result = JSC::evaluateWithScopeExtension(globalObject, makeSource(program, callFrame->callerSourceOrigin(vm), SourceTaintedOrigin::Untainted), scopeExtension, exception);
+
     if (exception)
         throwException(globalObject, scope, exception);
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3927,6 +3927,12 @@ static void runInteractive(GlobalObject* globalObject)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    bool didAllowRedeclaringSymbols = vm.allowRedeclaringSymbols();
+    vm.setAllowRedeclaringSymbols(true);
+    auto resetAllowRedeclaringSymbols = makeScopeExit([&] {
+        vm.setAllowRedeclaringSymbols(didAllowRedeclaringSymbols);
+    });
+
     URL directoryName = currentWorkingDirectory();
     if (!directoryName.isValid())
         return;

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -125,6 +125,8 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, entry.key.get());
                 RETURN_IF_EXCEPTION(throwScope, nullptr);
                 if (hasProperty) {
+                    if (vm.allowRedeclaringSymbols()) [[unlikely]]
+                        continue;
                     if (entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext()) [[unlikely]] {
                         // We only allow "const" duplicate declarations under this setting.
                         // For example, we don't allow "let" variables to be overridden by "const" variables.
@@ -250,6 +252,8 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
         SymbolTable* symbolTable = globalLexicalEnvironment->symbolTable();
         ConcurrentJSLocker locker(symbolTable->m_lock);
         for (auto& entry : lexicalDeclarations) {
+            if (vm.allowRedeclaringSymbols() && symbolTable->contains(locker, entry.key.get())) [[unlikely]]
+                continue;
             if (entry.value.isConst() && !vm.globalConstRedeclarationShouldThrow() && !isInStrictContext()) [[unlikely]] {
                 if (symbolTable->contains(locker, entry.key.get()))
                     continue;

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1026,6 +1026,9 @@ public:
     void setGlobalConstRedeclarationShouldThrow(bool globalConstRedeclarationThrow) { m_globalConstRedeclarationShouldThrow = globalConstRedeclarationThrow; }
     ALWAYS_INLINE bool globalConstRedeclarationShouldThrow() const { return m_globalConstRedeclarationShouldThrow; }
 
+    void setAllowRedeclaringSymbols(bool allowRedeclaringSymbols) { m_allowRedeclaringSymbols = allowRedeclaringSymbols; }
+    ALWAYS_INLINE bool allowRedeclaringSymbols() const { return m_allowRedeclaringSymbols; }
+
     void setShouldBuildPCToCodeOriginMapping() { m_shouldBuildPCToCodeOriginMapping = true; }
     bool shouldBuilderPCToCodeOriginMapping() const { return m_shouldBuildPCToCodeOriginMapping; }
 
@@ -1211,6 +1214,7 @@ public:
 private:
     bool m_failNextNewCodeBlock { false };
     bool m_globalConstRedeclarationShouldThrow { true };
+    bool m_allowRedeclaringSymbols { false };
     bool m_shouldBuildPCToCodeOriginMapping { false };
     DeletePropertyMode m_deletePropertyMode { DeletePropertyMode::Default };
     HeapAnalyzer* m_activeHeapAnalyzer { nullptr };


### PR DESCRIPTION
#### 7c9b3a28260f813e33d0a601c4d00a957347905e
<pre>
Web Inspector: Allow redefinition of let and const in REPL
<a href="https://bugs.webkit.org/show_bug.cgi?id=285757">https://bugs.webkit.org/show_bug.cgi?id=285757</a>
&lt;<a href="https://rdar.apple.com/problem/143140659">rdar://problem/143140659</a>&gt;

Reviewed by Keith Miller.

* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::setAllowRedeclaringSymbols): Added.
(JSC::VM::allowRedeclaringSymbols const): Added.
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::evaluateWithScopeExtension):

* Source/JavaScriptCore/jsc.cpp:
(runInteractive):
Drive-by: also add this for `jsc`.

* LayoutTests/inspector/runtime/evaluate-CommandLineAPI.html:
* LayoutTests/inspector/runtime/evaluate-CommandLineAPI-expected.txt:
* LayoutTests/inspector/runtime/repl-redeclaration.html: Added.
* LayoutTests/inspector/runtime/repl-redeclaration-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/316523@main">https://commits.webkit.org/316523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/900b7b23fe206432b7193de44305e01e98de8adc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114741 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36308 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34617 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30686 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3331 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184620 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33890 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143055 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142933 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38594 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46897 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111807 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37948 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118649 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205307 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45414 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9255 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54810 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->