### PR TITLE
Web Inspector: Copy Link doesn't respect <base> element

### DIFF
--- a/LayoutTests/inspector/dom/resolve-attribute-url-with-base-element-expected.txt
+++ b/LayoutTests/inspector/dom/resolve-attribute-url-with-base-element-expected.txt
@@ -1,0 +1,10 @@
+Testing that attribute URLs resolve against the document's base element.
+
+
+
+== Running test suite: DOM.ResolveAttributeURLWithBaseElement
+-- Running test case: ResolveAttributeURLWithBaseElement
+PASS: Document node should expose the <base> element URL.
+PASS: Base URL should differ from the document URL when a <base> element is present.
+PASS: Relative href should resolve against the <base> element URL.
+

--- a/LayoutTests/inspector/dom/resolve-attribute-url-with-base-element.html
+++ b/LayoutTests/inspector/dom/resolve-attribute-url-with-base-element.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("DOM.ResolveAttributeURLWithBaseElement");
+
+    suite.addTestCase({
+        name: "ResolveAttributeURLWithBaseElement",
+        description: "Attribute URLs should resolve against the document's <base> element so that clicking or copying a link matches the browser.",
+        async test() {
+            let childFrame = Array.from(WI.networkManager.mainFrame.childFrameCollection)[0];
+            InspectorTest.assert(childFrame, "Should have a subframe.");
+
+            let documentNode = await new Promise((resolve) => childFrame.domTree.requestRootDOMNode(resolve));
+            InspectorTest.assert(documentNode, "Should have a document node for the subframe.");
+
+            InspectorTest.expectEqual(documentNode.baseURL, "https://example.com/base/", "Document node should expose the <base> element URL.");
+            InspectorTest.expectThat(documentNode.baseURL !== documentNode.documentURL, "Base URL should differ from the document URL when a <base> element is present.");
+
+            let linkNodeId = await documentNode.querySelector("#link");
+            let linkNode = WI.domManager.nodeForId(linkNodeId);
+            InspectorTest.expectEqual(absoluteURL(linkNode.getAttribute("href"), documentNode.baseURL), "https://example.com/base/page.html", "Relative href should resolve against the <base> element URL.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Testing that attribute URLs resolve against the document's base element.</p>
+<iframe src="resources/base-element.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/inspector/dom/resources/base-element.html
+++ b/LayoutTests/inspector/dom/resources/base-element.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<base href="https://example.com/base/">
+</head>
+<body>
+<a id="link" href="page.html">link</a>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -153,13 +153,12 @@ WI.DOMNode = class DOMNode extends WI.Object
                 this.ownerDocument.documentElement = this;
             if (this.ownerDocument && !this.ownerDocument.body && this._nodeName === "BODY")
                 this.ownerDocument.body = this;
-            if (payload.documentURL)
-                this.documentURL = payload.documentURL;
         } else if (this._nodeType === Node.DOCUMENT_TYPE_NODE) {
             this.publicId = payload.publicId;
             this.systemId = payload.systemId;
         } else if (this._nodeType === Node.DOCUMENT_NODE) {
             this.documentURL = payload.documentURL;
+            this.baseURL = payload.baseURL;
             this.xmlVersion = payload.xmlVersion;
         } else if (this._nodeType === Node.ATTRIBUTE_NODE) {
             this.name = payload.name;

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -1459,7 +1459,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             attrSpanElement.append("=\u200B", quote);
 
         if (name === "src" || /\bhref\b/.test(name)) {
-            let baseURL = node.frame ? node.frame.url : null;
+            let baseURL = node.ownerDocument?.baseURL || node.frame?.url || null;
             let rewrittenURL = absoluteURL(value, baseURL);
             value = value.insertWordBreakCharacters();
             if (!rewrittenURL) {
@@ -1475,7 +1475,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
                 attrSpanElement.appendChild(attrValueElement);
             }
         } else if (name === "srcset") {
-            let baseURL = node.frame ? node.frame.url : null;
+            let baseURL = node.ownerDocument?.baseURL || node.frame?.url || null;
             attrValueElement = attrSpanElement.createChild("span", "html-attribute-value");
 
             // Leading whitespace.


### PR DESCRIPTION
#### 923d01508dbcf9ae23287223629ac6764639cd90
<pre>
Web Inspector: Copy Link doesn&apos;t respect &lt;base&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=317619">https://bugs.webkit.org/show_bug.cgi?id=317619</a>
&lt;<a href="https://rdar.apple.com/problem/180972849">rdar://problem/180972849</a>&gt;

Reviewed by Alexey Proskuryakov.

Use the already provided protocol `DOM.Node.baseURL`.

* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._buildAttributeDOM):

* LayoutTests/inspector/dom/resolve-attribute-url-with-base-element.html: Added.
* LayoutTests/inspector/dom/resolve-attribute-url-with-base-element-expected.txt: Added.
* LayoutTests/inspector/dom/resources/base-element.html: Added.

Canonical link: <a href="https://commits.webkit.org/316599@main">https://commits.webkit.org/316599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/200ef404f1a67c9c46c5bfd21eb214ac6bc76147

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46865 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/40335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/134501 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175904 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114970 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31004 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/34581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184940 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/143309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46536 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/154643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143180 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38642 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47214 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112218 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38165 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/118974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45731 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45132 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/45364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->