### PR TITLE
Show console warning when input[type=color] is clicked without user gesture

### DIFF
--- a/LayoutTests/fast/forms/color/color-input-click-without-user-gesture-expected.txt
+++ b/LayoutTests/fast/forms/color/color-input-click-without-user-gesture-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Color picker was not shown because showing it requires a user gesture.
+

--- a/LayoutTests/fast/forms/color/color-input-click-without-user-gesture.html
+++ b/LayoutTests/fast/forms/color/color-input-click-without-user-gesture.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+<input id="colorInput" type="color">
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener("load", () => {
+    const input = document.getElementById("colorInput");
+    input.offsetHeight;
+
+    // Clicking without a user gesture should not show the picker and should log a warning.
+    input.click();
+
+    // Clicking with a user gesture should show the picker without logging a warning.
+    if (window.internals)
+        internals.withUserGesture(() => { input.click(); });
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -58,6 +58,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UserAgentParts.h"
 #include "UserGestureIndicator.h"
+#include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -253,8 +254,10 @@ void ColorInputType::handleDOMActivateEvent(Event& event)
     if (element()->isDisabledFormControl() || !element()->renderer())
         return;
 
-    if (!UserGestureIndicator::processingUserGesture())
+    if (!UserGestureIndicator::processingUserGesture()) {
+        protect(element()->document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Color picker was not shown because showing it requires a user gesture."_s);
         return;
+    }
 
     showPicker();
     event.setDefaultHandled();


### PR DESCRIPTION
#### b434d632558c7aaddd8e17ec864b702f4ab67eb8
<pre>
Show console warning when input[type=color] is clicked without user gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=263504">https://bugs.webkit.org/show_bug.cgi?id=263504</a>
&lt;<a href="https://rdar.apple.com/problem/117393527">rdar://problem/117393527</a>&gt;

Reviewed by NOBODY (OOPS!).

* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::handleDOMActivateEvent):

* LayoutTests/fast/forms/color/color-input-click-without-user-gesture.html: Added.
* LayoutTests/fast/forms/color/color-input-click-without-user-gesture-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b434d632558c7aaddd8e17ec864b702f4ab67eb8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/95080 "1 flakes 22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176155 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38084 "Found 1 new test failure: fast/css/getComputedStyle-font-variant-shorthand-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155473 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115144 "Found 1 new API test failure: WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35073 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185192 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/38013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143516 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47476 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31618 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112556 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38345 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/119225 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45982 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9917 "Passed tests") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->