### PR TITLE
Web Inspector: No stack trace for mime type errors, very difficult to debug

### DIFF
--- a/LayoutTests/http/tests/security/module-incorrect-mime-types-expected.txt
+++ b/LayoutTests/http/tests/security/module-incorrect-mime-types-expected.txt
@@ -1,12 +1,12 @@
-CONSOLE MESSAGE: TypeError: 'application/json' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'application/octet-stream' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'application/xml' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'image/png' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/html' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/plain' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/vbs' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/vbscript' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/xml' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: 'application/json' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=application/json'.
+CONSOLE MESSAGE: TypeError: 'application/octet-stream' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=application/octet-stream'.
+CONSOLE MESSAGE: TypeError: 'application/xml' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=application/xml'.
+CONSOLE MESSAGE: TypeError: 'image/png' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=image/png'.
+CONSOLE MESSAGE: TypeError: 'text/html' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/html'.
+CONSOLE MESSAGE: TypeError: 'text/plain' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/plain'.
+CONSOLE MESSAGE: TypeError: 'text/vbs' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/vbs'.
+CONSOLE MESSAGE: TypeError: 'text/vbscript' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/vbscript'.
+CONSOLE MESSAGE: TypeError: 'text/xml' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl?mime=text/xml'.
 Test module rejects scripts with incorrect mime types.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/security/module-no-mime-type-expected.txt
+++ b/LayoutTests/http/tests/security/module-no-mime-type-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: 'application/octet-stream' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: 'application/octet-stream' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl'.
 Test module rejects scripts with no mime type.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/wasm/wasm-esm-disabled-with-setting-expected.txt
+++ b/LayoutTests/http/tests/wasm/wasm-esm-disabled-with-setting-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: 'application/wasm' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: 'application/wasm' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/wasm/resources/empty-module.wasm'.
 Test that Wasm ESM integration is disabled when flag is off.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt
@@ -10,7 +10,7 @@ PASS EventSource() fetches with an empty string Request.destination
 PASS HTMLAudioElement fetches with an "audio" Request.destination
 PASS HTMLVideoElement fetches with a "video" Request.destination
 PASS HTMLScriptElement fetches with a "script" Request.destination
-FAIL AudioWorklet module fetches with a "audioworklet" Request.destination promise_test: Unhandled rejection with value: object "TypeError: 'application/octet-stream' is not a valid JavaScript MIME type."
+FAIL AudioWorklet module fetches with a "audioworklet" Request.destination promise_test: Unhandled rejection with value: object "TypeError: 'application/octet-stream' is not a valid JavaScript MIME type for module script 'https://web-platform.test:9443/fetch/api/request/destination/resources/dummy?dest=audioworklet'."
 PASS HTMLLinkElement with rel=stylesheet fetches with a "style" Request.destination
 FAIL Import declaration with `type: "css"` fetches with a "style" Request.destination promise_test: Unhandled rejection with value: "TypeError: Import attribute type \"css\" is not valid"
 PASS Import declaration with `type: "json"` fetches with a "json" Request.destination

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Load a CSS module with dynamic import() promise_test: Unhandled rejection with value: object "TypeError: 'text/css' is not a valid JavaScript MIME type."
+FAIL Load a CSS module with dynamic import() promise_test: Unhandled rejection with value: object "TypeError: 'text/css' is not a valid JavaScript MIME type for module script 'http://web-platform.test:8800/html/semantics/scripting-1/the-script-element/css-module/resources/basic.css'."
 PASS Ensure that loading a CSS module with dymnamic import() fails without a type assertion
 

--- a/LayoutTests/js/dom/modules/missing-exception-check-for-import-expected.txt
+++ b/LayoutTests/js/dom/modules/missing-exception-check-for-import-expected.txt
@@ -10,7 +10,7 @@ Importing a module script should fail if the file is not found.
 PASS String(error) is "TypeError: Importing a module script failed."
 
 Importing a module script should fail if it does not not a valid JavaScript MIME type.
-PASS String(error) is "TypeError: 'text/html' is not a valid JavaScript MIME type."
+PASS String(error) is "TypeError: 'text/html' is not a valid JavaScript MIME type for module script 'data:text/html,Hello World'."
 
 Importing a simple module script should succeed.
 PASS error is null

--- a/LayoutTests/js/dom/modules/missing-exception-check-for-import.html
+++ b/LayoutTests/js/dom/modules/missing-exception-check-for-import.html
@@ -41,7 +41,7 @@
           } catch (e) {
               error = e;
           }
-          shouldBeEqualToString(`String(error)`, `TypeError: 'text/html' is not a valid JavaScript MIME type.`);
+          shouldBeEqualToString(`String(error)`, `TypeError: 'text/html' is not a valid JavaScript MIME type for module script 'data:text/html,Hello World'.`);
 
           debug(`\nImporting a simple module script should succeed.`);
           error = null;

--- a/LayoutTests/platform/gtk/http/tests/security/module-no-mime-type-expected.txt
+++ b/LayoutTests/platform/gtk/http/tests/security/module-no-mime-type-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: 'text/plain' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: 'text/plain' is not a valid JavaScript MIME type for module script 'http://127.0.0.1:8000/security/contentTypeOptions/resources/script-with-header.pl'.
 Test module rejects scripts with no mime type.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt
@@ -10,7 +10,7 @@ PASS EventSource() fetches with an empty string Request.destination
 FAIL HTMLAudioElement fetches with an "audio" Request.destination assert_unreached: Fetch errored. Reached unreachable code
 PASS HTMLVideoElement fetches with a "video" Request.destination
 PASS HTMLScriptElement fetches with a "script" Request.destination
-FAIL AudioWorklet module fetches with a "audioworklet" Request.destination promise_test: Unhandled rejection with value: object "TypeError: 'application/octet-stream' is not a valid JavaScript MIME type."
+FAIL AudioWorklet module fetches with a "audioworklet" Request.destination promise_test: Unhandled rejection with value: object "TypeError: 'application/octet-stream' is not a valid JavaScript MIME type for module script 'https://web-platform.test:9443/fetch/api/request/destination/resources/dummy?dest=audioworklet'."
 PASS HTMLLinkElement with rel=stylesheet fetches with a "style" Request.destination
 FAIL Import declaration with `type: "css"` fetches with a "style" Request.destination promise_test: Unhandled rejection with value: "TypeError: Import attribute type \"css\" is not valid"
 PASS Import declaration with `type: "json"` fetches with a "json" Request.destination

--- a/LayoutTests/webaudio/worklet-crash-expected.txt
+++ b/LayoutTests/webaudio/worklet-crash-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: TypeError: 'text/html' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: 'text/html' is not a valid JavaScript MIME type for module script 'worklet-crash.html'.
 This test passes if it does not crash.

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -516,7 +516,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedScript->response().mimeType(), "' is not a valid JavaScript MIME type."_s));
+            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedScript->response().mimeType(), "' is not a valid JavaScript MIME type for module script '"_s, sourceURL.string(), "'."_s));
             return;
         }
 
@@ -586,7 +586,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', loader.responseMIMEType(), "' is not a valid JavaScript MIME type."_s));
+            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', loader.responseMIMEType(), "' is not a valid JavaScript MIME type for module script '"_s, sourceURL.string(), "'."_s));
             return;
         }
 


### PR DESCRIPTION
#### 2833205e84d545e12f74cc83737b51913848cedb
<pre>
Web Inspector: No stack trace for mime type errors, very difficult to debug
<a href="https://bugs.webkit.org/show_bug.cgi?id=306218">https://bugs.webkit.org/show_bug.cgi?id=306218</a>
&lt;<a href="https://rdar.apple.com/problem/169396940">rdar://problem/169396940</a>&gt;

Reviewed by Yusuke Suzuki.

* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::notifyFinished):

* LayoutTests/http/tests/security/module-incorrect-mime-types-expected.txt:
* LayoutTests/http/tests/security/module-no-mime-type-expected.txt:
* LayoutTests/platform/gtk/http/tests/security/module-no-mime-type-expected.txt:
* LayoutTests/http/tests/wasm/wasm-esm-disabled-with-setting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/fetch/api/request/destination/fetch-destination.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic-expected.txt:
* LayoutTests/js/dom/modules/missing-exception-check-for-import.html:
* LayoutTests/js/dom/modules/missing-exception-check-for-import-expected.txt:
* LayoutTests/webaudio/worklet-crash-expected.txt:

Canonical link: <a href="https://commits.webkit.org/316529@main">https://commits.webkit.org/316529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e2732050e0c3353cbce350beb9c97fc20d8867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34636 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30715 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3355 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184649 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33919 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38837 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143078 "Found 1 new test failure: fast/parser/entity-comment-in-textarea.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142955 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38600 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46926 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111855 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37964 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118678 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45443 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54815 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44843 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->