### PR TITLE
Fix incorrect debug-output strings in RenderStyleConstants.cpp operator<< overloads

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -429,7 +429,7 @@ TextStream& operator<<(TextStream& ts, CursorType cursor)
     case CursorType::NResize: ts << "n-resize"_s; break;
     case CursorType::NEResize: ts << "ne-resize"_s; break;
     case CursorType::NWResize: ts << "nw-resize"_s; break;
-    case CursorType::SResize: ts << "sr-esize"_s; break;
+    case CursorType::SResize: ts << "s-resize"_s; break;
     case CursorType::SEResize: ts << "se-resize"_s; break;
     case CursorType::SWResize: ts << "sw-resize"_s; break;
     case CursorType::WResize: ts << "w-resize"_s; break;
@@ -497,22 +497,22 @@ TextStream& operator<<(TextStream& ts, EventListenerRegionType listenerType)
     case EventListenerRegionType::PointerDown: ts << "pointer down"_s; break;
     case EventListenerRegionType::NonPassivePointerDown: ts << "active pointer down"_s; break;
     case EventListenerRegionType::PointerEnter: ts << "pointer enter"_s; break;
-    case EventListenerRegionType::NonPassivePointerEnter: ts << "active pointer down"_s; break;
+    case EventListenerRegionType::NonPassivePointerEnter: ts << "active pointer enter"_s; break;
     case EventListenerRegionType::PointerLeave: ts << "pointer leave"_s; break;
-    case EventListenerRegionType::NonPassivePointerLeave: ts << "active pointer down"_s; break;
+    case EventListenerRegionType::NonPassivePointerLeave: ts << "active pointer leave"_s; break;
     case EventListenerRegionType::PointerMove: ts << "pointer move"_s; break;
-    case EventListenerRegionType::NonPassivePointerMove: ts << "active pointer down"_s; break;
+    case EventListenerRegionType::NonPassivePointerMove: ts << "active pointer move"_s; break;
     case EventListenerRegionType::PointerOut: ts << "pointer out"_s; break;
-    case EventListenerRegionType::NonPassivePointerOut: ts << "active pointer down"_s; break;
+    case EventListenerRegionType::NonPassivePointerOut: ts << "active pointer out"_s; break;
     case EventListenerRegionType::PointerOver: ts << "pointer over"_s; break;
-    case EventListenerRegionType::NonPassivePointerOver: ts << "active pointer down"_s; break;
+    case EventListenerRegionType::NonPassivePointerOver: ts << "active pointer over"_s; break;
     case EventListenerRegionType::PointerUp: ts << "pointer up"_s; break;
-    case EventListenerRegionType::NonPassivePointerUp: ts << "active pointer down"_s; break;
+    case EventListenerRegionType::NonPassivePointerUp: ts << "active pointer up"_s; break;
     case EventListenerRegionType::MouseDown: ts << "mouse down"_s; break;
     case EventListenerRegionType::NonPassiveMouseDown: ts << "active mouse down"_s; break;
     case EventListenerRegionType::MouseUp: ts << "mouse up"_s; break;
     case EventListenerRegionType::NonPassiveMouseUp: ts << "active mouse up"_s; break;
-    case EventListenerRegionType::MouseMove: ts << "mouse down"_s; break;
+    case EventListenerRegionType::MouseMove: ts << "mouse move"_s; break;
     case EventListenerRegionType::NonPassiveMouseMove: ts << "active mouse move"_s; break;
     case EventListenerRegionType::GestureChange: ts << "gesture change"_s; break;
     case EventListenerRegionType::NonPassiveGestureChange: ts << "active gesture change"_s; break;
@@ -985,7 +985,7 @@ TextStream& operator<<(TextStream& ts, ScrollSnapAxis axis)
 {
     switch (axis) {
     case ScrollSnapAxis::XAxis: ts << "x-axis"_s; break;
-    case ScrollSnapAxis::YAxis: ts << "y-Axis"_s; break;
+    case ScrollSnapAxis::YAxis: ts << "y-axis"_s; break;
     case ScrollSnapAxis::Block: ts << "block"_s; break;
     case ScrollSnapAxis::Inline: ts << "inline"_s; break;
     case ScrollSnapAxis::Both: ts << "both"_s; break;


### PR DESCRIPTION
#### a4e6363db4707922c4b17923b65516c67abd123b
<pre>
Fix incorrect debug-output strings in RenderStyleConstants.cpp operator&lt;&lt; overloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=318608">https://bugs.webkit.org/show_bug.cgi?id=318608</a>
<a href="https://rdar.apple.com/181402749">rdar://181402749</a>

Reviewed by Abrar Rahman Protyasha.

Several TextStream operator&lt;&lt; overloads emitted wrong strings due to
copy-paste errors, producing misleading logging output. These are debug-only
strings, so there is no behavior change.

* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/316518@main">https://commits.webkit.org/316518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da2a47ffbf2f66b650069235f6696eeb44276a7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130170 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7cec1b08-3a5f-446e-8f3e-0c79a4d8a3f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134262 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0e5deea-270c-4030-821f-58815005e8c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37666 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114734 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db6f5f8c-d08e-43b9-b9ad-c1e7af01ee77) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36301 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30671 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34297 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184605 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143048 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46204 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38590 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46882 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111774 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37941 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118634 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45399 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9244 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44799 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->