### PR TITLE
[CMake] clangd sometimes produces incorrect diagnostics for .mm, .m, and .h files

### DIFF
--- a/Tools/clangd/clangd-config.yaml.tpl
+++ b/Tools/clangd/clangd-config.yaml.tpl
@@ -27,16 +27,16 @@ CompileFlags:
     Add: [
         $header_file_platform_specific_flags
         $platform_specific_flags
-        --include=config.h,
+        -Xclang, -include, -Xclang, config.h,
         -std=c++2b,
     ]
 ---
 If:
     PathMatch: [.*\.mm]
 CompileFlags:
-    Add: [$platform_specific_flags -xobjective-c++, --include=config.h, -std=c++2b]
+    Add: [$platform_specific_flags -xobjective-c++, -std=c++2b]
 ---
 If:
     PathMatch: [.*\.m]
 CompileFlags:
-    Add: [$platform_specific_flags -xobjective-c, --include=config.h]
+    Add: [$platform_specific_flags -xobjective-c]


### PR DESCRIPTION
#### fbd1ff7b1fa573f055c0d17af1133a7e8a30846d
<pre>
[CMake] clangd sometimes produces incorrect diagnostics for .mm, .m, and .h files
<a href="https://bugs.webkit.org/show_bug.cgi?id=318615">https://bugs.webkit.org/show_bug.cgi?id=318615</a>
<a href="https://rdar.apple.com/181408485">rdar://181408485</a>

Reviewed by Pascoe.

clangd was reporting some incorrect diagnostics like &quot;called object type &apos;const char[75]&apos; is not
a function or function pointer&quot;, &quot;expected &apos;)&apos;&quot;.

The root cause is a force-include ordering bug. WebKitPrefix.h ends by &quot;poisoning&quot; new/delete so
that accidental new/delete usage without config.h is caught. config.h is what #undefs that.
WebKitPrefix.h is force-included by the frontend (via -Xclang -include via the PCH prefix header),
but the clangd config force-included config.h at the driver level (--include=config.h). The driver
injects its includes before frontend includes, so config.h&apos;s #undefs ran before the poison macros
were even defined. Force-including config.h also marked it as already-seen, so the body&apos;s own

Fix by (a) removing &quot;--include=config.h&quot; from the .mm/.m customizations, since that was pointless
anyways since those files already include it, and (b) for headers, inject the include via the
frontend instead of the driver to fix the ordering issue.

* Tools/clangd/clangd-config.yaml.tpl:

Canonical link: <a href="https://commits.webkit.org/316522@main">https://commits.webkit.org/316522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac3922e3c055fe3f1913001efc3f1d959e1b9a92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130183 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c86b9a4f-74e2-4584-b1dc-edc2b5e08cdd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c90a5de9-0f8d-43a4-91c8-ab36525491b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114740 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f540ed59-0481-4420-9b05-6d32f25d7cb7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34616 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30684 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34305 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184618 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46217 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142932 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38593 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46895 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111802 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37946 "Passed tests") | | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45412 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44812 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45044 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->