### PR TITLE
anchor-center in a vertical writing mode is not scroll-adjusted along the block axis

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<body style="margin:0">
+  <!-- Reproduces the post-scroll layout with a real scroller so the scrollbar
+       matches the test. The anchored box is a static child of the anchor,
+       centered on it vertically (25px = (100 - 50) / 2). -->
+  <div id="scroller" style="width:400px;height:400px;overflow:auto;background:orange">
+    <div style="height:100px"></div>
+    <div style="width:100px;height:100px;background:pink">
+      <div style="height:25px"></div>
+      <div style="width:50px;height:50px;background:purple"></div>
+    </div>
+    <div style="height:1000px"></div>
+  </div>
+</body>
+<script>
+  scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<body style="margin:0">
+  <!-- Reproduces the post-scroll layout with a real scroller so the scrollbar
+       matches the test. The anchored box is a static child of the anchor,
+       centered on it vertically (25px = (100 - 50) / 2). -->
+  <div id="scroller" style="width:400px;height:400px;overflow:auto;background:orange">
+    <div style="height:100px"></div>
+    <div style="width:100px;height:100px;background:pink">
+      <div style="height:25px"></div>
+      <div style="width:50px;height:50px;background:purple"></div>
+    </div>
+    <div style="height:1000px"></div>
+  </div>
+</body>
+<script>
+  scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning Test: scroll adjusted anchor-center with a horizontal writing-mode containing block (control)</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<link rel="match" href="anchor-center-scroll-horizontal-wm-001-ref.html">
+<meta name="assert" content="Horizontal-writing-mode control for anchor-center-scroll-vertical-wm-001: an abspos box with align-self:anchor-center whose containing block is a horizontal writing mode stays centered on its anchor along the block (vertical) axis after the anchor's scroller scrolls. Uses the identical harness so the only difference from the vertical test is the writing-mode/alignment axis pairing.">
+<style>
+  body { margin: 0; }
+  /* The containing block of #anchored. Horizontal writing-mode makes
+     align-self the property that controls the vertical (Y) axis. */
+  #cb {
+    position: relative;
+    writing-mode: horizontal-tb;
+    width: 400px;
+    height: 400px;
+  }
+  #scroller {
+    writing-mode: horizontal-tb;
+    width: 400px;
+    height: 400px;
+    overflow: auto;
+    background: orange;
+  }
+  #spacer { height: 100px; }
+  #anchor {
+    width: 100px;
+    height: 100px;
+    background: pink;
+    anchor-name: --anchor;
+  }
+  #anchored {
+    position: absolute;
+    position-anchor: --anchor;
+    align-self: anchor-center;
+    left: 0;
+    width: 50px;
+    height: 50px;
+    background: purple;
+  }
+  #filler { height: 1000px; }
+</style>
+<div id="cb">
+  <div id="scroller">
+    <div id="spacer"></div>
+    <div id="anchor"></div>
+    <div id="filler"></div>
+  </div>
+  <div id="anchored"></div>
+</div>
+<script>
+  scroller.offsetTop;
+  scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<body style="margin:0">
+  <!-- Reproduces the post-scroll layout with a real scroller so the scrollbar
+       matches the test. The anchored box is a static child of the anchor,
+       centered on it vertically (25px = (100 - 50) / 2). -->
+  <div id="scroller" style="width:400px;height:400px;overflow:auto;background:orange">
+    <div style="height:100px"></div>
+    <div style="width:100px;height:100px;background:pink">
+      <div style="height:25px"></div>
+      <div style="width:50px;height:50px;background:purple"></div>
+    </div>
+    <div style="height:1000px"></div>
+  </div>
+</body>
+<script>
+  scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<body style="margin:0">
+  <!-- Reproduces the post-scroll layout with a real scroller so the scrollbar
+       matches the test. The anchored box is a static child of the anchor,
+       centered on it vertically (25px = (100 - 50) / 2). -->
+  <div id="scroller" style="width:400px;height:400px;overflow:auto;background:orange">
+    <div style="height:100px"></div>
+    <div style="width:100px;height:100px;background:pink">
+      <div style="height:25px"></div>
+      <div style="width:50px;height:50px;background:purple"></div>
+    </div>
+    <div style="height:1000px"></div>
+  </div>
+</body>
+<script>
+  scroller.scrollTop = 100;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning Test: scroll adjusted anchor-center with a vertical writing-mode containing block</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#anchor-center">
+<link rel="match" href="anchor-center-scroll-vertical-wm-001-ref.html">
+<meta name="assert" content="An abspos box with justify-self:anchor-center whose containing block is a vertical writing mode stays centered on its anchor along the block (vertical) axis after the anchor's scroller scrolls.">
+<style>
+  body { margin: 0; }
+  /* The containing block of #anchored. Its vertical writing-mode makes
+     justify-self the property that controls the vertical (Y) axis. */
+  #cb {
+    position: relative;
+    writing-mode: vertical-rl;
+    width: 400px;
+    height: 400px;
+  }
+  /* Reset to horizontal so the scroller's internal layout/scroll matches
+     the horizontal-writing-mode scroll tests. */
+  #scroller {
+    writing-mode: horizontal-tb;
+    width: 400px;
+    height: 400px;
+    overflow: auto;
+    background: orange;
+  }
+  #spacer { height: 100px; }
+  #anchor {
+    width: 100px;
+    height: 100px;
+    background: pink;
+    anchor-name: --anchor;
+  }
+  #anchored {
+    position: absolute;
+    position-anchor: --anchor;
+    justify-self: anchor-center;
+    left: 0;
+    width: 50px;
+    height: 50px;
+    background: purple;
+  }
+  #filler { height: 1000px; }
+</style>
+<div id="cb">
+  <div id="scroller">
+    <div id="spacer"></div>
+    <div id="anchor"></div>
+    <div id="filler"></div>
+  </div>
+  <div id="anchored"></div>
+</div>
+<script>
+  scroller.offsetTop;
+  scroller.scrollTop = 100;
+</script>

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -132,7 +132,7 @@ AnchorScrollAdjuster::AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxM
     if (!m_needsYAdjustment) {
         m_needsYAdjustment = containingWritingMode.isHorizontal()
             ? style.alignSelf().isAnchorCenter()
-            : style.alignSelf().isAnchorCenter();
+            : style.justifySelf().isAnchorCenter();
     }
 
     m_isHidden = style.isForceHidden();


### PR DESCRIPTION
#### c1dbbbee21268435cb02a16d1dc354d11a79f338
<pre>
anchor-center in a vertical writing mode is not scroll-adjusted along the block axis
<a href="https://bugs.webkit.org/show_bug.cgi?id=318618">https://bugs.webkit.org/show_bug.cgi?id=318618</a>
<a href="https://rdar.apple.com/181413103">rdar://181413103</a>

Reviewed by Simon Fraser.

In AnchorScrollAdjuster, the block-axis (Y) scroll-adjustment check for
anchor-center read alignSelf().isAnchorCenter() in both the horizontal and
vertical writing-mode arms of the ternary. The horizontal-axis (X) check
correctly pairs justify-self/align-self per axis, but the vertical arm of the
Y check was a copy-paste of the horizontal arm.

For a vertical containing writing mode, the block (Y) axis is controlled by
justify-self, not align-self, so an abspos box using anchor-center never set
m_needsYAdjustment. As a result it was not compensated for its anchor&apos;s scroll
offset and drifted away from the anchor after scrolling.

Pair the vertical arm with justifySelf().isAnchorCenter(), matching the
per-axis logic already used by the position-area block above.

Tests: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001.html
       imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-horizontal-wm-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll-vertical-wm-001.html: Added.
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::AnchorScrollAdjuster::AnchorScrollAdjuster):

Canonical link: <a href="https://commits.webkit.org/316537@main">https://commits.webkit.org/316537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6f8230a526ddd38043ae06914d5ca98f23c3255

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130221 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98653cfc-cd98-4aa5-8b76-15e5e3e2b4ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134293 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a66e4c5b-2574-4872-b2e5-251df6ca91d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114765 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf218b90-c190-4676-b5ab-9923a5dbef27) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36329 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30722 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146758 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184656 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143083 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142960 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38604 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46933 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111875 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37969 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118685 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45450 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9284 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44850 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->