### PR TITLE
PannerNode orientation-only changes don't update the directional cone gain

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Changing orientation via AudioParam.value updates the cone gain
+PASS Changing orientation via setOrientation() updates the cone gain
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html>
+  <head>
+    <title>PannerNode orientation change updates cone gain</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../../resources/audit-util.js"></script>
+  </head>
+
+  <body>
+    <script>
+      // Power-of-two sample rate to keep frame math exact.
+      const sampleRate = 16384;
+
+      // Render enough to have a clean region before and after the change.
+      const renderFrames = 2048;
+
+      // Frame (a render-quantum multiple) at which the orientation flips.
+      const moveFrame = 512;
+
+      // Force the PannerNode onto its cached (non sample-accurate) cone-gain
+      // path.  That path is only taken when neither the panner nor the listener
+      // uses an a-rate position/orientation AudioParam, so every relevant param
+      // is switched to "k-rate".  This is the only path where the cone gain is
+      // cached across render quanta, so it is the only path that can go stale
+      // when the orientation (but not the position) changes.
+      function forceKRate(context, panner) {
+        for (const p of [panner.positionX, panner.positionY, panner.positionZ,
+                         panner.orientationX, panner.orientationY,
+                         panner.orientationZ])
+          p.automationRate = 'k-rate';
+
+        const l = context.listener;
+        for (const p of [l.positionX, l.positionY, l.positionZ,
+                         l.forwardX, l.forwardY, l.forwardZ,
+                         l.upX, l.upY, l.upZ])
+          p.automationRate = 'k-rate';
+      }
+
+      // Build a graph where a directional cone gates the panner's output.
+      //
+      // Listener sits at the origin; the source sits at (1, 0, 0), so the
+      // source->listener direction is (-1, 0, 0).  A narrow cone
+      // (inner 60 deg, outer 120 deg, outer gain 0) means:
+      //   orientation (-1, 0, 0)  -> angle 0 deg   -> full cone gain (1)
+      //   orientation ( 1, 0, 0)  -> angle 180 deg -> outer cone gain (0)
+      // so an orientation-only flip must take the output from full to silent.
+      function createGraph(context) {
+        const panner = new PannerNode(context, {
+          panningModel: 'equalpower',
+          distanceModel: 'inverse',
+          refDistance: 1,
+          coneInnerAngle: 60,
+          coneOuterAngle: 120,
+          coneOuterGain: 0,
+          positionX: 1,
+          positionY: 0,
+          positionZ: 0,
+          // Point at the listener initially: full cone gain.
+          orientationX: -1,
+          orientationY: 0,
+          orientationZ: 0
+        });
+
+        forceKRate(context, panner);
+
+        // A steady DC source makes the per-channel gain trivial to read.
+        const src = new ConstantSourceNode(context, {offset: 1});
+        src.connect(panner).connect(context.destination);
+        src.start();
+
+        return panner;
+      }
+
+      function maxAbs(array) {
+        let m = 0;
+        for (const v of array)
+          m = Math.max(m, Math.abs(v));
+        return m;
+      }
+
+      // Render, then verify the output is audible before |moveFrame| and
+      // (nearly) silent afterwards once the cone points away from the listener.
+      async function verify(context, prefix) {
+        const buffer = await context.startRendering();
+        const c0 = buffer.getChannelData(0);
+        const c1 = buffer.getChannelData(1);
+
+        // Before the flip the cone gain is 1, so at least one channel carries
+        // the source. This guards against the test trivially passing on
+        // silence.
+        assert_true(
+            maxAbs(c0.slice(0, moveFrame)) > 0.1 ||
+                maxAbs(c1.slice(0, moveFrame)) > 0.1,
+            `${prefix}: output is audible before the orientation flip`);
+
+        // After the flip the cone points away from the listener, so the cone
+        // gain is coneOuterGain (0) and both channels must be silent. Skip one
+        // render quantum around the boundary to avoid the transition sample.
+        const start = moveFrame + 128;
+        const zeros = new Float32Array(c0.length - start);
+        assert_array_equal_within_eps(
+            c0.slice(start), zeros, {absoluteThreshold: 1e-6},
+            `${prefix}: left channel after orientation-only flip`);
+        assert_array_equal_within_eps(
+            c1.slice(start), zeros, {absoluteThreshold: 1e-6},
+            `${prefix}: right channel after orientation-only flip`);
+      }
+
+      // Flip the orientation using the AudioParam .value setters.
+      promise_test(async () => {
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        const panner = createGraph(context);
+
+        context.suspend(moveFrame / context.sampleRate).then(() => {
+          // Point away from the listener; position is left unchanged.
+          panner.orientationX.value = 1;
+          panner.orientationY.value = 0;
+          panner.orientationZ.value = 0;
+          context.resume();
+        });
+
+        await verify(context, 'orientationX.value');
+      }, 'Changing orientation via AudioParam.value updates the cone gain');
+
+      // Flip the orientation using the legacy setOrientation() setter.
+      promise_test(async () => {
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
+        const panner = createGraph(context);
+
+        context.suspend(moveFrame / context.sampleRate).then(() => {
+          panner.setOrientation(1, 0, 0);
+          context.resume();
+        });
+
+        await verify(context, 'setOrientation');
+      }, 'Changing orientation via setOrientation() updates the cone gain');
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/webaudio/PannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/PannerNode.cpp
@@ -579,7 +579,7 @@ void PannerNode::invalidateCachedPropertiesIfNecessary()
 {
     auto lastPosition = std::exchange(m_lastPosition, position());
     bool hasPositionChanged = m_lastPosition != lastPosition;
-    auto lastOrientation = std::exchange(m_lastOrientation, position());
+    auto lastOrientation = std::exchange(m_lastOrientation, orientation());
     bool hasOrientationChanged = m_lastOrientation != lastOrientation;
     auto& listener = this->listener();
 


### PR DESCRIPTION
#### 74a12b6a1be8da6d70333bc4f407e49127205edf
<pre>
PannerNode orientation-only changes don&apos;t update the directional cone gain
<a href="https://bugs.webkit.org/show_bug.cgi?id=318619">https://bugs.webkit.org/show_bug.cgi?id=318619</a>
<a href="https://rdar.apple.com/181413407">rdar://181413407</a>

Reviewed by Jean-Yves Avenard.

PannerNode::invalidateCachedPropertiesIfNecessary() stored position()
into m_lastOrientation instead of orientation(), so hasOrientationChanged
was computed as an alias of hasPositionChanged. As a result, rotating a
panner in place (changing orientation while leaving position unchanged)
never invalidated m_cachedConeGain, and the directional cone attenuation
stayed stale until some other property forced a recompute.

This only affects the cached (non sample-accurate) cone-gain path; the
sample-accurate path recomputes the cone gain every render quantum, so
the bug was masked whenever any panner or listener position/orientation
AudioParam was a-rate.

Fix the typo so orientation-only changes correctly drop the cached cone
gain.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-orientation-cone-gain-changes.html: Added.
* Source/WebCore/Modules/webaudio/PannerNode.cpp:
(WebCore::PannerNode::invalidateCachedPropertiesIfNecessary):

Canonical link: <a href="https://commits.webkit.org/316541@main">https://commits.webkit.org/316541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09688a32415113a854ae0a7e51361fb4b8afe68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130188 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f6ab21f-1f4b-4fa1-a4b5-9194b7693d1a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/824a8586-0ef4-4fca-b58b-ac9c3f39ce79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37675 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154805 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41b14bb3-f759-49fe-9801-9329f9801b4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34619 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30689 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184623 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143058 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46900 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111811 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37950 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118652 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45417 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9257 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45049 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44876 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->