### PR TITLE
Use correct HRTF elevation response for negative elevations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation-expected.txt
@@ -1,0 +1,10 @@
+
+PASS # AUDIT TASK RUNNER STARTED.
+PASS Executing "negative-elevation"
+PASS Audit report
+PASS > [negative-elevation] A below-horizon source must not collapse onto the overhead response
+PASS   Peak of the overhead (+90) response is greater than 0.
+PASS   Relative max difference between +90 and -45 responses is greater than or equal to 0.01.
+PASS < [negative-elevation] All assertions passed. (total 2 assertions)
+PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test HRTF panning at negative elevation</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../../resources/audit.js"></script>
+  </head>
+
+  <body>
+    <script>
+      // Many HRTF databases are sampled at 44100 Hz. Use that rate so an
+      // implementation does not have to resample its impulse responses, which
+      // keeps the two renders below comparable.
+      const sampleRate = 44100;
+      const renderFrames = 1024;
+
+      const audit = Audit.createTaskRunner();
+
+      // Render an impulse through an HRTF panner positioned at |x, y, z|.
+      // The rendered stereo buffer is essentially the pair of head-related
+      // impulse responses selected for that direction, so it is sensitive to
+      // which elevation of the database is used.
+      function renderImpulseAtPosition(x, y, z) {
+        const context = new OfflineAudioContext(2, renderFrames, sampleRate);
+
+        const impulse = new AudioBuffer(
+            {numberOfChannels: 1, length: renderFrames, sampleRate});
+        impulse.getChannelData(0)[0] = 1;
+
+        const source = new AudioBufferSourceNode(context, {buffer: impulse});
+
+        const panner = new PannerNode(context, {
+          panningModel: 'HRTF',
+          // Neutralize the distance gain so only the HRTF kernels can affect
+          // the output.
+          rolloffFactor: 0,
+          positionX: x,
+          positionY: y,
+          positionZ: z,
+        });
+
+        source.connect(panner).connect(context.destination);
+        source.start();
+
+        return context.startRendering();
+      }
+
+      audit.define(
+          {
+            label: 'negative-elevation',
+            description:
+                'A below-horizon source must not collapse onto the overhead response'
+          },
+          (task, should) => {
+            // Both positions are the same distance (sqrt(2)) from the listener
+            // and resolve to azimuth 0, so azimuth and distance gain are
+            // identical. They differ only in elevation: +90 (straight overhead)
+            // versus -45 (below the horizon, in front). A correct HRTF panner
+            // must select a different elevation response for each direction, so
+            // the two renders must not be identical.
+            Promise
+                .all([
+                  renderImpulseAtPosition(0, Math.SQRT2, 0),   // elevation +90
+                  renderImpulseAtPosition(0, -1, -1),          // elevation -45
+                ])
+                .then(([overhead, below]) => {
+                  let maxDifference = 0;
+                  let overheadPeak = 0;
+                  for (let channel = 0; channel < 2; ++channel) {
+                    const a = overhead.getChannelData(channel);
+                    const b = below.getChannelData(channel);
+                    for (let i = 0; i < renderFrames; ++i) {
+                      maxDifference =
+                          Math.max(maxDifference, Math.abs(a[i] - b[i]));
+                      overheadPeak = Math.max(overheadPeak, Math.abs(a[i]));
+                    }
+                  }
+
+                  // Sanity check: the overhead response is not silence, so a
+                  // difference is meaningful.
+                  should(overheadPeak, 'Peak of the overhead (+90) response')
+                      .beGreaterThan(0);
+
+                  // The two directions must produce audibly different responses.
+                  // Require the difference to be a non-trivial fraction of the
+                  // overhead peak rather than merely non-zero, so floating-point
+                  // noise cannot satisfy the test.
+                  should(
+                      maxDifference / overheadPeak,
+                      'Relative max difference between +90 and -45 responses')
+                      .beGreaterThanOrEqualTo(0.01);
+                })
+                .then(() => task.done());
+          });
+
+      audit.run();
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -52,6 +52,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HRTFElevation);
 // Total number of components of an HRTF database.
 constexpr size_t TotalNumberOfResponses = 240;
 
+// This table maps an index into the concatenated elevation table to its
+// corresponding elevation angle. The elevations are stored in this (non-contiguous)
+// order, with negative elevations expressed as angle + 360. See
+// https://bugs.webkit.org/show_bug.cgi?id=98294#c9 for details.
+constexpr std::array<int, HRTFDatabase::NumberOfRawElevations> elevationIndexTable {
+    0, 15, 30, 45, 60, 75, 90, 315, 330, 345
+};
+
 // Number of frames in an individual impulse response.
 constexpr size_t ResponseFrameSize = 256;
 
@@ -132,9 +140,22 @@ bool HRTFElevation::calculateKernelsForAzimuthElevation(int azimuth, int elevati
     if (!bus)
         return false;
 
-    int elevationIndex = positiveElevation / AzimuthSpacing;
-    if (positiveElevation > 90)
-        elevationIndex -= AzimuthSpacing;
+    int elevationIndex = -1;
+    for (size_t k = 0; k < elevationIndexTable.size(); ++k) {
+        if (elevationIndexTable[k] == positiveElevation) {
+            elevationIndex = static_cast<int>(k);
+            break;
+        }
+    }
+
+    // The isElevationGood check above restricts elevation to the multiples of
+    // AzimuthSpacing in [-45, 90], so positiveElevation is always one of the ten
+    // values in elevationIndexTable and the lookup above always finds a match.
+    // This is defense-in-depth in case that invariant is ever broken.
+    bool isElevationIndexGood = elevationIndex >= 0;
+    ASSERT(isElevationIndexGood);
+    if (!isElevationIndexGood)
+        return false;
 
     // The concatenated impulse response is a bus containing all
     // the elevations per azimuth, for all azimuths by increasing


### PR DESCRIPTION
#### 963830df3d69a3a517d66705200ad497b00311bd
<pre>
Use correct HRTF elevation response for negative elevations
<a href="https://bugs.webkit.org/show_bug.cgi?id=250279">https://bugs.webkit.org/show_bug.cgi?id=250279</a>
<a href="https://rdar.apple.com/104265673">rdar://104265673</a>

Reviewed by Jean-Yves Avenard.

Merge: <a href="https://github.com/chromium/chromium/commit/5c31073f086be3f8c226c01d7954ea8f4d7eddaf">https://github.com/chromium/chromium/commit/5c31073f086be3f8c226c01d7954ea8f4d7eddaf</a>

The computed index for negative elevations was off by one. When the
elevation is -45 deg, the selected response corresponded to the entry
for 90 deg, not 315 deg, so sources below the horizon collapsed onto
the overhead response.

To simplify things, we use a short table to map the (positive) elevation
angle to its index in the concatenated database.

Test: imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation.html

* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-hrtf-negative-elevation.html: Added.
* Source/WebCore/platform/audio/HRTFElevation.cpp:
(WebCore::HRTFElevation::calculateKernelsForAzimuthElevation):

Canonical link: <a href="https://commits.webkit.org/317043@main">https://commits.webkit.org/317043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8abe342bc51ccb4193c9220150b7e1fcb010ae70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/174191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/48124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/132059 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/318c8119-2ff8-42db-82f3-5ebebd073003) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/176056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/135488 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/95578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12848a38-752c-4385-99c7-0cf230e3afca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/177149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/156281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a461cfda-1129-4630-b5a3-13632b31d1c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37560 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/35929 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/32249 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/186191 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/39355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/40127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/144392 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/155836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/144252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38876 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/32394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113985 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/39158 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/120378 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46976 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10736 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46379 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46437 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->