### PR TITLE
[webkitscmpy] Treat webkitglib/N.N stable branches as production branches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -37,7 +37,7 @@ class ScmBase(object):
     # Projects can define for themselves what constitutes a development vs a production branch,
     # the following idioms seem common enough to be shared.
     DEV_BRANCHES = re.compile(r'^(.+/)?((eng)|(dev)|(bug)|(integration)|(clone))/.+')
-    PROD_BRANCHES = re.compile(r'^(rapid/)?[^-/]+-[\d+\.]+-branch')
+    PROD_BRANCHES = re.compile(r'^(rapid/)?([^-/]+-[\d+\.]+-branch|webkitglib/\d+\.\d+)')
     GIT_SVN_REVISION = re.compile(r'^git-svn-id: \S+:\/\/.+@(?P<revision>\d+) .+-.+-.+-.+', flags=re.MULTILINE)
     DEFAULT_BRANCHES = ['main', 'master', 'trunk']
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/scm_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/scm_unittest.py
@@ -70,8 +70,12 @@ class TestScm(testing.PathTestCase):
         self.assertTrue(local.Scm.PROD_BRANCHES.match('safari-610-branch'))
         self.assertTrue(local.Scm.PROD_BRANCHES.match('safari-610.1-branch'))
         self.assertTrue(local.Scm.PROD_BRANCHES.match('rapid/safari-7624.1.16.110-branch'))
+        self.assertTrue(local.Scm.PROD_BRANCHES.match('webkitglib/2.52'))
+        self.assertTrue(local.Scm.PROD_BRANCHES.match('webkitglib/2.52-security'))
 
         self.assertFalse(local.Scm.PROD_BRANCHES.match('main'))
         self.assertFalse(local.Scm.PROD_BRANCHES.match('eng/1234'))
+        self.assertFalse(local.Scm.PROD_BRANCHES.match('eng/2.52'))
+        self.assertFalse(local.Scm.PROD_BRANCHES.match('webkitglib/main'))
         self.assertFalse(local.Scm.PROD_BRANCHES.match('integration/ci/stuff/safari-606-branch'))
         self.assertFalse(local.Scm.PROD_BRANCHES.match('clone/1234'))


### PR DESCRIPTION
#### 9c9bb7fa5839861591e82988b141448efa3cb81b
<pre>
[webkitscmpy] Treat webkitglib/N.N stable branches as production branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=318621">https://bugs.webkit.org/show_bug.cgi?id=318621</a>

Reviewed by Aakash Jain.

Recognize the WebKitGTK/WPE stable branch naming convention
(webkitglib/2.52) in ScmBase.PROD_BRANCHES so it is classified as a
production branch alongside the safari-N-branch convention.

This fixes commits.webkit.org failing to resolve identifiers on those
branches (e.g. NNNN.M@webkitglib/2.52): reporelaypy&apos;s update_for() gates
branch tracking and identifier-cache population on prod_branches.match(),
so pushes to webkitglib/N.N were never indexed. It also makes the tooling
apply production-branch semantics (such as the rebase ban) to them.

A webkitglib-specific alternative is used rather than a generic word/N.N
pattern to avoid misclassifying dev branches.

Canonical link: <a href="https://commits.webkit.org/316929@main">https://commits.webkit.org/316929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/227dc59b471eed3ab225ed4c8737f975c6e64e12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173832 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47765 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/49057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47447 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/135182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176790 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/38612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/115660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/173153 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/37253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31890 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/147677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/35463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185832 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/144074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/173232 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47432 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/155525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/143933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/48111 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/32079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113408 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26431 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/38852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46617 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/10418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/46019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/46250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/46078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->