### PR TITLE
Web Inspector: Zero-width joiners and other hidden Unicode characters are not displayed

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -913,10 +913,14 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
                 });
             }
 
-            if (textNode?.textContent.length) {
-                subMenus.copy.appendItem(WI.UIString("Text"), () => {
-                    InspectorFrontendHost.copyText(textNode.textContent);
-                });
+            if (textNode) {
+                let {domNode, isSourceCode} = this._editableTextInfo();
+                let text = (domNode && !isSourceCode) ? domNode.nodeValue() : textNode.textContent;
+                if (text.length) {
+                    subMenus.copy.appendItem(WI.UIString("Text"), () => {
+                        InspectorFrontendHost.copyText(text);
+                    });
+                }
             }
 
             if (this.editable) {
@@ -1069,10 +1073,23 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         return true;
     }
 
+    _editableTextInfo()
+    {
+        let domNode = this.representedObject;
+        if (domNode.nodeType() !== Node.TEXT_NODE)
+            domNode = domNode.firstChild;
+        let parentNodeName = domNode?.parentNode?.nodeName().toLowerCase();
+        return {domNode, isSourceCode: parentNodeName === "script" || parentNodeName === "style"};
+    }
+
     _startEditingTextNode(textNode)
     {
         if (WI.isBeingEdited(textNode))
             return true;
+
+        let {domNode, isSourceCode} = this._editableTextInfo();
+        if (domNode && !isSourceCode)
+            textNode.textContent = domNode.nodeValue();
 
         var config = new WI.EditingConfig(this._textNodeEditingCommitted.bind(this), this._editingCancelled.bind(this));
         config.spellcheck = true;
@@ -1383,15 +1400,8 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
     {
         this._editing = false;
 
-        var textNode;
-        if (this.representedObject.nodeType() === Node.ELEMENT_NODE) {
-            // We only show text nodes inline in elements if the element only
-            // has a single child, and that child is a text node.
-            textNode = this.representedObject.firstChild;
-        } else if (this.representedObject.nodeType() === Node.TEXT_NODE)
-            textNode = this.representedObject;
-
-        textNode.setNodeValue(newText, this.updateTitle.bind(this));
+        let {domNode} = this._editableTextInfo();
+        domNode.setNodeValue(newText, this.updateTitle.bind(this));
     }
 
     _editingCancelled(element, context)
@@ -1646,7 +1656,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
                     else if (nodeNameLowerCase === "style")
                         textNodeElement.appendChild(WI.syntaxHighlightStringAsDocumentFragment(textChild.nodeValue().trim(), "text/css"));
                     else
-                        textNodeElement.textContent = textChild.nodeValue();
+                        this._appendTextNodeValue(textNodeElement, textChild.nodeValue());
 
                     info.titleDOM.append("\u200B");
 
@@ -1671,7 +1681,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
                 } else {
                     info.titleDOM.append("\"");
                     var textNodeElement = info.titleDOM.createChild("span", "html-text-node");
-                    textNodeElement.textContent = node.nodeValue();
+                    this._appendTextNodeValue(textNodeElement, node.nodeValue());
                     info.titleDOM.append("\"");
                 }
                 break;
@@ -1712,6 +1722,26 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         }
 
         return info;
+    }
+
+    _appendTextNodeValue(parentElement, value)
+    {
+        let lastIndex = 0;
+        for (let i = 0; i < value.length; ++i) {
+            let entity = WI.DOMTreeElement.CharacterToEntity.get(value[i]);
+            if (!entity)
+                continue;
+
+            if (i > lastIndex)
+                parentElement.append(value.substring(lastIndex, i));
+
+            parentElement.createChild("span", "html-entity-value").textContent = entity;
+
+            lastIndex = i + 1;
+        }
+
+        if (lastIndex < value.length)
+            parentElement.append(value.substring(lastIndex));
     }
 
     _singleTextChild(node)
@@ -2404,6 +2434,27 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
 WI.DOMTreeElement.InitialChildrenLimit = 500;
 WI.DOMTreeElement.MaximumInlineTextChildLength = 80;
+
+WI.DOMTreeElement.CharacterToEntity = new Map([
+    ["\u00A0", "&nbsp;"],
+    ["\u00AD", "&shy;"],
+    ["\u2002", "&ensp;"],
+    ["\u2003", "&emsp;"],
+    ["\u2009", "&thinsp;"],
+    ["\u200A", "&hairsp;"],
+    ["\u200B", "&ZeroWidthSpace;"],
+    ["\u200C", "&zwnj;"],
+    ["\u200D", "&zwj;"],
+    ["\u200E", "&lrm;"],
+    ["\u200F", "&rlm;"],
+    ["\u202A", "&#x202A;"],
+    ["\u202B", "&#x202B;"],
+    ["\u202C", "&#x202C;"],
+    ["\u202D", "&#x202D;"],
+    ["\u202E", "&#x202E;"],
+    ["\u2060", "&NoBreak;"],
+    ["\uFEFF", "&#xFEFF;"],
+]);
 
 // A union of HTML4 and HTML5-Draft elements that explicitly
 // or implicitly (for HTML5) forbid the closing tag.

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -152,6 +152,14 @@ body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree.deemph
     unicode-bidi: isolate;
 }
 
+.tree-outline.dom .html-entity-value {
+    padding: 0 2px;
+    color: var(--text-color-secondary);
+    background-color: hsla(0, 0%, 50%, 0.15);
+    border-radius: 3px;
+    unicode-bidi: isolate;
+}
+
 .tree-outline.dom li .pseudo-class-indicator {
     display: inline-block;
     position: absolute;


### PR DESCRIPTION
#### 1893f621cd8c41a704b7016601f1e822b7344cd4
<pre>
Web Inspector: Zero-width joiners and other hidden Unicode characters are not displayed
<a href="https://bugs.webkit.org/show_bug.cgi?id=181302">https://bugs.webkit.org/show_bug.cgi?id=181302</a>
&lt;<a href="https://rdar.apple.com/problem/36307533">rdar://problem/36307533</a>&gt;

Reviewed by Alexey Proskuryakov.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.populateDOMNodeContextMenu):
(WI.DOMTreeElement.prototype._editableTextInfo): Added.
(WI.DOMTreeElement.prototype._startEditingTextNode):
(WI.DOMTreeElement.prototype._nodeTitleInfo):
(WI.DOMTreeElement.prototype._textNodeEditingCommitted):
(WI.DOMTreeElement.prototype._appendTextNodeValue): Added.
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(.tree-outline.dom .html-entity-value): Added.

Canonical link: <a href="https://commits.webkit.org/316616@main">https://commits.webkit.org/316616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76c13e9e748cc4030405395000ba818d6305d234

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182436 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/130532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134532 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/130532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37925 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/155101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115001 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/36570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/34898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184971 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/37738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/39100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143339 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46566 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143210 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38651 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47244 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112254 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38192 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/119004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45761 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9547 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45162 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->