### PR TITLE
Fix issues with DOMMatrix/IntersectionObserver absolute length unit requirements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt
@@ -23,7 +23,7 @@ PASS new DOMMatrix("scale(2) translateX(5px) translateY(5px) rotate(5deg) rotate
 PASS new DOMMatrix("translateX    (5px)")
 PASS new DOMMatrix("scale(2 2) translateX(5) translateY(5)")
 PASS new DOMMatrix("scale(2, 2), translateX(5)  ,translateY(5)")
-FAIL new DOMMatrix("scale(sign(1em))") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
+PASS new DOMMatrix("scale(sign(1em))")
 PASS new DOMMatrix("scale(sibling-index())")
 PASS new DOMMatrix("translateX(5em)")
 PASS new DOMMatrix("translateX(5ex)")
@@ -92,7 +92,7 @@ PASS new DOMMatrixReadOnly("scale(2) translateX(5px) translateY(5px) rotate(5deg
 PASS new DOMMatrixReadOnly("translateX    (5px)")
 PASS new DOMMatrixReadOnly("scale(2 2) translateX(5) translateY(5)")
 PASS new DOMMatrixReadOnly("scale(2, 2), translateX(5)  ,translateY(5)")
-FAIL new DOMMatrixReadOnly("scale(sign(1em))") assert_throws_dom: function "function() { new self[constr](string); }" did not throw
+PASS new DOMMatrixReadOnly("scale(sign(1em))")
 PASS new DOMMatrixReadOnly("scale(sibling-index())")
 PASS new DOMMatrixReadOnly("translateX(5em)")
 PASS new DOMMatrixReadOnly("translateX(5ex)")

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units-expected.txt
@@ -1,0 +1,16 @@
+
+PASS observer.rootMargin using 'px'
+PASS observer.scrollMargin using 'px'
+PASS observer.rootMargin using 'cm'
+PASS observer.scrollMargin using 'cm'
+PASS observer.rootMargin using 'mm'
+PASS observer.scrollMargin using 'mm'
+PASS observer.rootMargin using 'q'
+PASS observer.scrollMargin using 'q'
+PASS observer.rootMargin using 'in'
+PASS observer.scrollMargin using 'in'
+PASS observer.rootMargin using 'pt'
+PASS observer.scrollMargin using 'pt'
+PASS observer.rootMargin using 'pc'
+PASS observer.scrollMargin using 'pc'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="author" href="mailto:sam@webkit.org" title="Sam Weinig">
+  <link rel="help" href="https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin">
+  <link rel="help" href="https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-scrollmargin">
+
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<script>
+  const testcases = [
+    { unit: "px", expected: "10px" },
+    { unit: "cm", expected: "377px" },
+    { unit: "mm", expected: "37px" },
+    { unit: "q", expected: "9px" },
+    { unit: "in", expected: "960px" },
+    { unit: "pt", expected: "13px" },
+    { unit: "pc", expected: "160px" },
+  ];
+
+  for (testcase of testcases) {
+    test(function() {
+      const observer = new IntersectionObserver(function(e) {}, {
+        rootMargin: `10${testcase.unit}`,
+      });
+      assert_equals(observer.rootMargin, `${testcase.expected} ${testcase.expected} ${testcase.expected} ${testcase.expected}`)
+    }, `observer.rootMargin using '${testcase.unit}'`);
+
+    test(function() {
+      const observer = new IntersectionObserver(function(e) {}, {
+        scrollMargin: `10${testcase.unit}`,
+      });
+      assert_equals(observer.scrollMargin, `${testcase.expected} ${testcase.expected} ${testcase.expected} ${testcase.expected}`)
+    }, `observer.scrollMargin using '${testcase.unit}'`);
+  }
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -667,7 +667,13 @@ static std::optional<Random::SharingFixed> consumeOptionalRandomSharingFixed(CSS
 
     // Use a non-property parsing state for the fixed number value to disconnect it from the current parse.
     // FIXME: Add a mechanism to pass along the depth count when doing this so that we can limit stack usage.
-    auto numberParsingState = CSS::PropertyParserState { .context = state.propertyParserState.context, .pool = state.propertyParserState.pool };
+    // FIXME: This should probably maintain the `cssRandomFunctionCount` state from the current state to allow for random() functions nested in the <number> or should document why this is not necessary.
+    auto numberParsingState = CSS::PropertyParserState {
+        .context = state.propertyParserState.context,
+        .pool = state.propertyParserState.pool,
+        .absoluteLengthUnitsOnly = state.propertyParserState.absoluteLengthUnitsOnly
+    };
+
     auto number = CSSPropertyParserHelpers::MetaConsumer<CSS::Number<CSS::ClosedUnitRange>>::consume(tokens, numberParsingState);
     if (!number)
         return { };
@@ -1683,8 +1689,11 @@ std::optional<TypedChild> parseCalcKeyword(const CSSParserToken& token, ParserSt
         auto child = Symbol { token.id(), *unit };
         auto type = Type::determineType(*unit);
 
-        if (conversionToCanonicalUnitRequiresConversionData(*unit))
+        if (conversionToCanonicalUnitRequiresConversionData(*unit)) {
+            if (state.propertyParserState.absoluteLengthUnitsOnly)
+                return std::nullopt;
             state.requiresConversionData = true;
+        }
 
         if (auto* simplificationOptions = state.simplificationOptions) {
             if (auto replacement = simplify(child, *simplificationOptions))
@@ -1726,8 +1735,11 @@ std::optional<TypedChild> parseCalcDimension(const CSSParserToken& token, Parser
     auto child = makeNumeric(token.numericValue(), token.unitType());
     auto type = Type::determineType(token.unitType());
 
-    if (conversionToCanonicalUnitRequiresConversionData(token.unitType()))
+    if (conversionToCanonicalUnitRequiresConversionData(token.unitType())) {
+        if (state.propertyParserState.absoluteLengthUnitsOnly)
+            return std::nullopt;
         state.requiresConversionData = true;
+    }
 
     if (auto* simplificationOptions = state.simplificationOptions)
         return TypedChild { copyAndSimplify(WTF::move(child), *simplificationOptions), type };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h
@@ -65,5 +65,10 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Angle<R, V>> {
     using NumberToken = NumberConsumerForUnitlessValues<CSS::Angle<R, V>, AngleValidator, CSS::AngleUnit::Deg>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::AngleRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::Angle<R, V>, AngleValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::Angle<R, V>, AngleValidator, CSS::AngleUnit::Deg>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentageDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentageDefinitions.h
@@ -59,5 +59,11 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::AnglePercentage<R, V
     using NumberToken = NumberConsumerForUnitlessValues<CSS::AnglePercentage<R, V>, AnglePercentageValidator, CSS::AngleUnit::Deg>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::AnglePercentageRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::AnglePercentage<R, V>, AnglePercentageValidator>;
+    using PercentageToken = PercentageConsumer<CSS::AnglePercentage<R, V>, AnglePercentageValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::AnglePercentage<R, V>, AnglePercentageValidator, CSS::AngleUnit::Deg>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+FlexDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+FlexDefinitions.h
@@ -46,5 +46,9 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Flex<R, V>> {
     using DimensionToken = DimensionConsumer<CSS::Flex<R, V>, FlexValidator>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::FlexRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::Flex<R, V>, FlexValidator>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h
@@ -50,5 +50,9 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Frequency<R, V>> {
     using DimensionToken = DimensionConsumer<CSS::Frequency<R, V>, FrequencyValidator>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::FrequencyRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::Frequency<R, V>, FrequencyValidator>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h
@@ -60,10 +60,13 @@ template<typename Primitive, typename Validator> struct NumberConsumerForInteger
     }
 };
 
-template<CSS::Range R, typename IntType>
-struct ConsumerDefinition<CSS::Integer<R, IntType>> {
-    using FunctionToken = FunctionConsumerForCalcValues<CSS::Integer<R, IntType>>;
-    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<R, IntType>, IntegerValidator>;
+template<auto R, typename V> struct ConsumerDefinition<CSS::Integer<R, V>> {
+    using FunctionToken = FunctionConsumerForCalcValues<CSS::Integer<R, V>>;
+    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<R, V>, IntegerValidator>;
+};
+
+template<auto R, typename V> struct ConsumerDefinition<CSS::IntegerRaw<R, V>> {
+    using NumberToken = NumberConsumerForIntegerValues<CSS::Integer<R, V>, IntegerValidator>;
 };
 
 } // namespace CSSPropertyParserHelpers

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h
@@ -37,7 +37,10 @@ struct LengthValidator {
     {
         if (unitType == CSSUnitType::CSS_QUIRKY_EM && !isUASheetBehavior(options.overrideParserMode.value_or(state.context.mode)))
             return std::nullopt;
-        return CSS::UnitTraits<CSS::LengthUnit>::validate(unitType);
+        auto result = CSS::UnitTraits<CSS::LengthUnit>::validate(unitType);
+        if (result && state.absoluteLengthUnitsOnly && CSS::conversionToCanonicalUnitRequiresConversionData(*result))
+            return std::nullopt;
+        return result;
     }
 
     template<auto R, typename V> static bool isValid(CSS::LengthRaw<R, V> raw, CSSPropertyParserOptions)
@@ -62,6 +65,11 @@ struct LengthValidator {
 
 template<auto R, typename V> struct ConsumerDefinition<CSS::Length<R, V>> {
     using FunctionToken = FunctionConsumerForCalcValues<CSS::Length<R, V>>;
+    using DimensionToken = DimensionConsumer<CSS::Length<R, V>, LengthValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::Length<R, V>, LengthValidator, CSS::LengthUnit::Px>;
+};
+
+template<auto R, typename V> struct ConsumerDefinition<CSS::LengthRaw<R, V>> {
     using DimensionToken = DimensionConsumer<CSS::Length<R, V>, LengthValidator>;
     using NumberToken = NumberConsumerForUnitlessValues<CSS::Length<R, V>, LengthValidator, CSS::LengthUnit::Px>;
 };

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h
@@ -59,5 +59,11 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::LengthPercentage<R, 
     using NumberToken = NumberConsumerForUnitlessValues<CSS::LengthPercentage<R, V>, LengthPercentageValidator, CSS::LengthUnit::Px>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::LengthPercentageRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::LengthPercentage<R, V>, LengthPercentageValidator>;
+    using PercentageToken = PercentageConsumer<CSS::LengthPercentage<R, V>, LengthPercentageValidator>;
+    using NumberToken = NumberConsumerForUnitlessValues<CSS::LengthPercentage<R, V>, LengthPercentageValidator, CSS::LengthUnit::Px>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h
@@ -46,5 +46,9 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Number<R, V>> {
     using NumberToken = NumberConsumer<CSS::Number<R, V>, NumberValidator>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::NumberRaw<R, V>> {
+    using NumberToken = NumberConsumer<CSS::Number<R, V>, NumberValidator>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h
@@ -46,5 +46,9 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Percentage<R, V>> {
     using PercentageToken = PercentageConsumer<CSS::Percentage<R, V>, PercentageValidator>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::PercentageRaw<R, V>> {
+    using PercentageToken = PercentageConsumer<CSS::Percentage<R, V>, PercentageValidator>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h
@@ -50,5 +50,9 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Resolution<R, V>> {
     using DimensionToken = DimensionConsumer<CSS::Resolution<R, V>, ResolutionValidator>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::ResolutionRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::Resolution<R, V>, ResolutionValidator>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h
@@ -50,5 +50,9 @@ template<auto R, typename V> struct ConsumerDefinition<CSS::Time<R, V>> {
     using DimensionToken = DimensionConsumer<CSS::Time<R, V>, TimeValidator>;
 };
 
+template<auto R, typename V> struct ConsumerDefinition<CSS::TimeRaw<R, V>> {
+    using DimensionToken = DimensionConsumer<CSS::Time<R, V>, TimeValidator>;
+};
+
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
@@ -418,7 +418,7 @@ std::optional<Style::Transform> parseTransformRaw(const String& string, const CS
     // Handle leading whitespace.
     range.consumeWhitespace();
 
-    auto state = CSS::PropertyParserState { .context = context };
+    auto state = CSS::PropertyParserState { .context = context, .absoluteLengthUnitsOnly = true };
     auto parsedValue = CSSPropertyParsing::consumeTransform(range, state);
     if (!parsedValue)
         return { };
@@ -432,8 +432,7 @@ std::optional<Style::Transform> parseTransformRaw(const String& string, const CS
     auto dummyStyle = Style::ComputedStyle::create();
     auto dummyState = Style::BuilderState::create(dummyStyle);
 
-    if (!parsedValue->canResolveDependenciesWithConversionData(dummyState->cssToLengthConversionData()))
-        return { };
+    ASSERT(parsedValue->canResolveDependenciesWithConversionData(dummyState->cssToLengthConversionData()));
 
     return Style::toStyleFromCSSValue<Style::Transform>(*CheckedPtr { dummyState.ptr() }, *parsedValue);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -45,6 +45,9 @@ struct PropertyParserState {
 
     // Count of CSS random() functions seen so far for the current property.
     unsigned cssRandomFunctionCount { 0 };
+
+    // Used by non-CSS users of the CSS parsers like `DOMMatrix` to limit <length> and <length-percentage> parsing to only absolute units.
+    bool absoluteLengthUnitsOnly { false };
 };
 
 } // namespace CSS

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -80,6 +80,7 @@ static ExceptionOr<IntersectionObserverMarginBox> parseMargin(String& margin, co
     auto parserContext = CSSParserContext { HTMLStandardMode };
     auto parserState = CSS::PropertyParserState {
         .context = parserContext,
+        .absoluteLengthUnitsOnly = true
     };
 
     CSSTokenizer tokenizer(margin);
@@ -90,30 +91,15 @@ static ExceptionOr<IntersectionObserverMarginBox> parseMargin(String& margin, co
         return IntersectionObserverMarginBox { IntersectionObserverMarginEdge::Dimension { 0 } };
 
     auto consumeEdge = [&] -> ExceptionOr<IntersectionObserverMarginEdge> {
-        auto parsedValue = MetaConsumer<CSS::LengthPercentage<CSS::All, float>>::consume(tokenRange, parserState);
+        auto parsedValue = MetaConsumer<CSS::LengthPercentageRaw<CSS::All, float>>::consume(tokenRange, parserState);
 
-        if (!parsedValue || parsedValue->isCalc())
-            return Exception { ExceptionCode::SyntaxError, makeString("Failed to construct 'IntersectionObserver': "_s, marginName, " must be specified in pixels or percent."_s) };
+        if (!parsedValue)
+            return Exception { ExceptionCode::SyntaxError, makeString("Failed to construct 'IntersectionObserver': "_s, marginName, " must be specified as an absolute length or a percentage."_s) };
 
-        auto raw = parsedValue->raw();
-        return CSS::switchOnUnitType(raw->unit,
-            [&](CSS::PercentageUnit) -> ExceptionOr<IntersectionObserverMarginEdge> {
-                return { IntersectionObserverMarginEdge::Percentage {
-                    Style::toStyle(CSS::PercentageRaw<CSS::All, float> { raw->value }, NoConversionDataRequiredToken { }).value
-                } };
-            },
-            [&](CSS::LengthUnit lengthUnit) -> ExceptionOr<IntersectionObserverMarginEdge> {
-                // FIXME: This should support all absolute length units, not just px.
-                // Spec states: "Similar to the CSS margin property, this is a string of 1-4 components, each either an *absolute length* or a percentage."
-                // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin
-                if (lengthUnit == CSS::LengthUnit::Px) {
-                    return { IntersectionObserverMarginEdge::Dimension {
-                        Style::toStyle(CSS::LengthRaw<CSS::All, float> { lengthUnit, raw->value }, NoConversionDataRequiredToken { }).unresolvedValue()
-                    } };
-                }
-                return Exception { ExceptionCode::SyntaxError, makeString("Failed to construct 'IntersectionObserver': "_s, marginName, " must be specified in pixels or percent."_s) };
-            }
-        );
+        // Due to setting the parser state's `absoluteLengthUnitsOnly` to true, no units requiring conversion data should be present.
+        ASSERT(!conversionToCanonicalUnitRequiresConversionData(parsedValue->unit));
+
+        return Style::toStyle(*parsedValue, NoConversionDataRequiredToken { });
     };
 
     auto edge1 = consumeEdge();


### PR DESCRIPTION
#### 31871cbfb029cd2dc2389d87b70af72876ef52ec
<pre>
Fix issues with DOMMatrix/IntersectionObserver absolute length unit requirements
<a href="https://bugs.webkit.org/show_bug.cgi?id=318632">https://bugs.webkit.org/show_bug.cgi?id=318632</a>

Reviewed by Darin Adler.

Adds a new off by default bit to `CSS::PropertyParserState` called `absoluteLengthUnitsOnly`
to make it parse error to consume length units that are not absolute (e.g. font/viewport/container
relative units). Uses this for the `DOMMatrix` (`parseTransformRaw`) and `IntersectionObserver`
(`parseMargin`) parsers.

Additionally, added support for using a `CSS::{primitive}Raw` type in the MetaConsumer, indicating
that the parse should not allow `calc()`. Uses this to remove the post parse check in the
`IntersectionObserver` (`parseMargin`) parser.

Added a test for non-px, but still absolute units in IntersectionObserver and updated a failing
DOMMatrix test result.

Test: imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units.html
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMMatrix-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-scroll-margin-units.html: Added.
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AngleDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AnglePercentageDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+FlexDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+FrequencyDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+IntegerDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+LengthPercentageDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+NumberDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+PercentageDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ResolutionDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+TimeDefinitions.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp:
* Source/WebCore/css/parser/CSSPropertyParserState.h:
* Source/WebCore/page/IntersectionObserver.cpp:

Canonical link: <a href="https://commits.webkit.org/316532@main">https://commits.webkit.org/316532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/597286162c993f57663f3475ae0890f5caef6358

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134292 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34640 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30721 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184655 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143082 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142959 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38602 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46932 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31174 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111874 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37968 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118684 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45449 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->