### PR TITLE
Lock::tryLockWithTimeout sleeps one extra second and mishandles sub-second timeouts

### DIFF
--- a/Source/WTF/wtf/Lock.cpp
+++ b/Source/WTF/wtf/Lock.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/Lock.h>
 
+#include <cmath>
 #include <wtf/LockAlgorithmInlines.h>
 #include <wtf/StackShotProfiler.h>
 
@@ -81,9 +82,11 @@ bool Lock::tryLockWithTimeout(Seconds timeout)
     // why we use unistd.h's sleep() instead of its alternatives.
 
     // We'll be doing sleep(1) between tries below. Hence, sleepPerRetry is 1.
-    unsigned maxRetries = (timeout < Seconds::infinity()) ? timeout.value() : std::numeric_limits<unsigned>::max();
+    // Round up so a non-zero sub-second timeout still retries at least once, while a
+    // zero timeout does not sleep at all.
+    unsigned maxRetries = (timeout < Seconds::infinity()) ? std::ceil(timeout.value()) : std::numeric_limits<unsigned>::max();
     unsigned tryCount = 0;
-    while (!tryLock() && tryCount++ <= maxRetries) {
+    while (!tryLock() && tryCount++ < maxRetries) {
 #if OS(WINDOWS)
         Sleep(1000);
 #else

--- a/Tools/TestWebKitAPI/Tests/WTF/Lock.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Lock.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include <wtf/Lock.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/Threading.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/UniqueArray.h>
@@ -221,6 +222,47 @@ TEST(WTF_Lock, Basic)
     MyValue v;
     v.setValue(7);
     v.maybeSetOtherValue(34);
+}
+
+TEST(WTF_Lock, TryLockWithTimeoutZeroDoesNotSleep)
+{
+    // A zero timeout on a contended lock must fail promptly rather than sleeping a
+    // full second (regression test for the off-by-one / sub-second-truncation bug in
+    // tryLockWithTimeout, where maxRetries == 0 still slept once).
+    //
+    // Note: we assert on elapsed time only, not on the return value. tryLockWithTimeout
+    // returns isHeld(), which reports whether the lock is held by *any* thread, so with
+    // the main thread holding the lock the worker observes true regardless of whether it
+    // acquired the lock. The timing is the meaningful signal for this fix.
+    Lock lock;
+    Locker holder { lock };
+
+    MonotonicTime start = MonotonicTime::now();
+    Thread::create("tryLockWithTimeout test"_s, [&] {
+        lock.tryLockWithTimeout(0_s);
+    })->waitForCompletion();
+    Seconds elapsed = MonotonicTime::now() - start;
+
+    EXPECT_LT(elapsed, 500_ms);
+}
+
+TEST(WTF_Lock, TryLockWithTimeoutHonorsTimeoutWithoutOvershoot)
+{
+    // With a 1s timeout on a permanently-held lock, the retry loop must sleep exactly
+    // once (~1s) and then give up. The off-by-one bug slept twice (~2s), overshooting
+    // the requested timeout. We bound elapsed below the pre-fix ~2s and above the single
+    // ~1s sleep so the test fails for either the old off-by-one or a no-sleep regression.
+    Lock lock;
+    Locker holder { lock };
+
+    MonotonicTime start = MonotonicTime::now();
+    Thread::create("tryLockWithTimeout overshoot test"_s, [&] {
+        lock.tryLockWithTimeout(1_s);
+    })->waitForCompletion();
+    Seconds elapsed = MonotonicTime::now() - start;
+
+    EXPECT_GE(elapsed, 900_ms);
+    EXPECT_LT(elapsed, 1600_ms);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### c16bab048b2b606c0002964becbab1d4cecbfbc4
<pre>
Lock::tryLockWithTimeout sleeps one extra second and mishandles sub-second timeouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=318636">https://bugs.webkit.org/show_bug.cgi?id=318636</a>
<a href="https://rdar.apple.com/181444289">rdar://181444289</a>

Reviewed by NOBODY (OOPS!).

Lock::tryLockWithTimeout() had two defects in its retry loop:

- Off-by-one: the loop condition `tryCount++ &lt;= maxRetries` uses a
  post-increment, so the sleep body runs for tryCount 0..maxRetries,
  i.e. maxRetries + 1 times. A caller passing a 2s timeout would sleep
  up to 3 seconds before giving up.

- Sub-second / zero truncation: maxRetries was assigned from
  timeout.value() (a double, in seconds) truncated to unsigned, so a
  0s (or any sub-second) timeout became 0 retries. Combined with the
  off-by-one, even a 0s timeout still slept a full second, which is
  especially bad given this function may be called from a signal
  handler.

Fix the loop bound to `&lt; maxRetries` so the loop sleeps exactly
maxRetries times (and 0 retries means no sleep), and round the timeout
up with std::ceil so a non-zero sub-second timeout still retries at
least once. This is a no-op for the existing whole-second callers.

Test: Tools/TestWebKitAPI/Tests/WTF/Lock.cpp

* Source/WTF/wtf/Lock.cpp:
(WTF::Lock::tryLockWithTimeout):
* Tools/TestWebKitAPI/Tests/WTF/Lock.cpp:
(TestWebKitAPI::TEST(WTF_Lock, TryLockWithTimeoutZeroDoesNotSleep)):
(TestWebKitAPI::TEST(WTF_Lock, TryLockWithTimeoutHonorsTimeoutWithoutOvershoot)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c16bab048b2b606c0002964becbab1d4cecbfbc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a102b685-0a99-45c3-b8a6-b49fddd9c470) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134295 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94778 "21 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/274a27e1-db48-4caa-8174-ce227cdc979e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114767 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aebea25c-ad49-4b93-a835-ce4582942559) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34643 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30725 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3362 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184659 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33929 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143085 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46258 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46936 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111878 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37971 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118688 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205346 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45453 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9286 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54817 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44853 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45085 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44912 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->