### PR TITLE
Re-introduce NativePromiseRequest semantics as they were before 302170@main

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -212,6 +212,7 @@ template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> cl
 using GenericPromise = NativePromise<void, void>;
 using GenericNonExclusivePromise = NativePromise<void, void, 1>;
 class NativePromiseRequest;
+class NativePromiseRequestData;
 
 template<typename ValueArg, typename HashArg = DefaultHash<WeakPtr<ValueArg>>, typename HashTraitsArg = HashTraits<WeakPtr<ValueArg>>, typename HashTableTraitsArg = HashTableTraits>
 using WeakKeyHashSet = HashSet<WeakPtr<ValueArg>, HashArg, HashTraitsArg, HashTableTraitsArg>;
@@ -292,6 +293,7 @@ using WTF::MediaTime;
 using WTF::MonotonicTime;
 using WTF::NativePromise;
 using WTF::NativePromiseRequest;
+using WTF::NativePromiseRequestData;
 using WTF::NeverDestroyed;
 using WTF::OSObjectPtr;
 using WTF::ObjectIdentifier;

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -276,15 +276,16 @@ public:
 
 class ConvertibleToNativePromise { };
 
-class NativePromiseRequest final : public RefCountedAndCanMakeWeakPtr<NativePromiseRequest> {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NativePromiseRequest);
+// Implementation detail of NativePromiseRequest; do not use directly.
+class NativePromiseRequestData final : public RefCountedAndCanMakeWeakPtr<NativePromiseRequestData> {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NativePromiseRequestData);
 public:
-    static Ref<NativePromiseRequest> create()
+    static Ref<NativePromiseRequestData> create()
     {
-        return adoptRef(*new NativePromiseRequest);
+        return adoptRef(*new NativePromiseRequestData);
     }
 
-    ~NativePromiseRequest()
+    ~NativePromiseRequestData()
     {
         ASSERT(!m_callback, "complete() or disconnect() wasn't called");
     }
@@ -294,7 +295,6 @@ public:
         virtual ~Callback() = default;
         virtual void disconnect() = 0;
     };
-
 
     void track(Ref<Callback> callback)
     {
@@ -321,9 +321,36 @@ public:
     }
 
 private:
-    NativePromiseRequest() = default;
+    NativePromiseRequestData() = default;
 
     RefPtr<Callback> m_callback;
+};
+
+// Stack/member value type used to track a then()/whenSettled() command and cancel its delivery via
+// disconnect(). Movable (so it can be captured by move into a callback); copying is disabled.
+class NativePromiseRequest final {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NativePromiseRequest);
+public:
+    using Callback = NativePromiseRequestData::Callback;
+
+    NativePromiseRequest() = default;
+    NativePromiseRequest(NativePromiseRequest&&) = default;
+    NativePromiseRequest& operator=(NativePromiseRequest&&) = default;
+
+    void track(Ref<Callback> callback) { protect(m_data)->track(WTF::move(callback)); }
+
+    explicit operator bool() const { return m_data->hasCallback(); }
+
+    void complete() { protect(m_data)->complete(); }
+
+    void disconnect() { protect(m_data)->disconnect(); }
+
+    // Weak reference to the internal state, for tracking in a WeakHashSet. Stays valid across moves
+    // of this NativePromiseRequest.
+    WeakPtr<NativePromiseRequestData> weakPtr() const { return m_data.get(); }
+
+private:
+    Ref<NativePromiseRequestData> m_data { NativePromiseRequestData::create() };
 };
 
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0>
@@ -700,7 +727,7 @@ private:
         PROMISE_LOG("creating ", *this);
     }
 
-    class ThenCallbackBase : public NativePromiseRequest::Callback {
+    class ThenCallbackBase : public NativePromiseRequestData::Callback {
 
     public:
         ThenCallbackBase(RefPtr<GuaranteedSerialFunctionDispatcher>&& targetQueue, const Logger::LogSiteIdentifier& callSite)
@@ -932,7 +959,11 @@ private:
             return completionPromise()->whenSettled(targetQueue, thisVal, std::forward<SettleMethod>(settleMethod), callSite);
         }
 
-        void track(NativePromiseRequest& requestHolder)
+        // Tracks the command through either a NativePromiseRequest (the common stack/member value
+        // type) or its internal NativePromiseRequestData (used when only a WeakPtr to the state is
+        // available, e.g. after the request has been moved into the settle callback).
+        template<typename RequestType>
+        void track(RequestType& requestHolder)
         {
             ASSERT(m_thenCallback, "Can only track a request once");
             requestHolder.track(*m_thenCallback);
@@ -1607,5 +1638,6 @@ using WTF::GenericPromise;
 using WTF::GenericNonExclusivePromise;
 using WTF::NativePromise;
 using WTF::NativePromiseRequest;
+using WTF::NativePromiseRequestData;
 using WTF::PromiseDispatchMode;
 using WTF::PromiseOption;

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -42,11 +42,13 @@
 namespace WTF {
 class CrossThreadTask;
 class NativePromiseRequest;
+class NativePromiseRequestData;
 class URL;
 } // namespace WTF
 
 using WTF::CrossThreadTask;
 using WTF::NativePromiseRequest;
+using WTF::NativePromiseRequestData;
 using WTF::URL;
 
 namespace JSC {
@@ -481,7 +483,7 @@ private:
     bool m_hasLoggedAuthenticatedEncryptionWarning { false };
 
     const RefPtr<GuaranteedSerialFunctionDispatcher> m_nativePromiseDispatcher;
-    WeakHashSet<NativePromiseRequest> m_nativePromiseRequests;
+    WeakHashSet<NativePromiseRequestData> m_nativePromiseRequests;
     std::unique_ptr<JSC::WeakGCSet<JSC::JSGlobalObject, JSC::WeakGCSetHash<JSC::JSGlobalObject>, JSC::WeakGCSetHashTraits<JSC::JSGlobalObject>>> m_microtaskGlobalObjects;
 };
 

--- a/Source/WebCore/dom/ScriptExecutionContextInlines.h
+++ b/Source/WebCore/dom/ScriptExecutionContextInlines.h
@@ -61,10 +61,10 @@ inline void ScriptExecutionContext::postCrossThreadTask(Arguments&&... arguments
 template<typename Promise, typename TaskType>
 void ScriptExecutionContext::enqueueTaskWhenSettled(Ref<Promise>&& promise, TaskSource taskSource, TaskType&& task)
 {
-    auto request = NativePromiseRequest::create();
-    WeakPtr weakRequest { request.get() };
+    NativePromiseRequest request;
+    auto weakRequest = request.weakPtr();
     auto command = promise->whenSettled(protect(nativePromiseDispatcher()), [weakThis = WeakPtr { *this }, taskSource, task = WTF::move(task), request = WTF::move(request)] (auto&& result) mutable {
-        request->complete();
+        request.complete();
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -610,7 +610,6 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_playbackControlsManagerBehaviorRestrictionsTimer(*this, &HTMLMediaElement::playbackControlsManagerBehaviorRestrictionsTimerFired)
     , m_seekToPlaybackPositionEndedTimer(*this, &HTMLMediaElement::seekToPlaybackPositionEndedTimerFired)
     , m_checkPlaybackTargetCompatibilityTimer(*this, &HTMLMediaElement::checkPlaybackTargetCompatibility)
-    , m_seekRequest(NativePromiseRequest::create())
     , m_currentIdentifier(MediaUniqueIdentifier::generate())
     , m_lastTimeUpdateEventMovieTime(MediaTime::positiveInfiniteTime())
     , m_firstTimePlaying(true)
@@ -779,8 +778,8 @@ HTMLMediaElement::~HTMLMediaElement()
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(Destructor);
 
-    if (m_seekRequest->hasCallback())
-        m_seekRequest->disconnect();
+    if (m_seekRequest)
+        m_seekRequest.disconnect();
 
     invalidateWatchtimeTimer();
     invalidateBufferingStopwatch();
@@ -4127,13 +4126,13 @@ void HTMLMediaElement::seekTask()
     // 11 - Set the current playback position to the given new playback position
     // A previous seek's promise may still be tracked if a new seekTask runs before it settled;
     // cancel it so the new request can be tracked.
-    if (m_seekRequest->hasCallback())
-        m_seekRequest->disconnect();
+    if (m_seekRequest)
+        m_seekRequest.disconnect();
     player->seekToTarget({ time, negativeTolerance, positiveTolerance })->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }](auto&& result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->m_seekRequest->complete();
+        protectedThis->m_seekRequest.complete();
         if (!result) {
             if (result.error() == PlatformMediaError::Cancelled)
                 ALWAYS_LOG_WITH_THIS(protectedThis, LOGIDENTIFIER_WITH_THIS(protectedThis), "seek cancelled");
@@ -4171,8 +4170,8 @@ void HTMLMediaElement::clearSeeking()
     if (RefPtr player = m_player)
         player->willSeekToTarget(MediaTime::invalidTime());
     setSeeking(false);
-    if (m_seekRequest->hasCallback())
-        m_seekRequest->disconnect();
+    if (m_seekRequest)
+        m_seekRequest.disconnect();
     m_pendingSeekType = NoSeek;
     m_wasPlayingBeforeSeeking = false;
     invalidateOfficialPlaybackPosition();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1211,7 +1211,7 @@ private:
     TaskCancellationGroup m_updatePlayStateTaskCancellationGroup;
     TaskCancellationGroup m_resumeTaskCancellationGroup;
     TaskCancellationGroup m_seekTaskCancellationGroup;
-    const Ref<NativePromiseRequest> m_seekRequest;
+    NativePromiseRequest m_seekRequest;
     TaskCancellationGroup m_playbackControlsManagerBehaviorRestrictionsTaskCancellationGroup;
     TaskCancellationGroup m_bufferedTimeRangesChangedTaskCancellationGroup;
     TaskCancellationGroup m_resourceSelectionTaskCancellationGroup;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -356,10 +356,10 @@ private:
     // Seeking
     Timer m_seekTimer WTF_GUARDED_BY_CAPABILITY(mainThread);
     std::optional<SeekTarget> m_pendingSeek WTF_GUARDED_BY_CAPABILITY(mainThread);
-    const Ref<NativePromiseRequest> m_waitForTargetRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
-    const Ref<NativePromiseRequest> m_rendererPrepareSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
-    const Ref<NativePromiseRequest> m_rendererFinishSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
-    const Ref<NativePromiseRequest> m_stallRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    NativePromiseRequest m_waitForTargetRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    NativePromiseRequest m_rendererPrepareSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    NativePromiseRequest m_rendererFinishSeekRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
+    NativePromiseRequest m_stallRequest WTF_GUARDED_BY_CAPABILITY(mainThread);
     std::optional<MediaTimePromise::AutoRejectProducer> m_seekPromise WTF_GUARDED_BY_CAPABILITY(mainThread);
     bool m_seeking WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -103,10 +103,6 @@ Ref<AudioVideoRenderer> MediaPlayerPrivateMediaSourceAVFObjC::createRenderer(Log
 MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC(MediaPlayer& player)
     : m_player(player)
     , m_seekTimer(*this, &MediaPlayerPrivateMediaSourceAVFObjC::seekInternal)
-    , m_waitForTargetRequest(NativePromiseRequest::create())
-    , m_rendererPrepareSeekRequest(NativePromiseRequest::create())
-    , m_rendererFinishSeekRequest(NativePromiseRequest::create())
-    , m_stallRequest(NativePromiseRequest::create())
     , m_networkState(MediaPlayer::NetworkState::Empty)
     , m_pageIsVisible { player.pageIsVisible() }
     , m_viewportVisibility { player.viewportVisibility() }
@@ -137,8 +133,8 @@ MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
     // which accesses the already-destroyed m_logger).
     weakPtrFactory().revokeAll();
 
-    if (m_stallRequest->hasCallback())
-        protect(m_stallRequest)->disconnect();
+    if (m_stallRequest)
+        m_stallRequest.disconnect();
 
     cancelPendingSeek();
     m_seekTimer.stop();
@@ -588,7 +584,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->m_waitForTargetRequest->complete();
+        protectedThis->m_waitForTargetRequest.complete();
 
         if (!result)
             return; // seek cancelled;
@@ -610,7 +606,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::continueSeek(const MediaTime& seekTim
         if (!protectedThis)
             return;
 
-        protectedThis->m_rendererPrepareSeekRequest->complete();
+        protectedThis->m_rendererPrepareSeekRequest.complete();
 
         if (!result)
             return;
@@ -646,7 +642,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek(co
         if (!protectedThis)
             return;
 
-        protectedThis->m_rendererFinishSeekRequest->complete();
+        protectedThis->m_rendererFinishSeekRequest.complete();
 
         if (!result)
             return; // cancelled.
@@ -659,12 +655,12 @@ void MediaPlayerPrivateMediaSourceAVFObjC::cancelPendingSeek()
 {
     assertIsMainThread();
 
-    if (m_waitForTargetRequest->hasCallback())
-        m_waitForTargetRequest->disconnect();
-    if (m_rendererPrepareSeekRequest->hasCallback())
-        m_rendererPrepareSeekRequest->disconnect();
-    if (m_rendererFinishSeekRequest->hasCallback())
-        m_rendererFinishSeekRequest->disconnect();
+    if (m_waitForTargetRequest)
+        m_waitForTargetRequest.disconnect();
+    if (m_rendererPrepareSeekRequest)
+        m_rendererPrepareSeekRequest.disconnect();
+    if (m_rendererFinishSeekRequest)
+        m_rendererFinishSeekRequest.disconnect();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::completeSeek(const MediaTime& seekedTime)
@@ -770,8 +766,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
 void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& time)
 {
     assertIsMainThread();
-    if (m_stallRequest->hasCallback())
-        protect(m_stallRequest)->disconnect();
+    if (m_stallRequest)
+        m_stallRequest.disconnect();
     m_renderer->cancelTimeReachedAction();
 
     auto logSiteIdentifier = LOGIDENTIFIER;
@@ -782,8 +778,8 @@ void MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime(const MediaTime& ti
         if (!protectedThis)
             return;
 
-        if (protectedThis->m_stallRequest->hasCallback())
-            protect(protectedThis->m_stallRequest)->complete();
+        if (protectedThis->m_stallRequest)
+            protectedThis->m_stallRequest.complete();
 
         if (!result)
             return;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -396,8 +396,8 @@ private:
     std::optional<SeekTarget> m_pendingSeek WTF_GUARDED_BY_CAPABILITY(mainThread);
     std::atomic<bool> m_hasPendingSeek { false };
     std::optional<GenericPromise::AutoRejectProducer> m_waitForTimeBufferedPromise WTF_GUARDED_BY_CAPABILITY(runningQueue());
-    Ref<NativePromiseRequest> m_rendererSeekRequest;
-    Ref<NativePromiseRequest> m_stallRequest;
+    NativePromiseRequest m_rendererSeekRequest;
+    NativePromiseRequest m_stallRequest;
     std::atomic<bool> m_seeking { false };
     std::optional<MediaTimePromise::AutoRejectProducer> m_seekPromise WTF_GUARDED_BY_CAPABILITY(mainThread);
 #if HAVE(SPATIAL_TRACKING_LABEL)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -101,8 +101,6 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer& player)
     , m_logger(player.mediaPlayerLogger())
     , m_logIdentifier(player.mediaPlayerLogIdentifier())
     , m_seekTimer(*this, &MediaPlayerPrivateWebM::seekInternal)
-    , m_rendererSeekRequest(NativePromiseRequest::create())
-    , m_stallRequest(NativePromiseRequest::create())
     , m_playerIdentifier(MediaPlayerIdentifier::generate())
     , m_renderer(createRenderer(*this, player.clientIdentifier(), m_playerIdentifier))
     , m_runningQueue(m_appendQueue.get())
@@ -138,11 +136,11 @@ MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM() WTF_IGNORES_THREAD_SAFETY_ANAL
     // cancelPendingSeek() requires being on m_runningQueue because disconnecting a
     // NativePromiseRequest requires being on the queue the callback was registered on.
     // Move the seek request out and dispatch to that queue.
-    m_runningQueue->dispatch([seekRequest = std::exchange(m_rendererSeekRequest, NativePromiseRequest::create()), stallRequest = std::exchange(m_stallRequest, NativePromiseRequest::create())]() mutable {
-        if (seekRequest->hasCallback())
-            seekRequest->disconnect();
-        if (stallRequest->hasCallback())
-            stallRequest->disconnect();
+    m_runningQueue->dispatch([seekRequest = std::exchange(m_rendererSeekRequest, NativePromiseRequest { }), stallRequest = std::exchange(m_stallRequest, NativePromiseRequest { })]() mutable {
+        if (seekRequest)
+            seekRequest.disconnect();
+        if (stallRequest)
+            stallRequest.disconnect();
     });
 
     // clearTracks() and cancelLoad() access running-queue-guarded members on the main thread.
@@ -663,7 +661,7 @@ void MediaPlayerPrivateWebM::seekInternal()
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
-                protect(protectedThis->m_rendererSeekRequest)->complete();
+                protectedThis->m_rendererSeekRequest.complete();
 
                 if (!result)
                     return;
@@ -676,8 +674,8 @@ void MediaPlayerPrivateWebM::seekInternal()
 void MediaPlayerPrivateWebM::cancelPendingSeek()
 {
     assertIsCurrent(runningQueue());
-    if (m_rendererSeekRequest->hasCallback())
-        protect(m_rendererSeekRequest)->disconnect();
+    if (m_rendererSeekRequest)
+        m_rendererSeekRequest.disconnect();
     m_waitForTimeBufferedPromise.reset();
 }
 
@@ -1001,8 +999,8 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
     if (duration == m_duration)
         return;
 
-    if (m_stallRequest->hasCallback())
-        protect(m_stallRequest)->disconnect();
+    if (m_stallRequest)
+        m_stallRequest.disconnect();
 
     m_renderer->cancelTimeReachedAction();
 
@@ -1010,7 +1008,7 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protect(protectedThis->m_stallRequest)->complete();
+        protectedThis->m_stallRequest.complete();
         if (!result)
             return;
         ensureOnMainThread([weakThis] {

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -86,9 +86,6 @@ AudioVideoRendererRemote::AudioVideoRendererRemote(LoggerHelper* loggerHelper, G
     : m_gpuProcessConnection(connection)
     , m_receiver(MessageReceiver::create(*this))
     , m_identifier(identifier)
-    , m_stallRequest(NativePromiseRequest::create())
-    , m_prepareSeekRequest(NativePromiseRequest::create())
-    , m_finishSeekRequest(NativePromiseRequest::create())
 #if PLATFORM(COCOA)
     , m_videoLayerManager(makeUniqueRef<VideoLayerManagerObjC>(loggerHelper->logger(), loggerHelper->logIdentifier()))
 #endif
@@ -141,16 +138,16 @@ AudioVideoRendererRemote::~AudioVideoRendererRemote() WTF_IGNORES_THREAD_SAFETY_
 #endif
 
     ensureOnDispatcher([prepareSeekRequest = WTF::move(m_prepareSeekRequest), prepareSeekPromise = WTF::move(m_prepareSeekPromise), finishSeekRequest = WTF::move(m_finishSeekRequest), finishSeekPromise = WTF::move(m_finishSeekPromise), stallRequest = WTF::move(m_stallRequest), stallProducer = WTF::move(m_stallProducer)]() mutable {
-        if (prepareSeekRequest->hasCallback())
-            prepareSeekRequest->disconnect();
+        if (prepareSeekRequest)
+            prepareSeekRequest.disconnect();
         if (auto promise = std::exchange(prepareSeekPromise, std::nullopt))
             promise->reject(PlatformMediaError::Cancelled);
-        if (finishSeekRequest->hasCallback())
-            finishSeekRequest->disconnect();
+        if (finishSeekRequest)
+            finishSeekRequest.disconnect();
         if (auto promise = std::exchange(finishSeekPromise, std::nullopt))
             promise->reject();
-        if (stallRequest->hasCallback())
-            stallRequest->disconnect();
+        if (stallRequest)
+            stallRequest.disconnect();
         if (auto producer = std::exchange(stallProducer, std::nullopt))
             producer->reject(PlatformMediaError::Cancelled);
     });
@@ -497,12 +494,12 @@ void AudioVideoRendererRemote::cancelPendingSeek()
 {
     assertIsCurrent(queueSingleton());
 
-    if (m_prepareSeekRequest->hasCallback())
-        protect(m_prepareSeekRequest)->disconnect();
+    if (m_prepareSeekRequest)
+        m_prepareSeekRequest.disconnect();
     if (auto promise = std::exchange(m_prepareSeekPromise, std::nullopt))
         promise->reject(PlatformMediaError::Cancelled);
-    if (m_finishSeekRequest->hasCallback())
-        protect(m_finishSeekRequest)->disconnect();
+    if (m_finishSeekRequest)
+        m_finishSeekRequest.disconnect();
     if (auto promise = std::exchange(m_finishSeekPromise, std::nullopt))
         promise->reject();
 }
@@ -544,7 +541,7 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& t
                 return;
 
             assertIsCurrent(queueSingleton());
-            protect(protectedThis->m_prepareSeekRequest)->complete();
+            protectedThis->m_prepareSeekRequest.complete();
 
             if (result && !result->isIndefinite())
                 protectedThis->m_seeking = false;
@@ -581,7 +578,7 @@ Ref<GenericPromise> AudioVideoRendererRemote::finishSeek(const MediaTime& time)
                 return;
 
             assertIsCurrent(queueSingleton());
-            protect(protectedThis->m_finishSeekRequest)->complete();
+            protectedThis->m_finishSeekRequest.complete();
 
             protectedThis->m_seeking = false;
 
@@ -760,8 +757,8 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::notifyTimeReachedAndStall(const 
     }
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
         assertIsCurrent(queueSingleton());
-        if (m_stallRequest->hasCallback())
-            protect(m_stallRequest)->disconnect();
+        if (m_stallRequest)
+            m_stallRequest.disconnect();
         if (auto previous = std::exchange(m_stallProducer, std::nullopt))
             previous->reject(PlatformMediaError::Cancelled);
 
@@ -776,7 +773,7 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::notifyTimeReachedAndStall(const 
             if (!protectedThis)
                 return;
             assertIsCurrent(queueSingleton());
-            protect(protectedThis->m_stallRequest)->complete();
+            protectedThis->m_stallRequest.complete();
             if (auto producer = std::exchange(protectedThis->m_stallProducer, std::nullopt))
                 producer->settle(WTF::move(result));
         })->track(m_stallRequest);
@@ -792,8 +789,8 @@ void AudioVideoRendererRemote::cancelTimeReachedAction()
     }
     ensureOnDispatcherWithConnection([](auto& renderer, auto& connection) {
         assertIsCurrent(queueSingleton());
-        if (renderer.m_stallRequest->hasCallback())
-            protect(renderer.m_stallRequest)->disconnect();
+        if (renderer.m_stallRequest)
+            renderer.m_stallRequest.disconnect();
         if (auto producer = std::exchange(renderer.m_stallProducer, std::nullopt))
             producer->reject(PlatformMediaError::Cancelled);
         connection.send(Messages::RemoteAudioVideoRendererProxyManager::CancelTimeReachedAction(renderer.m_identifier), 0);

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -272,7 +272,7 @@ private:
     Function<void(const MediaTime&)> m_currentTimeDidChangeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(double)> m_effectiveRateChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::optional<WebCore::MediaTimePromise::Producer> m_stallProducer WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Ref<NativePromiseRequest> m_stallRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    NativePromiseRequest m_stallRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(const MediaTime&)> m_performTaskAtTimeCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     MediaTime m_performTaskAtTime WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     Function<void(const MediaTime&, WebCore::FloatSize)> m_videoLayerSizeChangedCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());
@@ -287,9 +287,9 @@ private:
     WebCore::FloatSize m_naturalSize WTF_GUARDED_BY_LOCK(m_lock);
 
     // Seek Tracking
-    Ref<NativePromiseRequest> m_prepareSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    NativePromiseRequest m_prepareSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::optional<WebCore::MediaTimePromise::Producer> m_prepareSeekPromise WTF_GUARDED_BY_CAPABILITY(queueSingleton());
-    Ref<NativePromiseRequest> m_finishSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
+    NativePromiseRequest m_finishSeekRequest WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::optional<GenericPromise::Producer> m_finishSeekPromise WTF_GUARDED_BY_CAPABILITY(queueSingleton());
     std::atomic<bool> m_seeking { false };
     MediaTime m_lastSeekTime WTF_GUARDED_BY_LOCK(m_lock);

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -296,15 +296,15 @@ TEST(NativePromise, GenericPromise)
 
         GenericPromise::Producer producer3;
         Ref<GenericPromise> promise3 = producer3;
-        auto request3 = NativePromiseRequest::create();
+        NativePromiseRequest request3;
 
         // Note that if you're not interested in the result you can provide two Function<void()> to then()
-        promise3->then(queue, doFail(), doFail()).track(request3.get());
+        promise3->then(queue, doFail(), doFail()).track(request3);
         producer3.resolve();
 
         // We are no longer interested by the result of the promise. We disconnect the request holder.
         // doFail() above will never be called.
-        request3->disconnect();
+        request3.disconnect();
 
         // Note that if you're not interested in the result you can also provide one Function<void()> with whenSettled()
         GenericPromise::Producer producer4;
@@ -422,7 +422,7 @@ TEST(NativePromise, PromiseRequest)
     // We declare the Request holder before using the runLoop to ensure it stays in scope for the entire run.
     // ASSERTION FAILED: !m_request
     using MyPromise = NativePromise<bool, bool>;
-    auto request1 = NativePromiseRequest::create();
+    NativePromiseRequest request1;
 
     runInCurrentRunLoop([&](auto& runLoop) {
         MyPromise::Producer producer1;
@@ -433,17 +433,17 @@ TEST(NativePromise, PromiseRequest)
             [&](MyPromise::Result&& result) {
                 EXPECT_TRUE(result.has_value());
                 EXPECT_TRUE(result.value());
-                EXPECT_TRUE(request1->hasCallback());
-                request1->complete();
-                EXPECT_FALSE(request1->hasCallback());
-            }).track(request1.get());
+                EXPECT_TRUE(!!request1);
+                request1.complete();
+                EXPECT_FALSE(!!request1);
+            }).track(request1);
     });
 
     // PromiseRequest allows to use capture by reference or pointer to ref-counted object and ensure the
     // lifetime of the object.
     bool objectToShare = true;
     runInCurrentRunLoop([&](auto& runLoop) {
-        auto request2 = NativePromiseRequest::create();
+        NativePromiseRequest request2;
         GenericPromise::Producer producer2;
         Ref<GenericPromise> promise2 = producer2;
         promise2->whenSettled(runLoop,
@@ -451,10 +451,10 @@ TEST(NativePromise, PromiseRequest)
                 // It would be normally unsafe to access `objectToShare` as it went out of scope.
                 // but this function will never run as we've disconnected the ThenCommand.
                 objectToShare = false;
-            }).track(request2.get());
-        EXPECT_TRUE(request2->hasCallback());
-        request2->disconnect();
-        EXPECT_FALSE(request2->hasCallback());
+            }).track(request2);
+        EXPECT_TRUE(!!request2);
+        request2.disconnect();
+        EXPECT_FALSE(!!request2);
         producer2.resolve();
         EXPECT_TRUE(objectToShare);
     });
@@ -465,14 +465,14 @@ TEST(NativePromise, PromiseRequest)
 TEST(NativePromise, PromiseRequestDisconnected1)
 {
     runInCurrentRunLoop([](auto& runLoop) {
-        auto request = NativePromiseRequest::create();
+        NativePromiseRequest request;
 
         TestPromise::Producer producer;
         Ref<TestPromise> promise = producer;
-        promise->then(runLoop, doFail(), doFail()).track(request.get());
+        promise->then(runLoop, doFail(), doFail()).track(request);
 
         producer.resolve(1);
-        request->disconnect();
+        request.disconnect();
     });
 }
 
@@ -480,15 +480,15 @@ TEST(NativePromise, PromiseRequestDisconnected1)
 TEST(NativePromise, PromiseRequestDisconnected2)
 {
     runInCurrentRunLoop([](auto& runLoop) {
-        auto request = NativePromiseRequest::create();
+        NativePromiseRequest request;
 
         TestPromise::Producer producer;
         Ref<TestPromise> promise = producer;
         producer.resolve(1);
 
-        promise->then(runLoop, doFail(), doFail())->track(request.get());
+        promise->then(runLoop, doFail(), doFail())->track(request);
 
-        request->disconnect();
+        request.disconnect();
     });
 }
 
@@ -928,7 +928,7 @@ TEST(NativePromise, PromiseAllSettledAsync)
 TEST(NativePromise, Chaining)
 {
     // We declare this variable before |awq| to ensure the destructor is run after |holder.disconnect()|.
-    auto holder = NativePromiseRequest::create();
+    NativePromiseRequest holder;
 
     AutoWorkQueue awq;
     auto queue = awq.queue();
@@ -949,7 +949,7 @@ TEST(NativePromise, Chaining)
             if (i == kIterations / 2) {
                 promise->then(queue,
                     [queue, &holder] {
-                        holder->disconnect();
+                        holder.disconnect();
                         queue->beginShutdown();
                     },
                     doFail());
@@ -957,7 +957,7 @@ TEST(NativePromise, Chaining)
         }
         // We will hit the assertion if we don't disconnect the leaf Request
         // in the promise chain.
-        promise->whenSettled(queue, [] { })->track(holder.get());
+        promise->whenSettled(queue, [] { })->track(holder);
     });
 }
 
@@ -1261,7 +1261,7 @@ TEST(NativePromise, HeterogeneousChaining)
     using Promise1 = NativePromise<std::unique_ptr<char>, bool>;
     using Promise2 = NativePromise<std::unique_ptr<int>, bool>;
 
-    auto holder = NativePromiseRequest::create();
+    NativePromiseRequest holder;
 
     AutoWorkQueue awq;
     auto queue = awq.queue();
@@ -1269,13 +1269,13 @@ TEST(NativePromise, HeterogeneousChaining)
     queue->dispatch([queue, &holder] {
         Promise1::createAndResolve(makeUniqueWithoutFastMallocCheck<char>(0))->whenSettled(queue,
             [&holder] {
-                holder->disconnect();
+                holder.disconnect();
                 return Promise2::createAndResolve(makeUniqueWithoutFastMallocCheck<int>(0));
             })->whenSettled(queue,
                 [] {
                     // Shouldn't be called for we've disconnected the request.
                     EXPECT_FALSE(true);
-                })->track(holder.get());
+                })->track(holder);
     });
 
     Promise1::createAndResolve(makeUniqueWithoutFastMallocCheck<char>(87))->then(queue,
@@ -1681,10 +1681,10 @@ TEST(NativePromise, CreateSettledPromise)
 TEST(NativePromise, DisconnectNotOwnedInstance)
 {
     GenericPromise::Producer producer;
-    auto request = NativePromiseRequest::create();
-    WeakPtr weakRequest { request.get() };
+    NativePromiseRequest request;
+    auto weakRequest = request.weakPtr();
     producer->whenSettled(RunLoop::mainSingleton(), [request = WTF::move(request)] (auto&& result) mutable {
-        request->complete();
+        request.complete();
         EXPECT_TRUE(false);
     })->track(*weakRequest);
     weakRequest->disconnect();


### PR DESCRIPTION
#### f465d6f4c2089707eddc162ac48cc6fccca085be
<pre>
Re-introduce NativePromiseRequest semantics as they were before <a href="https://commits.webkit.org/302170@main">302170@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=318639">https://bugs.webkit.org/show_bug.cgi?id=318639</a>
<a href="https://rdar.apple.com/181444915">rdar://181444915</a>

Reviewed by NOBODY (OOPS!).

Split NativePromiseRequest into a stack value type + a heap-allocated inner object, restoring
the pre-<a href="https://commits.webkit.org/302170@main">302170@main</a> ergonomic API while keeping the IsDeprecatedWeakRefSmartPointerException
removed.

Test: Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp

* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContextInlines.h:
(WebCore::ScriptExecutionContext::enqueueTaskWhenSettled):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::clearSeeking):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekInternal):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::continueSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::reenqueueMediaForTimeAndFinishSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::cancelPendingSeek):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::resetStallForTime):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::seekInternal):
(WebCore::MediaPlayerPrivateWebM::cancelPendingSeek):
(WebCore::MediaPlayerPrivateWebM::setDuration):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::AudioVideoRendererRemote):
(WebKit::AudioVideoRendererRemote::cancelPendingSeek):
(WebKit::AudioVideoRendererRemote::prepareToSeek):
(WebKit::AudioVideoRendererRemote::finishSeek):
(WebKit::AudioVideoRendererRemote::notifyTimeReachedAndStall):
(WebKit::AudioVideoRendererRemote::cancelTimeReachedAction):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::TEST(NativePromise, GenericPromise)):
(TestWebKitAPI::TEST(NativePromise, PromiseRequest)):
(TestWebKitAPI::TEST(NativePromise, PromiseRequestDisconnected1)):
(TestWebKitAPI::TEST(NativePromise, PromiseRequestDisconnected2)):
(TestWebKitAPI::TEST(NativePromise, Chaining)):
(TestWebKitAPI::TEST(NativePromise, HeterogeneousChaining)):
(TestWebKitAPI::TEST(NativePromise, DisconnectNotOwnedInstance)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c12d036353d2540dce22b04b9fc79843240180b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130300 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adf2af01-edaf-424c-988d-c6fe3edacc75) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134353 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe9282d4-f102-43a7-972e-079964d8f9e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114825 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b42daf0-5e53-4394-ae39-167657fb4a1a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36388 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30801 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3428 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184735 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34005 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143144 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46334 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143022 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47012 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111980 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38027 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118764 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205422 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45529 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/9355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54845 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44929 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44988 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->