### PR TITLE
[JSC] Skip LowerEntrySwitch and SimplifyCFG if possible

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -6644,6 +6644,7 @@ private:
         }
             
         case B3::EntrySwitch: {
+            m_procedure.setUsesEntrySwitch(true);
             append(Air::EntrySwitch);
             return;
         }

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -323,6 +323,8 @@ public:
     bool usesColdCCall() const { return m_usesColdCCall; }
     void setUsesShuffle(bool flag) { m_usesShuffle = flag; }
     bool usesShuffle() const { return m_usesShuffle; }
+    void setUsesEntrySwitch(bool flag) { m_usesEntrySwitch = flag; }
+    bool usesEntrySwitch() const { return m_usesEntrySwitch; }
 
 private:
     friend class BlockInsertionSet;
@@ -359,6 +361,7 @@ private:
     bool m_isWasm : 1 { false };
     bool m_usesColdCCall : 1 { false };
     bool m_usesShuffle : 1 { false };
+    bool m_usesEntrySwitch : 1 { false };
 };
     
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -141,20 +141,21 @@ void prepareForGeneration(Code& code)
 
     // This is needed to satisfy a requirement of B3::StackmapValue. This also removes dead
     // code. We can avoid running this when certain optimizations are disabled.
+    bool cfgMayHaveChanged = false;
     if (code.optLevel() >= 2 || code.needsUsedRegisters())
-        reportUsedRegisters(code);
+        cfgMayHaveChanged |= reportUsedRegisters(code);
 
     // Attempt to remove false dependencies between instructions created by partial register changes.
     // This must be executed as late as possible as it depends on the instructions order and register
     // use. We _must_ run this after reportUsedRegisters(), since that kills variable assignments
     // that seem dead. Luckily, this phase does not change register liveness, so that's OK.
     fixPartialRegisterStalls(code);
-    
+
     // Actually create entrypoints.
-    lowerEntrySwitch(code);
-    
-    // The control flow graph can be simplified further after we have lowered EntrySwitch.
-    simplifyCFG(code);
+    cfgMayHaveChanged |= lowerEntrySwitch(code);
+
+    if (cfgMayHaveChanged)
+        simplifyCFG(code);
 
     // We do this optimization at the very end of Air generation pipeline since it can be beneficial after
     // spills are lowered to load/store with the frame pointer or the stack pointer. And this is block-local

--- a/Source/JavaScriptCore/b3/air/AirLowerEntrySwitch.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerEntrySwitch.cpp
@@ -35,22 +35,27 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-void lowerEntrySwitch(Code& code)
+bool lowerEntrySwitch(Code& code)
 {
     PhaseScope phaseScope(code, "lowerEntrySwitch"_s);
-    
+
+    if (!code.proc().usesEntrySwitch()) {
+        Vector<FrequentedBlock> entrypoints(FillWith { }, code.proc().numEntrypoints(), FrequentedBlock(code[0]));
+        code.setEntrypoints(WTF::move(entrypoints));
+        return false;
+    }
+
     // Figure out the set of blocks that should be duplicated.
     BlockWorklist worklist;
     for (BasicBlock* block : code) {
         if (block->last().kind.opcode == EntrySwitch)
             worklist.push(block);
     }
-    
-    // It's possible that we don't have any EntrySwitches. That's fine.
+
     if (worklist.seen().isEmpty()) {
         Vector<FrequentedBlock> entrypoints(FillWith { }, code.proc().numEntrypoints(), FrequentedBlock(code[0]));
         code.setEntrypoints(WTF::move(entrypoints));
-        return;
+        return false;
     }
     
     while (BasicBlock* block = worklist.pop())
@@ -104,6 +109,7 @@ void lowerEntrySwitch(Code& code)
     
     code.setEntrypoints(WTF::move(entrypoints));
     code.resetReachability();
+    return true;
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirLowerEntrySwitch.h
+++ b/Source/JavaScriptCore/b3/air/AirLowerEntrySwitch.h
@@ -34,7 +34,7 @@ class Code;
 // Converts code that seems to have one entrypoint and emulates multiple entrypoints with
 // EntrySwitch into code that really has multiple entrypoints. This is accomplished by duplicating
 // the backwards transitive closure from all EntrySwitches.
-void lowerEntrySwitch(Code&);
+bool lowerEntrySwitch(Code&);
 
 } } } // namespace JSC::B3::Air
 

--- a/Source/JavaScriptCore/b3/air/AirReportUsedRegisters.cpp
+++ b/Source/JavaScriptCore/b3/air/AirReportUsedRegisters.cpp
@@ -36,28 +36,29 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-void reportUsedRegisters(Code& code)
+bool reportUsedRegisters(Code& code)
 {
     PhaseScope phaseScope(code, "reportUsedRegisters"_s);
-    
+
     static constexpr bool verbose = false;
 
     padInterference(code);
-    
+
     if (verbose)
         dataLog("Doing reportUsedRegisters on:\n", code);
 
     RegLiveness liveness(code);
 
+    bool changed = false;
     for (BasicBlock* block : code) {
         if (verbose)
             dataLog("Looking at: ", *block, "\n");
-        
+
         RegLiveness::LocalCalc localCalc(liveness, block);
 
         for (unsigned instIndex = block->size(); instIndex--;) {
             Inst& inst = block->at(instIndex);
-            
+
             if (verbose)
                 dataLog("   Looking at: ", inst, "\n");
 
@@ -96,15 +97,20 @@ void reportUsedRegisters(Code& code)
                 inst.reportUsedRegisters(localCalc.live());
             localCalc.execute(instIndex);
         }
-        
-        block->insts().removeAllMatching(
-            [&] (const Inst& inst) -> bool {
+
+        unsigned sizeBefore = block->size();
+        unsigned removed = block->insts().removeAllMatching(
+            [&](const Inst& inst) -> bool {
                 return !inst;
             });
+        if (removed && sizeBefore - removed <= 1)
+            changed = true;
     }
 
     if (verbose)
         dataLog("After reportUsedRegisters:\n", code);
+
+    return changed;
 }
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirReportUsedRegisters.h
+++ b/Source/JavaScriptCore/b3/air/AirReportUsedRegisters.h
@@ -34,7 +34,7 @@ class Code;
 // Performs a liveness analysis over registers and reports the live registers to every Special. Takes
 // the opportunity to kill dead assignments to registers, since it has access to register liveness.
 
-void reportUsedRegisters(Code&);
+bool reportUsedRegisters(Code&);
 
 } } } // namespace JSC::B3::Air
 


### PR DESCRIPTION
#### 7b3dbc197b140fa6c1b7383e6770bb3f1cb9be7b
<pre>
[JSC] Skip LowerEntrySwitch and SimplifyCFG if possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=318640">https://bugs.webkit.org/show_bug.cgi?id=318640</a>
<a href="https://rdar.apple.com/181445350">rdar://181445350</a>

Reviewed by Yijia Huang.

1. Have usesEntrySwitch flag to avoid scanning the graph in Air::lowerEntrySwitch.
   EntrySwitch is not frequently used, thus we can remember when it is
   added.
2. Record whether simplifyCFG can be beneficial and run it only it can
   make code changed.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::setUsesEntrySwitch):
(JSC::B3::Procedure::usesEntrySwitch const):
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirLowerEntrySwitch.cpp:
(JSC::B3::Air::lowerEntrySwitch):
* Source/JavaScriptCore/b3/air/AirLowerEntrySwitch.h:
* Source/JavaScriptCore/b3/air/AirReportUsedRegisters.cpp:
(JSC::B3::Air::reportUsedRegisters):
* Source/JavaScriptCore/b3/air/AirReportUsedRegisters.h:

Canonical link: <a href="https://commits.webkit.org/316535@main">https://commits.webkit.org/316535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4df7e0bf8ab1038a658f7630d0e4ffca00b655b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182130 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130228 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67967593-6694-491a-8879-feff5a49f095) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134297 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4739b5dd-f322-4e69-a951-b989ab5fd246) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114769 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5766f40b-029a-4663-9cbd-4dec489a89ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36333 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34645 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30729 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3363 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184663 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33933 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38846 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143087 "Found 1 new test failure: compositing/color-matching/image-color-matching.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46262 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142964 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46940 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111882 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26205 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37973 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118692 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45457 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9287 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54820 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44857 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45089 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->