### PR TITLE
[JSC] Add AtomString Array loop in DFG / FTL

### DIFF
--- a/JSTests/stress/array-indexof-includes-cow-atom-strings.js
+++ b/JSTests/stress/array-indexof-includes-cow-atom-strings.js
@@ -1,0 +1,50 @@
+// indexOf/includes on copy-on-write "only atom strings" array literals, with a fallback
+// when the search element is not an atom.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+function idx(s) { return ['__flags', '__methods', '_obj', 'assert'].indexOf(s); }
+noInline(idx);
+
+function idxFrom(s, from) { return ['__flags', '__methods', '_obj', 'assert'].indexOf(s, from); }
+noInline(idxFrom);
+
+function inc(s) { return ['__flags', '__methods', '_obj', 'assert'].includes(s); }
+noInline(inc);
+
+function idxEmptyAndSingle(s) { return ['', 'a', 'bb'].indexOf(s); }
+noInline(idxEmptyAndSingle);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(idx('__flags'), 0);
+    shouldBe(idx('__methods'), 1);
+    shouldBe(idx('_obj'), 2);
+    shouldBe(idx('assert'), 3);
+
+    shouldBe(idx('nope'), -1);
+    shouldBe(idx('then'), -1);
+
+    shouldBe(inc('__methods'), true);
+    shouldBe(inc('xyz'), false);
+
+    // Non-atom search string equal to an element must hit the slow path and return the right index.
+    const dyn = '_o' + 'bj';
+    shouldBe(idx(dyn), 2);
+    shouldBe(inc(dyn), true);
+    shouldBe(idx('as' + 'sert'), 3);
+    shouldBe(idx('no' + 'match'), -1);
+
+    shouldBe(idxFrom('__flags', 1), -1);
+    shouldBe(idxFrom('assert', 2), 3);
+    shouldBe(idxFrom('_obj', 3), -1);
+
+    shouldBe(idxEmptyAndSingle(''), 0);
+    shouldBe(idxEmptyAndSingle('a'), 1);
+    shouldBe(idxEmptyAndSingle('bb'), 2);
+    shouldBe(idxEmptyAndSingle('' + ''), 0);
+    shouldBe(idxEmptyAndSingle(String.fromCharCode(97)), 1);
+    shouldBe(idxEmptyAndSingle('z'), -1);
+}

--- a/JSTests/stress/array-indexof-includes-result-boundaries.js
+++ b/JSTests/stress/array-indexof-includes-result-boundaries.js
@@ -1,0 +1,65 @@
+// indexOf/includes result materialization across element types and tiers. Covers the boundary
+// cases for the branchless includes result (index != length): match at index 0, empty arrays
+// (length 0), and fromIndex >= length.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${expected} but got ${actual}`);
+}
+
+function i32Index(a, x) { return a.indexOf(x); }
+noInline(i32Index);
+function i32Includes(a, x) { return a.includes(x); }
+noInline(i32Includes);
+function i32IncludesFrom(a, x, from) { return a.includes(x, from); }
+noInline(i32IncludesFrom);
+
+function dblIndex(a, x) { return a.indexOf(x); }
+noInline(dblIndex);
+function dblIncludes(a, x) { return a.includes(x); }
+noInline(dblIncludes);
+
+function strIndex(a, x) { return a.indexOf(x); }
+noInline(strIndex);
+function strIncludes(a, x) { return a.includes(x); }
+noInline(strIncludes);
+
+const i32 = [10, 20, 30, 40];
+const i32Empty = [];
+const dbl = [1.5, 2.5, 3.5];
+const dblEmpty = [];
+const str = ['a', 'bb', 'ccc'];
+const strEmpty = [];
+
+for (let i = 0; i < testLoopCount; ++i) {
+    // Match at index 0 must be found (guards against a naive "0 means not found" scheme).
+    shouldBe(i32Index(i32, 10), 0);
+    shouldBe(i32Includes(i32, 10), true);
+    shouldBe(i32Index(i32, 40), 3);
+    shouldBe(i32Includes(i32, 40), true);
+    shouldBe(i32Index(i32, 99), -1);
+    shouldBe(i32Includes(i32, 99), false);
+
+    shouldBe(dblIndex(dbl, 1.5), 0);
+    shouldBe(dblIncludes(dbl, 1.5), true);
+    shouldBe(dblIndex(dbl, 9.9), -1);
+    shouldBe(dblIncludes(dbl, 9.9), false);
+
+    shouldBe(strIndex(str, 'a'), 0);
+    shouldBe(strIncludes(str, 'a'), true);
+    shouldBe(strIndex(str, 'zz'), -1);
+    shouldBe(strIncludes(str, 'zz'), false);
+
+    // Empty arrays (length 0): includes -> false, indexOf -> -1.
+    shouldBe(i32Index(i32Empty, 5), -1);
+    shouldBe(i32Includes(i32Empty, 5), false);
+    shouldBe(dblIndex(dblEmpty, 1.5), -1);
+    shouldBe(dblIncludes(dblEmpty, 1.5), false);
+    shouldBe(strIndex(strEmpty, 'x'), -1);
+    shouldBe(strIncludes(strEmpty, 'x'), false);
+
+    // fromIndex >= length clamps to length, taking the not-found path.
+    shouldBe(i32IncludesFrom(i32, 20, 5), false);
+    shouldBe(i32IncludesFrom(i32, 10, 4), false);
+    shouldBe(i32IncludesFrom(i32, 40, 3), true);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -10328,6 +10328,20 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         move(TrustedImm32(0), indexGPR);
 
     Edge& searchElementEdge = m_graph.varArgChild(node, 1);
+
+    // Materialize the loop result into indexGPR by using lengthGPR comparison.
+    auto emitResult = [&](Jump notFound, JumpList found) {
+        if (isArrayIncludes) {
+            notFound.link(this);
+            found.link(this);
+            compare32(NotEqual, indexGPR, lengthGPR, indexGPR);
+        } else {
+            notFound.link(this);
+            move(TrustedImm32(-1), indexGPR);
+            found.link(this);
+        }
+    };
+
     switch (searchElementEdge.useKind()) {
     case Int32Use: {
         auto emitLoop = [&] (auto emitCompare) {
@@ -10346,20 +10360,11 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             add32(TrustedImm32(1), indexGPR);
             jump().linkTo(loop, this);
 
-            if (isArrayIncludes) {
-                notFound.link(this);
-                move(TrustedImm32(0), indexGPR);
-                Jump done = jump();
-                found.link(this);
-                move(TrustedImm32(1), indexGPR);
-                done.link(this);
+            emitResult(notFound, found);
+            if (isArrayIncludes)
                 unblessedBooleanResult(indexGPR, node);
-            } else {
-                notFound.link(this);
-                move(TrustedImm32(-1), indexGPR);
-                found.link(this);
+            else
                 strictInt32Result(indexGPR, node);
-            }
         };
 
         ASSERT(node->arrayMode().type() == Array::Int32);
@@ -10411,20 +10416,11 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         add32(TrustedImm32(1), indexGPR);
         jump().linkTo(loop, this);
 
-        if (isArrayIncludes) {
-            notFound.link(this);
-            move(TrustedImm32(0), indexGPR);
-            Jump done = jump();
-            found.link(this);
-            move(TrustedImm32(1), indexGPR);
-            done.link(this);
+        emitResult(notFound, found);
+        if (isArrayIncludes)
             unblessedBooleanResult(indexGPR, node);
-        } else {
-            notFound.link(this);
-            move(TrustedImm32(-1), indexGPR);
-            found.link(this);
+        else
             strictInt32Result(indexGPR, node);
-        }
         return;
     }
 
@@ -10485,22 +10481,33 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             return false;
         };
 
-        if (isCopyOnWriteArrayWithContiguous()) {
-            operation = operationCopyOnWriteArrayIndexOfString;
-            loadLinkableConstant(LinkableConstant(*this, vm().cellButterflyOnlyAtomStringsStructure.get()), compareLengthGPR);
-            emitEncodeStructureID(compareLengthGPR, compareLengthGPR);
-            addPtr(TrustedImm32(-static_cast<ptrdiff_t>(JSCellButterfly::offsetOfData())), storageGPR, leftStringGPR);
-            slowCase.append(branch32(Equal, Address(leftStringGPR, JSCell::structureIDOffset()), compareLengthGPR));
-        }
-
         loadPtr(Address(searchElementGPR, JSString::offsetOfValue()), rightStringGPR);
         if (canBeRope(searchElementEdge))
             slowCase.append(branchIfRopeStringImpl(rightStringGPR));
-        slowCase.append(branchTest32(
-            Zero,
-            Address(rightStringGPR, StringImpl::flagsOffset()),
-            TrustedImm32(StringImpl::flagIs8Bit())
-        ));
+
+        Jump skipGeneric;
+        if (isCopyOnWriteArrayWithContiguous()) {
+            operation = operationCopyOnWriteArrayIndexOfString;
+            auto notAtomStructure = branchWeakStructure(NotEqual, Address(storageGPR, -static_cast<ptrdiff_t>(JSCellButterfly::offsetOfData()) + JSCell::structureIDOffset()), m_graph.registerStructure(vm().cellButterflyOnlyAtomStringsStructure.get()));
+
+            slowCase.append(branchTest32(Zero, Address(rightStringGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIsAtom())));
+
+            JumpList atomFound;
+            Label atomLoop = label();
+            Jump atomNotFound = branch32(Equal, indexGPR, lengthGPR);
+            loadPtr(BaseIndex(storageGPR, indexGPR, TimesEight), leftStringGPR);
+            loadPtr(Address(leftStringGPR, JSString::offsetOfValue()), leftStringGPR);
+            atomFound.append(branchPtr(Equal, leftStringGPR, rightStringGPR));
+            add32(TrustedImm32(1), indexGPR);
+            jump().linkTo(atomLoop, this);
+
+            emitResult(atomNotFound, atomFound);
+            skipGeneric = jump();
+
+            notAtomStructure.link(this);
+        }
+
+        slowCase.append(branchTest32(Zero, Address(rightStringGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
 
         auto emitLoop = [&](auto emitCompare) {
 #if ENABLE(DFG_REGISTER_ALLOCATION_VALIDATION)
@@ -10515,18 +10522,7 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             add32(TrustedImm32(1), indexGPR);
             jump().linkTo(loop, this);
 
-            if (isArrayIncludes) {
-                notFound.link(this);
-                move(TrustedImm32(0), indexGPR);
-                Jump done = jump();
-                found.link(this);
-                move(TrustedImm32(1), indexGPR);
-                done.link(this);
-            } else {
-                notFound.link(this);
-                move(TrustedImm32(-1), indexGPR);
-                found.link(this);
-            }
+            emitResult(notFound, found);
         };
 
         auto emitCompare = [&]() -> JumpList {
@@ -10593,6 +10589,9 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         };
 
         emitLoop(emitCompare);
+
+        if (skipGeneric.isSet())
+            skipGeneric.link(this);
 
         if (isArrayIncludes) {
             addSlowPathGenerator(slowPathCall(

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8750,19 +8750,39 @@ IGNORE_CLANG_WARNINGS_END
                 return false;
             };
 
-            if (isCopyOnWriteArrayWithContiguous()) {
+            bool isOnlyAtomStrings = isCopyOnWriteArrayWithContiguous();
+            LBasicBlock checkAtomStructure = nullptr;
+            LBasicBlock atomCheckSearchIsAtom = nullptr;
+            LBasicBlock atomLoopHeader = nullptr;
+            LBasicBlock atomLoopBody = nullptr;
+            LBasicBlock atomLoopNext = nullptr;
+            LBasicBlock atomNotFound = nullptr;
+            ValueFromBlock initialStartIndexForAtom;
+
+            if (isOnlyAtomStrings) {
                 operation = operationCopyOnWriteArrayIndexOfString;
-                LValue targetStructureID = encodeStructureID(weakPointer(vm().cellButterflyOnlyAtomStringsStructure.get()));
-                LValue butterflyStructureID = m_out.load32(m_out.add(storage, m_out.constIntPtr(-JSCellButterfly::offsetOfData())), m_heaps.JSCell_structureID);
-                m_out.branch(m_out.equal(butterflyStructureID, targetStructureID), unsure(slowCase), unsure(checkSearchRopeString));
-            } else
-                m_out.jump(checkSearchRopeString);
+                checkAtomStructure = m_out.newBlock();
+                atomCheckSearchIsAtom = m_out.newBlock();
+                atomLoopHeader = m_out.newBlock();
+                atomLoopBody = m_out.newBlock();
+                atomLoopNext = m_out.newBlock();
+                atomNotFound = m_out.newBlock();
+                initialStartIndexForAtom = m_out.anchor(startIndex);
+            }
+            m_out.jump(checkSearchRopeString);
 
             LBasicBlock lastNext = m_out.appendTo(checkSearchRopeString, checkSearchElement8Bit);
-            m_out.branch(isRopeString(searchElement, searchElementEdge), rarely(slowCase), usually(checkSearchElement8Bit));
+            LValue searchElementImpl = m_out.loadPtr(searchElement, m_heaps.JSString_value);
+            m_out.branch(isRopeString(searchElement, searchElementEdge), rarely(slowCase), usually(isOnlyAtomStrings ? checkAtomStructure : checkSearchElement8Bit));
+
+            if (isOnlyAtomStrings) {
+                m_out.appendTo(checkAtomStructure, checkSearchElement8Bit);
+                LValue targetStructureID = weakStructureID(m_graph.registerStructure(vm().cellButterflyOnlyAtomStringsStructure.get()));
+                LValue butterflyStructureID = m_out.load32(m_out.add(storage, m_out.constIntPtr(-JSCellButterfly::offsetOfData())), m_heaps.JSCell_structureID);
+                m_out.branch(m_out.equal(butterflyStructureID, targetStructureID), unsure(atomCheckSearchIsAtom), unsure(checkSearchElement8Bit));
+            }
 
             m_out.appendTo(checkSearchElement8Bit, loopHeader);
-            LValue searchElementImpl = m_out.loadPtr(searchElement, m_heaps.JSString_value);
             m_out.branch(m_out.testIsZero32(m_out.load32(searchElementImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())), unsure(slowCase), unsure(loopHeader));
 
             m_out.appendTo(loopHeader, fastCheckElementEmpty);
@@ -8859,13 +8879,45 @@ IGNORE_CLANG_WARNINGS_END
             ValueFromBlock slowCaseResult = isArrayIncludes ? m_out.anchor(vmCall(Int32, operationArrayIncludesString, weakPointer(globalObject), storage, searchElement, startIndex)) : m_out.anchor(vmCall(Int64, operation, weakPointer(globalObject), storage, searchElement, startIndex));
             m_out.jump(continuation);
 
+            Vector<ValueFromBlock, 5> results;
+            results.append(notFoundResult);
+            results.append(foundResult);
+            results.append(slowCaseResult);
+
+            if (isOnlyAtomStrings) {
+                m_out.appendTo(atomCheckSearchIsAtom, atomLoopHeader);
+                m_out.branch(m_out.testIsZero32(m_out.load32(searchElementImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIsAtom())), rarely(slowCase), usually(atomLoopHeader));
+
+                m_out.appendTo(atomLoopHeader, atomLoopBody);
+                LValue atomIndex = m_out.phi(pointerType(), initialStartIndexForAtom);
+                m_out.branch(m_out.notEqual(atomIndex, length), usually(atomLoopBody), rarely(atomNotFound));
+
+                m_out.appendTo(atomLoopBody, atomLoopNext);
+                ValueFromBlock atomFoundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(true)) : m_out.anchor(atomIndex);
+                LValue atomElement = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, storage, atomIndex));
+                LValue atomElementImpl = m_out.loadPtr(atomElement, m_heaps.JSString_value);
+                m_out.branch(m_out.equal(atomElementImpl, searchElementImpl), rarely(continuation), usually(atomLoopNext));
+
+                m_out.appendTo(atomLoopNext, atomNotFound);
+                LValue atomNextIndex = m_out.add(atomIndex, m_out.intPtrOne);
+                m_out.addIncomingToPhi(atomIndex, m_out.anchor(atomNextIndex));
+                m_out.jump(atomLoopHeader);
+
+                m_out.appendTo(atomNotFound, continuation);
+                ValueFromBlock atomNotFoundResult = isArrayIncludes ? m_out.anchor(m_out.constBool(false)) : m_out.anchor(m_out.constIntPtr(-1));
+                m_out.jump(continuation);
+
+                results.append(atomNotFoundResult);
+                results.append(atomFoundResult);
+            }
+
             m_out.appendTo(continuation, lastNext);
             // We have to keep base alive since that keeps content of storage alive.
             ensureStillAliveHere(base);
             if (isArrayIncludes)
-                setBoolean(m_out.phi(Int32, notFoundResult, foundResult, slowCaseResult));
+                setBoolean(m_out.phi(Int32, results));
             else
-                setInt32(m_out.castToInt32(m_out.phi(Int64, notFoundResult, foundResult, slowCaseResult)));
+                setInt32(m_out.castToInt32(m_out.phi(Int64, results)));
             return;
         }
 


### PR DESCRIPTION
#### 23903f1a1cc7fa0b403cd150387669c8ecb3a6ad
<pre>
[JSC] Add AtomString Array loop in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=318642">https://bugs.webkit.org/show_bug.cgi?id=318642</a>
<a href="https://rdar.apple.com/181445937">rdar://181445937</a>

Reviewed by Yijia Huang.

This patch adds fast path for indexOf / includes with AtomString arrays.
If Array is an AtomString array and input is JSString with AtomString,
we do pointer comparison loop. Also we use compare32 to clean up result
generation in DFG code, which becomes branchless and faster. FTL already
achieves it due to B3&apos;s conversion.

Tests: JSTests/stress/array-indexof-includes-cow-atom-strings.js
       JSTests/stress/array-indexof-includes-result-boundaries.js

* JSTests/stress/array-indexof-includes-cow-atom-strings.js: Added.
(shouldBe):
(idxFrom):
(inc):
(idxEmptyAndSingle):
* JSTests/stress/array-indexof-includes-result-boundaries.js: Added.
(shouldBe):
(i32Includes):
(i32IncludesFrom):
(dblIndex):
(dblIncludes):
(strIndex):
(strIncludes):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):

Canonical link: <a href="https://commits.webkit.org/316534@main">https://commits.webkit.org/316534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c1d19ec517d6302743993cc76e28618f065f7bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130230 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a721a474-1538-4c87-acc7-5d8c396493e7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08fd32b6-bec4-4109-a5d4-b36cbfe3a333) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37702 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154837 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.CrossProcessHistoryTraversalCoalesce (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114770 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dd416ce-a3fc-46db-995f-0468d6aab2a0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34650 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30731 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3364 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184665 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33935 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143091 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46264 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142968 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46942 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111888 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26204 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37975 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118694 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205352 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45459 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9288 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54822 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44859 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->