### PR TITLE
[Text Extraction] Apply the latest set of `replacementStrings` to interaction descriptions

### DIFF
--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -490,6 +490,7 @@ static FoldedTextResult foldForReplacement(const String& source)
         appendCodePoint(quoteFoldedView.substring(start, i - start), start);
     }
     sourceOffsetByFoldedIndex.append(quoteFolded.length());
+    ASSERT(sourceOffsetByFoldedIndex.size() == builder.length() + 1);
 
     return { builder.toString(), WTF::move(sourceOffsetByFoldedIndex) };
 }
@@ -497,6 +498,46 @@ static FoldedTextResult foldForReplacement(const String& source)
 String foldTextForReplacement(const String& source)
 {
     return foldForReplacement(source).text;
+}
+
+String applyReplacements(const String& text, const Vector<std::pair<String, String>>& replacementStrings)
+{
+    if (replacementStrings.isEmpty())
+        return text;
+
+    auto folded = foldForReplacement(text);
+    StringBuilder result;
+    result.reserveCapacity(text.length());
+    unsigned cursor = 0;
+    while (cursor < folded.text.length()) {
+        bool matched = false;
+        for (auto [foldedKey, replacement] : replacementStrings) {
+            if (foldedKey.isEmpty()) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
+
+            if (foldedKey.length() > folded.text.length() - cursor)
+                continue;
+
+            if (StringView { folded.text }.substring(cursor, foldedKey.length()) != foldedKey)
+                continue;
+
+            result.append(replacement);
+            cursor += foldedKey.length();
+            matched = true;
+            break;
+        }
+
+        if (matched)
+            continue;
+
+        unsigned originalStart = folded.sourceOffsetByFoldedIndex[cursor];
+        unsigned originalEnd = folded.sourceOffsetByFoldedIndex[cursor + 1];
+        result.append(StringView { text }.substring(originalStart, originalEnd - originalStart));
+        ++cursor;
+    }
+    return result.toString();
 }
 
 class TextExtractionAggregator : public RefCounted<TextExtractionAggregator> {
@@ -716,38 +757,8 @@ public:
 
     void applyReplacements(String& text)
     {
-        if (m_options.replacementStrings.isEmpty())
-            return;
-
-        auto folded = foldForReplacement(text);
-        StringBuilder result;
-        result.reserveCapacity(text.length());
-        unsigned cursor = 0;
-        while (cursor < folded.text.length()) {
-            bool matched = false;
-            for (auto& [foldedKey, replacement] : m_options.replacementStrings) {
-                if (foldedKey.length() > folded.text.length() - cursor)
-                    continue;
-                if (StringView { folded.text }.substring(cursor, foldedKey.length()) != foldedKey)
-                    continue;
-
-                result.append(replacement);
-                cursor += foldedKey.length();
-                matched = true;
-                break;
-            }
-
-            if (matched)
-                continue;
-
-            unsigned originalStart = folded.sourceOffsetByFoldedIndex[cursor];
-            unsigned originalEnd = folded.sourceOffsetByFoldedIndex[cursor + 1];
-            result.append(StringView { text }.substring(originalStart, originalEnd - originalStart));
-            ++cursor;
-        }
-        text = result.toString();
+        text = WebKit::applyReplacements(text, m_options.replacementStrings);
     }
-
 
     void truncateTextByWordLimitIfNeeded(String& text, const Vector<CharacterRange>& linkCharacterRanges = { }, HasAdjacentLinkAfter hasAdjacentLinkAfter = HasAdjacentLinkAfter::No)
     {

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.h
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.h
@@ -131,4 +131,6 @@ std::optional<ExtractedNodeInfo> parseExtractedNodeInfo(StringView);
 
 String foldTextForReplacement(const String& source);
 
+String applyReplacements(const String& text, const Vector<std::pair<String, String>>& replacementStrings);
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7306,6 +7306,8 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
     if (!_textExtractionURLCache)
         _textExtractionURLCache = WebKit::TextExtractionURLCache::create();
 
+    _lastTextExtractionReplacementStrings = extractReplacementStrings(configuration);
+
     [self _requestTextExtractionInternal:configuration completion:[
         startTime = MonotonicTime::now(),
         completionHandler = makeBlockPtr(completionHandler),
@@ -7321,7 +7323,7 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
         shortenURLs = configuration.shortenURLs,
         maxWordsPerParagraph = WTF::move(maxWordsPerParagraph),
         version,
-        replacementStrings = extractReplacementStrings(configuration),
+        replacementStrings = _lastTextExtractionReplacementStrings,
         outputFormat = textExtractionOutputFormat(configuration),
         endTextExtractionScope = WTF::move(endTextExtractionScope),
         origin = _page->pageLoadState().origin(),
@@ -8189,7 +8191,7 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
         auto description = WTF::move(result.description);
         auto stringsToValidate = WTF::move(result.stringsToValidate);
         auto valid = Box<bool>::create(true);
-        Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTF::move(completionHandler), description, valid, staleNodeNote] {
+        Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTF::move(completionHandler), description, valid, staleNodeNote, weakSelf, stringsToValidate] {
             if (!valid.get()) {
                 completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{
                     NSDebugDescriptionErrorKey: @"One or more strings failed validation."
@@ -8197,7 +8199,16 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
                 return;
             }
 
-            RetainPtr summary = description.createNSString();
+            String replacedDescription = description;
+            if (RetainPtr strongSelf = weakSelf.get(); strongSelf && !strongSelf->_lastTextExtractionReplacementStrings.isEmpty()) {
+                for (auto& string : stringsToValidate) {
+                    auto replaced = WebKit::applyReplacements(string, strongSelf->_lastTextExtractionReplacementStrings);
+                    if (replaced != string)
+                        replacedDescription = makeStringByReplacingAll(replacedDescription, string, replaced);
+                }
+            }
+
+            RetainPtr summary = replacedDescription.createNSString();
             if (!staleNodeNote.isEmpty())
                 summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeNote.createNSString().get()]);
             completionHandler(summary, nil);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -587,6 +587,7 @@ struct LiveResizeSnapshotState {
     std::optional<HashSet<String>> _textExtractionRecognizedWords;
 #endif
     RefPtr<WebKit::TextExtractionURLCache> _textExtractionURLCache;
+    Vector<std::pair<String, String>> _lastTextExtractionReplacementStrings;
 
 #if ENABLE(SYSTEM_TEXT_EXTRACTION)
     std::optional<WTF::UUID> _textExtractionIdentifier;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -659,6 +659,38 @@ TEST(TextExtractionTests, ReplacementStringsDiacriticInsensitive)
     EXPECT_FALSE([debugText containsString:@"Zurich"]);
 }
 
+TEST(TextExtractionTests, ReplacementStringsAppliedToInteractionDescription)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+    RetainPtr composeID = extractNodeIdentifier(debugText, @"Compose");
+
+    [webView synchronouslyGetDebugText:^{
+        RetainPtr replacementConfiguration = adoptNS([_WKTextExtractionConfiguration new]);
+        [replacementConfiguration setReplacementStrings:@{
+            @"FOX": @"cat",
+            @"compose a new message": @"[redacted subject]",
+        }];
+        return replacementConfiguration.autorelease();
+    }()];
+
+    NSError *error = nil;
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [interaction setNodeIdentifier:composeID];
+    RetainPtr description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_NULL(error);
+
+    EXPECT_TRUE([description containsString:@"[redacted subject]"]);
+    EXPECT_TRUE([description containsString:@"brown cat jumped over the lazy dog"]);
+    EXPECT_FALSE([description containsString:@"Compose a new message"]);
+    EXPECT_FALSE([description containsString:@"fox"]);
+}
+
 TEST(TextExtractionTests, VisibleTextOnly)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{


### PR DESCRIPTION
#### 363d0afe5c5de177b384d85a2e72caa18030d544
<pre>
[Text Extraction] Apply the latest set of `replacementStrings` to interaction descriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=318646">https://bugs.webkit.org/show_bug.cgi?id=318646</a>
<a href="https://rdar.apple.com/181448617">rdar://181448617</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Cache the latest `replacementStrings` upon extracting text, and use it to sanitize interaction
description strings retrieved using `-debugDescriptionInWebView:completionHandler:`.

Test: TextExtractionTests.ReplacementStringsAppliedToInteractionDescription

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::foldForReplacement):
(WebKit::applyReplacements):
(WebKit::TextExtractionAggregator::applyReplacements):
* Source/WebKit/Shared/TextExtractionToStringConversion.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
(-[WKWebView _describeInteraction:inFrame:nodeIdentifier:staleNodeNote:shouldResolveStaleNodeIdentifier:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, ReplacementStringsAppliedToInteractionDescription)):

Canonical link: <a href="https://commits.webkit.org/316548@main">https://commits.webkit.org/316548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/239c00a8d39ac026c99d9919c79509df9518c4e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130239 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c500420-f7b2-4501-838b-9d49a2ecee1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134305 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/94788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95354de6-b7a7-490d-9a8d-b7cfa1ea4c07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114777 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f25f8efa-6b6c-466d-9f4f-ef557a8e1d4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34655 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30740 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184674 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143096 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46273 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38615 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46951 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/31188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111898 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37981 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118703 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45468 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9296 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44868 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44927 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->