### PR TITLE
fix style false positive

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		50DE35F5215BB01500B979C7 /* ExternalStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */; };
 		515F794E1CFC9F4A00CCED93 /* CrossThreadCopier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 515F794B1CFC9F4A00CCED93 /* CrossThreadCopier.cpp */; };
 		5164042D2AB1D46B0042B1C3 /* NativePromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 5164042C2AB1D46B0042B1C3 /* NativePromise.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5164042E2AB1D46B0042B1C3 /* NativePromiseCoroutine.h in Headers */ = {isa = PBXBuildFile; fileRef = 5164042F2AB1D46B0042B1C3 /* NativePromiseCoroutine.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5164042F2AB1D4DD0042B1C3 /* TypeTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 5164042E2AB1D4DD0042B1C3 /* TypeTraits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		517F82D71FD22F3000DA3DEA /* CrossThreadTaskHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 517F82D51FD22F2F00DA3DEA /* CrossThreadTaskHandler.cpp */; };
 		5187AC952C08570600549EFE /* MainThreadDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5187AC942C08570600549EFE /* MainThreadDispatcher.cpp */; };
@@ -1418,6 +1419,7 @@
 		515F794D1CFC9F4A00CCED93 /* CrossThreadTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CrossThreadTask.h; sourceTree = "<group>"; };
 		515F79551CFD3A6900CCED93 /* CrossThreadQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CrossThreadQueue.h; sourceTree = "<group>"; };
 		5164042C2AB1D46B0042B1C3 /* NativePromise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativePromise.h; sourceTree = "<group>"; };
+		5164042F2AB1D46B0042B1C3 /* NativePromiseCoroutine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativePromiseCoroutine.h; sourceTree = "<group>"; };
 		5164042E2AB1D4DD0042B1C3 /* TypeTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeTraits.h; sourceTree = "<group>"; };
 		517A53571F5734B700DCDC0A /* Identified.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Identified.h; sourceTree = "<group>"; };
 		517F82D51FD22F2F00DA3DEA /* CrossThreadTaskHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CrossThreadTaskHandler.cpp; sourceTree = "<group>"; };
@@ -2629,6 +2631,7 @@
 				FE8225301B2A1E5B00BA68FD /* NakedPtr.h */,
 				51B07F532AB8797300E14EE9 /* NativePromise.cpp */,
 				5164042C2AB1D46B0042B1C3 /* NativePromise.h */,
+				5164042F2AB1D46B0042B1C3 /* NativePromiseCoroutine.h */,
 				0F5BF1651F2317830029D91D /* NaturalLoops.h */,
 				1A3F6BE6174ADA2100B2EEA7 /* NeverDestroyed.h */,
 				0F0D85B317234CB100338210 /* NoLock.h */,
@@ -3796,6 +3799,7 @@
 				DD3DC96827A4BF8E007E5B61 /* MonotonicTime.h in Headers */,
 				DD3DC96227A4BF8E007E5B61 /* NakedPtr.h in Headers */,
 				5164042D2AB1D46B0042B1C3 /* NativePromise.h in Headers */,
+				5164042E2AB1D46B0042B1C3 /* NativePromiseCoroutine.h in Headers */,
 				DD3DC8D827A4BF8E007E5B61 /* NaturalLoops.h in Headers */,
 				E396C11D2BE885D9000CBAE1 /* neon.h in Headers */,
 				46335BEF2E778B1300860375 /* NetworkOSObject.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -203,6 +203,7 @@ set(WTF_PUBLIC_HEADERS
     module.modulemap
     NakedPtr.h
     NativePromise.h
+    NativePromiseCoroutine.h
     NaturalLoops.h
     NeverDestroyed.h
     NoLock.h

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -30,7 +30,9 @@
 #if ASSERT_ENABLED
 #include <atomic>
 #endif
+#include <coroutine>
 #include <functional>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <wtf/Assertions.h>
@@ -1080,6 +1082,64 @@ public:
             }
             return invokeWithVoidOrWithArg(thisVal.get(), rejectMethod, maybeMove(result.error()));
         }, callSite);
+    }
+
+    // Coroutine support. Suspends the current coroutine until the promise is settled, then
+    // resumes it on `dispatcher` with the promise's Result. `dispatcher` must be the
+    // dispatcher the coroutine is currently running on (asserted in awaitOn()) so that the
+    // coroutine resumes on the same thread it awaited from.
+    // Usage: auto result = co_await promise->awaitOn(dispatcher);
+    // (NativePromiseCoroutine.h defines `co_await promise` as a shorthand that resumes on
+    // the main thread.)
+    class [[nodiscard]] Awaiter {
+        WTF_FORBID_HEAP_ALLOCATION;
+    public:
+        Awaiter(Ref<NativePromise>&& promise, GuaranteedSerialFunctionDispatcher& dispatcher)
+            : m_promise(WTF::move(promise))
+            , m_dispatcher(dispatcher)
+        {
+        }
+
+        bool await_ready() const { return false; }
+
+        bool await_suspend(std::coroutine_handle<> handle)
+        {
+            m_handle = handle;
+            // If the promise is already settled and set to dispatch synchronously, the
+            // settle callback runs re-entrantly from the ThenCommand destructor at the end
+            // of this statement, before m_suspended is set: it stores the result but must
+            // not resume, and await_suspend returns false so the coroutine continues without
+            // suspending. Otherwise the callback runs later on m_dispatcher (the same thread,
+            // per the isCurrent() assert) and resumes the suspended coroutine. Either way
+            // there is no cross-thread race on m_suspended/m_result.
+            m_promise->whenSettled(m_dispatcher.get(), [this](ResultParam result) {
+                m_result.emplace(maybeMove(result));
+                if (m_suspended)
+                    m_handle.resume();
+            });
+            m_suspended = !m_result;
+            return m_suspended;
+        }
+
+        Result await_resume()
+        {
+            assertIsCurrent(m_dispatcher.get());
+            ASSERT(m_result);
+            return WTF::move(*m_result);
+        }
+
+    private:
+        const Ref<NativePromise> m_promise;
+        const Ref<GuaranteedSerialFunctionDispatcher> m_dispatcher;
+        std::optional<Result> m_result;
+        std::coroutine_handle<> m_handle;
+        bool m_suspended { false };
+    };
+
+    Awaiter awaitOn(GuaranteedSerialFunctionDispatcher& dispatcher)
+    {
+        ASSERT(dispatcher.isCurrent()); // The coroutine must resume on the thread it awaited from.
+        return Awaiter { Ref { *this }, dispatcher };
     }
 
     void chainTo(Producer&& chainedPromise, const Logger::LogSiteIdentifier& callSite = DEFAULT_LOGSITEIDENTIFIER)

--- a/Source/WTF/wtf/NativePromiseCoroutine.h
+++ b/Source/WTF/wtf/NativePromiseCoroutine.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/NativePromise.h>
+#include <wtf/WorkQueue.h>
+
+namespace WTF {
+
+// Allows a coroutine to write `co_await promise` to wait for a NativePromise and obtain its
+// Result. The coroutine is resumed on the main thread, so this is only valid when it is
+// already running on the main thread (asserted by NativePromise::awaitOn()). When running on
+// any other dispatcher, use `co_await promise->awaitOn(dispatcher)` instead, naming the
+// dispatcher the coroutine should resume on.
+template<typename ResolveValueT, typename RejectValueT, unsigned options>
+auto operator co_await(const Ref<NativePromise<ResolveValueT, RejectValueT, options>>& promise)
+{
+    return promise->awaitOn(WorkQueue::mainSingleton());
+}
+
+} // namespace WTF

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -53,6 +53,7 @@
 #include <WebCore/SharedTimebase.h>
 
 #include <wtf/LoggerHelper.h>
+#include <wtf/NativePromiseCoroutine.h>
 #if PLATFORM(COCOA)
 #include <wtf/MachSendRightAnnotated.h>
 #endif
@@ -268,17 +269,18 @@ void RemoteAudioVideoRendererProxyManager::removeTrack(RemoteAudioVideoRendererI
         renderer->removeTrack(trackIdentifier);
 }
 
-void RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier identifier, TrackIdentifier trackIdentifier)
+Awaitable<void> RemoteAudioVideoRendererProxyManager::requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier identifier, TrackIdentifier trackIdentifier)
 {
     RefPtr renderer = rendererFor(identifier);
     if (!renderer)
-        return;
-    renderer->requestMediaDataWhenReady(trackIdentifier)->whenSettled(RunLoop::mainSingleton(), [identifier, trackIdentifier, weakThis = ThreadSafeWeakPtr { *this }](auto result) {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis || !result)
-            return;
-        protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::ReadyForMoreMediaData(trackIdentifier));
-    });
+        co_return;
+
+    ThreadSafeWeakPtr weakThis { *this };
+    auto result = co_await renderer->requestMediaDataWhenReady(trackIdentifier);
+    RefPtr protectedThis = weakThis.get();
+    if (!protectedThis || !result)
+        co_return;
+    protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::ReadyForMoreMediaData(trackIdentifier));
 }
 
 MediaSampleConverter& RemoteAudioVideoRendererProxyManager::converterFor(RendererContext& context, TrackIdentifier trackIdentifier)
@@ -311,13 +313,12 @@ void RemoteAudioVideoRendererProxyManager::enqueueSample(RemoteAudioVideoRendere
     completionHandler(false);
 }
 
-void RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& time, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
+Awaitable<WebCore::MediaTimePromise::Result> RemoteAudioVideoRendererProxyManager::notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier identifier, MediaTime time)
 {
-    if (RefPtr renderer = rendererFor(identifier)) {
-        renderer->notifyTimeReachedAndStall(time)->whenSettled(RunLoop::mainSingleton(), WTF::move(completionHandler));
-        return;
-    }
-    completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
+    RefPtr renderer = rendererFor(identifier);
+    if (!renderer)
+        co_return makeUnexpected(PlatformMediaError::NotSupportedError);
+    co_return co_await renderer->notifyTimeReachedAndStall(time);
 }
 
 void RemoteAudioVideoRendererProxyManager::cancelTimeReachedAction(RemoteAudioVideoRendererIdentifier identifier)
@@ -437,32 +438,30 @@ void RemoteAudioVideoRendererProxyManager::stall(RemoteAudioVideoRendererIdentif
     context.renderer->stall();
 }
 
-void RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& seekTime, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&& completionHandler)
+Awaitable<WebCore::MediaTimePromise::Result> RemoteAudioVideoRendererProxyManager::prepareToSeek(RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime)
 {
     RefPtr renderer = rendererFor(identifier);
-    if (!renderer) {
-        completionHandler(makeUnexpected(PlatformMediaError::NotSupportedError));
-        return;
-    }
-    renderer->prepareToSeek(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
-        completionHandler(WTF::move(result));
-    });
+    if (!renderer)
+        co_return makeUnexpected(PlatformMediaError::NotSupportedError);
+
+    ThreadSafeWeakPtr weakThis { *this };
+    auto result = co_await renderer->prepareToSeek(seekTime);
+    if (RefPtr protectedThis = weakThis.get())
+        protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
+    co_return WTF::move(result);
 }
 
-void RemoteAudioVideoRendererProxyManager::finishSeek(RemoteAudioVideoRendererIdentifier identifier, const MediaTime& time, CompletionHandler<void(GenericPromise::Result&&)>&& completionHandler)
+Awaitable<GenericPromise::Result> RemoteAudioVideoRendererProxyManager::finishSeek(RemoteAudioVideoRendererIdentifier identifier, MediaTime time)
 {
     RefPtr renderer = rendererFor(identifier);
-    if (!renderer) {
-        completionHandler(makeUnexpected(GenericPromise::RejectValueType { }));
-        return;
-    }
-    renderer->finishSeek(time)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, identifier, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        if (RefPtr protectedThis = weakThis.get())
-            protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
-        completionHandler(WTF::move(result));
-    });
+    if (!renderer)
+        co_return makeUnexpected(GenericPromise::RejectValueType { });
+
+    ThreadSafeWeakPtr weakThis { *this };
+    auto result = co_await renderer->finishSeek(time);
+    if (RefPtr protectedThis = weakThis.get())
+        protectedThis->publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)));
+    co_return WTF::move(result);
 }
 
 void RemoteAudioVideoRendererProxyManager::setScreenReserved(RemoteAudioVideoRendererIdentifier identifier, bool reserved)
@@ -645,20 +644,16 @@ void RemoteAudioVideoRendererProxyManager::currentVideoFrame(RemoteAudioVideoRen
     completionHandler(WTF::move(result));
 }
 
-void RemoteAudioVideoRendererProxyManager::currentBitmapImage(RemoteAudioVideoRendererIdentifier identifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler) const
+Awaitable<std::optional<WebCore::ShareableBitmap::Handle>> RemoteAudioVideoRendererProxyManager::currentBitmapImage(RemoteAudioVideoRendererIdentifier identifier) const
 {
     RefPtr renderer = rendererFor(identifier);
-    if (!renderer) {
-        completionHandler(std::nullopt);
-        return;
-    }
-    renderer->currentBitmapImage()->whenSettled(RunLoop::mainSingleton(), [completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        if (!result) {
-            completionHandler(std::nullopt);
-            return;
-        }
-        completionHandler((*result)->createHandle());
-    });
+    if (!renderer)
+        co_return std::nullopt;
+
+    auto result = co_await renderer->currentBitmapImage();
+    if (!result)
+        co_return std::nullopt;
+    co_return (*result)->createHandle();
 }
 
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -44,6 +44,7 @@
 #include <WebCore/MediaSampleConverter.h>
 #include <WebCore/ShareableBitmapHandle.h>
 #include <WebCore/SharedTimebase.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
@@ -102,9 +103,9 @@ private:
 
     void newTrackInfoForTrack(RemoteAudioVideoRendererIdentifier, TrackIdentifier, Ref<WebCore::TrackInfo>&&);
     void enqueueSample(RemoteAudioVideoRendererIdentifier, TrackIdentifier, WebCore::MediaSamplesBlock&&, std::optional<MediaTime>, CompletionHandler<void(bool)>&&);
-    void requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
+    Awaitable<void> requestMediaDataWhenReady(RemoteAudioVideoRendererIdentifier, TrackIdentifier);
 
-    void notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
+    Awaitable<WebCore::MediaTimePromise::Result> notifyTimeReachedAndStall(RemoteAudioVideoRendererIdentifier, MediaTime);
     void cancelTimeReachedAction(RemoteAudioVideoRendererIdentifier);
     void performTaskAtTime(RemoteAudioVideoRendererIdentifier, const MediaTime&);
 
@@ -121,8 +122,8 @@ private:
     void pause(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>);
     void setRate(RemoteAudioVideoRendererIdentifier, double);
     void stall(RemoteAudioVideoRendererIdentifier);
-    void prepareToSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
-    void finishSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(GenericPromise::Result&&)>&&);
+    Awaitable<WebCore::MediaTimePromise::Result> prepareToSeek(RemoteAudioVideoRendererIdentifier, MediaTime);
+    Awaitable<GenericPromise::Result> finishSeek(RemoteAudioVideoRendererIdentifier, MediaTime);
     void setScreenReserved(RemoteAudioVideoRendererIdentifier, bool);
 
     // AudioInterface
@@ -147,7 +148,7 @@ private:
     void setVideoPlaybackMetricsUpdateInterval(RemoteAudioVideoRendererIdentifier, double);
     void flushAndRemoveImage(RemoteAudioVideoRendererIdentifier);
     void currentVideoFrame(RemoteAudioVideoRendererIdentifier, CompletionHandler<void(std::optional<RemoteVideoFrameProxy::Properties>)>&&) const;
-    void currentBitmapImage(RemoteAudioVideoRendererIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&) const;
+    Awaitable<std::optional<WebCore::ShareableBitmap::Handle>> currentBitmapImage(RemoteAudioVideoRendererIdentifier) const;
 
     // VideoFullscreenInterface
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -83,6 +83,7 @@
 #endif
 
 #include <wtf/NativePromise.h>
+#include <wtf/NativePromiseCoroutine.h>
 
 namespace WebKit {
 
@@ -253,21 +254,17 @@ static MediaTimeUpdateData timeUpdateData(const MediaPlayer& player, MediaTime t
     };
 }
 
-void RemoteMediaPlayerProxy::seekToTarget(const WebCore::SeekTarget& target, CompletionHandler<void(Expected<WebCore::MediaTimeUpdateData, WebCore::PlatformMediaError>)>&& handler)
+Awaitable<Expected<WebCore::MediaTimeUpdateData, WebCore::PlatformMediaError>> RemoteMediaPlayerProxy::seekToTarget(const WebCore::SeekTarget& target)
 {
     ALWAYS_LOG(LOGIDENTIFIER, target);
-    protect(m_player)->seekToTarget(target)->whenSettled(RunLoop::mainSingleton(), [weakThis = WeakPtr { *this }, handler = WTF::move(handler)](auto&& result) mutable {
-        if (!result) {
-            handler(makeUnexpected(result.error()));
-            return;
-        }
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis) {
-            handler(makeUnexpected(PlatformMediaError::Cancelled));
-            return;
-        }
-        handler(timeUpdateData(*protect(protectedThis->m_player), *result));
-    });
+    WeakPtr weakThis { *this };
+    auto result = co_await protect(m_player)->seekToTarget(target);
+    if (!result)
+        co_return makeUnexpected(result.error());
+    RefPtr protectedThis = weakThis.get();
+    if (!protectedThis)
+        co_return makeUnexpected(PlatformMediaError::Cancelled);
+    co_return timeUpdateData(*protect(protectedThis->m_player), *result);
 }
 
 void RemoteMediaPlayerProxy::setVolumeLocked(bool volumeLocked)
@@ -995,21 +992,16 @@ void RemoteMediaPlayerProxy::videoFrameForCurrentTimeIfChanged(CompletionHandler
     completionHandler(WTF::move(result), changed);
 }
 
-void RemoteMediaPlayerProxy::bitmapImageForCurrentTime(CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
+Awaitable<std::optional<WebCore::ShareableBitmap::Handle>> RemoteMediaPlayerProxy::bitmapImageForCurrentTime()
 {
     RefPtr player = m_player;
-    if (!player) {
-        completionHandler({ });
-        return;
-    }
+    if (!player)
+        co_return std::nullopt;
 
-    player->bitmapImageForCurrentTime()->whenSettled(RunLoop::mainSingleton(), [completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        if (!result) {
-            completionHandler({ });
-            return;
-        }
-        completionHandler((*result)->createHandle());
-    });
+    auto result = co_await player->bitmapImageForCurrentTime();
+    if (!result)
+        co_return std::nullopt;
+    co_return (*result)->createHandle();
 }
 
 void RemoteMediaPlayerProxy::setShouldDisableHDR(bool shouldDisable)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -49,6 +49,7 @@
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/ShareableBitmap.h>
 #include <optional>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
@@ -158,7 +159,7 @@ public:
     void play();
     void pause();
 
-    void seekToTarget(const WebCore::SeekTarget&, CompletionHandler<void(Expected<WebCore::MediaTimeUpdateData, WebCore::PlatformMediaError>)>&&);
+    Awaitable<Expected<WebCore::MediaTimeUpdateData, WebCore::PlatformMediaError>> seekToTarget(const WebCore::SeekTarget&);
 
     void setVolumeLocked(bool);
     void setVolume(double);
@@ -366,7 +367,7 @@ private:
     void colorSpace(CompletionHandler<void(WebCore::DestinationColorSpace)>&&);
 #endif
     void videoFrameForCurrentTimeIfChanged(CompletionHandler<void(std::optional<RemoteVideoFrameProxy::Properties>&&, bool)>&&);
-    void bitmapImageForCurrentTime(CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
+    Awaitable<std::optional<WebCore::ShareableBitmap::Handle>> bitmapImageForCurrentTime();
 
     void setShouldDisableHDR(bool);
     using LayerHostingContextCallback = WebCore::MediaPlayer::LayerHostingContextCallback;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -310,16 +310,13 @@ void NetworkRTCProvider::createClientTCPSocket(LibWebRTCSocketIdentifier identif
         signalSocketIsClosed(identifier);
 }
 
-void NetworkRTCProvider::getInterfaceName(URL&& url, WebPageProxyIdentifier pageIdentifier, RTCSocketCreationFlags flags, WebCore::RegistrableDomain&& domain, CompletionHandler<void(String&&)>&& completionHandler)
+Awaitable<String> NetworkRTCProvider::getInterfaceName(URL&& url, WebPageProxyIdentifier pageIdentifier, RTCSocketCreationFlags flags, WebCore::RegistrableDomain&& domain)
 {
-    if (!url.protocolIsInHTTPFamily()) {
-        completionHandler({ });
-        return;
-    }
+    if (!url.protocolIsInHTTPFamily())
+        co_return { };
 
-    NetworkRTCTCPSocketCocoa::getInterfaceName(*this, url, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), flags, domain)->whenSettled(m_rtcNetworkThreadQueue, [completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        completionHandler(result ? WTF::move(result.value()) : String { });
-    });
+    auto result = co_await NetworkRTCTCPSocketCocoa::getInterfaceName(*this, url, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), flags, domain)->awaitOn(m_rtcNetworkThreadQueue);
+    co_return result ? WTF::move(result.value()) : String { };
 }
 
 void NetworkRTCProvider::callOnRTCNetworkThread(Function<void()>&& callback)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -34,6 +34,7 @@
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
 #include <WebCore/LibWebRTCSocketIdentifier.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/FunctionDispatcher.h>
 #include <wtf/HashMap.h>
 #include <wtf/StdMap.h>
@@ -138,7 +139,7 @@ private:
 
     void createResolver(LibWebRTCResolverIdentifier, String&&);
     void stopResolver(LibWebRTCResolverIdentifier);
-    void getInterfaceName(URL&&, WebPageProxyIdentifier, RTCSocketCreationFlags, WebCore::RegistrableDomain&&, CompletionHandler<void(String&&)>&&);
+    Awaitable<String> getInterfaceName(URL&&, WebPageProxyIdentifier, RTCSocketCreationFlags, WebCore::RegistrableDomain&&);
 
     void addSocket(WebCore::LibWebRTCSocketIdentifier, std::unique_ptr<Socket>&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
@@ -36,7 +36,7 @@ messages -> NetworkRTCProvider {
     StopResolver(WebKit::LibWebRTCResolverIdentifier identifier)
 
 #if PLATFORM(COCOA)
-    GetInterfaceName(URL url, WebKit::WebPageProxyIdentifier pageIdentifier, struct WebKit::RTCSocketCreationFlags flags, WebCore::RegistrableDomain domain) -> (String interfaceName) async
+    GetInterfaceName(URL url, WebKit::WebPageProxyIdentifier pageIdentifier, struct WebKit::RTCSocketCreationFlags flags, WebCore::RegistrableDomain domain) -> (String interfaceName)
 #endif
 
     SendToSocket(WebCore::LibWebRTCSocketIdentifier identifier, std::span<const uint8_t> data, WebKit::WebRTCNetwork::SocketAddress address, struct WebKit::RTCPacketOptions options)

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -29,8 +29,11 @@
 #include <WebCore/HTMLNames.h>
 #include <WebCore/ICUSearcher.h>
 #include <WebCore/TextExtractionTypes.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/EnumSet.h>
 #include <wtf/JSONValues.h>
+#include <wtf/MainThread.h>
+#include <wtf/NativePromiseCoroutine.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -701,13 +704,14 @@ public:
 
     RefPtr<TextExtractionFilterPromise> filter(const String& text, const std::optional<FrameIdentifier>& frameIdentifier, const std::optional<NodeIdentifier>& identifier)
     {
+        assertIsMainThread();
         if (m_options.filterCallbacks.isEmpty())
             return nullptr;
 
         TextExtractionFilterPromise::Producer producer;
         Ref promise = producer.promise();
 
-        filterRecursive(text, frameIdentifier, identifier, 0, [producer = WTF::move(producer)](auto&& result) mutable {
+        filterRecursive(text, frameIdentifier, identifier, [producer = WTF::move(producer)](auto&& result) mutable {
             producer.settle(WTF::move(result));
         });
 
@@ -868,21 +872,20 @@ public:
     }
 
 private:
-    void filterRecursive(const String& originalText, const std::optional<FrameIdentifier>& frameIdentifier, const std::optional<NodeIdentifier>& identifier, size_t index, CompletionHandler<void(String&&)>&& completion)
+    Task filterRecursive(String originalText, std::optional<FrameIdentifier> frameIdentifier, std::optional<NodeIdentifier> identifier, CompletionHandler<void(String&&)>&& completion)
     {
-        if (index >= m_options.filterCallbacks.size())
-            return completion(String { originalText });
-
-        Ref promise = m_options.filterCallbacks[index](originalText, std::optional { frameIdentifier }, std::optional { identifier });
-        promise->whenSettled(RunLoop::mainSingleton(), [originalText, completion = WTF::move(completion), protectedThis = Ref { *this }, frameIdentifier, identifier, index](auto&& result) mutable {
+        Ref protectedThis { *this };
+        for (auto& filterCallback : m_options.filterCallbacks) {
+            auto result = co_await filterCallback(originalText, std::optional { frameIdentifier }, std::optional { identifier });
             if (originalText != result)
-                protectedThis->m_filteredOutAnyText = true;
-
-            if (!result)
-                return completion({ });
-
-            protectedThis->filterRecursive(WTF::move(*result), frameIdentifier, identifier, index + 1, WTF::move(completion));
-        });
+                m_filteredOutAnyText = true;
+            if (!result) {
+                completion({ });
+                co_return;
+            }
+            originalText = WTF::move(*result);
+        }
+        completion(WTF::move(originalText));
     }
 
     String stringForURL(const String& shortenedString, const URL& url, ExtractedURLType type)

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2460,7 +2460,7 @@ def check_spacing(file_extension, clean_lines, line_number, file_state, error):
     # 'delete []' or 'new char * []'. Objective-C can't follow this rule
     # because of method calls.
     if file_extension != 'mm' and file_extension != 'm':
-        if search(r'\w\s+\[', line) and not search(r'(delete|return|auto)\s+\[', line) and not search(r'\s+\[\[(likely|unlikely|noreturn)\]\]', line):
+        if search(r'\w\s+\[', line) and not search(r'(delete|return|auto)\s+\[', line) and not search(r'\s+\[\[(likely|unlikely|noreturn|nodiscard)\]\]', line):
             error(line_number, 'whitespace/brackets', 5,
                   'Extra space before [.')
 
@@ -4724,6 +4724,9 @@ def check_identifier_name_in_declaration(filename, line_number, line, file_state
                 and not modified_identifier.startswith('hb_')
                 and not modified_identifier.find('::_q_') >= 0
                 and not modified_identifier == "const_iterator"
+                and not modified_identifier == "await_ready"
+                and not modified_identifier == "await_suspend"
+                and not modified_identifier == "await_resume"
                 and not modified_identifier == "vm_throw"
                 and not modified_identifier == "DFG_OPERATION"
                 and not modified_identifier == "LIFETIME_BOUND"

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -1682,7 +1682,7 @@ def check_spacing_for_function_call(line, line_number, file_state, error):
     # Note that we assume the contents of [] to be short enough that
     # they'll never need to wrap.
     if (  # Ignore control structures / c++20 concept constraints.
-        not search(r'\b(if|for|while|switch|return|new|delete|requires)\b', function_call)
+        not search(r'\b(if|for|while|switch|return|co_await|co_return|co_yield|new|delete|requires)\b', function_call)
         # Ignore lambda functions
         and not regex_for_lambdas_and_blocks(function_call, line_number, file_state, error)
         # Ignore pointers/references to functions.

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -35,9 +35,12 @@
 
 #include "Helpers/Test.h"
 #include "Helpers/Utilities.h"
+#include <memory>
 #include <wtf/Atomics.h>
+#include <wtf/CoroutineUtilities.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
+#include <wtf/NativePromiseCoroutine.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedFixedVector.h>
 #include <wtf/RefPtr.h>
@@ -1878,6 +1881,199 @@ TEST(NativePromise, TakePhotoExample)
                 EXPECT_TRUE(false); // Got an unexpected error.
             queue->beginShutdown();
         });
+    });
+}
+
+// MARK: - Coroutine (co_await) support
+
+using CoTestPromise = NativePromise<int, double>; // Exclusive.
+using CoTestPromiseNonExcl = NativePromise<int, double, PromiseOption::Default | PromiseOption::NonExclusive>;
+using CoMoveOnlyPromise = NativePromise<std::unique_ptr<int>, double>;
+
+// Awaits `promise` via `co_await promise` (resuming on the main thread), runs `check` on the
+// settled Result, then sets `done`.
+template<typename PromiseType, typename CheckFunction>
+static Task coAwaitOnMain(Ref<PromiseType> promise, CheckFunction check, bool& done)
+{
+    auto result = co_await promise;
+    EXPECT_TRUE(WorkQueue::mainSingleton().isCurrent());
+    check(result);
+    done = true;
+}
+
+// Awaits `promise` on `queue` via awaitOn(), runs `check` on the settled Result, then shuts
+// the queue down.
+template<typename PromiseType, typename CheckFunction>
+static Task coAwaitOnQueue(Ref<WorkQueueWithShutdown> queue, Ref<PromiseType> promise, CheckFunction check)
+{
+    auto result = co_await promise->awaitOn(queue.get());
+    assertIsCurrent(queue.get());
+    check(result);
+    queue->beginShutdown();
+}
+
+// co_await two promises in sequence, proving linear composition, resuming on main each time.
+static Task coAwaitChainOnMain(Ref<CoTestPromise> first, Ref<CoTestPromise> second, bool& done)
+{
+    auto firstResult = co_await first;
+    EXPECT_TRUE(WorkQueue::mainSingleton().isCurrent());
+    EXPECT_TRUE(firstResult.has_value());
+    EXPECT_EQ(firstResult.value(), 1);
+
+    auto secondResult = co_await second;
+    EXPECT_TRUE(WorkQueue::mainSingleton().isCurrent());
+    EXPECT_TRUE(secondResult.has_value());
+    EXPECT_EQ(secondResult.value(), 2);
+    done = true;
+}
+
+// A coroutine whose return type is Awaitable<Result>: it forwards the awaited promise's
+// settled Result (resolution or rejection) as its own return value. This is how failure is
+// propagated across a coroutine boundary, since co_await does not short-circuit on rejection.
+static Awaitable<CoTestPromise::Result> coForwardResult(Ref<CoTestPromise> promise)
+{
+    co_return co_await promise;
+}
+
+// Consumes coForwardResult(), proving a rejection is carried through as the returned Result.
+static Task coAwaitForwardedRejection(bool& done)
+{
+    auto result = co_await coForwardResult(CoTestPromise::createAndReject(42.0));
+    EXPECT_TRUE(WorkQueue::mainSingleton().isCurrent());
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), 42.0);
+    done = true;
+}
+
+// Fast path: the promise is already settled before the co_await.
+TEST(NativePromise, CoAwaitAlreadyResolvedOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        coAwaitOnMain(CoTestPromise::createAndResolve(42), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), 42);
+        }, done);
+    });
+}
+
+TEST(NativePromise, CoAwaitAlreadyRejectedOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        coAwaitOnMain(CoTestPromise::createAndReject(42.0), [](auto& result) {
+            EXPECT_FALSE(result.has_value());
+            EXPECT_EQ(result.error(), 42.0);
+        }, done);
+    });
+}
+
+// Primary path: the promise is pending at the co_await and settled later.
+TEST(NativePromise, CoAwaitPendingResolveOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        CoTestPromise::Producer producer;
+        coAwaitOnMain(producer.promise(), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), 42);
+        }, done);
+        producer.resolve(42); // The coroutine has suspended; resume happens on the next run loop cycle.
+    });
+}
+
+TEST(NativePromise, CoAwaitPendingRejectOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        CoTestPromise::Producer producer;
+        coAwaitOnMain(producer.promise(), [](auto& result) {
+            EXPECT_FALSE(result.has_value());
+            EXPECT_EQ(result.error(), 42.0);
+        }, done);
+        producer.reject(42.0);
+    });
+}
+
+// Explicit dispatcher: co_await promise->awaitOn(queue), already-settled promise.
+TEST(NativePromise, CoAwaitResolvedOnWorkQueue)
+{
+    AutoWorkQueue awq;
+    auto queue = awq.queue();
+    queue->dispatch([queue] {
+        coAwaitOnQueue(queue, CoTestPromiseNonExcl::createAndResolve(42), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), 42);
+        });
+    });
+}
+
+// Explicit dispatcher, pending promise settled later from the same queue.
+TEST(NativePromise, CoAwaitPendingOnWorkQueue)
+{
+    AutoWorkQueue awq;
+    auto queue = awq.queue();
+    queue->dispatch([queue] {
+        RefPtr producer = adoptRef(new RefCountedProducer());
+        auto promise = producer->promise();
+        Ref delayedSettleTask = adoptRef(*new DelayedSettle(queue, producer, TestPromise::Result(42), 10));
+        delayedSettleTask->dispatch();
+        coAwaitOnQueue(queue, WTF::move(promise), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), 42);
+        });
+    });
+}
+
+// Sync-resume guard: an already-settled RunSynchronouslyOnTarget promise resumes the
+// coroutine without suspending (exercises the bool await_suspend synchronous path).
+TEST(NativePromise, CoAwaitAlreadySettledRunSynchronously)
+{
+    runInCurrentRunLoop([](RunLoop&) {
+        CoTestPromise::Producer producer(PromiseDispatchMode::RunSynchronouslyOnTarget);
+        producer.resolve(42);
+        bool done = false;
+        coAwaitOnMain(producer.promise(), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), 42);
+        }, done);
+        EXPECT_TRUE(done); // Resumed synchronously, no run loop cycle required.
+    });
+}
+
+// Several sequential co_awaits, mixing a pre-settled and a pending promise.
+TEST(NativePromise, CoAwaitChainedOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        CoTestPromise::Producer secondProducer;
+        coAwaitChainOnMain(CoTestPromise::createAndResolve(1), secondProducer.promise(), done);
+        secondProducer.resolve(2);
+    });
+}
+
+// Non-exclusive promise consumed via co_await (result is copied, not moved).
+TEST(NativePromise, CoAwaitNonExclusiveOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        coAwaitOnMain(CoTestPromiseNonExcl::createAndResolve(7), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(result.value(), 7);
+        }, done);
+    });
+}
+
+// Exclusive promise with a move-only resolve type, proving move semantics on co_await.
+TEST(NativePromise, CoAwaitMoveOnlyResultOnMainThread)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        coAwaitOnMain(CoMoveOnlyPromise::createAndResolve(makeUniqueWithoutFastMallocCheck<int>(99)), [](auto& result) {
+            EXPECT_TRUE(result.has_value());
+            EXPECT_EQ(*result.value(), 99);
+        }, done);
+    });
+}
+
+// A rejection propagates through a coroutine that returns Awaitable<Result> and co_returns it.
+TEST(NativePromise, CoAwaitForwardRejectionThroughAwaitable)
+{
+    runInCurrentRunLoopUntilDone([](RunLoop&, bool& done) {
+        coAwaitForwardedRejection(done);
     });
 }
 


### PR DESCRIPTION
#### 862c44c7eb2e56dc211b6e8b9b28da1b7ddad5e6
<pre>
fix style false positive
</pre>
----------------------------------------------------------------------
#### fb98a3e6a5166b6b47f7882a30de3b9ab836ef5a
<pre>
WIP: make use of co_await with NativePromise for code running on main thread only.

Suspended for now as co_await isn&apos;t allowed in webkit code apparently.
</pre>
----------------------------------------------------------------------
#### 796c97e529e3119596c5334ca0183e81c18e8a71
<pre>
Allow NativePromise to be used with C++20 coroutines
<a href="https://bugs.webkit.org/show_bug.cgi?id=318647">https://bugs.webkit.org/show_bug.cgi?id=318647</a>
<a href="https://rdar.apple.com/181449164">rdar://181449164</a>

Reviewed by NOBODY (OOPS!).

Allow a coroutine to co_await a NativePromise and receive its Result,
so async chains can be written as linear code instead of nested
whenSettled() callbacks.

- NativePromise::awaitOn(dispatcher): co_await a promise and resume the
coroutine on the given dispatcher.
- operator co_await(Ref&lt;NativePromise&gt;): shorthand that resumes on the
main thread (WorkQueue::mainSingleton()).
- New header NativePromiseCoroutine.h for the main-thread operator; the
core NativePromise.h stays free of RunLoop/WorkQueue dependencies.
- Tests covering already-settled, pending resolve/reject, explicit
WorkQueue dispatch, synchronous-resume, chained awaits, and
exclusive/non-exclusive/move-only results.

Fly-by for false-postive styling errors:
- Exempt the C++ coroutine customization-point names (await_ready/
await_suspend/await_resume) from the style checker&apos;s underscore rule.
- [[nodiscard]] added to the &quot;space before [&quot; attribute exemption.

Limitations:
- Consumer side only. A coroutine cannot yet return a NativePromise
(no producer-side coroutine support); that is a follow-up.
- No automatic rejection propagation: a rejected co_await yields the
Result as data, it does not short-circuit the enclosing coroutine.
To forward failure, return Awaitable&lt;Result&gt; and co_return it.
- The resume dispatcher is never inferred. co_await promise is
main-thread only (asserts if awaited elsewhere); off-main callers
must name the dispatcher via awaitOn(). Same-thread resume only;
intentional thread hops still use whenSettled() directly.
- No co_await-level cancellation. Disconnecting a suspended await is
not supported (an unsettled promise is already a contract violation).

Test: Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/NativePromiseCoroutine.h: Added.
(WTF::operator co_await):
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::coAwaitOnMain):
(TestWebKitAPI::coAwaitOnQueue):
(TestWebKitAPI::coAwaitChainOnMain):
(TestWebKitAPI::TEST(NativePromise, CoAwaitAlreadyResolvedOnMainThread)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitAlreadyRejectedOnMainThread)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitPendingResolveOnMainThread)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitPendingRejectOnMainThread)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitResolvedOnWorkQueue)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitPendingOnWorkQueue)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitAlreadySettledRunSynchronously)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitChainedOnMainThread)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitNonExclusiveOnMainThread)):
(TestWebKitAPI::TEST(NativePromise, CoAwaitMoveOnlyResultOnMainThread)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/862c44c7eb2e56dc211b6e8b9b28da1b7ddad5e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130347 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da117aed-2ef6-4105-a084-47b79a846063) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134388 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94863 "23 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/091b44f6-21bb-4a32-aa54-58354323e95d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175749 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37785 "Found 27 new test failures: fast/text-extraction/debug-text-extraction-all-container-uids.html fast/text-extraction/debug-text-extraction-autofilled-attributes.html fast/text-extraction/debug-text-extraction-basic.html fast/text-extraction/debug-text-extraction-click-offscreen-element.html fast/text-extraction/debug-text-extraction-covered-button.html fast/text-extraction/debug-text-extraction-data-detectors.html fast/text-extraction/debug-text-extraction-form-controls-2.html fast/text-extraction/debug-text-extraction-form-controls.html fast/text-extraction/debug-text-extraction-hidden-radio-checkbox.html fast/text-extraction/debug-text-extraction-highlight-text.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114859 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85c47e6e-97e7-4f27-81ff-3b96c5a310e5) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172112 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36420 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34747 "Found 32 new API test failures: TestWebKitAPI.TextExtractionTests.HoverInteractionWithExtractionContext, TestWebKitAPI.TextExtractionTests.ReplacementStringsDiacriticInsensitive, TestWebKitAPI.TextExtractionTests.RequestJSHandleForNodeIdentifierCaseSensitive, TestWebKitAPI.TextExtractionTests.ReplacementStringsAppliedToInteractionDescription, TestWebKitAPI.TextExtractionTests.TargetNodeWithSameOriginSubframe, TestWebKitAPI.TextExtractionTests.InteractionDebugDescription, TestWebKitAPI.TextExtractionTests.ClickInteractionWithExtractionContext, TestWebKitAPI.TextExtractionTests.RequestJSHandleForStaleNodeIdentifier, TestWebKitAPI.TextExtractionTests.InvalidURLsAreSkipped, TestWebKitAPI.TextExtractionTests.RequestContainerJSHandleForSearchTexts ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30848 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3467 "Passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146849 "Found 31 new API test failures: TestWebKitAPI.TextExtractionTests.SubframeOriginInDebugText, TestWebKitAPI.TextExtractionTests.ReplacementStrings, TestWebKitAPI.TextExtractionTests.ResolveTargetNodeFromSelectorData, TestWebKitAPI.TextExtractionTests.SubframeInteractions, TestWebKitAPI.TextExtractionTests.ExtractionContextPrefersInteractiveElement, TestWebKitAPI.TextExtractionTests.ClickInteractionWhileInBackground, TestWebKitAPI.TextExtractionTests.InvalidURLsAreSkipped, TestWebKitAPI.TextExtractionTests.ReplacementStringsLongestMatchWins, TestWebKitAPI.TextExtractionTests.ReplacementStringsAppliedToInteractionDescription, TestWebKitAPI.TextExtractionTests.ResultOrigin ... (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184782 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34052 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37509 "Found 2 new failures in GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp, GPUProcess/media/RemoteMediaPlayerProxy.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38954 "Found 28 new test failures: fast/text-extraction/debug-text-extraction-all-container-uids.html fast/text-extraction/debug-text-extraction-autofilled-attributes.html fast/text-extraction/debug-text-extraction-basic.html fast/text-extraction/debug-text-extraction-click-offscreen-element.html fast/text-extraction/debug-text-extraction-covered-button.html fast/text-extraction/debug-text-extraction-data-detectors.html fast/text-extraction/debug-text-extraction-form-controls-2.html fast/text-extraction/debug-text-extraction-form-controls.html fast/text-extraction/debug-text-extraction-hidden-radio-checkbox.html fast/text-extraction/debug-text-extraction-highlight-text.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143185 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46381 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143062 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47059 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112041 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38061 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118811 "Found 2 new failures in GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp, GPUProcess/media/RemoteMediaPlayerProxy.cpp") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205469 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45576 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9394 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45208 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->