### PR TITLE
Refactor SelectionGeometry constructors to use auxiliary structs

### DIFF
--- a/Source/WebCore/platform/SelectionGeometry.cpp
+++ b/Source/WebCore/platform/SelectionGeometry.cpp
@@ -42,40 +42,29 @@ SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBe
 {
 }
 
-// FIXME: We should move some of these arguments to an auxillary struct.
-SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBehavior behavior, TextDirection direction, int minX, int maxX, int maxY, int lineNumber, bool isLineBreak, bool isFirstOnLine, bool isLastOnLine, bool containsStart, bool containsEnd, bool isHorizontal, bool isInFixedPosition, int pageNumber)
+SelectionGeometry::SelectionGeometry(const FloatQuad& quad, Options&& options)
     : m_quad(quad)
-    , m_behavior(behavior)
-    , m_direction(direction)
-    , m_minX(minX)
-    , m_maxX(maxX)
-    , m_maxY(maxY)
-    , m_lineNumber(lineNumber)
-    , m_isLineBreak(isLineBreak)
-    , m_isFirstOnLine(isFirstOnLine)
-    , m_isLastOnLine(isLastOnLine)
-    , m_containsStart(containsStart)
-    , m_containsEnd(containsEnd)
-    , m_isHorizontal(isHorizontal)
-    , m_isInFixedPosition(isInFixedPosition)
-    , m_pageNumber(pageNumber)
+    , m_behavior(options.behavior)
+    , m_direction(options.direction)
+    , m_minX(options.minX)
+    , m_maxX(options.maxX)
+    , m_maxY(options.maxY)
+    , m_lineNumber(options.lineNumber)
+    , m_isLineBreak(options.isLineBreak)
+    , m_isFirstOnLine(options.isFirstOnLine)
+    , m_isLastOnLine(options.isLastOnLine)
+    , m_containsStart(options.containsStart)
+    , m_containsEnd(options.containsEnd)
+    , m_isHorizontal(options.isHorizontal)
+    , m_isInFixedPosition(options.isInFixedPosition)
+    , m_pageNumber(options.pageNumber)
 {
 }
 
+// FIXME: This constructor exists so the generated IPC decoder can reconstruct a SelectionGeometry from its
+// serialized members; keep its argument order in sync with WebCoreArgumentCodersPlatform.serialization.in.
 SelectionGeometry::SelectionGeometry(const FloatQuad& quad, SelectionRenderingBehavior behavior, TextDirection direction, int minX, int maxX, int maxY, int lineNumber, bool isLineBreak, bool isFirstOnLine, bool isLastOnLine, bool containsStart, bool containsEnd, bool isHorizontal)
-    : m_quad(quad)
-    , m_behavior(behavior)
-    , m_direction(direction)
-    , m_minX(minX)
-    , m_maxX(maxX)
-    , m_maxY(maxY)
-    , m_lineNumber(lineNumber)
-    , m_isLineBreak(isLineBreak)
-    , m_isFirstOnLine(isFirstOnLine)
-    , m_isLastOnLine(isLastOnLine)
-    , m_containsStart(containsStart)
-    , m_containsEnd(containsEnd)
-    , m_isHorizontal(isHorizontal)
+    : SelectionGeometry(quad, { behavior, direction, minX, maxX, maxY, lineNumber, isLineBreak, isFirstOnLine, isLastOnLine, containsStart, containsEnd, isHorizontal, false, 0 })
 {
 }
 

--- a/Source/WebCore/platform/SelectionGeometry.h
+++ b/Source/WebCore/platform/SelectionGeometry.h
@@ -41,8 +41,26 @@ class SelectionGeometry {
 public:
     WEBCORE_EXPORT explicit SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, bool isHorizontal, int columnNumber);
 
-    // FIXME: We should move some of these arguments to an auxillary struct.
-    SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool, bool, int);
+    struct Options {
+        SelectionRenderingBehavior behavior;
+        TextDirection direction;
+        int minX;
+        int maxX;
+        int maxY;
+        int lineNumber;
+        bool isLineBreak;
+        bool isFirstOnLine;
+        bool isLastOnLine;
+        bool containsStart;
+        bool containsEnd;
+        bool isHorizontal;
+        bool isInFixedPosition;
+        int pageNumber;
+    };
+
+    WEBCORE_EXPORT SelectionGeometry(const FloatQuad&, Options&&);
+    // FIXME: This flat constructor exists so the generated IPC decoder can reconstruct a SelectionGeometry from its
+    // serialized members; keep its argument order in sync with WebCoreArgumentCodersPlatform.serialization.in.
     WEBCORE_EXPORT SelectionGeometry(const FloatQuad&, SelectionRenderingBehavior, TextDirection, int, int, int, int, bool, bool, bool, bool, bool, bool);
     SelectionGeometry() = default;
     ~SelectionGeometry() = default;

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -145,9 +145,23 @@ void RenderImage::collectSelectionGeometries(Vector<SelectionGeometry>& geometri
     if (!containingBlock->isHorizontalWritingMode())
         lineExtentBounds = lineExtentBounds.transposedRect();
 
-    // FIXME: We should consider either making SelectionGeometry a struct or better organize its optional fields into
-    // an auxiliary struct to simplify its initialization.
-    geometries.append(SelectionGeometry(absoluteQuad, SelectionRenderingBehavior::CoalesceBoundingRects, containingBlock->writingMode().bidiDirection(), lineExtentBounds.x(), lineExtentBounds.maxX(), lineExtentBounds.maxY(), 0, false /* line break */, isFirstOnLine, isLastOnLine, false /* contains start */, false /* contains end */, containingBlock->writingMode().isHorizontal(), isFixed, view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
+    geometries.append(SelectionGeometry(absoluteQuad, {
+        .behavior = SelectionRenderingBehavior::CoalesceBoundingRects,
+        .direction = containingBlock->writingMode().bidiDirection(),
+        .minX = lineExtentBounds.x(),
+        .maxX = lineExtentBounds.maxX(),
+        .maxY = lineExtentBounds.maxY(),
+        .lineNumber = 0,
+        .isLineBreak = false,
+        .isFirstOnLine = isFirstOnLine,
+        .isLastOnLine = isLastOnLine,
+        .containsStart = false,
+        .containsEnd = false,
+        .isHorizontal = containingBlock->writingMode().isHorizontal(),
+        .isInFixedPosition = isFixed,
+        .pageNumber = static_cast<int>(view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x()))
+    }));
+
 }
 
 using namespace HTMLNames;

--- a/Source/WebCore/rendering/RenderLineBreak.cpp
+++ b/Source/WebCore/rendering/RenderLineBreak.cpp
@@ -153,7 +153,22 @@ void RenderLineBreak::collectSelectionGeometries(Vector<SelectionGeometry>& rect
     auto absoluteQuad = localToAbsoluteQuad(FloatRect(rect), MapCoordinatesMode::UseTransforms, &isFixed);
     bool boxIsHorizontal = !is<InlineIterator::SVGTextBoxIterator>(run) ? run->isHorizontal() : !writingMode().isVertical();
 
-    rects.append(SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(WTF::protect(element())), run->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, run->isLineBreak(), isFirstOnLine, isLastOnLine, false, false, boxIsHorizontal, isFixed, view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x())));
+    rects.append(SelectionGeometry(absoluteQuad, {
+        .behavior = HTMLElement::selectionRenderingBehavior(WTF::protect(element())),
+        .direction = run->direction(),
+        .minX = extentsRect.x(),
+        .maxX = extentsRect.maxX(),
+        .maxY = extentsRect.maxY(),
+        .lineNumber = 0,
+        .isLineBreak = run->isLineBreak(),
+        .isFirstOnLine = isFirstOnLine,
+        .isLastOnLine = isLastOnLine,
+        .containsStart = false,
+        .containsEnd = false,
+        .isHorizontal = boxIsHorizontal,
+        .isInFixedPosition = isFixed,
+        .pageNumber = static_cast<int>(view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x()))
+    }));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -657,7 +657,22 @@ void RenderText::collectSelectionGeometries(Vector<SelectionGeometry>& rects, un
         auto absoluteQuad = localToAbsoluteQuad(FloatRect(rect), MapCoordinatesMode::UseTransforms, &isFixed);
         bool boxIsHorizontal = !is<InlineIterator::SVGTextBoxIterator>(textBox) ? textBox->isHorizontal() : !writingMode().isVertical();
 
-        auto selectionGeometry = SelectionGeometry(absoluteQuad, HTMLElement::selectionRenderingBehavior(protect(textNode())), textBox->direction(), extentsRect.x(), extentsRect.maxX(), extentsRect.maxY(), 0, textBox->isLineBreak(), isFirstOnLine, isLastOnLine, containsStart, containsEnd, boxIsHorizontal, isFixed, view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x()));
+        auto selectionGeometry = SelectionGeometry(absoluteQuad, {
+            .behavior = HTMLElement::selectionRenderingBehavior(protect(textNode())),
+            .direction = textBox->direction(),
+            .minX = extentsRect.x(),
+            .maxX = extentsRect.maxX(),
+            .maxY = extentsRect.maxY(),
+            .lineNumber = 0,
+            .isLineBreak = textBox->isLineBreak(),
+            .isFirstOnLine = isFirstOnLine,
+            .isLastOnLine = isLastOnLine,
+            .containsStart = containsStart,
+            .containsEnd = containsEnd,
+            .isHorizontal = boxIsHorizontal,
+            .isInFixedPosition = isFixed,
+            .pageNumber = static_cast<int>(view().pageNumberForBlockProgressionOffset(absoluteQuad.enclosingBoundingBox().x()))
+        });
         selectionGeometry.setSeparateFromPreviousLine(separateLines);
         rects.append(selectionGeometry);
     }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4673,19 +4673,22 @@ bool UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded(EditorState& state) c
 
     auto selectionGeometries = selectionRects.map([](auto& rectInRootView) {
         return SelectionGeometry {
-            rectInRootView,
-            SelectionRenderingBehavior::CoalesceBoundingRects,
-            TextDirection::LTR,
-            0, // minX
-            0, // maxX
-            0, // maxY
-            0, // lineNumber
-            false, // isLineBreak
-            false, // isFirstOnLine
-            false, // isLastOnLine
-            false, // containsStart
-            false, // containsEnd
-            true, // isHorizontal
+            rectInRootView, {
+                .behavior = SelectionRenderingBehavior::CoalesceBoundingRects,
+                .direction = TextDirection::LTR,
+                .minX = 0,
+                .maxX = 0,
+                .maxY = 0,
+                .lineNumber = 0,
+                .isLineBreak = false,
+                .isFirstOnLine = false,
+                .isLastOnLine = false,
+                .containsStart = false,
+                .containsEnd = false,
+                .isHorizontal = true,
+                .isInFixedPosition = false,
+                .pageNumber = 0
+            }
         };
     });
 


### PR DESCRIPTION
#### 64e362c5e9c9f86241f38fc5c59e290c9860cb42
<pre>
Refactor SelectionGeometry constructors to use auxiliary structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=318651">https://bugs.webkit.org/show_bug.cgi?id=318651</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

The primary SelectionGeometry constructor took a long list of positional int/bool arguments that were easy to mix up at call
sites. Grouped them into a single auxiliary struct:

SelectionGeometry::Options { behavior, direction, minX, maxX, maxY,
    lineNumber, isLineBreak, isFirstOnLine,isLastOnLine, containsStart,
    containsEnd, isHorizontal, isInFixedPosition, pageNumber }

Call sites are updated to construct Options inline using designated initializers to maintain readability.

This is a refactor with no intended behavior change.

Combined Changes:
* Source/WebCore/platform/SelectionGeometry.h:
* Source/WebCore/platform/SelectionGeometry.cpp:
(WebCore::SelectionGeometry::SelectionGeometry):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::collectSelectionGeometries):
* Source/WebCore/rendering/RenderLineBreak.cpp:
(WebCore::RenderLineBreak::collectSelectionGeometries):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::collectSelectionGeometries):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e362c5e9c9f86241f38fc5c59e290c9860cb42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/41285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134525 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94949 "2 flakes 23 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36563 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34891 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31027 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184964 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143332 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46559 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143203 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47237 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31888 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/112246 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38189 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118997 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45754 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10227 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45155 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45213 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->