### PR TITLE
[JSC] Make Air::simplifyCFG single path by chasing foldable blocks repeatedly

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirSimplifyCFG.cpp
+++ b/Source/JavaScriptCore/b3/air/AirSimplifyCFG.cpp
@@ -36,9 +36,9 @@ namespace JSC { namespace B3 { namespace Air {
 bool simplifyCFG(Code& code)
 {
     constexpr bool verbose = false;
-    
+
     PhaseScope phaseScope(code, "simplifyCFG"_s);
-    
+
     // We have three easy simplification rules:
     //
     // 1) If a successor is a block that just jumps to another block, then jump directly to
@@ -52,115 +52,136 @@ bool simplifyCFG(Code& code)
     // Note that because of the first rule, this phase may introduce critical edges. That's fine.
     // If you need broken critical edges, then you have to break them yourself.
 
-    bool result = false;
-    for (;;) {
-        if (verbose) {
-            dataLog("Air before an iteration of simplifyCFG:\n");
-            dataLog(code);
-        }
-        
-        bool changed = false;
-        for (BasicBlock* block : code) {
-            // We rely on predecessors being conservatively correct. Verify this here.
-            if (shouldValidateIRAtEachPhase()) {
-                for (BasicBlock* block : code) {
-                    for (BasicBlock* successor : block->successorBlocks())
-                        RELEASE_ASSERT(successor->containsPredecessor(block));
-                }
-            }
-
-            // We don't care about blocks that don't have successors.
-            if (!block->numSuccessors())
-                continue;
-
-            // First check if any of the successors of this block can be forwarded over.
-            for (BasicBlock*& successor : block->successorBlocks()) {
-                if (successor != block
-                    && successor->size() == 1
-                    && successor->last().kind.opcode == Jump) {
-                    BasicBlock* newSuccessor = successor->successorBlock(0);
-                    if (newSuccessor != successor) {
-                        if (verbose) {
-                            dataLog(
-                                "Replacing ", pointerDump(block), "->", pointerDump(successor),
-                                " with ", pointerDump(block), "->", pointerDump(newSuccessor), "\n");
-                        }
-                        // Note that we do not do replacePredecessor() because the block we're
-                        // skipping will still have newSuccessor as its successor.
-                        newSuccessor->addPredecessor(block);
-                        successor = newSuccessor;
-                        changed = true;
-                    }
-                }
-            }
-
-            // Now check if the block's terminal can be replaced with a jump. The terminal must not
-            // have weird effects.
-            if (block->numSuccessors() > 1 
-                && !block->last().hasNonControlEffects()) {
-                // All of the successors must be the same.
-                bool allSame = true;
-                BasicBlock* firstSuccessor = block->successorBlock(0);
-                for (unsigned i = 1; i < block->numSuccessors(); ++i) {
-                    if (block->successorBlock(i) != firstSuccessor) {
-                        allSame = false;
-                        break;
-                    }
-                }
-                if (allSame) {
-                    if (verbose)
-                        dataLog("Changing ", pointerDump(block), "'s terminal to a Jump.\n");
-                    block->last() = Inst(Jump, block->last().origin);
-                    block->successors().resize(1);
-                    block->successors()[0].frequency() = FrequencyClass::Normal;
-                    changed = true;
-                }
-            }
-
-            // Finally handle jumps to a block with one predecessor.
-            if (block->numSuccessors() == 1
-                && !block->last().hasNonControlEffects()) {
-                BasicBlock* successor = block->successorBlock(0);
-                if (successor != block && successor->numPredecessors() == 1) {
-                    RELEASE_ASSERT(successor->predecessor(0) == block);
-
-                    // We can merge the two blocks because the predecessor only jumps to the successor
-                    // and the successor is only reachable from the predecessor.
-
-                    // Remove the terminal.
-                    Value* origin = block->insts().takeLast().origin;
-
-                    // Append the full contents of the successor to the predecessor.
-                    block->insts().reserveCapacity(block->size() + successor->size());
-                    for (Inst& inst : *successor)
-                        block->appendInst(WTF::move(inst));
-
-                    // Make sure that our successors are the successor's successors.
-                    block->successors() = WTF::move(successor->successors());
-
-                    // Make sure that the successor has nothing left in it except an oops.
-                    successor->resize(1);
-                    successor->last() = Inst(Oops, origin);
-                    successor->successors().clear();
-
-                    // Ensure that the predecessors of block's new successors know what's up.
-                    for (BasicBlock* newSuccessor : block->successorBlocks())
-                        newSuccessor->replacePredecessor(successor, block);
-
-                    if (verbose)
-                        dataLog("Merged ", pointerDump(block), "->", pointerDump(successor), "\n");
-                    changed = true;
-                }
-            }
-        }
-
-        if (!changed)
-            break;
-        result = true;
-        code.resetReachability();
+    if (verbose) {
+        dataLog("Air before simplifyCFG:\n");
+        dataLog(code);
     }
 
-    return result;
+    bool changed = false;
+    for (BasicBlock* block : code) {
+        // We rely on predecessors being conservatively correct. Verify this here.
+        if (shouldValidateIRAtEachPhase()) {
+            for (BasicBlock* block : code) {
+                for (BasicBlock* successor : block->successorBlocks())
+                    RELEASE_ASSERT(successor->containsPredecessor(block));
+            }
+        }
+
+        // We don't care about blocks that don't have successors.
+        if (!block->numSuccessors())
+            continue;
+
+        // First check if any of the successors of this block can be forwarded over.
+        // We compress multiple basic blocks into one jump so long as isForwardable is met.
+        for (BasicBlock*& successor : block->successorBlocks()) {
+            auto isForwardable = [&](BasicBlock* candidate) {
+                return candidate != block
+                    && candidate->size() == 1
+                    && candidate->last().kind.opcode == Jump
+                    && candidate->successorBlock(0) != candidate;
+            };
+
+            // Trace the chain of jump-only blocks with a Floyd tortoise/hare walk. The hare
+            // (fast) moves two hops at a time, so it reaches the end of the chain first. When it
+            // lands on a non-forwardable block, that block is the chain end and there is no cycle.
+            // Orphan basic blocks can instead form a cycle with no end, in which case the hare
+            // laps the tortoise (slow) and we bail. Cycles are extremely rare.
+            bool sawCycle = false;
+            BasicBlock* slow = successor;
+            BasicBlock* fast = successor;
+            while (true) {
+                if (!isForwardable(fast))
+                    break;
+                fast = fast->successorBlock(0);
+                if (!isForwardable(fast))
+                    break;
+                fast = fast->successorBlock(0);
+
+                slow = slow->successorBlock(0);
+                if (slow == fast) {
+                    sawCycle = true;
+                    break;
+                }
+            }
+
+            // When there is no cycle, fast is the end of the chain.
+            if (!sawCycle && fast != successor) {
+                BasicBlock* newSuccessor = fast;
+                dataLogLnIf(verbose, "Replacing ", pointerDump(block), "->", pointerDump(successor), " with ", pointerDump(block), "->", pointerDump(newSuccessor));
+                for (BasicBlock* current = successor; current != newSuccessor;) {
+                    BasicBlock* next = current->successorBlock(0);
+                    current->successorBlock(0) = newSuccessor;
+                    newSuccessor->addPredecessor(current);
+                    current = next;
+                }
+                newSuccessor->addPredecessor(block);
+                successor = newSuccessor;
+                changed = true;
+            }
+        }
+
+        // Now check if the block's terminal can be replaced with a jump. The terminal must not
+        // have weird effects.
+        if (block->numSuccessors() > 1
+            && !block->last().hasNonControlEffects()) {
+            // All of the successors must be the same.
+            bool allSame = true;
+            BasicBlock* firstSuccessor = block->successorBlock(0);
+            for (unsigned i = 1; i < block->numSuccessors(); ++i) {
+                if (block->successorBlock(i) != firstSuccessor) {
+                    allSame = false;
+                    break;
+                }
+            }
+            if (allSame) {
+                dataLogLnIf(verbose, "Changing ", pointerDump(block), "'s terminal to a Jump.");
+                block->last() = Inst(Jump, block->last().origin);
+                block->successors().resize(1);
+                block->successors()[0].frequency() = FrequencyClass::Normal;
+                changed = true;
+            }
+        }
+
+        // Finally handle jumps to a block with one predecessor.
+        if (block->numSuccessors() == 1
+            && !block->last().hasNonControlEffects()) {
+            BasicBlock* successor = block->successorBlock(0);
+            if (successor != block && successor->numPredecessors() == 1) {
+                RELEASE_ASSERT(successor->predecessor(0) == block);
+
+                // We can merge the two blocks because the predecessor only jumps to the successor
+                // and the successor is only reachable from the predecessor.
+
+                // Remove the terminal.
+                Value* origin = block->insts().takeLast().origin;
+
+                // Append the full contents of the successor to the predecessor.
+                block->insts().reserveCapacity(block->size() + successor->size());
+                for (Inst& inst : *successor)
+                    block->appendInst(WTF::move(inst));
+
+                // Make sure that our successors are the successor's successors.
+                block->successors() = WTF::move(successor->successors());
+
+                // Make sure that the successor has nothing left in it except an oops.
+                successor->resize(1);
+                successor->last() = Inst(Oops, origin);
+                successor->successors().clear();
+
+                // Ensure that the predecessors of block's new successors know what's up.
+                for (BasicBlock* newSuccessor : block->successorBlocks())
+                    newSuccessor->replacePredecessor(successor, block);
+
+                dataLogLnIf(verbose, "Merged ", pointerDump(block), "->", pointerDump(successor));
+                changed = true;
+            }
+        }
+    }
+
+    if (changed)
+        code.resetReachability();
+
+    return changed;
 }
 
 } } } // namespace JSC::B3::Air


### PR DESCRIPTION
#### 5d5a2e3a036f05666f9f21cb2026896b9f0d8a05
<pre>
[JSC] Make Air::simplifyCFG single path by chasing foldable blocks repeatedly
<a href="https://bugs.webkit.org/show_bug.cgi?id=318653">https://bugs.webkit.org/show_bug.cgi?id=318653</a>
<a href="https://rdar.apple.com/181461212">rdar://181461212</a>

Reviewed by Yijia Huang.

We make Air::simplifyCFG better by reorganizing it into a single path
form instead of fix-point iteration to avoid repeated graph iterations.

1. When folding thread of basic blocks with only one jump, we chase the
   final target instead of folding only one. So we can quickly fold them.
   When the basic blocks are constructing a loop (and they are orphans
   since there is no entrance), then this chase never finishes. So we
   deploy Floyd&apos;s cycle detection mechanism to avoid this case. But note
   that this cycle should be extremely rare.
2. Other rewrites are as-is.

We found that by (1), 99.9% of conversion can be covered by a single-path.

* Source/JavaScriptCore/b3/air/AirSimplifyCFG.cpp:
(JSC::B3::Air::simplifyCFG):

Canonical link: <a href="https://commits.webkit.org/316588@main">https://commits.webkit.org/316588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8552cfb2e49256a46b78a9d5593ea5827f11a96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130267 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fab57f0d-012c-43bb-a06e-432868036019) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134320 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94802 "1 flakes 22 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9425f670-2d64-410e-91a5-bf8804164548) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67d9ebfd-3e24-4c53-8935-224bafffc237) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36358 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34670 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30768 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/3394 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184702 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33972 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143111 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46301 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142988 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46979 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111940 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26242 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37996 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118731 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/205389 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45496 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9320 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54833 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44896 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45128 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44955 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->